### PR TITLE
Added metadata for PyPI and bumped version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 *.egg-info/
 site/
 .cache/
+.venv/
 
 # Misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 ## Supercharge Your Model with Liger Kernel
 
 
-![Banner](/docs/images/banner.GIF)
+![Banner](https://raw.githubusercontent.com/linkedin/Liger-Kernel/main/docs/images/banner.GIF)
 
 With one line of code, Liger Kernel can increase throughput by more than 20% and reduce memory usage by 60%, thereby enabling longer context lengths, larger batch sizes, and massive vocabularies.
 
 
 | Speed Up                 | Memory Reduction        |
 |--------------------------|-------------------------|
-| ![Speed up](docs/images/e2e-tps.png) | ![Memory](docs/images/e2e-memory.png) |
+| ![Speed up](https://raw.githubusercontent.com/linkedin/Liger-Kernel/main/docs/images/e2e-tps.png) | ![Memory](https://raw.githubusercontent.com/linkedin/Liger-Kernel/main/docs/images/e2e-memory.png) |
 
 > **Note:**
 > - Benchmark conditions: LLaMA 3-8B, Batch Size = 8, Data Type = `bf16`, Optimizer = AdamW, Gradient Checkpointing = True, Distributed Strategy = FSDP1 on 8 A100s. 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,31 @@
 from setuptools import find_namespace_packages, setup
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 setup(
     name="liger_kernel",
     version=__version__,
+    description="Efficient Triton kernels for LLM Training",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    license="BSD-2-Clause",
+    url="https://github.com/linkedin/Liger-Kernel",
     package_dir={"": "src"},
     packages=find_namespace_packages(where="src"),
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'Intended Audience :: Education',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Topic :: Software Development :: Libraries',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
+    ],
+    keywords='triton kernels LLM training deep learning Hugging Face PyTorch GPU optimization',
     include_package_data=True,
     install_requires=[
         "torch>=2.1.2",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'Topic :: Software Development :: Libraries',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
     ],
-    keywords='triton kernels LLM training deep learning Hugging Face PyTorch GPU optimization',
+    keywords="triton,kernels,LLM training,deep learning,Hugging Face,PyTorch,GPU optimization",
     include_package_data=True,
     install_requires=[
         "torch>=2.1.2",


### PR DESCRIPTION
## Summary
- Added metadata to populate the PyPI entry
- bumped version

## Testing Done
`twine check dist/*`
```
Checking dist/liger_kernel-0.1.1-py3-none-any.whl: PASSED
Checking dist/liger_kernel-0.1.1.tar.gz: PASSED
```

`python -m readme_renderer README.md --output rendered_readme.html` --> renders properly
