### PR TITLE
Fix Gemma RMSNorm

### DIFF
--- a/src/liger_kernel/ops/rms_norm.py
+++ b/src/liger_kernel/ops/rms_norm.py
@@ -17,6 +17,7 @@ def _rms_norm_forward(
     r_row_stride,
     n_cols,
     eps,
+    offset,
     BLOCK_SIZE: tl.constexpr,
 ):
     """
@@ -47,7 +48,7 @@ def _rms_norm_forward(
     # However, on the computation side, it can save 4 operations (*, sum, /, sqrt).
     tl.store(r_ptr, inv_rms)
 
-    Y_row = X_row * inv_rms * W_row
+    Y_row = X_row * inv_rms * (offset + W_row)
 
     tl.store(Y_ptr + col_offsets, Y_row, mask=mask)
 
@@ -66,6 +67,7 @@ def _rms_norm_backward(
     dW_row_stride,
     n_cols,
     eps,
+    offset,
     BLOCK_SIZE: tl.constexpr,
 ):
     """
@@ -89,6 +91,7 @@ def _rms_norm_backward(
     # Get cached rms
     inv_rms_row = tl.load(r_ptr)
 
+    W_row = W_row + offset
     dX_row = (inv_rms_row) * (
         dY_row * W_row
         - (1 / n_cols)
@@ -107,7 +110,7 @@ def _rms_norm_backward(
 class LigerRMSNormFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, X, W, eps):
+    def forward(ctx, X, W, eps, offset=0.0):
         """
         X: (B, T, H) or (BxT, H)
         W: (H,)
@@ -139,10 +142,12 @@ class LigerRMSNormFunction(torch.autograd.Function):
             r.stride(0),
             n_cols,
             eps,
+            offset,
             BLOCK_SIZE=BLOCK_SIZE,
             num_warps=num_warps,
         )
         ctx.eps = eps
+        ctx.offset = offset
         ctx.BLOCK_SIZE = BLOCK_SIZE
         ctx.num_warps = num_warps
 
@@ -177,9 +182,10 @@ class LigerRMSNormFunction(torch.autograd.Function):
             dW.stride(0),
             n_cols,
             ctx.eps,
+            ctx.offset,
             BLOCK_SIZE=ctx.BLOCK_SIZE,
             num_warps=ctx.num_warps,
         )
         dX = dY.view(*shape)
         dW = torch.sum(dW, dim=0)
-        return dX, dW, None
+        return dX, dW, None, None

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from liger_kernel.transformers.cross_entropy import LigerCrossEntropyLoss
 from liger_kernel.transformers.geglu import LigerGEGLUMLP
 from liger_kernel.transformers.model.llama import lce_forward
@@ -124,7 +126,7 @@ def apply_liger_kernel_to_gemma(
     if rope:
         modeling_gemma.apply_rotary_pos_emb = liger_rotary_pos_emb
     if rms_norm:
-        modeling_gemma.GemmaRMSNorm = LigerRMSNorm
+        modeling_gemma.GemmaRMSNorm = partial(LigerRMSNorm, offset=1.0)
     if cross_entropy:
         modeling_gemma.CrossEntropyLoss = LigerCrossEntropyLoss
     if geglu:

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -120,13 +120,13 @@ def apply_liger_kernel_to_gemma(
         rms_norm (bool): Whether to apply Liger's RMSNorm. Default is True.
         geglu (bool): Whether to apply Liger's GeGLU MLP. Default is True.
     """
-    # TODO(yundai424): add convergence test for gemma
     from transformers.models.gemma import modeling_gemma
 
     if rope:
         modeling_gemma.apply_rotary_pos_emb = liger_rotary_pos_emb
     if rms_norm:
-        modeling_gemma.GemmaRMSNorm = partial(LigerRMSNorm, offset=1.0)
+        # https://github.com/huggingface/transformers/blob/v4.44.2/src/transformers/models/gemma/modeling_gemma.py#L109
+        modeling_gemma.GemmaRMSNorm = partial(LigerRMSNorm, offset=1.0, init_fn="zeros")
     if cross_entropy:
         modeling_gemma.CrossEntropyLoss = LigerCrossEntropyLoss
     if geglu:

--- a/src/liger_kernel/transformers/rms_norm.py
+++ b/src/liger_kernel/transformers/rms_norm.py
@@ -5,12 +5,13 @@ from liger_kernel.ops.rms_norm import LigerRMSNormFunction
 
 
 class LigerRMSNorm(nn.Module):
-    def __init__(self, hidden_size, eps=1e-6):
+    def __init__(self, hidden_size, eps=1e-6, offset=0.0):
         super().__init__()
         self.weight = nn.Parameter(torch.ones(hidden_size))
         self.variance_epsilon = eps
+        self.offset = offset
 
     def forward(self, hidden_states):
         return LigerRMSNormFunction.apply(
-            hidden_states, self.weight, self.variance_epsilon
+            hidden_states, self.weight, self.variance_epsilon, self.offset
         )

--- a/src/liger_kernel/transformers/rms_norm.py
+++ b/src/liger_kernel/transformers/rms_norm.py
@@ -5,9 +5,15 @@ from liger_kernel.ops.rms_norm import LigerRMSNormFunction
 
 
 class LigerRMSNorm(nn.Module):
-    def __init__(self, hidden_size, eps=1e-6, offset=0.0):
+    def __init__(self, hidden_size, eps=1e-6, offset=0.0, init_fn="ones"):
         super().__init__()
-        self.weight = nn.Parameter(torch.ones(hidden_size))
+        assert init_fn in [
+            "ones",
+            "zeros",
+        ], f"init_fn must be either 'ones' or 'zeros', got {init_fn}"
+        self.weight = nn.Parameter(
+            torch.ones(hidden_size) if init_fn == "ones" else torch.zeros(hidden_size)
+        )
         self.variance_epsilon = eps
         self.offset = offset
 

--- a/test/convergence/test_mini_models.py
+++ b/test/convergence/test_mini_models.py
@@ -11,12 +11,14 @@ import pytest
 import torch
 from datasets import load_from_disk
 from torch.utils.data import DataLoader
+from transformers.models.gemma import GemmaConfig, GemmaForCausalLM
 from transformers.models.llama import LlamaConfig, LlamaForCausalLM
 from transformers.models.mistral import MistralConfig, MistralForCausalLM
 from transformers.models.mixtral import MixtralConfig, MixtralForCausalLM
 from transformers.models.qwen2 import Qwen2Config, Qwen2ForCausalLM
 
 from liger_kernel.transformers import (
+    apply_liger_kernel_to_gemma,
     apply_liger_kernel_to_llama,
     apply_liger_kernel_to_mistral,
     apply_liger_kernel_to_mixtral,
@@ -56,6 +58,34 @@ MINI_MODEL_SETUPS = {
             # SDPA produces contiguous dq and incontiguous dk
             # Flash_attn produces contiguous dq and dk
             attn_implementation="sdpa",  # default value, pytorch native attention
+        ),
+    ),
+    "mini_gemma": MiniModelConfig(
+        liger_kernel_patch_func=apply_liger_kernel_to_gemma,
+        model_class=GemmaForCausalLM,
+        mini_model_config=GemmaConfig(
+            vocab_size=32000,  # 256000
+            hidden_size=1024,  # 3072
+            intermediate_size=2048,  # 24576
+            num_hidden_layers=4,  # 28
+            num_attention_heads=4,  # 16
+            num_key_value_heads=4,  # 16
+            head_dim=256,
+            hidden_act="gelu_pytorch_tanh",
+            hidden_activation=None,
+            max_position_embeddings=8192,
+            initializer_range=0.02,
+            rms_norm_eps=1e-06,
+            use_cache=True,
+            pad_token_id=0,
+            # Special token ids/vocab size to match Mistral-7B tokenizer used to create the tokenized dataset
+            # https://huggingface.co/mistralai/Mistral-7B-v0.1/blob/main/config.json
+            bos_token_id=1,  # 128000
+            eos_token_id=2,  # 128001
+            tie_word_embeddings=True,
+            rope_theta=10000.0,
+            attention_bias=False,
+            attention_dropout=0.0,
         ),
     ),
     "mini_mistral": MiniModelConfig(
@@ -172,9 +202,16 @@ def run_mini_model(
     set_seed(42)
 
     if with_liger is True:
-        MINI_MODEL_SETUPS[model_name].liger_kernel_patch_func(
-            rope=True, rms_norm=True, cross_entropy=True, swiglu=True
-        )
+        kwargs = {
+            "rope": True,
+            "rms_norm": True,
+            "cross_entropy": True,
+        }
+        if model_name == "mini_gemma":
+            kwargs["geglu"] = True
+        else:
+            kwargs["swiglu"] = True
+        MINI_MODEL_SETUPS[model_name].liger_kernel_patch_func(**kwargs)
 
     model = create_model(model_name).to(dtype).to("cuda")
     train_dataset = load_from_disk(DEFAULT_DATASET_PATH)
@@ -201,6 +238,9 @@ def run_mini_model(
 @pytest.mark.parametrize(
     "model_name, num_steps, lr, dtype, loss_atol, loss_rtol, logits_atol, logits_rtol, param_atol, param_rtol",
     [
+        ("mini_gemma", 32, 1e-4, torch.float32, 1e-8, 1e-5, 5e-3, 1e-5, 5e-3, 1e-5),
+        # mini_gemma has more tolerance because currently, the kernel is not a perfect match (casts are not done the same way)
+        ("mini_gemma", 32, 1e-4, torch.bfloat16, 1e-2, 1e-4, 2e-1, 1e-5, 1e-2, 1e-5),
         ("mini_llama3", 32, 1e-4, torch.float32, 1e-8, 1e-5, 1e-4, 1e-5, 2e-3, 1e-5),
         ("mini_llama3", 32, 1e-4, torch.bfloat16, 1e-8, 1e-5, 1e-1, 1e-5, 1e-2, 1e-5),
         # TODO: torch 2.5.0 nightly breaks mixtral test, but torch 2.3.0 works fine


### PR DESCRIPTION
## Summary
Fixes https://github.com/linkedin/Liger-Kernel/issues/74. Allows Gemma's RMSNorm by adding a generic offset parameter to RMSNorm.

## Testing Done
Parametrize the RMSNorm tests to test both Llama's and Gemma's versions (as per Hugging Face's transformers library).

- Hardware Type: tested on NVIDIA L4/L40
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence

## Test outputs
```
test/transformers/test_rms_norm.py ................................                                                                                                                                                                                            [100%]

========================================================================================================================= 32 passed in 3.74s =========================================================================================================================

test/convergence/test_mini_models.py ......                                                                                                                                                                                                                    [100%]

========================================================================================================================= 6 passed in 32.04s =========================================================================================================================
```