### PR TITLE
Make tests passing on AMD GPU with 24GB ram

### DIFF
--- a/test/transformers/test_cross_entropy.py
+++ b/test/transformers/test_cross_entropy.py
@@ -89,9 +89,9 @@ def _test_correctness_not_last_layer_once(
 @pytest.mark.parametrize(
     "B, T, V",
     [
-        (4, 4096, 32000),  # llama2, mistral
-        (8, 4096, 32000),  # llama2, mistral
-        (4, 4096, 128256),  # llama3
+        (2, 4096, 32000),  # llama2, mistral
+        (2, 4096, 32000),  # llama2, mistral
+        (1, 4096, 128256),  # llama3
         # # weird shapes
         (3, 423, 32000),
     ],
@@ -115,9 +115,9 @@ def test_correctness(B, T, V, scalar, dtype, atol, rtol):
 @pytest.mark.parametrize(
     "B, T, V, ignore_index",
     [
-        (4, 4096, 32000, -100),  # llama2, mistral
-        (8, 4096, 32000, 2),  # llama2, mistral
-        (4, 4096, 128256, -300),  # llama3
+        (2, 4096, 32000, -100),  # llama2, mistral
+        (2, 4096, 32000, 2),  # llama2, mistral
+        (1, 4096, 128256, -300),  # llama3
         # weird shapes
         (3, 423, 32000, -123),
     ],
@@ -145,9 +145,9 @@ def test_correctness_with_ignore_index(
 @pytest.mark.parametrize(
     "B, T, V",
     [
-        (4, 4096, 32000),  # llama2, mistral
-        (8, 4096, 32000),  # llama2, mistral
-        (4, 4096, 128256),  # llama3
+        (2, 4096, 32000),  # llama2, mistral
+        (2, 4096, 32000),  # llama2, mistral
+        (1, 4096, 128256),  # llama3
         # # weird shapes
         (3, 423, 32000),
     ],
@@ -192,6 +192,10 @@ def _full_pass_once(B, T, V):
         ),  # _input = 16GB, total = ~32GB, 8405385216 > 2,147,483,647, so we need int64
         (8, 16384, 128256),  # _input = 32GB, total = ~64GB
     ],
+)
+@pytest.mark.skipif(
+    torch.cuda.get_device_properties(0).total_memory < 64000000000,
+    reason="Needs 64GB+ GPU memory.",
 )
 def test_large_no_exception(B, T, V):
     # The large inputs were hitting cuda illegal memory access because of


### PR DESCRIPTION
## Summary
Make tests passing on AMD GPU with 24GB ram by reducing the number of batches for some tests and conditions on the tests

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
make test && make test-convergence && make checkstyle

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type:  AMD 7900XTX
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
