### PR TITLE
pytest without need to dealing with PYTHONPATH

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,13 +42,8 @@ Create unit tests and convergence tests for your kernel in the tests directory. 
 2. run `make checkstyle` to ensure code style.
 3. run `make test-convergence` to ensure convergence.
 
-If encounter the import error `ModuleNotFoundError: No module named 'test.utils'`, please add `Liger-Kernel` folder in the path
-```
-export PYTHONPATH="${PYTHONPATH}:your-path-here/Liger-Kernel"
-```
-
 ### Run pytest on single file
-`pytest test_sample.py::test_function_name`
+`python -m pytest test_sample.py::test_function_name`
 
 ## Submit PR
 Fork the repo, copy and paste the successful test logs in the PR and submit the PR followed by the PR template (**[example PR](https://github.com/linkedin/Liger-Kernel/pull/21)**).

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-.PHONY: test checkstyle test-convergence
+.PHONY: test checkstyle test-convergence all
+
+
+all: test test-convergence checkstyle
 
 # Command to run pytest for correctness tests
 test:
-	pytest --disable-warnings test/ --ignore=test/convergence
+	python -m pytest --disable-warnings test/ --ignore=test/convergence
 	
 
 # Command to run flake8 (code style check), isort (import ordering), and black (code formatting)
@@ -18,4 +21,4 @@ checkstyle:
 # Command to run pytest for convergence tests
 # We have to explicitly set HF_DATASETS_OFFLINE=1, or dataset will silently try to send metrics and timeout (80s) https://github.com/huggingface/datasets/blob/37a603679f451826cfafd8aae00738b01dcb9d58/src/datasets/load.py#L286
 test-convergence:
-	HF_DATASETS_OFFLINE=1 pytest --disable-warnings test/convergence
+	HF_DATASETS_OFFLINE=1 python -m pytest --disable-warnings test/convergence


### PR DESCRIPTION
## Summary
pytest without need to dealing with PYTHONPATH

According to [pytest doc](https://docs.pytest.org/en/7.1.x/explanation/pythonpath.html#invoking-pytest-versus-python-m-pytest), `python -m pytest` will put current dir to sys.path, eliminating the need to add `PYTHONPATH=.` to make test passing

## Testing Done
make
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: AMD 7900 XTX
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
