### PR TITLE
Add convergence tests and trainer integration test for Qwen2

### DIFF
--- a/test/transformers/test_trainer_integration.py
+++ b/test/transformers/test_trainer_integration.py
@@ -20,6 +20,7 @@ def test_apply_liger_kernel_only_supported_model_type_called():
     mock_gemma = Mock()
     mock_llama = Mock()
     mock_mistral = Mock()
+    mock_qwen2 = Mock()
 
     with patch.dict(
         MODEL_TYPE_TO_APPLY_LIGER_FN,
@@ -29,6 +30,7 @@ def test_apply_liger_kernel_only_supported_model_type_called():
         mock_llama.assert_called_once()
         mock_gemma.assert_not_called()
         mock_mistral.assert_not_called()
+        mock_qwen2.assert_not_called()
 
 
 def test_apply_liger_kernel_passes_kwargs():

--- a/test/transformers/test_trainer_integration.py
+++ b/test/transformers/test_trainer_integration.py
@@ -24,7 +24,12 @@ def test_apply_liger_kernel_only_supported_model_type_called():
 
     with patch.dict(
         MODEL_TYPE_TO_APPLY_LIGER_FN,
-        {"gemma": mock_gemma, "llama": mock_llama, "mistral": mock_mistral},
+        {
+            "gemma": mock_gemma,
+            "llama": mock_llama,
+            "mistral": mock_mistral,
+            "qwen2": mock_gemma,
+        },
     ):
         _apply_liger_kernel("llama")
         mock_llama.assert_called_once()

--- a/test/transformers/test_trainer_integration.py
+++ b/test/transformers/test_trainer_integration.py
@@ -20,7 +20,6 @@ def test_apply_liger_kernel_only_supported_model_type_called():
     mock_gemma = Mock()
     mock_llama = Mock()
     mock_mistral = Mock()
-    mock_qwen2 = Mock()
 
     with patch.dict(
         MODEL_TYPE_TO_APPLY_LIGER_FN,
@@ -28,14 +27,12 @@ def test_apply_liger_kernel_only_supported_model_type_called():
             "gemma": mock_gemma,
             "llama": mock_llama,
             "mistral": mock_mistral,
-            "qwen2": mock_gemma,
         },
     ):
         _apply_liger_kernel("llama")
         mock_llama.assert_called_once()
         mock_gemma.assert_not_called()
         mock_mistral.assert_not_called()
-        mock_qwen2.assert_not_called()
 
 
 def test_apply_liger_kernel_passes_kwargs():


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
[Discussion](https://github.com/linkedin/Liger-Kernel/pull/93#issuecomment-2310468447)

Add convergence tests and trainer integration test for Qwen2

## Details

Qwen2's config and parameters are copied from `test_cross_entropy.py`. 

I also added qwen2 mock in `test_apply_liger_kernel_only_supported_model_type_called` just in case. But are we going to add every new models from now on?

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
I don't have a GPU with enough memory, only run `test_trainer_integration.py` and `test_transformers_monkey_patch.py`.
Need others to help with `make test`.
<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: RTX-3080-10G
- [ ] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
```bash
❯ pytest test/transformers/test_transformers_monkey_patch.py
============================================ test session starts =============================================
platform linux -- Python 3.10.12, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/tcc/Liger-Kernel
collected 1 item

test/transformers/test_transformers_monkey_patch.py .                                                  [100%]

============================================= 1 passed in 1.72s ==============================================
❯ pytest test/transformers/test_trainer_integration.py
============================================ test session starts =============================================
platform linux -- Python 3.10.12, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/tcc/Liger-Kernel
collected 3 items

test/transformers/test_trainer_integration.py ...                                                      [100%]

============================================= 3 passed in 1.84s ==============================================
```
```bash
❯ make checkstyle
flake8 .; flake8_status=$?; \
isort .; isort_status=$?; \
black .; black_status=$?; \
if [ $flake8_status -ne 0 ] || [ $isort_status -ne 0 ] || [ $black_status -ne 0 ]; then \
        exit 1; \
fi
Skipped 2 files
All done! ✨ 🍰 ✨
52 files left unchanged.
```
```bash
❯ make test-convergence
HF_DATASETS_OFFLINE=1 pytest --disable-warnings test/convergence
============================================ test session starts =============================================
platform linux -- Python 3.10.12, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/tcc/Liger-Kernel
collected 12 items

test/convergence/test_mini_models.py ........                                                          [ 66%]
test/convergence/test_mini_models_no_logits.py ....                                                    [100%]

======================================= 12 passed in 81.23s (0:01:21) ========================================
```