### PR TITLE
Add FusedLinearCrossEntropy to Gemma

### DIFF
--- a/src/liger_kernel/transformers/model/gemma.py
+++ b/src/liger_kernel/transformers/model/gemma.py
@@ -1,0 +1,138 @@
+from typing import List, Optional, Tuple, Union
+
+import torch
+from torch.nn import CrossEntropyLoss
+from transformers.cache_utils import Cache
+from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers.models.gemma.modeling_gemma import (
+    _CONFIG_FOR_DOC,
+    GEMMA_INPUTS_DOCSTRING,
+)
+from transformers.utils import (
+    add_start_docstrings_to_model_forward,
+    replace_return_docstrings,
+)
+
+from liger_kernel.transformers.fused_linear_cross_entropy import (
+    LigerFusedLinearCrossEntropyLoss,
+)
+
+
+@add_start_docstrings_to_model_forward(GEMMA_INPUTS_DOCSTRING)
+@replace_return_docstrings(
+    output_type=CausalLMOutputWithPast, config_class=_CONFIG_FOR_DOC
+)
+def lce_forward(
+    self,
+    input_ids: torch.LongTensor = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values: Optional[Union[Cache, List[torch.FloatTensor]]] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    labels: Optional[torch.LongTensor] = None,
+    use_cache: Optional[bool] = None,
+    output_attentions: Optional[bool] = None,
+    output_hidden_states: Optional[bool] = None,
+    return_dict: Optional[bool] = None,
+    cache_position: Optional[torch.LongTensor] = None,
+) -> Union[Tuple, CausalLMOutputWithPast]:
+    r"""
+
+    copy paste transformers.models.gemma.modeling_gemma causalLM with loss replaced with liger fused cross entropy
+
+    Args:
+        labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
+            config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
+            (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+    Returns:
+
+    Example:
+
+    ```python
+    >>> from transformers import AutoTokenizer, GemmaForCausalLM
+
+    >>> model = GemmaForCausalLM.from_pretrained("google/gemma-7b")
+    >>> tokenizer = AutoTokenizer.from_pretrained("google/gemma-7b")
+
+    >>> prompt = "What is your favorite condiment?"
+    >>> inputs = tokenizer(prompt, return_tensors="pt")
+
+    >>> # Generate
+    >>> generate_ids = model.generate(inputs.input_ids, max_length=30)
+    >>> tokenizer.batch_decode(generate_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)[0]
+    "What is your favorite condiment?"
+    ```"""
+    output_attentions = (
+        output_attentions
+        if output_attentions is not None
+        else self.config.output_attentions
+    )
+    output_hidden_states = (
+        output_hidden_states
+        if output_hidden_states is not None
+        else self.config.output_hidden_states
+    )
+    return_dict = (
+        return_dict if return_dict is not None else self.config.use_return_dict
+    )
+
+    # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
+    outputs = self.model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        past_key_values=past_key_values,
+        inputs_embeds=inputs_embeds,
+        use_cache=use_cache,
+        output_attentions=output_attentions,
+        output_hidden_states=output_hidden_states,
+        return_dict=return_dict,
+        cache_position=cache_position,
+    )
+
+    hidden_states = outputs[0]
+
+    loss = None
+    logits = None
+
+    if self.training:
+        shift_hidden_states = hidden_states[..., :-1, :].contiguous()
+        shift_labels = labels[..., 1:].contiguous()
+
+        # flatten
+
+        shift_hidden_states = shift_hidden_states.view(-1, self.config.hidden_size)
+        shift_labels = shift_labels.view(-1)
+
+        lce = LigerFusedLinearCrossEntropyLoss()
+        loss = lce(self.lm_head.weight, shift_hidden_states, shift_labels)
+
+    else:
+        logits = self.lm_head(hidden_states)
+        if labels is not None:
+            # Upcast to float if we need to compute the loss to avoid potential precision issues
+            logits = logits.float()
+            # Shift so that tokens < n predict n
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
+            # Flatten the tokens
+            shift_logits = shift_logits.view(-1, self.config.vocab_size)
+            shift_labels = shift_labels.view(-1)
+            # Ensure tensors are on the same device
+            shift_labels = shift_labels.to(shift_logits.device)
+            loss_fct = CrossEntropyLoss()
+            loss = loss_fct(shift_logits, shift_labels)
+
+    if not return_dict:
+        output = (logits,) + outputs[1:]
+        return (loss,) + output if loss is not None else output
+
+    return CausalLMOutputWithPast(
+        loss=loss,
+        logits=logits,
+        past_key_values=outputs.past_key_values,
+        hidden_states=outputs.hidden_states,
+        attentions=outputs.attentions,
+    )

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -134,6 +134,10 @@ def apply_liger_kernel_to_gemma(
         rms_norm (bool): Whether to apply Liger's RMSNorm. Default is True.
         geglu (bool): Whether to apply Liger's GeGLU MLP. Default is True.
     """
+    assert not (
+        cross_entropy and fused_linear_cross_entropy
+    ), "cross_entropy and fused_linear_cross_entropy cannot both be True."
+    
     from transformers.models.gemma import modeling_gemma
 
     if rope:

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -2,6 +2,7 @@ from functools import partial
 
 from liger_kernel.transformers.cross_entropy import LigerCrossEntropyLoss
 from liger_kernel.transformers.geglu import LigerGEGLUMLP
+from liger_kernel.transformers.model.gemma import lce_forward as gemma_lce_forward
 from liger_kernel.transformers.model.llama import lce_forward
 from liger_kernel.transformers.model.mistral import lce_forward as mistral_lce_forward
 from liger_kernel.transformers.model.qwen2 import lce_forward as qwen2_lce_forward
@@ -119,8 +120,10 @@ def apply_liger_kernel_to_mixtral(
 def apply_liger_kernel_to_gemma(
     rope: bool = True,
     cross_entropy: bool = True,
+    fused_linear_cross_entropy: bool = True,
     rms_norm: bool = True,
     geglu: bool = True,
+    swiglu: bool = True,
 ) -> None:
     """
     Apply Liger kernels to replace original implementation in HuggingFace Gemma2 models
@@ -143,6 +146,8 @@ def apply_liger_kernel_to_gemma(
         modeling_gemma.CrossEntropyLoss = LigerCrossEntropyLoss
     if geglu:
         modeling_gemma.GemmaMLP = LigerGEGLUMLP
+    if fused_linear_cross_entropy:
+        modeling_gemma.GemmaForCausalLM.forward = gemma_lce_forward
 
 
 def apply_liger_kernel_to_qwen2(

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -123,7 +123,6 @@ def apply_liger_kernel_to_gemma(
     fused_linear_cross_entropy: bool = True,
     rms_norm: bool = True,
     geglu: bool = True,
-    swiglu: bool = True,
 ) -> None:
     """
     Apply Liger kernels to replace original implementation in HuggingFace Gemma2 models

--- a/test/convergence/test_mini_models.py
+++ b/test/convergence/test_mini_models.py
@@ -61,7 +61,9 @@ MINI_MODEL_SETUPS = {
         ),
     ),
     "mini_gemma": MiniModelConfig(
-        liger_kernel_patch_func=apply_liger_kernel_to_gemma,
+        liger_kernel_patch_func=functools.partial(
+            apply_liger_kernel_to_gemma, fused_linear_cross_entropy=False
+        ),
         model_class=GemmaForCausalLM,
         mini_model_config=GemmaConfig(
             vocab_size=32000,  # 256000

--- a/test/convergence/test_mini_models_no_logits.py
+++ b/test/convergence/test_mini_models_no_logits.py
@@ -163,13 +163,18 @@ def run_mini_model(
     set_seed(42)
 
     if with_liger is True:
-        MINI_MODEL_SETUPS[model_name].liger_kernel_patch_func(
-            rope=True,
-            rms_norm=True,
-            cross_entropy=False,
-            swiglu=True,
-            fused_linear_cross_entropy=True,
-        )
+        kwargs = {
+            "rope": True,
+            "rms_norm": True,
+            "cross_entropy": False,
+            "fused_linear_cross_entropy": True,
+        }
+        if model_name == "mini_gemma":
+            kwargs["geglu"] = True
+        else:
+            kwargs["swiglu"] = True
+
+        MINI_MODEL_SETUPS[model_name].liger_kernel_patch_func(**kwargs)
 
     model = create_model(model_name).to(dtype).to("cuda")
     train_dataset = load_from_disk(DEFAULT_DATASET_PATH)

--- a/test/convergence/test_mini_models_no_logits.py
+++ b/test/convergence/test_mini_models_no_logits.py
@@ -10,11 +10,13 @@ import pytest
 import torch
 from datasets import load_from_disk
 from torch.utils.data import DataLoader
+from transformers.models.gemma import GemmaConfig, GemmaForCausalLM
 from transformers.models.llama import LlamaConfig, LlamaForCausalLM
 from transformers.models.mistral import MistralConfig, MistralForCausalLM
 from transformers.models.qwen2 import Qwen2Config, Qwen2ForCausalLM
 
 from liger_kernel.transformers import (
+    apply_liger_kernel_to_gemma,
     apply_liger_kernel_to_llama,
     apply_liger_kernel_to_mistral,
     apply_liger_kernel_to_qwen2,
@@ -105,6 +107,34 @@ MINI_MODEL_SETUPS = {
             attn_implementation="sdpa",
         ),
     ),
+    "mini_gemma": MiniModelConfig(
+        liger_kernel_patch_func=apply_liger_kernel_to_gemma,
+        model_class=GemmaForCausalLM,
+        mini_model_config=GemmaConfig(
+            vocab_size=32000,  # 256000
+            hidden_size=1024,  # 3072
+            intermediate_size=2048,  # 24576
+            num_hidden_layers=4,  # 28
+            num_attention_heads=4,  # 16
+            num_key_value_heads=4,  # 16
+            head_dim=256,
+            hidden_act="gelu_pytorch_tanh",
+            hidden_activation=None,
+            max_position_embeddings=8192,
+            initializer_range=0.02,
+            rms_norm_eps=1e-06,
+            use_cache=True,
+            pad_token_id=0,
+            # Special token ids/vocab size to match Mistral-7B tokenizer used to create the tokenized dataset
+            # https://huggingface.co/mistralai/Mistral-7B-v0.1/blob/main/config.json
+            bos_token_id=1,  # 128000
+            eos_token_id=2,  # 128001
+            tie_word_embeddings=True,
+            rope_theta=10000.0,
+            attention_bias=False,
+            attention_dropout=0.0,
+        ),
+    ),
 }
 
 
@@ -171,6 +201,9 @@ def run_mini_model(
         ("mini_qwen2", 32, 1e-4, torch.bfloat16, 1e-8, 1e-5, 1e-1, 1e-5, 1e-2, 1e-5),
         ("mini_mistral", 32, 1e-4, torch.float32, 1e-8, 1e-5, 5e-3, 1e-5, 5e-3, 1e-5),
         ("mini_mistral", 32, 1e-4, torch.bfloat16, 1e-8, 1e-5, 1e-1, 1e-5, 1e-2, 1e-5),
+        ("mini_gemma", 32, 1e-4, torch.float32, 1e-8, 1e-5, 5e-3, 1e-5, 5e-3, 1e-5),
+        # mini_gemma has more tolerance because currently, the kernel is not a perfect match (casts are not done the same way)
+        ("mini_gemma", 32, 1e-4, torch.bfloat16, 1e-2, 1e-4, 2e-1, 1e-5, 1e-2, 1e-5),
     ],
 )
 def test_mini_model(


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
This PR adds FusedLinearCrossEntropy support for gemma to resolve
issue https://github.com/linkedin/Liger-Kernel/issues/101.



## Details
I based the code in this PR off of https://github.com/linkedin/Liger-Kernel/pull/93 which does the same thing for Mistral. 

Since the parameters fused_linear_cross_entropy and cross_entropy cannot both be true, fused_linear_cross_entropy has to be explicitly set to False in test_mini_models.py, to avoid failing convergence
test due to setting both True.
In test_mini_models_no_logits.py, I add two extra tests for gemma to ensure that FusedLinearCrossEntropy part in gemma is tested.

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: NVIDIA A100-SXM4-80GB 
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence


```
Fixing ~/Liger-Kernel/test/convergence/test_mini_models_no_logits.py
Skipped 1 files
reformatted /home/luke/Desktop/Liger-Kernel/src/liger_kernel/transformers/model/gemma.py
reformatted /home/luke/Desktop/Liger-Kernel/src/liger_kernel/transformers/monkey_patch.py
reformatted /home/luke/Desktop/Liger-Kernel/test/convergence/test_mini_models_no_logits.py

All done! ✨ 🍰 ✨
3 files reformatted, 51 files left unchanged.
make: *** [Makefile:14: checkstyle] Error 1
luke@luke:~/Desktop/Liger-Kernel$ 


root@C.12106734:~/Liger-Kernel$ make test
python -m pytest --disable-warnings test/ --ignore=test/convergence
======================================================= test session starts =======================================================
platform linux -- Python 3.11.9, pytest-8.3.2, pluggy-1.5.0
rootdir: /root/Liger-Kernel
plugins: hypothesis-6.108.4, anyio-4.4.0
collected 130 items                                                                                                               

test/transformers/test_cross_entropy.py ..........................................................                          [ 44%]
test/transformers/test_fused_linear_cross_entropy.py ......                                                                 [ 49%]
test/transformers/test_geglu.py ........                                                                                    [ 55%]
test/transformers/test_rms_norm.py ................................                                                         [ 80%]
test/transformers/test_rope.py ............                                                                                 [ 89%]
test/transformers/test_swiglu.py ........                                                                                   [ 95%]
test/transformers/test_trainer_integration.py ...                                                                           [ 97%]
test/transformers/test_transformers_monkey_patch.py .                                                                       [ 98%]
test/triton/test_triton_monkey_patch.py ..                                                                                  [100%]

====================================================== 130 passed in 44.12s =======================================================



root@C.12106734:~/Liger-Kernel$ make test-convergence
HF_DATASETS_OFFLINE=1 python -m pytest --disable-warnings test/convergence
======================================================= test session starts =======================================================
platform linux -- Python 3.11.9, pytest-8.3.2, pluggy-1.5.0
rootdir: /root/Liger-Kernel
plugins: hypothesis-6.108.4, anyio-4.4.0
collected 14 items                                                                                                                

test/convergence/test_mini_models.py ........                                                                               [ 57%]
test/convergence/test_mini_models_no_logits.py ......                                                                       [100%]

================================================= 14 passed in 125.51s (0:02:05) ==================================================


```


