### PR TITLE
[Bug fix] Efficiency callback missing dataclass entries

### DIFF
--- a/examples/huggingface/callback.py
+++ b/examples/huggingface/callback.py
@@ -68,7 +68,9 @@ class Memory:
     """
 
     step_peak_memory_allocated_MB: float = 0.0
+    step_peak_memory_reserved_MB: float = 0.0
     total_peak_memory_allocated_MB: float = 0.0
+    total_peak_memory_reserved_MB: float = 0.0
 
 
 @dataclass


### PR DESCRIPTION
## Summary
Fix EfficiencyCallback missing entries for the Memory dataclass

## Testing Done
Ran a training run using the callback.
