### PR TITLE
[WIP] Fix confusion on Gemma

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ loss.backward()
 | LLaMA (2 & 3) | `liger_kernel.transformers.apply_liger_kernel_to_llama`   | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy        |
 | Mistral     | `liger_kernel.transformers.apply_liger_kernel_to_mistral`  | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy        |
 | Mixtral     | `liger_kernel.transformers.apply_liger_kernel_to_mixtral`  | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss        |
-| Gemma2      | `liger_kernel.transformers.apply_liger_kernel_to_gemma`    | RoPE, RMSNorm, GeGLU, CrossEntropyLoss         |
+| Gemma (1.1 & 2) | `liger_kernel.transformers.apply_liger_kernel_to_gemma`    | RoPE, RMSNorm, GeGLU, CrossEntropyLoss         |
 | Qwen2       | `liger_kernel.transformers.apply_liger_kernel_to_qwen2`    | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy        |
 | Phi3        | `liger_kernel.transformers.apply_liger_kernel_to_phi3`    | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss         |
 

--- a/src/liger_kernel/env_report.py
+++ b/src/liger_kernel/env_report.py
@@ -1,6 +1,7 @@
 import platform
 import sys
 
+
 def print_env_report():
     """
     Prints a report of the environment. Useful for debugging and reproducibility.
@@ -16,8 +17,11 @@ def print_env_report():
 
     try:
         import torch
+
         print(f"PyTorch version: {torch.__version__}")
-        cuda_version = torch.version.cuda if torch.cuda.is_available() else "Not available"
+        cuda_version = (
+            torch.version.cuda if torch.cuda.is_available() else "Not available"
+        )
         print(f"CUDA version: {cuda_version}")
     except ImportError:
         print("PyTorch: Not installed")
@@ -25,12 +29,14 @@ def print_env_report():
 
     try:
         import triton
+
         print(f"Triton version: {triton.__version__}")
     except ImportError:
         print("Triton: Not installed")
 
     try:
         import transformers
+
         print(f"Transformers version: {transformers.__version__}")
     except ImportError:
         print("Transformers: Not installed")

--- a/src/liger_kernel/transformers/geglu.py
+++ b/src/liger_kernel/transformers/geglu.py
@@ -13,7 +13,12 @@ class LigerGEGLUMLP(nn.Module):
         self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
         # TODO: support exact GELU
-        if config.hidden_act not in ["gelu_pytorch_tanh"]:
+        hidden_act = (
+            config.hidden_act
+            if hasattr(config, "hidden_act")
+            else config.hidden_activation
+        )
+        if hidden_act not in {"gelu_pytorch_tanh"}:
             raise ValueError(f"Activation function {config.hidden_act} not supported.")
 
     def forward(self, x):

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -129,8 +129,8 @@ def apply_liger_kernel_to_gemma(
     geglu: bool = True,
 ) -> None:
     """
-    Apply Liger kernels to replace original implementation in HuggingFace Gemma2 models
-    to make GPU go burrr.
+    Apply Liger kernels to replace original implementation in HuggingFace Gemma models
+    (Gemma 1.1 and Gemma 2 supported) to make GPU go burrr.
 
     Args:
         rope (bool): Whether to apply Liger's rotary position embedding. Default is True.
@@ -141,20 +141,28 @@ def apply_liger_kernel_to_gemma(
     assert not (
         cross_entropy and fused_linear_cross_entropy
     ), "cross_entropy and fused_linear_cross_entropy cannot both be True."
-    
+
     from transformers.models.gemma import modeling_gemma
+    from transformers.models.gemma2 import modeling_gemma2
 
     if rope:
         modeling_gemma.apply_rotary_pos_emb = liger_rotary_pos_emb
+        modeling_gemma2.apply_rotary_pos_emb = liger_rotary_pos_emb
     if rms_norm:
         # https://github.com/huggingface/transformers/blob/v4.44.2/src/transformers/models/gemma/modeling_gemma.py#L109
         modeling_gemma.GemmaRMSNorm = partial(LigerRMSNorm, offset=1.0, init_fn="zeros")
+        modeling_gemma2.Gemma2RMSNorm = partial(
+            LigerRMSNorm, offset=1.0, init_fn="zeros"
+        )
     if cross_entropy:
         modeling_gemma.CrossEntropyLoss = LigerCrossEntropyLoss
+        modeling_gemma2.CrossEntropyLoss = LigerCrossEntropyLoss
     if geglu:
         modeling_gemma.GemmaMLP = LigerGEGLUMLP
+        modeling_gemma2.Gemma2MLP = LigerGEGLUMLP
     if fused_linear_cross_entropy:
         modeling_gemma.GemmaForCausalLM.forward = gemma_lce_forward
+        modeling_gemma2.Gemma2ForCausalLM.forward = gemma_lce_forward
 
 
 def apply_liger_kernel_to_qwen2(

--- a/test/convergence/test_mini_models.py
+++ b/test/convergence/test_mini_models.py
@@ -12,6 +12,7 @@ import torch
 from datasets import load_from_disk
 from torch.utils.data import DataLoader
 from transformers.models.gemma import GemmaConfig, GemmaForCausalLM
+from transformers.models.gemma2 import Gemma2Config, Gemma2ForCausalLM
 from transformers.models.llama import LlamaConfig, LlamaForCausalLM
 from transformers.models.mistral import MistralConfig, MistralForCausalLM
 from transformers.models.mixtral import MixtralConfig, MixtralForCausalLM
@@ -75,8 +76,36 @@ MINI_MODEL_SETUPS = {
             num_attention_heads=4,  # 16
             num_key_value_heads=4,  # 16
             head_dim=256,
-            hidden_act="gelu_pytorch_tanh",
-            hidden_activation=None,
+            hidden_activation="gelu_pytorch_tanh",
+            max_position_embeddings=8192,
+            initializer_range=0.02,
+            rms_norm_eps=1e-06,
+            use_cache=True,
+            pad_token_id=0,
+            # Special token ids/vocab size to match Mistral-7B tokenizer used to create the tokenized dataset
+            # https://huggingface.co/mistralai/Mistral-7B-v0.1/blob/main/config.json
+            bos_token_id=1,  # 128000
+            eos_token_id=2,  # 128001
+            tie_word_embeddings=True,
+            rope_theta=10000.0,
+            attention_bias=False,
+            attention_dropout=0.0,
+        ),
+    ),
+    "mini_gemma2": MiniModelConfig(
+        liger_kernel_patch_func=functools.partial(
+            apply_liger_kernel_to_gemma, fused_linear_cross_entropy=False
+        ),
+        model_class=Gemma2ForCausalLM,
+        mini_model_config=Gemma2Config(
+            vocab_size=32000,  # 256000
+            hidden_size=1024,  # 3072
+            intermediate_size=2048,  # 24576
+            num_hidden_layers=4,  # 28
+            num_attention_heads=4,  # 16
+            num_key_value_heads=4,  # 16
+            head_dim=256,
+            hidden_activation="gelu_pytorch_tanh",
             max_position_embeddings=8192,
             initializer_range=0.02,
             rms_norm_eps=1e-06,
@@ -237,7 +266,7 @@ def run_mini_model(
             "rms_norm": True,
             "cross_entropy": True,
         }
-        if model_name == "mini_gemma":
+        if "mini_gemma" in model_name:
             kwargs["geglu"] = True
         else:
             kwargs["swiglu"] = True
@@ -268,9 +297,11 @@ def run_mini_model(
 @pytest.mark.parametrize(
     "model_name, num_steps, lr, dtype, loss_atol, loss_rtol, logits_atol, logits_rtol, param_atol, param_rtol",
     [
-        ("mini_gemma", 32, 1e-4, torch.float32, 1e-8, 1e-5, 5e-3, 1e-5, 5e-3, 1e-5),
-        # mini_gemma has more tolerance because currently, the kernel is not a perfect match (casts are not done the same way)
+        # Gemma 1.1 and 2 has more tolerance because currently, the kernel is not a perfect match (casts are not done the same way)
+        ("mini_gemma", 32, 1e-4, torch.float32, 1e-6, 1e-4, 5e-3, 1e-5, 5e-3, 1e-5),
         ("mini_gemma", 32, 1e-4, torch.bfloat16, 1e-2, 1e-4, 2e-1, 1e-5, 1e-2, 1e-5),
+        ("mini_gemma2", 32, 1e-4, torch.float32, 1e-6, 1e-4, 5e-3, 1e-5, 5e-3, 1e-5),
+        ("mini_gemma2", 32, 1e-4, torch.bfloat16, 1e-2, 1e-4, 2e-1, 1e-5, 1e-2, 1e-5),
         ("mini_llama3", 32, 1e-4, torch.float32, 1e-8, 1e-5, 1e-4, 1e-5, 2e-3, 1e-5),
         ("mini_llama3", 32, 1e-4, torch.bfloat16, 1e-8, 1e-5, 1e-1, 1e-5, 1e-2, 1e-5),
         # TODO: torch 2.5.0 nightly breaks mixtral test, but torch 2.3.0 works fine

--- a/test/convergence/test_mini_models_no_logits.py
+++ b/test/convergence/test_mini_models_no_logits.py
@@ -270,6 +270,15 @@ def test_mini_model(
         rtol=loss_rtol,
     )
 
+    # No logits are materialized
+    # # Compare the logits from the last step
+    # assert_verbose_allclose(
+    #     expected_output["logits"],
+    #     actual_output["logits"],
+    #     atol=logits_atol,
+    #     rtol=logits_rtol,
+    # )
+
     # Compare the params from the last step
     # Iterate over the model's parameters and compare them
     for expected_param, actual_param in zip(

--- a/test/convergence/test_mini_models_no_logits.py
+++ b/test/convergence/test_mini_models_no_logits.py
@@ -11,6 +11,7 @@ import torch
 from datasets import load_from_disk
 from torch.utils.data import DataLoader
 from transformers.models.gemma import GemmaConfig, GemmaForCausalLM
+from transformers.models.gemma2 import Gemma2Config, Gemma2ForCausalLM
 from transformers.models.llama import LlamaConfig, LlamaForCausalLM
 from transformers.models.mistral import MistralConfig, MistralForCausalLM
 from transformers.models.qwen2 import Qwen2Config, Qwen2ForCausalLM
@@ -118,8 +119,34 @@ MINI_MODEL_SETUPS = {
             num_attention_heads=4,  # 16
             num_key_value_heads=4,  # 16
             head_dim=256,
-            hidden_act="gelu_pytorch_tanh",
-            hidden_activation=None,
+            hidden_activation="gelu_pytorch_tanh",
+            max_position_embeddings=8192,
+            initializer_range=0.02,
+            rms_norm_eps=1e-06,
+            use_cache=True,
+            pad_token_id=0,
+            # Special token ids/vocab size to match Mistral-7B tokenizer used to create the tokenized dataset
+            # https://huggingface.co/mistralai/Mistral-7B-v0.1/blob/main/config.json
+            bos_token_id=1,  # 128000
+            eos_token_id=2,  # 128001
+            tie_word_embeddings=True,
+            rope_theta=10000.0,
+            attention_bias=False,
+            attention_dropout=0.0,
+        ),
+    ),
+    "mini_gemma2": MiniModelConfig(
+        liger_kernel_patch_func=apply_liger_kernel_to_gemma,
+        model_class=Gemma2ForCausalLM,
+        mini_model_config=Gemma2Config(
+            vocab_size=32000,  # 256000
+            hidden_size=1024,  # 3072
+            intermediate_size=2048,  # 24576
+            num_hidden_layers=4,  # 28
+            num_attention_heads=4,  # 16
+            num_key_value_heads=4,  # 16
+            head_dim=256,
+            hidden_activation="gelu_pytorch_tanh",
             max_position_embeddings=8192,
             initializer_range=0.02,
             rms_norm_eps=1e-06,
@@ -169,7 +196,7 @@ def run_mini_model(
             "cross_entropy": False,
             "fused_linear_cross_entropy": True,
         }
-        if model_name == "mini_gemma":
+        if "mini_gemma" in model_name:
             kwargs["geglu"] = True
         else:
             kwargs["swiglu"] = True
@@ -206,9 +233,11 @@ def run_mini_model(
         ("mini_qwen2", 32, 1e-4, torch.bfloat16, 1e-8, 1e-5, 1e-1, 1e-5, 1e-2, 1e-5),
         ("mini_mistral", 32, 1e-4, torch.float32, 1e-8, 1e-5, 5e-3, 1e-5, 5e-3, 1e-5),
         ("mini_mistral", 32, 1e-4, torch.bfloat16, 1e-8, 1e-5, 1e-1, 1e-5, 1e-2, 1e-5),
-        ("mini_gemma", 32, 1e-4, torch.float32, 1e-8, 1e-5, 5e-3, 1e-5, 5e-3, 1e-5),
-        # mini_gemma has more tolerance because currently, the kernel is not a perfect match (casts are not done the same way)
+        # Gemma 1.1 and 2 has more tolerance because currently, the kernel is not a perfect match (casts are not done the same way)
+        ("mini_gemma", 32, 1e-4, torch.float32, 1e-8, 1e-4, 5e-3, 1e-5, 5e-3, 1e-5),
         ("mini_gemma", 32, 1e-4, torch.bfloat16, 1e-2, 1e-4, 2e-1, 1e-5, 1e-2, 1e-5),
+        ("mini_gemma2", 32, 1e-4, torch.float32, 1e-8, 1e-5, 5e-3, 1e-5, 5e-3, 1e-5),
+        ("mini_gemma2", 32, 1e-4, torch.bfloat16, 1e-2, 1e-4, 2e-1, 1e-5, 1e-2, 1e-5),
     ],
 )
 def test_mini_model(
@@ -240,16 +269,6 @@ def test_mini_model(
         atol=loss_atol,
         rtol=loss_rtol,
     )
-
-    # No logits are materialized
-
-    # # Compare the logits from the last step
-    # assert_verbose_allclose(
-    #     expected_output["logits"],
-    #     actual_output["logits"],
-    #     atol=logits_atol,
-    #     rtol=logits_rtol,
-    # )
 
     # Compare the params from the last step
     # Iterate over the model's parameters and compare them


### PR DESCRIPTION
## Summary

**why**
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
1. From config point of view, Gemma1 is doing exact GeLU [[ref](https://huggingface.co/google/gemma-2b/blob/main/config.json#L10)] but gemma 1.1 and 2 are doing approximate gelu ([gemma2](https://huggingface.co/google/gemma-2-2b/blob/main/config.json#L14), [gemma1](https://huggingface.co/google/gemma-1.1-2b-it/blob/main/config.json#L10))
2. also, gemma uses `hidden_activation` config field and `hidden_act` is ignored ([gemma1 code](https://github.com/huggingface/transformers/blob/main/src/transformers/models/gemma/modeling_gemma.py#L170), [gemma2 code](https://github.com/huggingface/transformers/blob/main/src/transformers/models/gemma2/modeling_gemma2.py#L202))

That being said, we should be fine to claim that all of gemma 1, 1.1 and 2 are supported. But for safety i think we can first go with 1.1 and 2 first

**what**
1. adjust the monkey patch so it works properly with gemma2 code base too
2. checkstyle
3. **[TODO] add final logit softcapping for gemma2 https://github.com/huggingface/transformers/blob/main/src/transformers/models/gemma2/modeling_gemma2.py#L1054**
<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
