### PR TITLE
[Fix] Explicitly upcast `X_row` to fp32 in `_rms_norm_forward` op

### DIFF
--- a/src/liger_kernel/ops/rms_norm.py
+++ b/src/liger_kernel/ops/rms_norm.py
@@ -53,7 +53,7 @@ def _rms_norm_forward(
     X_ptr += row_idx * X_row_stride
     r_ptr += row_idx * r_row_stride
 
-    X_row = tl.load(X_ptr + col_offsets, mask=mask, other=0)
+    X_row = tl.load(X_ptr + col_offsets, mask=mask, other=0).to(tl.float32)
     W_row = tl.load(W_ptr + col_offsets, mask=mask, other=0)
 
     mean_square = tl.sum(X_row * X_row, axis=0) / n_cols


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: NVIDIA A40
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
