### PR TITLE
Fix gemma 1 and 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ loss.backward()
 | LLaMA (2 & 3) | `liger_kernel.transformers.apply_liger_kernel_to_llama`   | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy        |
 | Mistral     | `liger_kernel.transformers.apply_liger_kernel_to_mistral`  | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy        |
 | Mixtral     | `liger_kernel.transformers.apply_liger_kernel_to_mixtral`  | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss        |
-| Gemma2      | `liger_kernel.transformers.apply_liger_kernel_to_gemma`    | RoPE, RMSNorm, GeGLU, CrossEntropyLoss         |
+| Gemma1 (Gemma2 support on the way!) | `liger_kernel.transformers.apply_liger_kernel_to_gemma`    | RoPE, RMSNorm, GeGLU, CrossEntropyLoss         |
 | Qwen2       | `liger_kernel.transformers.apply_liger_kernel_to_qwen2`    | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy        |
 | Phi3        | `liger_kernel.transformers.apply_liger_kernel_to_phi3`    | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss         |
 

--- a/README.md
+++ b/README.md
@@ -156,12 +156,13 @@ loss.backward()
 
 | **Model**   | **API**                                                      | **Supported Operations**                                                |
 |-------------|--------------------------------------------------------------|-------------------------------------------------------------------------|
-| LLaMA (2 & 3) | `liger_kernel.transformers.apply_liger_kernel_to_llama`   | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy        |
+| LLaMA 2 & 3 | `liger_kernel.transformers.apply_liger_kernel_to_llama`   | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy        |
 | Mistral     | `liger_kernel.transformers.apply_liger_kernel_to_mistral`  | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy        |
 | Mixtral     | `liger_kernel.transformers.apply_liger_kernel_to_mixtral`  | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss        |
-| Gemma1 (Gemma2 support on the way!) | `liger_kernel.transformers.apply_liger_kernel_to_gemma`    | RoPE, RMSNorm, GeGLU, CrossEntropyLoss         |
+| Gemma1      | `liger_kernel.transformers.apply_liger_kernel_to_gemma`    | RoPE, RMSNorm, GeGLU, CrossEntropyLoss, FusedLinearCrossEntropy         |
+| Gemma2      | `liger_kernel.transformers.apply_liger_kernel_to_gemma2`   | RoPE, RMSNorm, GeGLU, CrossEntropyLoss         |
 | Qwen2       | `liger_kernel.transformers.apply_liger_kernel_to_qwen2`    | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy        |
-| Phi3        | `liger_kernel.transformers.apply_liger_kernel_to_phi3`    | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss         |
+| Phi3        | `liger_kernel.transformers.apply_liger_kernel_to_phi3`     | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss         |
 
 
 

--- a/src/liger_kernel/env_report.py
+++ b/src/liger_kernel/env_report.py
@@ -1,6 +1,7 @@
 import platform
 import sys
 
+
 def print_env_report():
     """
     Prints a report of the environment. Useful for debugging and reproducibility.
@@ -16,8 +17,11 @@ def print_env_report():
 
     try:
         import torch
+
         print(f"PyTorch version: {torch.__version__}")
-        cuda_version = torch.version.cuda if torch.cuda.is_available() else "Not available"
+        cuda_version = (
+            torch.version.cuda if torch.cuda.is_available() else "Not available"
+        )
         print(f"CUDA version: {cuda_version}")
     except ImportError:
         print("PyTorch: Not installed")
@@ -25,12 +29,14 @@ def print_env_report():
 
     try:
         import triton
+
         print(f"Triton version: {triton.__version__}")
     except ImportError:
         print("Triton: Not installed")
 
     try:
         import transformers
+
         print(f"Transformers version: {transformers.__version__}")
     except ImportError:
         print("Transformers: Not installed")

--- a/src/liger_kernel/transformers/__init__.py
+++ b/src/liger_kernel/transformers/__init__.py
@@ -1,5 +1,6 @@
 from liger_kernel.transformers.monkey_patch import (  # noqa: F401
     apply_liger_kernel_to_gemma,
+    apply_liger_kernel_to_gemma2,
     apply_liger_kernel_to_llama,
     apply_liger_kernel_to_mistral,
     apply_liger_kernel_to_mixtral,

--- a/src/liger_kernel/transformers/geglu.py
+++ b/src/liger_kernel/transformers/geglu.py
@@ -13,8 +13,10 @@ class LigerGEGLUMLP(nn.Module):
         self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
         # TODO: support exact GELU
-        if config.hidden_act not in ["gelu_pytorch_tanh"]:
-            raise ValueError(f"Activation function {config.hidden_act} not supported.")
+        # Right now Gemma 1, 1.1 and 2 models are all using `gelu_pytorch_tanh`
+        # https://github.com/huggingface/transformers/blob/v4.40.1/src/transformers/models/gemma/modeling_gemma.py#L175
+        # https://github.com/huggingface/transformers/blob/v4.40.1/src/transformers/activations.py#L46
+        # So we can safely assume we use tanh approximation form all the time
 
     def forward(self, x):
 

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -129,8 +129,8 @@ def apply_liger_kernel_to_gemma(
     geglu: bool = True,
 ) -> None:
     """
-    Apply Liger kernels to replace original implementation in HuggingFace Gemma2 models
-    to make GPU go burrr.
+    Apply Liger kernels to replace original implementation in HuggingFace Gemma models
+    (Gemma 1.1 and Gemma 2 supported) to make GPU go burrr.
 
     Args:
         rope (bool): Whether to apply Liger's rotary position embedding. Default is True.
@@ -141,7 +141,7 @@ def apply_liger_kernel_to_gemma(
     assert not (
         cross_entropy and fused_linear_cross_entropy
     ), "cross_entropy and fused_linear_cross_entropy cannot both be True."
-    
+
     from transformers.models.gemma import modeling_gemma
 
     if rope:

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -129,8 +129,8 @@ def apply_liger_kernel_to_gemma(
     geglu: bool = True,
 ) -> None:
     """
-    Apply Liger kernels to replace original implementation in HuggingFace Gemma models
-    (Gemma 1.1 and Gemma 2 supported) to make GPU go burrr.
+    Apply Liger kernels to replace original implementation in HuggingFace Gemma
+    (Gemma 1 and 1.1 supported, for Gemma2 please use `apply_liger_kernel_to_gemma2` ) to make GPU go burrr.
 
     Args:
         rope (bool): Whether to apply Liger's rotary position embedding. Default is True.
@@ -155,6 +155,37 @@ def apply_liger_kernel_to_gemma(
         modeling_gemma.GemmaMLP = LigerGEGLUMLP
     if fused_linear_cross_entropy:
         modeling_gemma.GemmaForCausalLM.forward = gemma_lce_forward
+
+
+def apply_liger_kernel_to_gemma2(
+    rope: bool = True,
+    cross_entropy: bool = True,
+    rms_norm: bool = True,
+    geglu: bool = True,
+) -> None:
+    """
+    Apply Liger kernels to replace original implementation in HuggingFace Gemma2
+    (for Gemma1 please use `apply_liger_kernel_to_gemma`) to make GPU go burrr.
+
+    Args:
+        rope (bool): Whether to apply Liger's rotary position embedding. Default is True.
+        cross_entropy (bool): Whether to apply Liger's cross entropy loss. Default is True.
+        rms_norm (bool): Whether to apply Liger's RMSNorm. Default is True.
+        geglu (bool): Whether to apply Liger's GeGLU MLP. Default is True.
+    """
+    from transformers.models.gemma2 import modeling_gemma2
+
+    if rope:
+        modeling_gemma2.apply_rotary_pos_emb = liger_rotary_pos_emb
+    if rms_norm:
+        # https://github.com/huggingface/transformers/blob/v4.44.2/src/transformers/models/gemma/modeling_gemma.py#L109
+        modeling_gemma2.Gemma2RMSNorm = partial(
+            LigerRMSNorm, offset=1.0, init_fn="zeros"
+        )
+    if cross_entropy:
+        modeling_gemma2.CrossEntropyLoss = LigerCrossEntropyLoss
+    if geglu:
+        modeling_gemma2.Gemma2MLP = LigerGEGLUMLP
 
 
 def apply_liger_kernel_to_qwen2(

--- a/test/convergence/test_mini_models.py
+++ b/test/convergence/test_mini_models.py
@@ -75,8 +75,7 @@ MINI_MODEL_SETUPS = {
             num_attention_heads=4,  # 16
             num_key_value_heads=4,  # 16
             head_dim=256,
-            hidden_act="gelu_pytorch_tanh",
-            hidden_activation=None,
+            hidden_activation="gelu_pytorch_tanh",
             max_position_embeddings=8192,
             initializer_range=0.02,
             rms_norm_eps=1e-06,
@@ -237,7 +236,7 @@ def run_mini_model(
             "rms_norm": True,
             "cross_entropy": True,
         }
-        if model_name == "mini_gemma":
+        if "mini_gemma" in model_name:
             kwargs["geglu"] = True
         else:
             kwargs["swiglu"] = True
@@ -268,8 +267,8 @@ def run_mini_model(
 @pytest.mark.parametrize(
     "model_name, num_steps, lr, dtype, loss_atol, loss_rtol, logits_atol, logits_rtol, param_atol, param_rtol",
     [
-        ("mini_gemma", 32, 1e-4, torch.float32, 1e-8, 1e-5, 5e-3, 1e-5, 5e-3, 1e-5),
-        # mini_gemma has more tolerance because currently, the kernel is not a perfect match (casts are not done the same way)
+        # Gemma 1.1 and 2 has more tolerance because currently, the kernel is not a perfect match (casts are not done the same way)
+        ("mini_gemma", 32, 1e-4, torch.float32, 1e-6, 1e-4, 5e-3, 1e-5, 5e-3, 1e-5),
         ("mini_gemma", 32, 1e-4, torch.bfloat16, 1e-2, 1e-4, 2e-1, 1e-5, 1e-2, 1e-5),
         ("mini_llama3", 32, 1e-4, torch.float32, 1e-8, 1e-5, 1e-4, 1e-5, 2e-3, 1e-5),
         ("mini_llama3", 32, 1e-4, torch.bfloat16, 1e-8, 1e-5, 1e-1, 1e-5, 1e-2, 1e-5),

--- a/test/convergence/test_mini_models.py
+++ b/test/convergence/test_mini_models.py
@@ -12,6 +12,7 @@ import torch
 from datasets import load_from_disk
 from torch.utils.data import DataLoader
 from transformers.models.gemma import GemmaConfig, GemmaForCausalLM
+from transformers.models.gemma2 import Gemma2Config, Gemma2ForCausalLM
 from transformers.models.llama import LlamaConfig, LlamaForCausalLM
 from transformers.models.mistral import MistralConfig, MistralForCausalLM
 from transformers.models.mixtral import MixtralConfig, MixtralForCausalLM
@@ -20,6 +21,7 @@ from transformers.models.qwen2 import Qwen2Config, Qwen2ForCausalLM
 
 from liger_kernel.transformers import (
     apply_liger_kernel_to_gemma,
+    apply_liger_kernel_to_gemma2,
     apply_liger_kernel_to_llama,
     apply_liger_kernel_to_mistral,
     apply_liger_kernel_to_mixtral,
@@ -62,12 +64,72 @@ MINI_MODEL_SETUPS = {
             attn_implementation="sdpa",  # default value, pytorch native attention
         ),
     ),
-    "mini_gemma": MiniModelConfig(
+    "mini_gemma1": MiniModelConfig(
         liger_kernel_patch_func=functools.partial(
             apply_liger_kernel_to_gemma, fused_linear_cross_entropy=False
         ),
         model_class=GemmaForCausalLM,
         mini_model_config=GemmaConfig(
+            vocab_size=32000,  # 256000
+            hidden_size=1024,  # 3072
+            intermediate_size=2048,  # 24576
+            num_hidden_layers=4,  # 28
+            num_attention_heads=4,  # 16
+            num_key_value_heads=4,  # 16
+            head_dim=256,
+            # gemma1 model config uses `hidden_act` and point it to gelu,
+            # https://huggingface.co/google/gemma-7b/blob/main/config.json#L10
+            # but in reality it's ignored and HuggingFace will use tanh approximation:
+            # https://github.com/huggingface/transformers/blob/v4.40.1/src/transformers/models/gemma/modeling_gemma.py#L175
+            hidden_act="gelu",
+            max_position_embeddings=8192,
+            initializer_range=0.02,
+            rms_norm_eps=1e-06,
+            use_cache=True,
+            pad_token_id=0,
+            # Special token ids/vocab size to match Mistral-7B tokenizer used to create the tokenized dataset
+            # https://huggingface.co/mistralai/Mistral-7B-v0.1/blob/main/config.json
+            bos_token_id=1,  # 128000
+            eos_token_id=2,  # 128001
+            tie_word_embeddings=True,
+            rope_theta=10000.0,
+            attention_bias=False,
+            attention_dropout=0.0,
+        ),
+    ),
+    "mini_gemma1.1": MiniModelConfig(
+        liger_kernel_patch_func=functools.partial(
+            apply_liger_kernel_to_gemma, fused_linear_cross_entropy=False
+        ),
+        model_class=GemmaForCausalLM,
+        mini_model_config=GemmaConfig(
+            vocab_size=32000,  # 256000
+            hidden_size=1024,  # 3072
+            intermediate_size=2048,  # 24576
+            num_hidden_layers=4,  # 28
+            num_attention_heads=4,  # 16
+            num_key_value_heads=4,  # 16
+            head_dim=256,
+            hidden_activation="gelu_pytorch_tanh",
+            max_position_embeddings=8192,
+            initializer_range=0.02,
+            rms_norm_eps=1e-06,
+            use_cache=True,
+            pad_token_id=0,
+            # Special token ids/vocab size to match Mistral-7B tokenizer used to create the tokenized dataset
+            # https://huggingface.co/mistralai/Mistral-7B-v0.1/blob/main/config.json
+            bos_token_id=1,  # 128000
+            eos_token_id=2,  # 128001
+            tie_word_embeddings=True,
+            rope_theta=10000.0,
+            attention_bias=False,
+            attention_dropout=0.0,
+        ),
+    ),
+    "mini_gemma2": MiniModelConfig(
+        liger_kernel_patch_func=apply_liger_kernel_to_gemma2,
+        model_class=Gemma2ForCausalLM,
+        mini_model_config=Gemma2Config(
             vocab_size=32000,  # 256000
             hidden_size=1024,  # 3072
             intermediate_size=2048,  # 24576
@@ -180,7 +242,9 @@ MINI_MODEL_SETUPS = {
         ),
     ),
     "mini_phi3": MiniModelConfig(
-        liger_kernel_patch_func=apply_liger_kernel_to_phi3,
+        liger_kernel_patch_func=functools.partial(
+            apply_liger_kernel_to_phi3, fused_linear_cross_entropy=False
+        ),
         model_class=Phi3ForCausalLM,
         mini_model_config=Phi3Config(
             attention_dropout=0.0,
@@ -236,7 +300,7 @@ def run_mini_model(
             "rms_norm": True,
             "cross_entropy": True,
         }
-        if "mini_gemma" in model_name:
+        if "gemma" in model_name:
             kwargs["geglu"] = True
         else:
             kwargs["swiglu"] = True
@@ -268,8 +332,12 @@ def run_mini_model(
     "model_name, num_steps, lr, dtype, loss_atol, loss_rtol, logits_atol, logits_rtol, param_atol, param_rtol",
     [
         # Gemma 1.1 and 2 has more tolerance because currently, the kernel is not a perfect match (casts are not done the same way)
-        ("mini_gemma", 32, 1e-4, torch.float32, 1e-6, 1e-4, 5e-3, 1e-5, 5e-3, 1e-5),
-        ("mini_gemma", 32, 1e-4, torch.bfloat16, 1e-2, 1e-4, 2e-1, 1e-5, 1e-2, 1e-5),
+        ("mini_gemma1", 32, 1e-4, torch.float32, 1e-6, 1e-4, 5e-3, 1e-5, 5e-3, 1e-5),
+        ("mini_gemma1", 32, 1e-4, torch.bfloat16, 1e-2, 1e-4, 2e-1, 1e-5, 1e-2, 1e-5),
+        ("mini_gemma1.1", 32, 1e-4, torch.float32, 1e-6, 1e-4, 5e-3, 1e-5, 5e-3, 1e-5),
+        ("mini_gemma1.1", 32, 1e-4, torch.bfloat16, 1e-2, 1e-4, 2e-1, 1e-5, 1e-2, 1e-5),
+        ("mini_gemma2", 32, 1e-4, torch.float32, 1e-8, 1e-4, 5e-3, 1e-5, 5e-3, 1e-5),
+        ("mini_gemma2", 32, 1e-4, torch.bfloat16, 1e-2, 1e-4, 2e-1, 1e-5, 1e-2, 1e-5),
         ("mini_llama3", 32, 1e-4, torch.float32, 1e-8, 1e-5, 1e-4, 1e-5, 2e-3, 1e-5),
         ("mini_llama3", 32, 1e-4, torch.bfloat16, 1e-8, 1e-5, 1e-1, 1e-5, 1e-2, 1e-5),
         # TODO: torch 2.5.0 nightly breaks mixtral test, but torch 2.3.0 works fine

--- a/test/convergence/test_mini_models_no_logits.py
+++ b/test/convergence/test_mini_models_no_logits.py
@@ -11,12 +11,14 @@ import torch
 from datasets import load_from_disk
 from torch.utils.data import DataLoader
 from transformers.models.gemma import GemmaConfig, GemmaForCausalLM
+from transformers.models.gemma2 import Gemma2Config, Gemma2ForCausalLM
 from transformers.models.llama import LlamaConfig, LlamaForCausalLM
 from transformers.models.mistral import MistralConfig, MistralForCausalLM
 from transformers.models.qwen2 import Qwen2Config, Qwen2ForCausalLM
 
 from liger_kernel.transformers import (
     apply_liger_kernel_to_gemma,
+    apply_liger_kernel_to_gemma2,
     apply_liger_kernel_to_llama,
     apply_liger_kernel_to_mistral,
     apply_liger_kernel_to_qwen2,
@@ -118,6 +120,10 @@ MINI_MODEL_SETUPS = {
             num_attention_heads=4,  # 16
             num_key_value_heads=4,  # 16
             head_dim=256,
+            # gemma1 model config uses `hidden_act` and point it to gelu,
+            # https://huggingface.co/google/gemma-7b/blob/main/config.json#L10
+            # but in reality it's ignored and HuggingFace will use tanh approximation:
+            # https://github.com/huggingface/transformers/blob/v4.40.1/src/transformers/models/gemma/modeling_gemma.py#L175
             hidden_act="gelu",
             max_position_embeddings=8192,
             initializer_range=0.02,
@@ -138,6 +144,33 @@ MINI_MODEL_SETUPS = {
         liger_kernel_patch_func=apply_liger_kernel_to_gemma,
         model_class=GemmaForCausalLM,
         mini_model_config=GemmaConfig(
+            vocab_size=32000,  # 256000
+            hidden_size=1024,  # 3072
+            intermediate_size=2048,  # 24576
+            num_hidden_layers=4,  # 28
+            num_attention_heads=4,  # 16
+            num_key_value_heads=4,  # 16
+            head_dim=256,
+            hidden_activation="gelu_pytorch_tanh",
+            max_position_embeddings=8192,
+            initializer_range=0.02,
+            rms_norm_eps=1e-06,
+            use_cache=True,
+            pad_token_id=0,
+            # Special token ids/vocab size to match Mistral-7B tokenizer used to create the tokenized dataset
+            # https://huggingface.co/mistralai/Mistral-7B-v0.1/blob/main/config.json
+            bos_token_id=1,  # 128000
+            eos_token_id=2,  # 128001
+            tie_word_embeddings=True,
+            rope_theta=10000.0,
+            attention_bias=False,
+            attention_dropout=0.0,
+        ),
+    ),
+    "mini_gemma2": MiniModelConfig(
+        liger_kernel_patch_func=apply_liger_kernel_to_gemma2,
+        model_class=Gemma2ForCausalLM,
+        mini_model_config=Gemma2Config(
             vocab_size=32000,  # 256000
             hidden_size=1024,  # 3072
             intermediate_size=2048,  # 24576
@@ -192,13 +225,18 @@ def run_mini_model(
         kwargs = {
             "rope": True,
             "rms_norm": True,
-            "cross_entropy": False,
-            "fused_linear_cross_entropy": True,
         }
-        if "mini_gemma" in model_name:
+        if "gemma" in model_name:
             kwargs["geglu"] = True
         else:
             kwargs["swiglu"] = True
+
+        model_support_flce = "gemma2" not in model_name
+        if model_support_flce:
+            kwargs["fused_linear_cross_entropy"] = True
+            kwargs["cross_entropy"] = False
+        else:
+            kwargs["cross_entropy"] = True
 
         MINI_MODEL_SETUPS[model_name].liger_kernel_patch_func(**kwargs)
 
@@ -237,6 +275,8 @@ def run_mini_model(
         ("mini_gemma1", 32, 1e-4, torch.bfloat16, 1e-2, 1e-4, 2e-1, 1e-5, 1e-2, 1e-5),
         ("mini_gemma1.1", 32, 1e-4, torch.float32, 1e-8, 1e-4, 5e-3, 1e-5, 5e-3, 1e-5),
         ("mini_gemma1.1", 32, 1e-4, torch.bfloat16, 1e-2, 1e-4, 2e-1, 1e-5, 1e-2, 1e-5),
+        ("mini_gemma2", 32, 1e-4, torch.float32, 1e-8, 1e-4, 5e-3, 1e-5, 5e-3, 1e-5),
+        ("mini_gemma2", 32, 1e-4, torch.bfloat16, 1e-2, 1e-4, 2e-1, 1e-5, 1e-2, 1e-5),
     ],
 )
 def test_mini_model(


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Right now for gemma:
- Gemma1 and 1.1 can be fully supported (FLCE included). Gemma 1, though using `hidden_act="gelu"` in their config, is actually gonna use tanh approximation because this is ignored in [model code](https://github.com/huggingface/transformers/blob/v4.40.1/src/transformers/models/gemma/modeling_gemma.py#L175)
- Gemma2 can be supported without FLCE. That's because Gemma2 has a soft capping after `lm_head`. Thanks a lot @DocShotgun for pointing this out! We have a TODO item for doing it properly.
- 
<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
