### PR TITLE
Make GPU CI optional until it is more stable

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -14,6 +14,7 @@ jobs:
 
     steps:
     - name: Run on GPU host
+      continue-on-error: true
       run: |
         echo "Source ${{ github.head_ref }} base ref ${{ github.base_ref}} ref ${{ github.ref }}";
         curl -s -f -N -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \


### PR DESCRIPTION
## Summary
Make GPU CI optional until it is more stable

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
Testing CI

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
