### PR TITLE
Bias for fused linear cross entropy

### DIFF
--- a/src/liger_kernel/ops/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_cross_entropy.py
@@ -137,7 +137,7 @@ class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
         ctx.save_for_backward(
             grad_input.detach(),
             grad_weight.detach(),
-            grad_bias.to(bias.dtype).detach() if bias is not None else None,
+            grad_bias.detach() if bias is not None else None,
         )
         return loss
 

--- a/src/liger_kernel/ops/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_cross_entropy.py
@@ -11,7 +11,7 @@ MAX_FUSED_SIZE = 65536 // 2
 
 class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, _input, linear, target, ignore_index):
+    def forward(ctx, _input, weight, target, bias=None, ignore_index=-100):
         """
         Fusing the last linear layer with cross-entropy loss
             Reference: https://github.com/mgmalek/efficient_cross_entropy
@@ -23,7 +23,8 @@ class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
 
         _input: (B*T, H) where B is batch size, T is sequence length, H is hidden dimension.
         target: (B*T) where each value is in [0, V-1]
-        linear: linear projection matrix of shape V x H.
+        weight: (V, H) where V is the number of classes
+        bias: (V) where V is the number of classes
         ignore_index: the index to ignore in the target
         """
         dtype = (
@@ -41,7 +42,7 @@ class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
         # inc_factor = (V+H-1)//H, chunk_size = (BT + inc_factor - 1)//inc_factor
         # for ex: BT = 4096*4, V = 32000, H = 4096 ==> inc_factor = 8, chunk_size = 2048
         BT, H = _input.shape
-        V = linear.shape[0]
+        V = weight.shape[0]
         BLOCK_SIZE = min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
 
         inc_factor = triton.cdiv(V, H)  # (V + H - 1) // H
@@ -50,9 +51,9 @@ class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
         )  # (BT + inc_factor - 1) // inc_factor
         num_chunks = triton.cdiv(BT, chunk_size)  # (BT + chunk_size - 1) // chunk_size
 
-        grad_linear = torch.zeros_like(linear, device=device)
+        grad_weight = torch.zeros_like(weight, device=device)
         grad_input = torch.zeros_like(_input, device=device)
-
+        grad_bias = torch.zeros_like(bias, device=device) if bias is not None else None
         # we use fp32 for loss accumulator
         loss_1d = torch.zeros(BT, dtype=torch.float32, device=device)
 
@@ -64,7 +65,9 @@ class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
             _input_chunk = _input[start_idx:end_idx]  # chunk_size x H
 
             # when doing matmul, use the original precision
-            logits_chunk = _input_chunk @ linear.t()  # chunk_size x V
+            logits_chunk = _input_chunk @ weight.t()  # chunk_size x V
+            if bias is not None:
+                logits_chunk = logits_chunk + bias
             target_chunk = target[start_idx:end_idx]  # chunk_size,
 
             n_rows = logits_chunk.shape[0]
@@ -107,27 +110,36 @@ class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
             # additionally, since we are chunking the inputs, observe that the loss and gradients are calculated only
             # on `n_non_ignore` tokens. However, the gradient of the input should be calculated for all tokens.
             # Thus, we need an additional scaling factor of (n_non_ignore/total_n_non_ignore) to scale the gradients.
-            grad_logits_chunk = logits_chunk * (n_non_ignore / total_n_non_ignore)
-            grad_input[start_idx:end_idx] = grad_logits_chunk @ linear
-
+            grad_logits_chunk = logits_chunk * (n_non_ignore / total_n_non_ignore) # chunk_size x V
+            grad_input[start_idx:end_idx] = grad_logits_chunk @ weight
             torch.addmm(
-                input=grad_linear,
+                input=grad_weight,
                 mat1=logits_chunk.t(),
                 mat2=_input_chunk,
-                out=grad_linear,
+                out=grad_weight,
                 alpha=n_non_ignore / total_n_non_ignore,
                 beta=1.0,
             )
 
+            if bias is not None:
+                torch.add(
+                    input=grad_bias,
+                    other=logits_chunk.sum(dim=0),
+                    out=grad_bias,
+                    alpha=n_non_ignore / total_n_non_ignore
+                )
+
+            
+
         loss = torch.sum(loss_1d) / total_n_non_ignore
 
         # downcast to dtype and store for backward
-        ctx.save_for_backward(grad_input.detach(), grad_linear.detach())
+        ctx.save_for_backward(grad_input.detach(), grad_weight.detach(), grad_bias.to(bias.dtype).detach() if bias is not None else None)
         return loss
 
     @staticmethod
     def backward(ctx, grad_output):
-        (grad_input, grad_linear) = ctx.saved_tensors
+        (grad_input, grad_weight, grad_bias) = ctx.saved_tensors
         # If cross entropy is the last layer, grad_output is 1.0. Skip the mul to save time
         if torch.ne(grad_output, torch.tensor(1.0, device=grad_output.device)):
             # We use a Triton kernel instead of a PyTorch operation because modifying inputs in-place
@@ -145,17 +157,31 @@ class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
                 num_warps=32,
             )
 
-            # handle grad_linear
-            V, H = grad_linear.shape
+            # handle grad_weight
+            V, H = grad_weight.shape
             n_rows = V
 
             element_mul[(n_rows,)](
-                grad_linear,
-                grad_linear.stride(-2),
+                grad_weight,
+                grad_weight.stride(-2),
                 grad_output,
                 H,
                 BLOCK_SIZE=BLOCK_SIZE,
                 num_warps=32,
             )
 
-        return (grad_input, grad_linear, None, None)
+            if grad_bias is not None:
+                V = grad_bias.shape[0]
+                n_rows = V
+
+                element_mul[(n_rows,)](
+                    grad_bias,
+                    grad_bias.stride(-1),
+                    grad_output,
+                    1,
+                    BLOCK_SIZE=BLOCK_SIZE,
+                    num_warps=32,
+                )
+
+        
+        return (grad_input, grad_weight, None, grad_bias, None)

--- a/src/liger_kernel/transformers/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/transformers/fused_linear_cross_entropy.py
@@ -9,7 +9,7 @@ class LigerFusedLinearCrossEntropyLoss(CrossEntropyLoss):
     def __init__(self, *args, **kwargs):
         super(LigerFusedLinearCrossEntropyLoss, self).__init__(*args, **kwargs)
 
-    def forward(self, lin_weight, _input, target):
+    def forward(self, lin_weight, _input, target, bias=None):
         return LigerFusedLinearCrossEntropyFunction.apply(
-            _input, lin_weight, target, self.ignore_index
+            _input, lin_weight, target, bias, self.ignore_index
         )

--- a/test/transformers/test_fused_linear_cross_entropy.py
+++ b/test/transformers/test_fused_linear_cross_entropy.py
@@ -20,10 +20,10 @@ class TorchLMHeadCE(torch.nn.Module):
     :param reduction: reduction method
     """
 
-    def __init__(self, H: int, V: int, dtype: torch.dtype, ignore_index: int = -100):
+    def __init__(self, H: int, V: int, dtype: torch.dtype, bias: bool = False, ignore_index: int = -100):
         super().__init__()
         self.lin = torch.nn.Linear(
-            in_features=H, out_features=V, bias=False, dtype=dtype
+            in_features=H, out_features=V, bias=bias, dtype=dtype
         )
         self.ce_loss = torch.nn.CrossEntropyLoss(
             ignore_index=ignore_index, reduction="mean"
@@ -35,17 +35,17 @@ class TorchLMHeadCE(torch.nn.Module):
 
 
 class LigerLMHeadCE(torch.nn.Module):
-    def __init__(self, H: int, V: int, dtype: torch.dtype, ignore_index: int = -100):
+    def __init__(self, H: int, V: int, dtype: torch.dtype, bias: bool = False, ignore_index: int = -100):
         super().__init__()
         self.lin = torch.nn.Linear(
-            in_features=H, out_features=V, bias=False, dtype=dtype
+            in_features=H, out_features=V, bias=bias, dtype=dtype
         )
         self.ce_loss = LigerFusedLinearCrossEntropyLoss(
             ignore_index=ignore_index, reduction="mean"
         )
 
     def forward(self, x, y):
-        return self.ce_loss(self.lin.weight, x, y)
+        return self.ce_loss(self.lin.weight, x, y, self.lin.bias)
 
 
 #############################################################################
@@ -71,15 +71,21 @@ class LigerLMHeadCE(torch.nn.Module):
         (1.0, torch.float32, 1e-5, 5e-4),
     ],
 )
-def test_correctness(B, T, H, V, scalar, dtype, atol, rtol):
+@pytest.mark.parametrize("bias", [True, False])
+def test_correctness(B, T, H, V, scalar, dtype, bias, atol, rtol):
     device = "cuda"
-    torch_lm_head_ce = TorchLMHeadCE(H=H, V=V, dtype=dtype).to(device)
-    liger_lm_head_ce = LigerLMHeadCE(H=H, V=V, dtype=dtype).to(device)
+    torch_lm_head_ce = TorchLMHeadCE(H=H, V=V, bias=bias, dtype=dtype).to(device)
+    liger_lm_head_ce = LigerLMHeadCE(H=H, V=V, bias=bias, dtype=dtype).to(device)
 
     # init the linear in all CEs with the same weights
-    torch_lm_head_ce.lin.weight.data = liger_lm_head_ce.lin.weight.data = torch.randn(
+    torch_lm_head_ce.lin.weight.data = liger_lm_head_ce.lin.weight.data = torch.rand(
         V, H, device=device, dtype=dtype
     )
+
+    if bias:
+        torch_lm_head_ce.lin.bias.data = liger_lm_head_ce.lin.bias.data = torch.rand(
+            V, device=device, dtype=dtype
+        )
 
     _tensor = torch.randn(B * T, H, device=device, dtype=dtype) * scalar
     _input1 = _tensor.detach().clone().requires_grad_(True)
@@ -103,3 +109,11 @@ def test_correctness(B, T, H, V, scalar, dtype, atol, rtol):
         atol=atol,
         rtol=rtol,
     )
+
+    if bias:
+        assert_verbose_allclose(
+            torch_lm_head_ce.lin.bias.grad,
+            liger_lm_head_ce.lin.bias.grad,
+            atol=atol,
+            rtol=rtol,
+        )

--- a/test/transformers/test_fused_linear_cross_entropy.py
+++ b/test/transformers/test_fused_linear_cross_entropy.py
@@ -20,7 +20,14 @@ class TorchLMHeadCE(torch.nn.Module):
     :param reduction: reduction method
     """
 
-    def __init__(self, H: int, V: int, dtype: torch.dtype, bias: bool = False, ignore_index: int = -100):
+    def __init__(
+        self,
+        H: int,
+        V: int,
+        dtype: torch.dtype,
+        bias: bool = False,
+        ignore_index: int = -100,
+    ):
         super().__init__()
         self.lin = torch.nn.Linear(
             in_features=H, out_features=V, bias=bias, dtype=dtype
@@ -35,7 +42,14 @@ class TorchLMHeadCE(torch.nn.Module):
 
 
 class LigerLMHeadCE(torch.nn.Module):
-    def __init__(self, H: int, V: int, dtype: torch.dtype, bias: bool = False, ignore_index: int = -100):
+    def __init__(
+        self,
+        H: int,
+        V: int,
+        dtype: torch.dtype,
+        bias: bool = False,
+        ignore_index: int = -100,
+    ):
         super().__init__()
         self.lin = torch.nn.Linear(
             in_features=H, out_features=V, bias=bias, dtype=dtype


### PR DESCRIPTION
## Summary
Adds optional bias param for fused linear cross entropy!
Added bias = {true, false} for the testing space.
Also changed weight/bias generation in tests to uniform rand instead of normal (seems stabler for low precision bfloat16).

## Testing Done
Tests for convergence + tests for fused linear cross entropy. 
Replace BLANK with your device type. For example, A100-80G-PCIe

**Results**
```
test/transformers/test_fused_linear_cross_entropy.py ............                                                                                                                                                                                              [100%]

======================================================================================================================== 12 passed in 31.61s =========================================================================================================================
```

- Hardware Type: NVIDIA L4
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
