### PR TITLE
Add missing tf_keras to req.txt 

### DIFF
--- a/examples/huggingface/requirements.txt
+++ b/examples/huggingface/requirements.txt
@@ -1,5 +1,6 @@
 transformers==4.43.3
 trl
 liger-kernel
+tf-keras
 torch
 triton


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Add missing tf_keras to req.txt 
<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->
Add missing tf_keras to req.txt , otherwise pip install -r requirement.txt and then run the script will result in 

```
ValueError: Your currently installed version of Keras is Keras 3, but this is not yet supported in Transformers. Please install the backwards-compatible tf-keras package with `pip install tf-keras`.
```

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
Done
<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
