### PR TITLE
Bug fix for gemma: fused_linear_cross_entropy flag and cross_entropy flag are mutual exclusive

### DIFF
--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -128,7 +128,7 @@ def apply_liger_kernel_to_mixtral(
 
 def apply_liger_kernel_to_gemma(
     rope: bool = True,
-    cross_entropy: bool = True,
+    cross_entropy: bool = False,
     fused_linear_cross_entropy: bool = True,
     rms_norm: bool = True,
     geglu: bool = True,


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Bug fix for gemma: fused_linear_cross_entropy flag and cross_entropy flag are mutual exclusive

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->
Bug fix for gemma: fused_linear_cross_entropy flag and cross_entropy flag are mutual exclusive
## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
Done, test model training 

```
{'loss': 2.5808, 'grad_norm': 77.5, 'learning_rate': 3e-06, 'epoch': 0.0, 'num_input_tokens_seen': 18256}

  5%|▌         | 1/20 [00:05<01:45,  5.55s/it]
 10%|█         | 2/20 [00:07<01:04,  3.59s/it]
                                              
{'loss': 2.652, 'grad_norm': 80.0, 'learning_rate': 6e-06, 'epoch': 0.0, 'num_input_tokens_seen': 33376, 'step': 2, 'step_time_sec': 2.18, 'avg_step_time_sec': 2.18, 'time_to_completion_sec': 39.29, 'estimated_total_time_sec': 43.66, 'step_peak_memory_allocated_MB': 21965.16, 'step_peak_memory_reserved_MB': 34126.0, 'total_peak_memory_allocated_MB': 21965.16, 'total_peak_memory_reserved_MB': 34126.0, 'step_tokens_per_second': 6926.16, 'avg_tokens_per_second': 6926.16}

 10%|█         | 2/20 [00:07<01:04,  3.59s/it]
 15%|█▌        | 3/20 [00:09<00:49,  2.93s/it]
                                              
{'loss': 2.1275, 'grad_norm': 46.0, 'learning_rate': 5.954423259036625e-06, 'epoch': 0.0, 'num_input_tokens_seen': 47504, 'step': 3, 'step_time_sec': 2.08, 'avg_step_time_sec': 2.13, 'time_to_completion_sec': 36.2, 'estimated_total_time_sec': 42.59, 'step_peak_memory_allocated_MB': 21998.28, 'step_peak_memory_reserved_MB': 34126.0, 'total_peak_memory_allocated_MB': 21998.28, 'total_peak_memory_reserved_MB': 34126.0, 'step_tokens_per_second': 6804.83, 'avg_tokens_per_second': 6867.02}

 15%|█▌        | 3/20 [00:09<00:49,  2.93s/it]
 20%|██        | 4/20 [00:12<00:47,  2.94s/it]
                                              
{'loss': 1.7238, 'grad_norm': 15.75, 'learning_rate': 5.819077862357725e-06, 'epoch': 0.01, 'num_input_tokens_seen': 64176, 'step': 4, 'step_time_sec': 2.89, 'avg_step_time_sec': 2.38, 'time_to_completion_sec': 38.14, 'estimated_total_time_sec': 47.68, 'step_peak_memory_allocated_MB': 21734.73, 'step_peak_memory_reserved_MB': 35628.0, 'total_peak_memory_allocated_MB': 21998.28, 'total_peak_memory_reserved_MB': 35628.0, 'step_tokens_per_second': 5763.26, 'avg_tokens_per_second': 6420.58}

```
<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
