### PR TITLE
Uplift kernel APIs to top level

### DIFF
--- a/src/liger_kernel/transformers/__init__.py
+++ b/src/liger_kernel/transformers/__init__.py
@@ -1,6 +1,12 @@
 from liger_kernel.transformers.auto_model import (  # noqa: F401
     AutoLigerKernelForCausalLM,
 )
+from liger_kernel.transformers.cross_entropy import LigerCrossEntropyLoss  # noqa: F401
+from liger_kernel.transformers.fused_linear_cross_entropy import (  # noqa: F401
+    LigerFusedLinearCrossEntropyLoss,
+)
+from liger_kernel.transformers.geglu import LigerGEGLUMLP  # noqa: F401
+from liger_kernel.transformers.layer_norm import LigerLayerNorm  # noqa: F401
 from liger_kernel.transformers.monkey_patch import (  # noqa: F401
     apply_liger_kernel_to_gemma,
     apply_liger_kernel_to_gemma2,
@@ -10,23 +16,10 @@ from liger_kernel.transformers.monkey_patch import (  # noqa: F401
     apply_liger_kernel_to_phi3,
     apply_liger_kernel_to_qwen2,
 )
-
-from .cross_entropy import LigerCrossEntropyLoss
-from .fused_linear_cross_entropy import LigerFusedLinearCrossEntropyLoss
-from .geglu import LigerGEGLUMLP
-from .layer_norm import LigerLayerNorm
-from .rms_norm import LigerRMSNorm
-from .rope import liger_rotary_pos_emb
-from .swiglu import LigerBlockSparseTop2MLP, LigerPhi3SwiGLUMLP, LigerSwiGLUMLP
-
-__all__ = [
-    "LigerCrossEntropyLoss",
-    "LigerFusedLinearCrossEntropyLoss",
-    "LigerGEGLUMLP",
-    "LigerLayerNorm",
-    "LigerRMSNorm",
-    "liger_rotary_pos_emb",
-    "LigerBlockSparseTop2MLP",
-    "LigerPhi3SwiGLUMLP",
-    "LigerSwiGLUMLP",
-]
+from liger_kernel.transformers.rms_norm import LigerRMSNorm  # noqa: F401
+from liger_kernel.transformers.rope import liger_rotary_pos_emb  # noqa: F401
+from liger_kernel.transformers.swiglu import (  # noqa: F401
+    LigerBlockSparseTop2MLP,
+    LigerPhi3SwiGLUMLP,
+    LigerSwiGLUMLP,
+)

--- a/src/liger_kernel/transformers/__init__.py
+++ b/src/liger_kernel/transformers/__init__.py
@@ -10,3 +10,23 @@ from liger_kernel.transformers.monkey_patch import (  # noqa: F401
     apply_liger_kernel_to_phi3,
     apply_liger_kernel_to_qwen2,
 )
+
+from .cross_entropy import LigerCrossEntropyLoss
+from .fused_linear_cross_entropy import LigerFusedLinearCrossEntropyLoss
+from .geglu import LigerGEGLUMLP
+from .layer_norm import LigerLayerNorm
+from .rms_norm import LigerRMSNorm
+from .rope import liger_rotary_pos_emb
+from .swiglu import LigerBlockSparseTop2MLP, LigerPhi3SwiGLUMLP, LigerSwiGLUMLP
+
+__all__ = [
+    "LigerCrossEntropyLoss",
+    "LigerFusedLinearCrossEntropyLoss",
+    "LigerGEGLUMLP",
+    "LigerLayerNorm",
+    "LigerRMSNorm",
+    "liger_rotary_pos_emb",
+    "LigerBlockSparseTop2MLP",
+    "LigerPhi3SwiGLUMLP",
+    "LigerSwiGLUMLP",
+]

--- a/test/transformers/test_transforemrs.py
+++ b/test/transformers/test_transforemrs.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+def test_import_from_root():
+    try:
+        from liger_kernel.transformers import (  # noqa: F401
+            LigerBlockSparseTop2MLP,
+            LigerCrossEntropyLoss,
+            LigerFusedLinearCrossEntropyLoss,
+            LigerGEGLUMLP,
+            LigerLayerNorm,
+            LigerPhi3SwiGLUMLP,
+            LigerRMSNorm,
+            LigerSwiGLUMLP,
+            liger_rotary_pos_emb,
+        )
+    except Exception:
+        pytest.fail("Import kernels from root fails")


### PR DESCRIPTION
closes https://github.com/linkedin/Liger-Kernel/issues/205

## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->

Uplift kernel api to top level by updating the `__init__.py` imports structure

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: CPU
```
⚡ ${branch:+$branch }${PWD/#$HOME/~} python
Python 3.10.10 (main, Mar 21 2023, 18:45:11) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from liger_kernel.transformers import LigerCrossEntropyLoss, LigerFusedLinearCrossEntropyLoss, LigerGEGLUMLP, LigerLayerNorm, LigerRMSNorm, liger_rotary_pos_emb, LigerBlockSparseTop2MLP, LigerPhi3SwiGLUMLP, LigerSwiGLUMLP
>>> 
```
- [X] run `make test` to ensure correctness
- [X] run `make checkstyle` to ensure code style
- [X] run `make test-convergence` to ensure convergence
