### PR TITLE
Update swiglu and geglu forward: zeros_like -> empty_like

### DIFF
--- a/src/liger_kernel/ops/geglu.py
+++ b/src/liger_kernel/ops/geglu.py
@@ -98,7 +98,7 @@ def geglu_forward(a, b):
     n_cols = ori_shape[-1]
     a = a.view(-1, n_cols)
     b = b.view(-1, n_cols)
-    c = torch.zeros_like(a)
+    c = torch.empty_like(a)
     n_rows = a.shape[0]
 
     BLOCK_SIZE, num_warps = calculate_settings(n_cols)

--- a/src/liger_kernel/ops/swiglu.py
+++ b/src/liger_kernel/ops/swiglu.py
@@ -66,7 +66,7 @@ def swiglu_forward(a, b):
     n_cols = ori_shape[-1]
     a = a.view(-1, n_cols)
     b = b.view(-1, n_cols)
-    c = torch.zeros_like(a)
+    c = torch.empty_like(a)
     n_rows = a.shape[0]
 
     BLOCK_SIZE, num_warps = calculate_settings(n_cols)


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
This PR improves the performance of swiglu and geglu forward by replacing `zeros_like` with `empty_like`. The difference is that `empty_like` doesn't require a separate kernel launch.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
Testing is covered by existing `test_geglu.py` and `test_swiglu.py`.

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: A100-80G-PCIe
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
