### PR TITLE
(fix) fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dev = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["src"]
+where = ["src"]
+include = ["liger_kernel"]
 
 [tool.pytest.ini_options]
 pythonpath = [


### PR DESCRIPTION
## Summary
Fix `tool.setuptools.packages.find` field in pyproject.toml. Otherwise in local build mode with `pip install .`, python system fails to locate liger_kernel.