### PR TITLE
add repr infomation for layer_norm and rms_norm

### DIFF
--- a/src/liger_kernel/transformers/layer_norm.py
+++ b/src/liger_kernel/transformers/layer_norm.py
@@ -11,6 +11,8 @@ class LigerLayerNorm(nn.Module):
             "ones",
             "zeros",
         ], f"init_fn must be either 'ones' or 'zeros', got {init_fn}"
+        self.hidden_size = hidden_size
+        self.eps = eps
         self.weight = nn.Parameter(
             torch.ones(hidden_size) if init_fn == "ones" else torch.zeros(hidden_size)
         )
@@ -23,3 +25,6 @@ class LigerLayerNorm(nn.Module):
         return LigerLayerNormFunction.apply(
             hidden_states, self.weight, self.bias, self.variance_epsilon
         )
+        
+    def extra_repr(self) -> str:
+        return f'{self.hidden_size}, eps={self.eps}'

--- a/src/liger_kernel/transformers/layer_norm.py
+++ b/src/liger_kernel/transformers/layer_norm.py
@@ -25,6 +25,6 @@ class LigerLayerNorm(nn.Module):
         return LigerLayerNormFunction.apply(
             hidden_states, self.weight, self.bias, self.variance_epsilon
         )
-        
-    def extra_repr(self) -> str:
-        return f'{self.hidden_size}, eps={self.eps}'
+
+    def extra_repr(self):
+        return f"{self.hidden_size}, eps={self.eps}"

--- a/src/liger_kernel/transformers/rms_norm.py
+++ b/src/liger_kernel/transformers/rms_norm.py
@@ -30,3 +30,6 @@ class LigerRMSNorm(nn.Module):
             self.offset,
             self.casting_mode,
         )
+
+    def extra_repr(self):
+        return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}, offset={self.offset}"

--- a/src/liger_kernel/triton/monkey_patch.py
+++ b/src/liger_kernel/triton/monkey_patch.py
@@ -37,6 +37,6 @@ def apply_liger_triton_cache_manager():
     Experimental feature to get around transient FileNotFoundError in triton compilation.
     For more details please see https://github.com/triton-lang/triton/pull/4295
     """
-    os.environ["TRITON_CACHE_MANAGER"] = (
-        "liger_kernel.triton.monkey_patch:LigerTritonFileCacheManager"
-    )
+    os.environ[
+        "TRITON_CACHE_MANAGER"
+    ] = "liger_kernel.triton.monkey_patch:LigerTritonFileCacheManager"


### PR DESCRIPTION
## Summary
Add repr information for layernorm and rmsnorm class so that the useful layer information can be displayed after the model is printed. Other classes are not modified because they inherit from related torch.nn classes, or there are torch.nn sub-modules.


## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
