### PR TITLE
Support Z Loss in CE

### DIFF
--- a/src/liger_kernel/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cross_entropy.py
@@ -40,7 +40,7 @@ def liger_cross_entropy_kernel(
     ignore_index (int): The index to ignore in the target.
     label_smoothing (float): The amount of smoothing when computing the loss, where 0.0 means no smoothing.
     lse_square_scale (float): The scaler of (logsumexp(_input)) ^ 2 adding to the loss for the stability of training.
-    RETURN_Z_LOSS (int): The boolean value to decide whether storing the z loss or not.
+    RETURN_Z_LOSS (int): The boolean value to decide whether storing z loss to z_loss_ptr or not. It must be 0 or 1.
     BLOCK_SIZE (int): The block size for Triton operations.
     """
 
@@ -331,7 +331,8 @@ class LigerCrossEntropyFunction(torch.autograd.Function):
         ignore_index (int): The index to ignore in the target.
         label_smoothing (float): The amount of smoothing when computing the loss, where 0.0 means no smoothing.
         lse_square_scale (float): The scaler of (logsumexp(_input)) ^ 2 adding to the loss for the stability of training.
-        return_z_loss (bool): Return z loss or not.
+        return_z_loss (bool): When `return_z_loss` is `True`, returns (loss, z_loss) instead of (loss, None). Default: `False`
+
 
         Returns:
         tuple: A tuple with the compouted losses with respect to loss and z loss. The elements are tensors or None.

--- a/src/liger_kernel/ops/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_cross_entropy.py
@@ -19,7 +19,7 @@ def fused_linear_cross_entropy_forward(
     bias=None,
     ignore_index=-100,
     label_smoothing=0.0,
-    z_loss_scale=0.0,
+    lse_square_scale=0.0,
 ):
     dtype = (
         torch.get_autocast_gpu_dtype() if torch.is_autocast_enabled() else _input.dtype
@@ -91,7 +91,7 @@ def fused_linear_cross_entropy_forward(
             n_non_ignore=n_non_ignore,
             ignore_index=ignore_index,
             label_smoothing=label_smoothing,
-            z_loss_scale=z_loss_scale,
+            lse_square_scale=lse_square_scale,
             BLOCK_SIZE=BLOCK_SIZE,
             RETURN_Z_LOSS=0,  # False
             num_warps=32,

--- a/src/liger_kernel/transformers/cross_entropy.py
+++ b/src/liger_kernel/transformers/cross_entropy.py
@@ -1,16 +1,34 @@
-from torch.nn import CrossEntropyLoss
+import torch.nn as nn
 
 from liger_kernel.ops.cross_entropy import LigerCrossEntropyFunction
 
 
-class LigerCrossEntropyLoss(CrossEntropyLoss):
-    def __init__(self, *args, **kwargs):
-        super(LigerCrossEntropyLoss, self).__init__(*args, **kwargs)
+class LigerCrossEntropyLoss(nn.Module):
+    def __init__(
+        self,
+        ignore_index=-100,
+        label_smoothing=0.0,
+        z_loss_scale=0.0,
+        return_z_loss=False,
+    ):
+        super().__init__()
+        self.ignore_index = ignore_index
+        self.label_smoothing = label_smoothing
+        self.z_loss_scale = z_loss_scale
+        self.return_z_loss = return_z_loss
         assert (self.label_smoothing >= 0) and (
             self.label_smoothing <= 1
         ), f"label_smoothing must be between 0.0 and 1.0. Got: {self.label_smoothing}"
 
     def forward(self, _input, target):
-        return LigerCrossEntropyFunction.apply(
-            _input, target, self.ignore_index, self.label_smoothing
+        loss, z_loss = LigerCrossEntropyFunction.apply(
+            _input,
+            target,
+            self.ignore_index,
+            self.label_smoothing,
+            self.z_loss_scale,
+            self.return_z_loss,
         )
+        if not self.return_z_loss:
+            return loss
+        return loss, z_loss

--- a/src/liger_kernel/transformers/cross_entropy.py
+++ b/src/liger_kernel/transformers/cross_entropy.py
@@ -8,13 +8,13 @@ class LigerCrossEntropyLoss(nn.Module):
         self,
         ignore_index=-100,
         label_smoothing=0.0,
-        z_loss_scale=0.0,
+        lse_square_scale=0.0,
         return_z_loss=False,
     ):
         super().__init__()
         self.ignore_index = ignore_index
         self.label_smoothing = label_smoothing
-        self.z_loss_scale = z_loss_scale
+        self.lse_square_scale = lse_square_scale
         self.return_z_loss = return_z_loss
         assert (self.label_smoothing >= 0) and (
             self.label_smoothing <= 1
@@ -26,7 +26,7 @@ class LigerCrossEntropyLoss(nn.Module):
             target,
             self.ignore_index,
             self.label_smoothing,
-            self.z_loss_scale,
+            self.lse_square_scale,
             self.return_z_loss,
         )
         if not self.return_z_loss:

--- a/src/liger_kernel/transformers/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/transformers/fused_linear_cross_entropy.py
@@ -1,15 +1,33 @@
-from torch.nn import CrossEntropyLoss
+import torch.nn as nn
 
 from liger_kernel.ops.fused_linear_cross_entropy import (
     LigerFusedLinearCrossEntropyFunction,
 )
 
 
-class LigerFusedLinearCrossEntropyLoss(CrossEntropyLoss):
-    def __init__(self, *args, **kwargs):
-        super(LigerFusedLinearCrossEntropyLoss, self).__init__(*args, **kwargs)
+class LigerFusedLinearCrossEntropyLoss(nn.Module):
+    def __init__(
+        self,
+        ignore_index=-100,
+        label_smoothing=0.0,
+        z_loss_scale=0.0,
+        reduction="mean",
+    ):
+        super().__init__()
+        self.ignore_index = ignore_index
+        self.label_smoothing = label_smoothing
+        self.z_loss_scale = z_loss_scale
+        self.reduction = reduction
+        assert (self.label_smoothing >= 0) and (
+            self.label_smoothing <= 1
+        ), f"label_smoothing must be between 0.0 and 1.0. Got: {self.label_smoothing}"
 
     def forward(self, lin_weight, _input, target, bias=None):
         return LigerFusedLinearCrossEntropyFunction.apply(
-            _input, lin_weight, target, bias, self.ignore_index
+            _input,
+            lin_weight,
+            target,
+            bias,
+            self.ignore_index,
+            self.z_loss_scale,
         )

--- a/src/liger_kernel/transformers/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/transformers/fused_linear_cross_entropy.py
@@ -10,13 +10,13 @@ class LigerFusedLinearCrossEntropyLoss(nn.Module):
         self,
         ignore_index=-100,
         label_smoothing=0.0,
-        z_loss_scale=0.0,
+        lse_square_scale=0.0,
         reduction="mean",
     ):
         super().__init__()
         self.ignore_index = ignore_index
         self.label_smoothing = label_smoothing
-        self.z_loss_scale = z_loss_scale
+        self.lse_square_scale = lse_square_scale
         self.reduction = reduction
         assert (self.label_smoothing >= 0) and (
             self.label_smoothing <= 1
@@ -29,5 +29,5 @@ class LigerFusedLinearCrossEntropyLoss(nn.Module):
             target,
             bias,
             self.ignore_index,
-            self.z_loss_scale,
+            self.lse_square_scale,
         )

--- a/src/liger_kernel/transformers/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/transformers/fused_linear_cross_entropy.py
@@ -10,13 +10,11 @@ class LigerFusedLinearCrossEntropyLoss(nn.Module):
         self,
         ignore_index=-100,
         label_smoothing=0.0,
-        lse_square_scale=0.0,
         reduction="mean",
     ):
         super().__init__()
         self.ignore_index = ignore_index
         self.label_smoothing = label_smoothing
-        self.lse_square_scale = lse_square_scale
         self.reduction = reduction
         assert (self.label_smoothing >= 0) and (
             self.label_smoothing <= 1
@@ -29,5 +27,4 @@ class LigerFusedLinearCrossEntropyLoss(nn.Module):
             target,
             bias,
             self.ignore_index,
-            self.lse_square_scale,
         )

--- a/test/transformers/test_cross_entropy.py
+++ b/test/transformers/test_cross_entropy.py
@@ -40,11 +40,9 @@ class CrossEntropyWithZLoss(torch.nn.Module):
         )
 
         # Compute log-sum-exp term
-        lse = torch.logsumexp(
-            logits, dim=-1
-        )  # Compute log-sum-exp along the class dimension
+        lse = torch.logsumexp(logits, dim=-1)
 
-        # Z-loss term: penalizing logits
+        # Z-loss term
         z_loss = torch.where(
             targets != self.ignore_index, self.lse_square_scale * (lse**2), 0.0
         )

--- a/test/transformers/test_cross_entropy.py
+++ b/test/transformers/test_cross_entropy.py
@@ -2,6 +2,7 @@ from test.utils import supports_bfloat16
 
 import pytest
 import torch
+import torch.nn.functional as F
 from torch.nn import CrossEntropyLoss
 
 from liger_kernel.ops.cross_entropy import LigerCrossEntropyFunction
@@ -9,6 +10,58 @@ from liger_kernel.transformers.cross_entropy import LigerCrossEntropyLoss
 from liger_kernel.transformers.functional import liger_cross_entropy
 
 SLEEP_SECONDS = 0.1
+
+
+class CrossEntropyWithZLoss(torch.nn.Module):
+    def __init__(
+        self,
+        z_loss_scale=0.0,
+        reduction="mean",
+        ignore_index=-100,
+        label_smoothing=0.0,
+        return_z_loss=False,
+    ):
+        super().__init__()
+        self.z_loss_scale = z_loss_scale
+        self.reduction = reduction
+        self.ignore_index = ignore_index
+        self.return_z_loss = return_z_loss
+        self.label_smoothing = label_smoothing
+        self.ignore_index = ignore_index
+
+    def forward(self, logits, targets):
+        # Standard cross entropy loss
+        ce_loss = F.cross_entropy(
+            logits,
+            targets,
+            reduction=self.reduction,
+            label_smoothing=self.label_smoothing,
+            ignore_index=self.ignore_index,
+        )
+
+        # Compute log-sum-exp term
+        lse = torch.logsumexp(
+            logits, dim=-1
+        )  # Compute log-sum-exp along the class dimension
+
+        # Z-loss term: penalizing logits
+        z_loss = torch.where(
+            targets != self.ignore_index, self.z_loss_scale * (lse**2), 0.0
+        )
+        z_loss = z_loss.to(logits.dtype)
+        if self.reduction == "mean":
+            z_loss = z_loss.sum() / (targets != self.ignore_index).sum()
+        elif self.reduction == "sum":
+            z_loss = z_loss.sum()
+        else:
+            z_loss = z_loss
+
+        # Final loss: cross-entropy loss + Z-loss
+        total_loss = ce_loss + z_loss
+        if self.return_z_loss:
+            return total_loss, z_loss
+        else:
+            return total_loss
 
 
 def _test_correctness_once(target_ce, B, T, V, scalar, dtype, atol, rtol):
@@ -116,6 +169,113 @@ def _test_correctness_with_label_smoothing_with_ignore_index_once(
     assert torch.allclose(_input.grad, _input2.grad, atol=atol, rtol=rtol)
 
 
+def _test_correctness_with_z_loss_once(
+    target_ce,
+    B,
+    T,
+    V,
+    scalar,
+    dtype,
+    atol,
+    rtol,
+    z_loss_scale,
+    return_z_loss,
+):
+    torch.manual_seed(0)
+    torch_ce = CrossEntropyWithZLoss(
+        z_loss_scale=z_loss_scale,
+        return_z_loss=return_z_loss,
+    )
+
+    _tensor = torch.randn(B * T, V, device="cuda", dtype=dtype) * scalar
+    _input = _tensor.detach().clone().requires_grad_(True)
+    _input2 = _tensor.detach().clone().requires_grad_(True)
+
+    target = torch.randint(0, V, (B * T,), device="cuda", dtype=torch.long)
+
+    if return_z_loss:
+        output, z_output = torch_ce(_input, target)
+        output2, z_output2 = target_ce(_input2, target)
+        output2, z_output2 = output2.to(dtype), z_output2.to(dtype)
+
+    else:
+        output = torch_ce(_input, target)
+        output2 = target_ce(_input2, target)
+        output2 = output2.to(dtype)
+
+    assert torch.allclose(output, output2, atol=atol, rtol=rtol)
+
+    if return_z_loss:
+        assert torch.allclose(z_output, z_output2, atol=atol, rtol=rtol)
+
+    output.backward()
+    output2.backward()
+
+    assert torch.allclose(_input.grad, _input2.grad, atol=atol, rtol=rtol)
+
+
+def _test_correctness_with_z_loss_with_other_params_once(
+    target_ce,
+    B,
+    T,
+    V,
+    scalar,
+    dtype,
+    atol,
+    rtol,
+    z_loss_scale,
+    return_z_loss,
+    label_smoothing,
+    ignore_index,
+):
+    torch.manual_seed(0)
+    torch_ce = CrossEntropyWithZLoss(
+        z_loss_scale=z_loss_scale,
+        return_z_loss=return_z_loss,
+        label_smoothing=label_smoothing,
+        ignore_index=ignore_index,
+    )
+
+    _tensor = torch.randn(B * T, V, device="cuda", dtype=dtype) * scalar
+    _input = _tensor.detach().clone().requires_grad_(True)
+    _input2 = _tensor.detach().clone().requires_grad_(True)
+
+    target = torch.randint(0, V, (B * T,), device="cuda", dtype=torch.long)
+
+    # Assign some random number of elements as ignore_index
+    num_elements_to_assign = torch.randint(
+        1, B * T // 2, (1,)
+    ).item()  # Random number of elements to set to ignore_index
+    indices_to_assign = torch.randperm(B * T)[
+        :num_elements_to_assign
+    ]  # Randomly select indices
+    target[indices_to_assign] = ignore_index
+
+    if return_z_loss:
+        output, z_output = torch_ce(_input, target)
+        output2, z_output2 = target_ce(_input2, target)
+        output2, z_output2 = output2.to(dtype), z_output2.to(dtype)
+
+    else:
+        output = torch_ce(_input, target)
+        output2 = target_ce(_input2, target)
+        output2 = output2.to(dtype)
+
+    assert torch.allclose(output, output2, atol=atol, rtol=rtol)
+
+    if return_z_loss:
+        assert torch.allclose(z_output, z_output2, atol=atol, rtol=rtol)
+
+    output.backward()
+    output2.backward()
+    print(_input.grad)
+    print(_input2.grad)
+
+    print(f"{(_input.grad - _input2.grad).sum()=}")
+
+    assert torch.allclose(_input.grad, _input2.grad, atol=atol, rtol=rtol)
+
+
 def _test_correctness_not_last_layer_once(
     target_ce, B, T, V, scalar, dtype, atol, rtol
 ):
@@ -150,10 +310,11 @@ def _test_correctness_functional(B, T, V, scalar, dtype, atol, rtol):
 
     target = torch.randint(0, V, (B * T,), device="cuda", dtype=torch.long)
 
-    y1 = liger_cross_entropy(x1, target, 0)
-    y2 = LigerCrossEntropyFunction.apply(x2, target, 0)
+    y1, y1_z = liger_cross_entropy(x1, target, 0, 0.1, 1e-4, True)
+    y2, y2_z = LigerCrossEntropyFunction.apply(x2, target, 0, 0.1, 1e-4, True)
 
     assert torch.allclose(y1, y2, atol=atol, rtol=rtol)
+    assert torch.allclose(y1_z, y2_z, atol=atol, rtol=rtol)
 
     grad = torch.randn_like(y2)
 
@@ -419,6 +580,196 @@ def test_correctness_with_label_smoothing_with_ignore_index_once(
     )
     _test_correctness_with_label_smoothing_with_ignore_index_once(
         liger_ce, B, T, V, ignore_index, label_smoothing, scalar, dtype, atol, rtol
+    )
+
+
+@pytest.mark.parametrize(
+    "B, T, V",
+    [
+        (2, 4096, 32000),  # llama2, mistral
+        (2, 4096, 32000),  # llama2, mistral
+        # (1, 4096, 128256),  # llama3
+        # # weird shapes
+        (3, 423, 32000),
+    ],
+)
+@pytest.mark.parametrize(
+    "scalar, dtype, atol, rtol",
+    [
+        pytest.param(
+            0.1,
+            torch.bfloat16,
+            1e-8,
+            5e-2,
+            marks=pytest.mark.skipif(
+                not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
+            ),
+        ),
+        pytest.param(
+            1.0,
+            torch.bfloat16,
+            1e-8,
+            5e-2,
+            marks=pytest.mark.skipif(
+                not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
+            ),
+        ),
+        pytest.param(
+            10.0,
+            torch.bfloat16,
+            1e-7,
+            5e-2,
+            marks=pytest.mark.skipif(
+                not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
+            ),
+        ),
+        (0.1, torch.float32, 1e-8, 1e-6),
+        (1.0, torch.float32, 1e-8, 1e-6),
+        (10.0, torch.float32, 1e-8, 1e-5),
+    ],
+)
+@pytest.mark.parametrize(
+    "return_z_loss",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "z_loss_scale",
+    [
+        1e-4,  # PaLM
+        1e-5,  # Chameleon
+    ],
+)
+@pytest.mark.skipif(
+    torch.cuda.get_device_properties(0).total_memory < 16 * 1000 * 1000 * 1000,
+    reason="Needs 16GB+ GPU memory.",
+)
+def test_correctness_with_z_loss_once(
+    B,
+    T,
+    V,
+    scalar,
+    dtype,
+    atol,
+    rtol,
+    z_loss_scale,
+    return_z_loss,
+):
+    test_ce = LigerCrossEntropyLoss(
+        z_loss_scale=z_loss_scale,
+        return_z_loss=return_z_loss,
+    )
+    _test_correctness_with_z_loss_once(
+        test_ce,
+        B,
+        T,
+        V,
+        scalar,
+        dtype,
+        atol,
+        rtol,
+        z_loss_scale,
+        return_z_loss,
+    )
+
+
+@pytest.mark.parametrize(
+    "B, T, V",
+    [
+        (2, 4096, 32000),  # llama2, mistral
+        (2, 4096, 32000),  # llama2, mistral
+        # (1, 4096, 128256),  # llama3
+        # # weird shapes
+        (3, 423, 32000),
+    ],
+)
+@pytest.mark.parametrize(
+    "scalar, dtype, atol, rtol",
+    [
+        pytest.param(
+            0.1,
+            torch.bfloat16,
+            1e-8,
+            5e-2,
+            marks=pytest.mark.skipif(
+                not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
+            ),
+        ),
+        pytest.param(
+            1.0,
+            torch.bfloat16,
+            1e-8,
+            5e-2,
+            marks=pytest.mark.skipif(
+                not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
+            ),
+        ),
+        pytest.param(
+            10.0,
+            torch.bfloat16,
+            1e-7,
+            5e-2,
+            marks=pytest.mark.skipif(
+                not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
+            ),
+        ),
+        (0.1, torch.float32, 1e-8, 1e-6),
+        (1.0, torch.float32, 1e-8, 1e-6),
+        (10.0, torch.float32, 1e-8, 1e-5),
+    ],
+)
+@pytest.mark.parametrize(
+    "return_z_loss, z_loss_scale",
+    [
+        (True, 1e-4),
+        (False, 1e-5),
+    ],
+)
+@pytest.mark.parametrize(
+    "label_smoothing, ignore_index",
+    [
+        (0.1, 42),
+        (0.2, -42),
+    ],
+)
+@pytest.mark.skipif(
+    torch.cuda.get_device_properties(0).total_memory < 16 * 1000 * 1000 * 1000,
+    reason="Needs 16GB+ GPU memory.",
+)
+def test_correctness_with_z_loss_with_other_params_once(
+    B,
+    T,
+    V,
+    scalar,
+    dtype,
+    atol,
+    rtol,
+    z_loss_scale,
+    return_z_loss,
+    label_smoothing,
+    ignore_index,
+):
+    test_ce = LigerCrossEntropyLoss(
+        z_loss_scale=z_loss_scale,
+        return_z_loss=return_z_loss,
+        label_smoothing=label_smoothing,
+        ignore_index=ignore_index,
+    )
+    _test_correctness_with_z_loss_with_other_params_once(
+        test_ce,
+        B,
+        T,
+        V,
+        scalar,
+        dtype,
+        atol,
+        rtol,
+        z_loss_scale,
+        return_z_loss,
+        label_smoothing,
+        ignore_index,
     )
 
 

--- a/test/transformers/test_cross_entropy.py
+++ b/test/transformers/test_cross_entropy.py
@@ -15,14 +15,14 @@ SLEEP_SECONDS = 0.1
 class CrossEntropyWithZLoss(torch.nn.Module):
     def __init__(
         self,
-        z_loss_scale=0.0,
+        lse_square_scale=0.0,
         reduction="mean",
         ignore_index=-100,
         label_smoothing=0.0,
         return_z_loss=False,
     ):
         super().__init__()
-        self.z_loss_scale = z_loss_scale
+        self.lse_square_scale = lse_square_scale
         self.reduction = reduction
         self.ignore_index = ignore_index
         self.return_z_loss = return_z_loss
@@ -46,7 +46,7 @@ class CrossEntropyWithZLoss(torch.nn.Module):
 
         # Z-loss term: penalizing logits
         z_loss = torch.where(
-            targets != self.ignore_index, self.z_loss_scale * (lse**2), 0.0
+            targets != self.ignore_index, self.lse_square_scale * (lse**2), 0.0
         )
         z_loss = z_loss.to(logits.dtype)
         if self.reduction == "mean":
@@ -178,12 +178,12 @@ def _test_correctness_with_z_loss_once(
     dtype,
     atol,
     rtol,
-    z_loss_scale,
+    lse_square_scale,
     return_z_loss,
 ):
     torch.manual_seed(0)
     torch_ce = CrossEntropyWithZLoss(
-        z_loss_scale=z_loss_scale,
+        lse_square_scale=lse_square_scale,
         return_z_loss=return_z_loss,
     )
 
@@ -223,14 +223,14 @@ def _test_correctness_with_z_loss_with_other_params_once(
     dtype,
     atol,
     rtol,
-    z_loss_scale,
+    lse_square_scale,
     return_z_loss,
     label_smoothing,
     ignore_index,
 ):
     torch.manual_seed(0)
     torch_ce = CrossEntropyWithZLoss(
-        z_loss_scale=z_loss_scale,
+        lse_square_scale=lse_square_scale,
         return_z_loss=return_z_loss,
         label_smoothing=label_smoothing,
         ignore_index=ignore_index,
@@ -636,7 +636,7 @@ def test_correctness_with_label_smoothing_with_ignore_index_once(
     ],
 )
 @pytest.mark.parametrize(
-    "z_loss_scale",
+    "lse_square_scale",
     [
         1e-4,  # PaLM
         1e-5,  # Chameleon
@@ -654,11 +654,11 @@ def test_correctness_with_z_loss_once(
     dtype,
     atol,
     rtol,
-    z_loss_scale,
+    lse_square_scale,
     return_z_loss,
 ):
     test_ce = LigerCrossEntropyLoss(
-        z_loss_scale=z_loss_scale,
+        lse_square_scale=lse_square_scale,
         return_z_loss=return_z_loss,
     )
     _test_correctness_with_z_loss_once(
@@ -670,7 +670,7 @@ def test_correctness_with_z_loss_once(
         dtype,
         atol,
         rtol,
-        z_loss_scale,
+        lse_square_scale,
         return_z_loss,
     )
 
@@ -721,7 +721,7 @@ def test_correctness_with_z_loss_once(
     ],
 )
 @pytest.mark.parametrize(
-    "return_z_loss, z_loss_scale",
+    "return_z_loss, lse_square_scale",
     [
         (True, 1e-4),
         (False, 1e-5),
@@ -746,13 +746,13 @@ def test_correctness_with_z_loss_with_other_params_once(
     dtype,
     atol,
     rtol,
-    z_loss_scale,
+    lse_square_scale,
     return_z_loss,
     label_smoothing,
     ignore_index,
 ):
     test_ce = LigerCrossEntropyLoss(
-        z_loss_scale=z_loss_scale,
+        lse_square_scale=lse_square_scale,
         return_z_loss=return_z_loss,
         label_smoothing=label_smoothing,
         ignore_index=ignore_index,
@@ -766,7 +766,7 @@ def test_correctness_with_z_loss_with_other_params_once(
         dtype,
         atol,
         rtol,
-        z_loss_scale,
+        lse_square_scale,
         return_z_loss,
         label_smoothing,
         ignore_index,


### PR DESCRIPTION
## Summary
This PR aims to resolve #197

Implemented z loss in LigerCrossEntropy.

note: `lse_square_scale` not exposed at flce yet, because lse calculation will be different if the loss is computed chunk by chunk
## Details
### For loss:
```math
\begin{align}
L_{total} &= L_{ce} + z\_loss\
z\_loss &= lse\_square\_scale \cdot lse^2\
lse &= log \sum e^{X_i}
\end{align}
```
We can use  $m = max(X_i)$ and $d = \sum e^{X_i - m}$, obtained from online softmax algorithm, to calculate $lse$ directly.
```math
\begin{align}
lse &= log \sum e^{X_i}\
     &= log \sum e^{X_i - m + m} = log \sum e^{X_i -m} \cdot e^m\
     &= log\ e^m\sum e^{X_i - m} = m + d
\end{align}
```
### For gradients:
First, we calculate the derivative of lse
```math
\begin{align}
\frac{\partial}{\partial x_i}(lse) &= \frac{\partial}{\partial x_i}(log \sum e^{x_i}) \
                                           &= \frac{1}{\sum e^{x_i}} \cdot  \frac{\partial}{\partial x_i} \sum e^{x_i}\
                                           &= \frac{e^{x_i}}{\sum e^{x_i}} = softmax(x_i).
\end{align}
```
Then we can obtain the derivative of z_loss by chain rule.
```math
\frac{\partial z\_loss}{\partial x_i} = \frac{\partial}{\partial x_i}\left( lse\_square\_scale \cdot lse^2\right)  = 2\cdot lse\_square\_scale \cdot lse \cdot  softmax(x_i),
```
and we have the derivative of cross entropy loss with label smoothing
```math
\frac{\partial L_{ce}}{\partial x_i} = softmax(x_i) - (1 - \epsilon)\delta_{k,y} + \frac{\epsilon}{K}= \begin{cases} softmax(x_i) - \frac{\epsilon}{K},                        &  i \neq y \\
                                                   softmax(x_i) - \frac{\epsilon}{K} - (1 - \epsilon) &  i = y \end{cases}
```
where $\epsilon$ is label_smoothing and $K$ is the number of total classes.
Thus, the derivative of total loss is
```math
\begin{align}
\frac{\partial}{\partial x_i}L_{total} &= \frac{\partial}{\partial x_i}L_{ce} + \frac{\partial}{\partial x_i}z\_loss\
                                                     &= softmax(x_i) - \frac{\epsilon}{K} - (1 - \epsilon)\delta_{k,y} +  2\cdot lse\_square\_scale \cdot lse \cdot softmax(x_i)\
                                                     &=\begin{cases} (1 + 2\cdot lse\_square\_scale \cdot lse)\ softmax(x_i) - \frac{\epsilon}{K}, & i \neq y\\
(1 + 2\cdot lse\_square\_scale \cdot lse)\ softmax(x_i) - \frac{\epsilon}{K} -  (1 - \epsilon), & i = y \end{cases} 
\end{align}
```
### Reference
[PaLM: Scaling Language Modeling with Pathways](https://www.jmlr.org/papers/v24/22-1144.html)
[Chameleon: Mixed-Modal Early-Fusion Foundation Models](https://arxiv.org/abs/2405.09818)
## Testing Done
[benchmark gist](https://gist.github.com/Tcc0403/b9120282334196f66b5169d9f52bccaa)
neglectable error in speed benchmark. 

This benchmark was done on my machine, which is probably not accurate.
```
liger ce: 66.123ms
Peak mem:  8.66200832

liger ce with zloss: 65.991ms
Peak mem:  8.66200832

liger ce with zloss with return zloss: 65.951ms
Peak mem:  8.662073856
```

- Hardware Type: <BLANK>
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
