### PR TITLE
fused_linear_cross_entropy: Move float32 cast into kernel

### DIFF
--- a/test/transformers/test_cross_entropy.py
+++ b/test/transformers/test_cross_entropy.py
@@ -4,7 +4,10 @@ import pytest
 import torch
 from torch.nn import CrossEntropyLoss
 
-from liger_kernel.ops.cross_entropy import LigerCrossEntropyFunction
+from liger_kernel.ops.cross_entropy import (
+    LigerCrossEntropyFunction,
+    liger_cross_entropy_kernel,
+)
 from liger_kernel.transformers.cross_entropy import LigerCrossEntropyLoss
 from liger_kernel.transformers.functional import liger_cross_entropy
 
@@ -493,3 +496,61 @@ def test_large_no_exception(B, T, V):
     # The large inputs were hitting cuda illegal memory access because of
     # https://github.com/triton-lang/triton/issues/1058
     _full_pass_once(B, T, V)
+
+
+def test_float32_internal():
+    """
+    This test validates that the internal softmax calculations occur in float32,
+    even if the input dtype is bfloat16.
+    """
+    # Set up test parameters
+    batch_size = 4
+    n_cols = 128256
+    n_non_ignore = batch_size
+    ignore_index = -100
+    label_smoothing = 0.0
+    BLOCK_SIZE = 32768
+
+    # Initialize input tensors
+    X_init = torch.randn(batch_size, n_cols, dtype=torch.bfloat16, device="cuda")
+    Y = torch.randint(0, n_cols, (batch_size,), device="cuda")
+
+    # Run kernel for bfloat16
+    X_bf16 = X_init.clone()
+    loss_bf16 = torch.zeros(batch_size, dtype=torch.float32, device="cuda")
+    liger_cross_entropy_kernel[(batch_size,)](
+        X_ptr=X_bf16,
+        X_stride=X_bf16.stride(-2),
+        Y_ptr=Y,
+        Y_stride=Y.stride(-1),
+        loss_ptr=loss_bf16,
+        loss_stride=loss_bf16.stride(-1),
+        n_cols=n_cols,
+        n_non_ignore=n_non_ignore,
+        ignore_index=ignore_index,
+        label_smoothing=label_smoothing,
+        BLOCK_SIZE=BLOCK_SIZE,
+        num_warps=32,
+    )
+
+    # Run kernel for float32
+    X_fp32 = X_init.float()
+    loss_fp32 = torch.zeros(batch_size, dtype=torch.float32, device="cuda")
+    liger_cross_entropy_kernel[(batch_size,)](
+        X_ptr=X_fp32,
+        X_stride=X_fp32.stride(-2),
+        Y_ptr=Y,
+        Y_stride=Y.stride(-1),
+        loss_ptr=loss_fp32,
+        loss_stride=loss_fp32.stride(-1),
+        n_cols=n_cols,
+        n_non_ignore=n_non_ignore,
+        ignore_index=ignore_index,
+        label_smoothing=label_smoothing,
+        BLOCK_SIZE=BLOCK_SIZE,
+        num_warps=32,
+    )
+
+    # The results should be **exactly** equal after downcasting
+    assert (X_bf16 == X_fp32.bfloat16()).all()
+    assert (loss_bf16 == loss_fp32).all()


### PR DESCRIPTION
## Summary

Another small optimization :) The `logits_chunk.float()` allocation may be surprisingly large, e.g. Cohere models have 256K vocabs, so each logit chunk in float32 could be something like 1024 * 256K * 4 = 1GB VRAM (even more if the chunk size is larger.)

I actually don't think any explicit casting is even required within the Triton kernel since the intermediate softmax calculation variables like `m`, `d`, etc. are already float32 by default, so [with type promotion](https://triton-lang.org/main/python-api/triton-semantics.html) the calculations should all be float32 regardless.

However, I added explicit casts `.cast(tl.float32)` around all of the X_ptr loads to make this more obvious to the reader. In either case, the actual `liger_cross_entropy_kernel` runs so quickly that I don't think there's any performance difference - this is purely to save the float32 allocation. (It might be more efficient without the explicit casts, but I was not able to measure anything - even with a 1K x 256K logit matrix the kernel kind of runs instantly lol.)

## Testing Done

- Hardware Type: A100 80GB
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence