### PR TITLE
Fix/kldiv

### DIFF
--- a/src/liger_kernel/ops/kl_div.py
+++ b/src/liger_kernel/ops/kl_div.py
@@ -252,4 +252,5 @@ class LigerKLDivLossFunction(torch.autograd.Function):
             None,
             None,
             None,
+            None,
         )

--- a/src/liger_kernel/ops/kl_div.py
+++ b/src/liger_kernel/ops/kl_div.py
@@ -112,9 +112,7 @@ def _kldiv_kernel_backward(
         tl.store(input_ptr + offsets, res, mask=mask)
 
 
-def kldiv_forward_triton(
-    y_pred, y_true, log_target, reduction, eps
-):  # [BT, V]
+def kldiv_forward_triton(y_pred, y_true, log_target, reduction, eps):  # [BT, V]
     BT, V = y_pred.shape
 
     BLOCK_SIZE = min(MAX_FUSED_SIZE, triton.next_power_of_2(V))

--- a/src/liger_kernel/transformers/kl_div.py
+++ b/src/liger_kernel/transformers/kl_div.py
@@ -4,7 +4,7 @@ from liger_kernel.ops.kl_div import LigerKLDivLossFunction
 
 
 class LigerKLDIVLoss(nn.KLDivLoss):
-    def __init__(self, eps=1e-10, *args, **kwargs):
+    def __init__(self, eps: float = 1e-10, *args, **kwargs):
         super(LigerKLDIVLoss, self).__init__(*args, **kwargs)
         self.eps = eps
 

--- a/src/liger_kernel/transformers/kl_div.py
+++ b/src/liger_kernel/transformers/kl_div.py
@@ -4,10 +4,11 @@ from liger_kernel.ops.kl_div import LigerKLDivLossFunction
 
 
 class LigerKLDIVLoss(nn.KLDivLoss):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, eps=1e-10, *args, **kwargs):
         super(LigerKLDIVLoss, self).__init__(*args, **kwargs)
+        self.eps = eps
 
     def forward(self, y_pred, y_true):
         return LigerKLDivLossFunction.apply(
-            y_pred, y_true, self.reduction, self.log_target
+            y_pred, y_true, self.reduction, self.log_target, self.eps
         )

--- a/test/transformers/test_kl_div.py
+++ b/test/transformers/test_kl_div.py
@@ -72,11 +72,9 @@ def _test_correctness_once(
 
     output = torch_kldiv(x1, target)
     output2 = target_kldiv(x2, target)
-    assert_verbose_allclose(output, output2, atol=atol, rtol=rtol)
+    assert torch.allclose(output, output2, atol=atol, rtol=rtol)
 
-    if (
-        not is_last_layer
-    ):  # if the loss is the last layer, grad_output is 1.0 and mul op is skipped, testing for that reason
+    if not is_last_layer:  # if the loss is the last layer, grad_output is 1.0 and mul op is skipped, testing for that reason
         output = output * 2.0
         output2 = output2 * 2.0
 
@@ -85,12 +83,12 @@ def _test_correctness_once(
 
     output.backward()
     output2.backward()
-    assert_verbose_allclose(x1.grad, x2.grad, atol=atol, rtol=rtol)
+    assert torch.allclose(x1.grad, x2.grad, atol=atol, rtol=rtol)
 
 
 @pytest.mark.parametrize(*_SHAPE_PARAMS)
-@pytest.mark.parametrize("log_target", [False, True])
-@pytest.mark.parametrize("reduction", ["none", "batchmean", "mean", "sum"])
+@pytest.mark.parametrize("log_target", [True, False])
+@pytest.mark.parametrize("reduction", ["batchmean", "sum", "mean", "none"])
 @pytest.mark.parametrize(*_DTYPE_PARAMS)
 def test_correctness(B, T, V, log_target, reduction, dtype, atol, rtol):
     liger_kldiv = LigerKLDIVLoss(reduction=reduction, log_target=log_target)
@@ -100,8 +98,8 @@ def test_correctness(B, T, V, log_target, reduction, dtype, atol, rtol):
 
 
 @pytest.mark.parametrize(*_SHAPE_PARAMS)
-@pytest.mark.parametrize("log_target", [False, True])
-@pytest.mark.parametrize("reduction", ["none", "batchmean", "mean", "sum"])
+@pytest.mark.parametrize("log_target", [True, False])
+@pytest.mark.parametrize("reduction", ["batchmean", "sum", "mean", "none"])
 @pytest.mark.parametrize(*_DTYPE_PARAMS)
 def test_correctness_not_last(B, T, V, log_target, reduction, dtype, atol, rtol):
     liger_kldiv = LigerKLDIVLoss(reduction=reduction, log_target=log_target)

--- a/test/transformers/test_kl_div.py
+++ b/test/transformers/test_kl_div.py
@@ -74,7 +74,9 @@ def _test_correctness_once(
     output2 = target_kldiv(x2, target)
     assert torch.allclose(output, output2, atol=atol, rtol=rtol)
 
-    if not is_last_layer:  # if the loss is the last layer, grad_output is 1.0 and mul op is skipped, testing for that reason
+    if (
+        not is_last_layer
+    ):  # if the loss is the last layer, grad_output is 1.0 and mul op is skipped, testing for that reason
         output = output * 2.0
         output2 = output2 * 2.0
 

--- a/test/transformers/test_kl_div.py
+++ b/test/transformers/test_kl_div.py
@@ -1,4 +1,4 @@
-from test.utils import assert_verbose_allclose, supports_bfloat16
+from test.utils import supports_bfloat16
 
 import pytest
 import torch
@@ -74,9 +74,7 @@ def _test_correctness_once(
     output2 = target_kldiv(x2, target)
     assert torch.allclose(output, output2, atol=atol, rtol=rtol)
 
-    if (
-        not is_last_layer
-    ):  # if the loss is the last layer, grad_output is 1.0 and mul op is skipped, testing for that reason
+    if not is_last_layer:  # if the loss is the last layer, grad_output is 1.0 and mul op is skipped, testing for that reason
         output = output * 2.0
         output2 = output2 * 2.0
 


### PR DESCRIPTION
## Summary
Fixes KLDiv being calculated wrong due to invalid tests as described in #259 . Now made KLDiv work for even bigger vocab size etc. The benchmarks remain +- the same. Therefore not adding those as I don't have access to the original GPU they were done on before.


## Testing Done
Tests stay the same, except replacing `assert_verbose_all_close` with `assert torch.allclose`


- Hardware Type: Nvidia RTX A5500
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
