### PR TITLE
Fix AutoLigerKernelForCausalLM to pass through original kwargs

### DIFF
--- a/src/liger_kernel/transformers/auto_model.py
+++ b/src/liger_kernel/transformers/auto_model.py
@@ -40,7 +40,6 @@ class AutoLigerKernelForCausalLM(AutoModelForCausalLM):
             if key not in apply_fn_signature.parameters
         }
 
-        print(applicable_kwargs)
         return super().from_pretrained(
             pretrained_model_name_or_path, *model_args, **applicable_kwargs
         )

--- a/src/liger_kernel/transformers/auto_model.py
+++ b/src/liger_kernel/transformers/auto_model.py
@@ -1,6 +1,11 @@
+import inspect
+
 from transformers import AutoConfig, AutoModelForCausalLM
 
-from liger_kernel.transformers.monkey_patch import _apply_liger_kernel
+from liger_kernel.transformers.monkey_patch import (
+    MODEL_TYPE_TO_APPLY_LIGER_FN,
+    _apply_liger_kernel,
+)
 
 
 def _get_model_config(model_dir, **model_init_kwargs):
@@ -21,13 +26,21 @@ class AutoLigerKernelForCausalLM(AutoModelForCausalLM):
         # Determine the model type and apply the Liger Kernel if applicable
         # Note: _apply_liger_kernel will only pass relevant kwargs to the apply_liger_kernel_to_* function
         model_type = model_config.model_type
+
         _apply_liger_kernel(model_type, **kwargs)
 
-        # Retain only the keyword args present in the model configuration
-        for k in list(kwargs.keys()):
-            if k not in model_config.__dict__:
-                del kwargs[k]
+        # Filter out kwargs that were passed to the apply_liger_* function, which will cause
+        # model initialization errors otherwise
+        apply_fn = MODEL_TYPE_TO_APPLY_LIGER_FN[model_type]
+        apply_fn_signature = inspect.signature(apply_fn)
 
+        applicable_kwargs = {
+            key: value
+            for key, value in kwargs.items()
+            if key not in apply_fn_signature.parameters
+        }
+
+        print(applicable_kwargs)
         return super().from_pretrained(
-            pretrained_model_name_or_path, *model_args, **kwargs
+            pretrained_model_name_or_path, *model_args, **applicable_kwargs
         )


### PR DESCRIPTION
## Summary
- Fixes https://github.com/linkedin/Liger-Kernel/issues/250 to correctly pass all original kwargs to .from_pretrained(). Previously we were only passing args that were part of the model config, but there are additional valid kwargs beyond that.
- We still need to filter out the kwargs passed into the apply_liger_* functions, or else will result in model init errors

## Testing Done
Tested on huggingface example with some of the args in https://github.com/linkedin/Liger-Kernel/issues/250

- Hardware Type: A100
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
