### PR TITLE
Fix sharing a ResBlock layer for each head in Medusa example

### DIFF
--- a/examples/medusa/medusa_util.py
+++ b/examples/medusa/medusa_util.py
@@ -114,7 +114,7 @@ def add_medusa_heads(
     model.medusa_head = nn.ModuleList(
         [
             nn.Sequential(
-                *([ResBlock(hidden_size)] * medusa_num_layers),
+                *([ResBlock(hidden_size) for _ in range(medusa_num_layers)]),
                 nn.Linear(hidden_size, vocab_size, bias=False),
             )
             for _ in range(medusa_num_heads)


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
There is a bug of incorrect weight sharing between layers for each Medusa head. Since `nn.Module` is Python reference, the original source code creates a list containing references to the same weights. This PR fixes the bug.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: A100-80G-PCIe
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
