### PR TITLE
Relaxed transformers dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,10 @@ With one line of code, Liger Kernel can increase throughput by more than 20% and
 
 - `torch >= 2.1.2`
 - `triton >= 2.3.0`
-- `transformers >= 4.42.0`
+
+### Optional Dependencies
+
+- `transformers >= 4.x`: Required if you plan to use the transformers models patching APIs. The specific model you are working will dictate the minimum version of transformers.
 
 > **Note:**
 > Our kernels inherit the full spectrum of hardware compatibility offered by [Triton](https://github.com/triton-lang/triton).
@@ -129,7 +132,10 @@ To install from source:
 git clone https://github.com/linkedin/Liger-Kernel.git
 cd Liger-Kernel
 pip install -e .
+# or if using transformers
+pip install -e .[transformers]
 ```
+
 ## Getting Started
 
 There are a couple of ways to apply Liger kernels, depending on the level of customization required.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,18 +12,21 @@ license = { file = "LICENSE" }
 dependencies = [
     "torch>=2.1.2",
     "triton>=2.3.0",
-    "transformers>=4.42.0"
 ]
 
 [project.optional-dependencies]
+transformers = [
+    "transformers~=4.0"
+]
+
 dev = [
+    "transformers>=4.44.2",
     "matplotlib>=3.7.2",
     "flake8>=4.0.1.1",
     "black>=24.4.2",
     "isort>=5.13.2",
     "pytest>=7.1.2",
     "datasets>=2.19.2",
-    "jupyter==1.0.0",
     "seaborn",
 ]
 


### PR DESCRIPTION
## Summary
- Make the `transformers` dependency optional so we only have `torch` and `triton` as required deps, which is helpful if you're not using `transformers` for modeling code. This was also causing installation issues for people using slightly older transformers versions.
- If transformers is needed, make it compatible with any 4.x version. The specific model being used should dictate the transformers version compatibility.

## Testing Done
`pip install -e .[transformers]`
`pip install -e .[dev]`

A100-80G-PCIe

- Hardware Type: A100-80G-PCIe
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
