### PR TITLE
Post-init model patching fix

### DIFF
--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -81,22 +81,25 @@ def apply_liger_kernel_to_llama(
             # Direct LlamaModel
             base_model = model
 
-        torch_dtype = config.torch_dtype
         if rms_norm:
-            base_model.norm = LigerRMSNorm(
-                config.hidden_size, eps=config.rms_norm_eps
-            ).to(torch_dtype)
+            base_model.offset = 0.0
+            base_model.casting_mode = "llama"
+            base_model.norm.forward = LigerRMSNorm.forward
+            base_model.norm.extra_repr = LigerRMSNorm.extra_repr
 
         for decoder_layer in base_model.layers:
             if swiglu:
-                decoder_layer.mlp = LigerSwiGLUMLP(config).to(torch_dtype)
+                decoder_layer.mlp.forward = LigerSwiGLUMLP.forward
             if rms_norm:
-                decoder_layer.input_layernorm = LigerRMSNorm(
-                    config.hidden_size, eps=config.rms_norm_eps
-                ).to(torch_dtype)
-                decoder_layer.post_attention_layernorm = LigerRMSNorm(
-                    config.hidden_size, eps=config.rms_norm_eps
-                ).to(torch_dtype)
+                decoder_layer.input_layernorm.offset = 0.0
+                decoder_layer.input_layernorm.casting_mode = "llama"
+                decoder_layer.input_layernorm.forward = LigerRMSNorm.forward
+                decoder_layer.input_layernorm.extra_repr = LigerRMSNorm.extra_repr
+
+                decoder_layer.post_attention_layernorm.offset = 0.0
+                decoder_layer.post_attention_layernorm.casting_mode = "llama"
+                decoder_layer.post_attention_layernorm.forward = LigerRMSNorm.forward
+                decoder_layer.post_attention_layernorm.extra_repr = LigerRMSNorm.extra_repr
 
 
 def apply_liger_kernel_to_mistral(

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 def _bind_method_to_module(module, method_name: str, new_method: Callable):
+    # Binds a new method to a module instance so that self is passed as the first argument
     module.__dict__[method_name] = new_method.__get__(module, module.__class__)
 
 

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -33,14 +33,17 @@ def _bind_method_to_module(module, method_name: str, new_method: Callable):
 def _patch_rms_norm_module(module, offset=0.0, eps=1e-6, casting_mode="llama"):
     module.offset = offset
     module.casting_mode = casting_mode
-    module.variance_epsilon = eps
+    module.variance_epsilon = (
+        getattr(module, "variance_epsilon", None) or getattr(module, "eps", None) or eps
+    )
     _bind_method_to_module(module, "forward", LigerRMSNorm.forward)
     _bind_method_to_module(module, "extra_repr", LigerRMSNorm.extra_repr)
 
 
 def _patch_layer_norm_module(module, eps=1e-6):
-    module.eps = eps
-    module.variance_epsilon = eps
+    module.variance_epsilon = (
+        getattr(module, "variance_epsilon", None) or getattr(module, "eps", None) or eps
+    )
     module.hidden_size = module.normalized_shape
     _bind_method_to_module(module, "forward", LigerLayerNorm.forward)
     _bind_method_to_module(module, "extra_repr", LigerLayerNorm.extra_repr)

--- a/test/convergence/test_mini_models.py
+++ b/test/convergence/test_mini_models.py
@@ -324,7 +324,7 @@ def run_mini_model(
 
     # Make sure any patches have been reverted before tests
     MINI_MODEL_SETUPS[model_name].liger_kernel_patch_revert_func()
-    
+
     if with_liger is True:
         kwargs = {
             "rope": True,
@@ -510,14 +510,25 @@ def test_mini_model(
     )
 
     actual_output_pre = run_mini_model(
-        model_name=model_name, num_steps=num_steps, dtype=dtype, lr=lr, with_liger=True, post_init_patching=False,
+        model_name=model_name,
+        num_steps=num_steps,
+        dtype=dtype,
+        lr=lr,
+        with_liger=True,
+        post_init_patching=False,
     )
 
     actual_output_post = run_mini_model(
-        model_name=model_name, num_steps=num_steps, dtype=dtype, lr=lr, with_liger=True, post_init_patching=True,
+        model_name=model_name,
+        num_steps=num_steps,
+        dtype=dtype,
+        lr=lr,
+        with_liger=True,
+        post_init_patching=True,
     )
 
-    ### Pre-init patching
+    # Pre-init patching
+
     # Compare the loss of every step
     assert_verbose_allclose(
         torch.tensor([expected_output["loss"]]),
@@ -538,13 +549,14 @@ def test_mini_model(
     # Iterate over the model's parameters and compare them
     for expected_param, actual_param in zip(
         expected_output["model"].named_parameters(),
-        actual_output_post["model"].named_parameters(),
+        actual_output_pre["model"].named_parameters(),
     ):
         assert_verbose_allclose(
             expected_param[1], actual_param[1], atol=param_atol, rtol=param_rtol
         )
 
-    ### Post-init patching
+    # Post-init patching
+
     # Compare the loss of every step
     assert_verbose_allclose(
         torch.tensor([expected_output["loss"]]),
@@ -570,4 +582,3 @@ def test_mini_model(
         assert_verbose_allclose(
             expected_param[1], actual_param[1], atol=param_atol, rtol=param_rtol
         )
-

--- a/test/transformers/test_monkey_patch.py
+++ b/test/transformers/test_monkey_patch.py
@@ -212,21 +212,21 @@ def test_apply_liger_kernel_to_instance_for_llama():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert not dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert not layer.mlp.forward == LigerSwiGLUMLP.forward
-            assert not layer.input_layernorm.forward == LigerRMSNorm.forward
-            assert not layer.post_attention_layernorm.forward == LigerRMSNorm.forward
+            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(LigerSwiGLUMLP.forward)
+            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert layer.mlp.forward == LigerSwiGLUMLP.forward
-            assert layer.input_layernorm.forward == LigerRMSNorm.forward
-            assert layer.post_attention_layernorm.forward == LigerRMSNorm.forward
+            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerSwiGLUMLP.forward)
+            assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
 
 
 def test_apply_liger_kernel_to_instance_for_mistral():
@@ -245,21 +245,21 @@ def test_apply_liger_kernel_to_instance_for_mistral():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert not dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert not layer.mlp.forward == LigerSwiGLUMLP.forward
-            assert not layer.input_layernorm.forward == LigerRMSNorm.forward
-            assert not layer.post_attention_layernorm.forward == LigerRMSNorm.forward
+            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(LigerSwiGLUMLP.forward)
+            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert layer.mlp.forward == LigerSwiGLUMLP.forward
-            assert layer.input_layernorm.forward == LigerRMSNorm.forward
-            assert layer.post_attention_layernorm.forward == LigerRMSNorm.forward
+            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerSwiGLUMLP.forward)
+            assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
 
 
 def test_apply_liger_kernel_to_instance_for_mixtral():
@@ -280,23 +280,23 @@ def test_apply_liger_kernel_to_instance_for_mixtral():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert not dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
             for expert in layer.block_sparse_moe.experts:
-                assert not expert.forward == LigerBlockSparseTop2MLP.forward
-            assert not layer.input_layernorm.forward == LigerRMSNorm.forward
-            assert not layer.post_attention_layernorm.forward == LigerRMSNorm.forward
+                assert inspect.getsource(expert.forward) != inspect.getsource(LigerBlockSparseTop2MLP.forward)
+            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
             for expert in layer.block_sparse_moe.experts:
-                assert expert.forward == LigerBlockSparseTop2MLP.forward
-            assert layer.input_layernorm.forward == LigerRMSNorm.forward
-            assert layer.post_attention_layernorm.forward == LigerRMSNorm.forward
+                assert inspect.getsource(expert.forward) == inspect.getsource(LigerBlockSparseTop2MLP.forward)
+            assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
 
 
 def test_apply_liger_kernel_to_instance_for_gemma():
@@ -315,21 +315,21 @@ def test_apply_liger_kernel_to_instance_for_gemma():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert not dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert not layer.mlp.forward == LigerGEGLUMLP.forward
-            assert not layer.input_layernorm.forward == LigerRMSNorm.forward
-            assert not layer.post_attention_layernorm.forward == LigerRMSNorm.forward
+            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(LigerGEGLUMLP.forward)
+            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert layer.mlp.forward == LigerGEGLUMLP.forward
-            assert layer.input_layernorm.forward == LigerRMSNorm.forward
-            assert layer.post_attention_layernorm.forward == LigerRMSNorm.forward
+            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerGEGLUMLP.forward)
+            assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
 
 
 def test_apply_liger_kernel_to_instance_for_gemma2():
@@ -348,25 +348,25 @@ def test_apply_liger_kernel_to_instance_for_gemma2():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert not dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert not layer.mlp.forward == LigerGEGLUMLP.forward
-            assert not layer.input_layernorm.forward == LigerRMSNorm.forward
-            assert not layer.post_attention_layernorm.forward == LigerRMSNorm.forward
-            assert not layer.pre_feedforward_layernorm.forward == LigerRMSNorm.forward
-            assert not layer.post_feedforward_layernorm.forward == LigerRMSNorm.forward
+            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(LigerGEGLUMLP.forward)
+            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.pre_feedforward_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_feedforward_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert layer.mlp.forward == LigerGEGLUMLP.forward
-            assert layer.input_layernorm.forward == LigerRMSNorm.forward
-            assert layer.post_attention_layernorm.forward == LigerRMSNorm.forward
-            assert layer.pre_feedforward_layernorm.forward == LigerRMSNorm.forward
-            assert layer.post_feedforward_layernorm.forward == LigerRMSNorm.forward
+            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerGEGLUMLP.forward)
+            assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.pre_feedforward_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_feedforward_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
 
 
 def test_apply_liger_kernel_to_instance_for_qwen2():
@@ -385,21 +385,21 @@ def test_apply_liger_kernel_to_instance_for_qwen2():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert not dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert not layer.mlp.forward == LigerSwiGLUMLP.forward
-            assert not layer.input_layernorm.forward == LigerRMSNorm.forward
-            assert not layer.post_attention_layernorm.forward == LigerRMSNorm.forward
+            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(LigerSwiGLUMLP.forward)
+            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert layer.mlp.forward == LigerSwiGLUMLP.forward
-            assert layer.input_layernorm.forward == LigerRMSNorm.forward
-            assert layer.post_attention_layernorm.forward == LigerRMSNorm.forward
+            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerSwiGLUMLP.forward)
+            assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
 
 
 def test_apply_liger_kernel_to_instance_for_phi3():
@@ -418,18 +418,18 @@ def test_apply_liger_kernel_to_instance_for_phi3():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert not dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert not layer.mlp.forward == LigerPhi3SwiGLUMLP.forward
-            assert not layer.input_layernorm.forward == LigerRMSNorm.forward
-            assert not layer.post_attention_layernorm.forward == LigerRMSNorm.forward
+            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(LigerPhi3SwiGLUMLP.forward)
+            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert layer.mlp.forward == LigerPhi3SwiGLUMLP.forward
-            assert layer.input_layernorm.forward == LigerRMSNorm.forward
-            assert layer.post_attention_layernorm.forward == LigerRMSNorm.forward
+            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerPhi3SwiGLUMLP.forward)
+            assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)

--- a/test/transformers/test_monkey_patch.py
+++ b/test/transformers/test_monkey_patch.py
@@ -212,21 +212,37 @@ def test_apply_liger_kernel_to_instance_for_llama():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert inspect.getsource(dummy_model_instance.model.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
+        assert inspect.getsource(
+            dummy_model_instance.model.norm.forward
+        ) != inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(LigerSwiGLUMLP.forward)
-            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(
+                LigerSwiGLUMLP.forward
+            )
+            assert inspect.getsource(
+                layer.input_layernorm.forward
+            ) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.post_attention_layernorm.forward
+            ) != inspect.getsource(LigerRMSNorm.forward)
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
+        assert inspect.getsource(
+            dummy_model_instance.model.norm.forward
+        ) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerSwiGLUMLP.forward)
-            assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(
+                LigerSwiGLUMLP.forward
+            )
+            assert inspect.getsource(
+                layer.input_layernorm.forward
+            ) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.post_attention_layernorm.forward
+            ) == inspect.getsource(LigerRMSNorm.forward)
 
 
 def test_apply_liger_kernel_to_instance_for_mistral():
@@ -245,21 +261,37 @@ def test_apply_liger_kernel_to_instance_for_mistral():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert inspect.getsource(dummy_model_instance.model.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
+        assert inspect.getsource(
+            dummy_model_instance.model.norm.forward
+        ) != inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(LigerSwiGLUMLP.forward)
-            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(
+                LigerSwiGLUMLP.forward
+            )
+            assert inspect.getsource(
+                layer.input_layernorm.forward
+            ) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.post_attention_layernorm.forward
+            ) != inspect.getsource(LigerRMSNorm.forward)
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
+        assert inspect.getsource(
+            dummy_model_instance.model.norm.forward
+        ) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerSwiGLUMLP.forward)
-            assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(
+                LigerSwiGLUMLP.forward
+            )
+            assert inspect.getsource(
+                layer.input_layernorm.forward
+            ) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.post_attention_layernorm.forward
+            ) == inspect.getsource(LigerRMSNorm.forward)
 
 
 def test_apply_liger_kernel_to_instance_for_mixtral():
@@ -280,23 +312,39 @@ def test_apply_liger_kernel_to_instance_for_mixtral():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert inspect.getsource(dummy_model_instance.model.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
+        assert inspect.getsource(
+            dummy_model_instance.model.norm.forward
+        ) != inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
             for expert in layer.block_sparse_moe.experts:
-                assert inspect.getsource(expert.forward) != inspect.getsource(LigerBlockSparseTop2MLP.forward)
-            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+                assert inspect.getsource(expert.forward) != inspect.getsource(
+                    LigerBlockSparseTop2MLP.forward
+                )
+            assert inspect.getsource(
+                layer.input_layernorm.forward
+            ) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.post_attention_layernorm.forward
+            ) != inspect.getsource(LigerRMSNorm.forward)
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
+        assert inspect.getsource(
+            dummy_model_instance.model.norm.forward
+        ) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
             for expert in layer.block_sparse_moe.experts:
-                assert inspect.getsource(expert.forward) == inspect.getsource(LigerBlockSparseTop2MLP.forward)
-            assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+                assert inspect.getsource(expert.forward) == inspect.getsource(
+                    LigerBlockSparseTop2MLP.forward
+                )
+            assert inspect.getsource(
+                layer.input_layernorm.forward
+            ) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.post_attention_layernorm.forward
+            ) == inspect.getsource(LigerRMSNorm.forward)
 
 
 def test_apply_liger_kernel_to_instance_for_gemma():
@@ -315,21 +363,37 @@ def test_apply_liger_kernel_to_instance_for_gemma():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert inspect.getsource(dummy_model_instance.model.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
+        assert inspect.getsource(
+            dummy_model_instance.model.norm.forward
+        ) != inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(LigerGEGLUMLP.forward)
-            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(
+                LigerGEGLUMLP.forward
+            )
+            assert inspect.getsource(
+                layer.input_layernorm.forward
+            ) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.post_attention_layernorm.forward
+            ) != inspect.getsource(LigerRMSNorm.forward)
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
+        assert inspect.getsource(
+            dummy_model_instance.model.norm.forward
+        ) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerGEGLUMLP.forward)
-            assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(
+                LigerGEGLUMLP.forward
+            )
+            assert inspect.getsource(
+                layer.input_layernorm.forward
+            ) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.post_attention_layernorm.forward
+            ) == inspect.getsource(LigerRMSNorm.forward)
 
 
 def test_apply_liger_kernel_to_instance_for_gemma2():
@@ -348,25 +412,49 @@ def test_apply_liger_kernel_to_instance_for_gemma2():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert inspect.getsource(dummy_model_instance.model.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
+        assert inspect.getsource(
+            dummy_model_instance.model.norm.forward
+        ) != inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(LigerGEGLUMLP.forward)
-            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.pre_feedforward_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.post_feedforward_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(
+                LigerGEGLUMLP.forward
+            )
+            assert inspect.getsource(
+                layer.input_layernorm.forward
+            ) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.post_attention_layernorm.forward
+            ) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.pre_feedforward_layernorm.forward
+            ) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.post_feedforward_layernorm.forward
+            ) != inspect.getsource(LigerRMSNorm.forward)
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
+        assert inspect.getsource(
+            dummy_model_instance.model.norm.forward
+        ) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerGEGLUMLP.forward)
-            assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.pre_feedforward_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.post_feedforward_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(
+                LigerGEGLUMLP.forward
+            )
+            assert inspect.getsource(
+                layer.input_layernorm.forward
+            ) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.post_attention_layernorm.forward
+            ) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.pre_feedforward_layernorm.forward
+            ) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.post_feedforward_layernorm.forward
+            ) == inspect.getsource(LigerRMSNorm.forward)
 
 
 def test_apply_liger_kernel_to_instance_for_qwen2():
@@ -385,21 +473,37 @@ def test_apply_liger_kernel_to_instance_for_qwen2():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert inspect.getsource(dummy_model_instance.model.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
+        assert inspect.getsource(
+            dummy_model_instance.model.norm.forward
+        ) != inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(LigerSwiGLUMLP.forward)
-            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(
+                LigerSwiGLUMLP.forward
+            )
+            assert inspect.getsource(
+                layer.input_layernorm.forward
+            ) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.post_attention_layernorm.forward
+            ) != inspect.getsource(LigerRMSNorm.forward)
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
+        assert inspect.getsource(
+            dummy_model_instance.model.norm.forward
+        ) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerSwiGLUMLP.forward)
-            assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(
+                LigerSwiGLUMLP.forward
+            )
+            assert inspect.getsource(
+                layer.input_layernorm.forward
+            ) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.post_attention_layernorm.forward
+            ) == inspect.getsource(LigerRMSNorm.forward)
 
 
 def test_apply_liger_kernel_to_instance_for_phi3():
@@ -418,18 +522,34 @@ def test_apply_liger_kernel_to_instance_for_phi3():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert inspect.getsource(dummy_model_instance.model.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
+        assert inspect.getsource(
+            dummy_model_instance.model.norm.forward
+        ) != inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(LigerPhi3SwiGLUMLP.forward)
-            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(
+                LigerPhi3SwiGLUMLP.forward
+            )
+            assert inspect.getsource(
+                layer.input_layernorm.forward
+            ) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.post_attention_layernorm.forward
+            ) != inspect.getsource(LigerRMSNorm.forward)
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
+        assert inspect.getsource(
+            dummy_model_instance.model.norm.forward
+        ) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
-            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerPhi3SwiGLUMLP.forward)
-            assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
-            assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(
+                LigerPhi3SwiGLUMLP.forward
+            )
+            assert inspect.getsource(
+                layer.input_layernorm.forward
+            ) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(
+                layer.post_attention_layernorm.forward
+            ) == inspect.getsource(LigerRMSNorm.forward)

--- a/test/transformers/test_monkey_patch.py
+++ b/test/transformers/test_monkey_patch.py
@@ -212,21 +212,21 @@ def test_apply_liger_kernel_to_instance_for_llama():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert not isinstance(dummy_model_instance.model.norm, LigerRMSNorm)
+        assert not dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
         for layer in dummy_model_instance.model.layers:
-            assert not isinstance(layer.mlp, LigerSwiGLUMLP)
-            assert not isinstance(layer.input_layernorm, LigerRMSNorm)
-            assert not isinstance(layer.post_attention_layernorm, LigerRMSNorm)
+            assert not layer.mlp.forward == LigerSwiGLUMLP.forward
+            assert not layer.input_layernorm.forward == LigerRMSNorm.forward
+            assert not layer.post_attention_layernorm.forward == LigerRMSNorm.forward
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert isinstance(dummy_model_instance.model.norm, LigerRMSNorm)
+        assert dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
         for layer in dummy_model_instance.model.layers:
-            assert isinstance(layer.mlp, LigerSwiGLUMLP)
-            assert isinstance(layer.input_layernorm, LigerRMSNorm)
-            assert isinstance(layer.post_attention_layernorm, LigerRMSNorm)
+            assert layer.mlp.forward == LigerSwiGLUMLP.forward
+            assert layer.input_layernorm.forward == LigerRMSNorm.forward
+            assert layer.post_attention_layernorm.forward == LigerRMSNorm.forward
 
 
 def test_apply_liger_kernel_to_instance_for_mistral():
@@ -245,21 +245,21 @@ def test_apply_liger_kernel_to_instance_for_mistral():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert not isinstance(dummy_model_instance.model.norm, LigerRMSNorm)
+        assert not dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
         for layer in dummy_model_instance.model.layers:
-            assert not isinstance(layer.mlp, LigerSwiGLUMLP)
-            assert not isinstance(layer.input_layernorm, LigerRMSNorm)
-            assert not isinstance(layer.post_attention_layernorm, LigerRMSNorm)
+            assert not layer.mlp.forward == LigerSwiGLUMLP.forward
+            assert not layer.input_layernorm.forward == LigerRMSNorm.forward
+            assert not layer.post_attention_layernorm.forward == LigerRMSNorm.forward
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert isinstance(dummy_model_instance.model.norm, LigerRMSNorm)
+        assert dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
         for layer in dummy_model_instance.model.layers:
-            assert isinstance(layer.mlp, LigerSwiGLUMLP)
-            assert isinstance(layer.input_layernorm, LigerRMSNorm)
-            assert isinstance(layer.post_attention_layernorm, LigerRMSNorm)
+            assert layer.mlp.forward == LigerSwiGLUMLP.forward
+            assert layer.input_layernorm.forward == LigerRMSNorm.forward
+            assert layer.post_attention_layernorm.forward == LigerRMSNorm.forward
 
 
 def test_apply_liger_kernel_to_instance_for_mixtral():
@@ -280,23 +280,23 @@ def test_apply_liger_kernel_to_instance_for_mixtral():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert not isinstance(dummy_model_instance.model.norm, LigerRMSNorm)
+        assert not dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
         for layer in dummy_model_instance.model.layers:
             for expert in layer.block_sparse_moe.experts:
-                assert not isinstance(expert, LigerBlockSparseTop2MLP)
-            assert not isinstance(layer.input_layernorm, LigerRMSNorm)
-            assert not isinstance(layer.post_attention_layernorm, LigerRMSNorm)
+                assert not expert.forward == LigerBlockSparseTop2MLP.forward
+            assert not layer.input_layernorm.forward == LigerRMSNorm.forward
+            assert not layer.post_attention_layernorm.forward == LigerRMSNorm.forward
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert isinstance(dummy_model_instance.model.norm, LigerRMSNorm)
+        assert dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
         for layer in dummy_model_instance.model.layers:
             for expert in layer.block_sparse_moe.experts:
-                assert isinstance(expert, LigerBlockSparseTop2MLP)
-            assert isinstance(layer.input_layernorm, LigerRMSNorm)
-            assert isinstance(layer.post_attention_layernorm, LigerRMSNorm)
+                assert expert.forward == LigerBlockSparseTop2MLP.forward
+            assert layer.input_layernorm.forward == LigerRMSNorm.forward
+            assert layer.post_attention_layernorm.forward == LigerRMSNorm.forward
 
 
 def test_apply_liger_kernel_to_instance_for_gemma():
@@ -315,21 +315,21 @@ def test_apply_liger_kernel_to_instance_for_gemma():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert not isinstance(dummy_model_instance.model.norm, LigerRMSNorm)
+        assert not dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
         for layer in dummy_model_instance.model.layers:
-            assert not isinstance(layer.mlp, LigerGEGLUMLP)
-            assert not isinstance(layer.input_layernorm, LigerRMSNorm)
-            assert not isinstance(layer.post_attention_layernorm, LigerRMSNorm)
+            assert not layer.mlp.forward == LigerGEGLUMLP.forward
+            assert not layer.input_layernorm.forward == LigerRMSNorm.forward
+            assert not layer.post_attention_layernorm.forward == LigerRMSNorm.forward
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert isinstance(dummy_model_instance.model.norm, LigerRMSNorm)
+        assert dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
         for layer in dummy_model_instance.model.layers:
-            assert isinstance(layer.mlp, LigerGEGLUMLP)
-            assert isinstance(layer.input_layernorm, LigerRMSNorm)
-            assert isinstance(layer.post_attention_layernorm, LigerRMSNorm)
+            assert layer.mlp.forward == LigerGEGLUMLP.forward
+            assert layer.input_layernorm.forward == LigerRMSNorm.forward
+            assert layer.post_attention_layernorm.forward == LigerRMSNorm.forward
 
 
 def test_apply_liger_kernel_to_instance_for_gemma2():
@@ -348,25 +348,25 @@ def test_apply_liger_kernel_to_instance_for_gemma2():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert not isinstance(dummy_model_instance.model.norm, LigerRMSNorm)
+        assert not dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
         for layer in dummy_model_instance.model.layers:
-            assert not isinstance(layer.mlp, LigerGEGLUMLP)
-            assert not isinstance(layer.input_layernorm, LigerRMSNorm)
-            assert not isinstance(layer.post_attention_layernorm, LigerRMSNorm)
-            assert not isinstance(layer.pre_feedforward_layernorm, LigerRMSNorm)
-            assert not isinstance(layer.post_feedforward_layernorm, LigerRMSNorm)
+            assert not layer.mlp.forward == LigerGEGLUMLP.forward
+            assert not layer.input_layernorm.forward == LigerRMSNorm.forward
+            assert not layer.post_attention_layernorm.forward == LigerRMSNorm.forward
+            assert not layer.pre_feedforward_layernorm.forward == LigerRMSNorm.forward
+            assert not layer.post_feedforward_layernorm.forward == LigerRMSNorm.forward
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert isinstance(dummy_model_instance.model.norm, LigerRMSNorm)
+        assert dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
         for layer in dummy_model_instance.model.layers:
-            assert isinstance(layer.mlp, LigerGEGLUMLP)
-            assert isinstance(layer.input_layernorm, LigerRMSNorm)
-            assert isinstance(layer.post_attention_layernorm, LigerRMSNorm)
-            assert isinstance(layer.pre_feedforward_layernorm, LigerRMSNorm)
-            assert isinstance(layer.post_feedforward_layernorm, LigerRMSNorm)
+            assert layer.mlp.forward == LigerGEGLUMLP.forward
+            assert layer.input_layernorm.forward == LigerRMSNorm.forward
+            assert layer.post_attention_layernorm.forward == LigerRMSNorm.forward
+            assert layer.pre_feedforward_layernorm.forward == LigerRMSNorm.forward
+            assert layer.post_feedforward_layernorm.forward == LigerRMSNorm.forward
 
 
 def test_apply_liger_kernel_to_instance_for_qwen2():
@@ -385,21 +385,21 @@ def test_apply_liger_kernel_to_instance_for_qwen2():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert not isinstance(dummy_model_instance.model.norm, LigerRMSNorm)
+        assert not dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
         for layer in dummy_model_instance.model.layers:
-            assert not isinstance(layer.mlp, LigerSwiGLUMLP)
-            assert not isinstance(layer.input_layernorm, LigerRMSNorm)
-            assert not isinstance(layer.post_attention_layernorm, LigerRMSNorm)
+            assert not layer.mlp.forward == LigerSwiGLUMLP.forward
+            assert not layer.input_layernorm.forward == LigerRMSNorm.forward
+            assert not layer.post_attention_layernorm.forward == LigerRMSNorm.forward
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert isinstance(dummy_model_instance.model.norm, LigerRMSNorm)
+        assert dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
         for layer in dummy_model_instance.model.layers:
-            assert isinstance(layer.mlp, LigerSwiGLUMLP)
-            assert isinstance(layer.input_layernorm, LigerRMSNorm)
-            assert isinstance(layer.post_attention_layernorm, LigerRMSNorm)
+            assert layer.mlp.forward == LigerSwiGLUMLP.forward
+            assert layer.input_layernorm.forward == LigerRMSNorm.forward
+            assert layer.post_attention_layernorm.forward == LigerRMSNorm.forward
 
 
 def test_apply_liger_kernel_to_instance_for_phi3():
@@ -418,18 +418,18 @@ def test_apply_liger_kernel_to_instance_for_phi3():
         dummy_model_instance = AutoModelForCausalLM.from_config(config)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert not isinstance(dummy_model_instance.model.norm, LigerRMSNorm)
+        assert not dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
         for layer in dummy_model_instance.model.layers:
-            assert not isinstance(layer.mlp, LigerPhi3SwiGLUMLP)
-            assert not isinstance(layer.input_layernorm, LigerRMSNorm)
-            assert not isinstance(layer.post_attention_layernorm, LigerRMSNorm)
+            assert not layer.mlp.forward == LigerPhi3SwiGLUMLP.forward
+            assert not layer.input_layernorm.forward == LigerRMSNorm.forward
+            assert not layer.post_attention_layernorm.forward == LigerRMSNorm.forward
 
         # Test applying kernels to the model instance
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert isinstance(dummy_model_instance.model.norm, LigerRMSNorm)
+        assert dummy_model_instance.model.norm.forward == LigerRMSNorm.forward
         for layer in dummy_model_instance.model.layers:
-            assert isinstance(layer.mlp, LigerPhi3SwiGLUMLP)
-            assert isinstance(layer.input_layernorm, LigerRMSNorm)
-            assert isinstance(layer.post_attention_layernorm, LigerRMSNorm)
+            assert layer.mlp.forward == LigerPhi3SwiGLUMLP.forward
+            assert layer.input_layernorm.forward == LigerRMSNorm.forward
+            assert layer.post_attention_layernorm.forward == LigerRMSNorm.forward


### PR DESCRIPTION
## Summary
- Previously, the pre-trained weights were not being loaded if patching model post-initialization
- Instead of loading weights, just patch the model instance module's forward method (see https://github.com/linkedin/Liger-Kernel/issues/279)

## Testing Done
- In convergence tests, check that pre-init patching and post-init patching match results from original model

- Hardware Type: A100
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence --> most tests working, waiting for other fixes for all tests to pass
