### PR TITLE
Introducing Liger Kernel Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
         <th style="padding: 10px;" colspan="2">Stable</th>
         <th style="padding: 10px;" colspan="2">Nightly</th>
         <th style="padding: 10px;">Discord</th>
-        <th style="padding: 10px;">Gurubase</th>
     </tr>
     <tr>
         <td style="padding: 10px;">
@@ -34,11 +33,6 @@
         <td style="padding: 10px;">
             <a href="https://discord.gg/gpumode">
                 <img src="https://dcbadge.vercel.app/api/server/gpumode?style=flat" alt="Join Our Discord">
-            </a>
-        </td>
-        <td style="padding: 10px;">
-            <a href="https://gurubase.io/g/liger-kernel">
-                <img src="https://img.shields.io/badge/Gurubase-Ask%20Liger%20Kernel%20Guru%20(experimental)-006BFF" alt="Ask Liger Kernel Guru">
             </a>
         </td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
         <th style="padding: 10px;" colspan="2">Stable</th>
         <th style="padding: 10px;" colspan="2">Nightly</th>
         <th style="padding: 10px;">Discord</th>
+        <th style="padding: 10px;">Gurubase (experimental)</th>
     </tr>
     <tr>
         <td style="padding: 10px;">
@@ -33,6 +34,11 @@
         <td style="padding: 10px;">
             <a href="https://discord.gg/gpumode">
                 <img src="https://dcbadge.vercel.app/api/server/gpumode?style=flat" alt="Join Our Discord">
+            </a>
+        </td>
+        <td style="padding: 10px;">
+            <a href="https://gurubase.io/g/liger-kernel">
+                <img src="https://img.shields.io/badge/Gurubase-Ask%20Liger%20Kernel%20Guru-006BFF" alt="Ask Liger Kernel Guru">
             </a>
         </td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
         <th style="padding: 10px;" colspan="2">Stable</th>
         <th style="padding: 10px;" colspan="2">Nightly</th>
         <th style="padding: 10px;">Discord</th>
+        <th style="padding: 10px;">Gurubase</th>
     </tr>
     <tr>
         <td style="padding: 10px;">
@@ -35,6 +36,11 @@
                 <img src="https://dcbadge.vercel.app/api/server/gpumode?style=flat" alt="Join Our Discord">
             </a>
         </td>
+        <td style="padding: 10px;">
+            <a href="https://gurubase.io/g/liger-kernel">
+                <img src="https://img.shields.io/badge/Gurubase-Ask%20Liger%20Kernel%20Guru-006BFF" alt="Ask Liger Kernel Guru">
+            </a>
+        </td>
     </tr>
 </table>
 
@@ -42,7 +48,7 @@
 
 <img src="https://raw.githubusercontent.com/linkedin/Liger-Kernel/main/docs/images/logo-banner.png">
 
-[Installation](#installation) | [Getting Started](#getting-started) | [Examples](#examples) | [APIs](#apis) | [Structure](#structure) | [Contributing](#contributing) | [Acknowledgement](#acknowledgement)
+[Installation](#installation) | [Getting Started](#getting-started) | [Examples](#examples) | [APIs](#apis) | [Structure](#structure) | [Contributing](#contributing) | [Acknowledgement](#acknowledgement) | [Ask Liger Kernel Guru](https://gurubase.io/g/liger-kernel)
 
 <details>
   <summary>Latest News 🔥</summary>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
         </td>
         <td style="padding: 10px;">
             <a href="https://gurubase.io/g/liger-kernel">
-                <img src="https://img.shields.io/badge/Gurubase-Ask%20Liger%20Kernel%20Guru-006BFF" alt="Ask Liger Kernel Guru">
+                <img src="https://img.shields.io/badge/Gurubase-Ask%20Liger%20Kernel%20Guru%20(experimental)-006BFF" alt="Ask Liger Kernel Guru">
             </a>
         </td>
     </tr>
@@ -48,7 +48,7 @@
 
 <img src="https://raw.githubusercontent.com/linkedin/Liger-Kernel/main/docs/images/logo-banner.png">
 
-[Installation](#installation) | [Getting Started](#getting-started) | [Examples](#examples) | [APIs](#apis) | [Structure](#structure) | [Contributing](#contributing) | [Acknowledgement](#acknowledgement) | [Ask Liger Kernel Guru](https://gurubase.io/g/liger-kernel)
+[Installation](#installation) | [Getting Started](#getting-started) | [Examples](#examples) | [APIs](#apis) | [Structure](#structure) | [Contributing](#contributing) | [Acknowledgement](#acknowledgement) | [Ask Liger Kernel Guru (experimental)](https://gurubase.io/g/liger-kernel)
 
 <details>
   <summary>Latest News 🔥</summary>


### PR DESCRIPTION
I created the [Liger Kernel Guru](https://gurubase.io/g/liger-kernel) badge on Gurubase.io upon request from @ByronHsu.

Adding a new badge next to the Discord badge made all the badge text smaller, as the current style presents all badges in a table row. To address this, I added the Liger Kernel Guru badge to the index section. Please let me know if you'd like me to move it to a different section.