### PR TITLE
Fix incorrect training of first and last Medusa heads

### DIFF
--- a/examples/medusa/medusa_util.py
+++ b/examples/medusa/medusa_util.py
@@ -212,7 +212,7 @@ def add_medusa_heads(
 
             if with_liger:
                 lce = LigerFusedLinearCrossEntropyLoss()
-                for i in range(model.medusa_num_heads):
+                for i in range(model.medusa_num_heads + 1):
                     shift_hidden_states = (
                         hidden_states[..., : -(1 + i), :]
                         .contiguous()
@@ -223,7 +223,7 @@ def add_medusa_heads(
                     weight = (
                         model.lm_head.weight
                         if i == 0
-                        else model.medusa_head[i][-1].weight
+                        else model.medusa_head[i - 1][-1].weight
                     )
                     loss_i = lce(weight, shift_hidden_states, shift_labels)
 
@@ -238,7 +238,7 @@ def add_medusa_heads(
             else:
 
                 loss_fct = CrossEntropyLoss()
-                for i in range(model.medusa_num_heads):
+                for i in range(model.medusa_num_heads + 1):
                     medusa_logits_i = (
                         medusa_logits[i, :, : -(1 + i)]
                         .contiguous()


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Currently, there are two errors on Medusa training examples:

1. When we use Liger Kernel, the first head (`model.medusa_head[0]`) is not trained.
2. When we don't use Liger Kernel, the logits of the last head (`medusa_logits[-1]`) is ignored.

This PR fixes these errors.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: A100 80GB 8 GPUs
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
