### PR TITLE
[WIP] Fix Qwen2-vl for transformers 4.46

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ transformers = [
 ]
 
 dev = [
-    "transformers>=4.44.2",
+    "transformers==4.45.2",
     "matplotlib>=3.7.2",
     "flake8>=4.0.1.1",
     "black>=24.4.2",

--- a/src/liger_kernel/transformers/model/qwen2_vl.py
+++ b/src/liger_kernel/transformers/model/qwen2_vl.py
@@ -100,23 +100,43 @@ def lce_forward(
         inputs_embeds = self.model.embed_tokens(input_ids)
         if pixel_values is not None:
             pixel_values = pixel_values.type(self.visual.get_dtype())
-            image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw).to(
-                inputs_embeds.device
+            image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
+            n_image_tokens = (input_ids == self.config.image_token_id).sum().item()
+            n_image_features = image_embeds.shape[0]
+            if n_image_tokens != n_image_features:
+                raise ValueError(
+                    f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
+                )
+            image_mask = (
+                (input_ids == self.config.image_token_id)
+                .unsqueeze(-1)
+                .expand_as(inputs_embeds)
+                .to(inputs_embeds.device)
             )
-            image_mask = input_ids == self.config.image_token_id
-            if self.training:
-                inputs_embeds = inputs_embeds.clone()
-            inputs_embeds[image_mask] = image_embeds
+            image_embeds = image_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+
         if pixel_values_videos is not None:
             pixel_values_videos = pixel_values_videos.type(self.visual.get_dtype())
-            video_embeds = self.visual(pixel_values_videos, grid_thw=video_grid_thw).to(
-                inputs_embeds.device
+            video_embeds = self.visual(pixel_values_videos, grid_thw=video_grid_thw)
+            n_video_tokens = (input_ids == self.config.video_token_id).sum().item()
+            n_video_features = video_embeds.shape[0]
+            if n_video_tokens != n_video_features:
+                raise ValueError(
+                    f"Video features and video tokens do not match: tokens: {n_video_tokens}, features {n_video_features}"
+                )
+            video_mask = (
+                (input_ids == self.config.video_token_id)
+                .unsqueeze(-1)
+                .expand_as(inputs_embeds)
+                .to(inputs_embeds.device)
             )
-            video_mask = input_ids == self.config.video_token_id
-            inputs_embeds[video_mask] = video_embeds
+            video_embeds = video_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
+
         if attention_mask is not None:
             attention_mask = attention_mask.to(inputs_embeds.device)
-    # The code is copied from https://github.com/huggingface/transformers/pull/33487
+
     if position_ids is None and input_ids is not None:
         position_ids, _ = self.get_rope_index(
             input_ids, image_grid_thw, video_grid_thw, attention_mask

--- a/test/convergence/test_mini_models.py
+++ b/test/convergence/test_mini_models.py
@@ -520,23 +520,22 @@ def run_mini_model(
         #         not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
         #     ),
         # ),
-        # FIXME qwen2 is broken and needs fix
-        # pytest.param(
-        #     "mini_qwen2_vl",
-        #     32,
-        #     1e-4,
-        #     torch.float32,
-        #     1e-8,
-        #     1e-5,
-        #     5e-3,
-        #     1e-5,
-        #     5e-3,
-        #     1e-5,
-        #     marks=pytest.mark.skipif(
-        #         not QWEN2_VL_AVAILABLE,
-        #         reason="Qwen2-VL not available in this version of transformers",
-        #     ),
-        # ),
+        pytest.param(
+            "mini_qwen2_vl",
+            32,
+            1e-4,
+            torch.float32,
+            1e-8,
+            1e-5,
+            5e-3,
+            1e-5,
+            5e-3,
+            1e-5,
+            marks=pytest.mark.skipif(
+                not QWEN2_VL_AVAILABLE,
+                reason="Qwen2-VL not available in this version of transformers",
+            ),
+        ),
         # pytest.param(
         #     "mini_qwen2_vl",
         #     32,

--- a/test/convergence/test_mini_models.py
+++ b/test/convergence/test_mini_models.py
@@ -10,7 +10,6 @@ from test.utils import (
     revert_liger_kernel_to_mllama,
     revert_liger_kernel_to_phi3,
     revert_liger_kernel_to_qwen2,
-    revert_liger_kernel_to_qwen2_vl,
     set_seed,
     simple_collate_fn,
 )
@@ -36,7 +35,6 @@ from liger_kernel.transformers import (
     apply_liger_kernel_to_mllama,
     apply_liger_kernel_to_phi3,
     apply_liger_kernel_to_qwen2,
-    apply_liger_kernel_to_qwen2_vl,
 )
 
 try:
@@ -47,17 +45,6 @@ try:
     MLLAMA_AVAILABLE = True
 except ImportError:
     MLLAMA_AVAILABLE = False
-
-try:
-    # Qwen2-VL is only available in transformers>4.44.2
-    from transformers.models.qwen2_vl.configuration_qwen2_vl import Qwen2VLConfig
-    from transformers.models.qwen2_vl.modeling_qwen2_vl import (
-        Qwen2VLForConditionalGeneration,
-    )
-
-    QWEN2_VL_AVAILABLE = True
-except ImportError:
-    QWEN2_VL_AVAILABLE = False
 
 MINI_MODEL_SETUPS = {
     "mini_llama3": MiniModelConfig(
@@ -86,35 +73,6 @@ MINI_MODEL_SETUPS = {
             tie_word_embeddings=False,
             use_cache=True,
             vocab_size=32000,  # 128256,
-            # At rope backward
-            # Eager produces incontiguous dq and dk
-            # SDPA produces contiguous dq and incontiguous dk
-            # Flash_attn produces contiguous dq and dk
-            attn_implementation="sdpa",  # default value, pytorch native attention
-        ),
-    ),
-    "mini_qwen2": MiniModelConfig(
-        liger_kernel_patch_func=apply_liger_kernel_to_qwen2,
-        liger_kernel_patch_revert_func=revert_liger_kernel_to_qwen2,
-        model_class=Qwen2ForCausalLM,
-        mini_model_config=Qwen2Config(
-            attention_dropout=0.0,
-            bos_token_id=1,  # 151643
-            eos_token_id=2,  # 151643
-            hidden_act="silu",
-            hidden_size=896,
-            initializer_range=0.02,
-            intermediate_size=4864,
-            max_position_embeddings=32768,  # 131072
-            num_attention_heads=8,
-            num_hidden_layers=4,
-            num_key_value_heads=2,
-            rms_norm_eps=1e-6,
-            rope_theta=1000000.0,
-            sliding_window=131072,
-            tie_word_embeddings=True,
-            use_cache=True,
-            vocab_size=32000,  # 151936
             # At rope backward
             # Eager produces incontiguous dq and dk
             # SDPA produces contiguous dq and incontiguous dk
@@ -323,51 +281,6 @@ if MLLAMA_AVAILABLE:
         ),
     )
 
-if QWEN2_VL_AVAILABLE:
-    MINI_MODEL_SETUPS["mini_qwen2_vl"] = MiniModelConfig(
-        liger_kernel_patch_func=apply_liger_kernel_to_qwen2_vl,
-        liger_kernel_patch_revert_func=revert_liger_kernel_to_qwen2_vl,
-        model_class=Qwen2VLForConditionalGeneration,
-        mini_model_config=Qwen2VLConfig(
-            attention_dropout=0.0,
-            bos_token_id=1,  # 151643
-            eos_token_id=2,  # 151645
-            hidden_act="silu",
-            hidden_size=1536,  # 8192
-            initializer_range=0.02,
-            intermediate_size=4864,  # 29568
-            max_position_embeddings=32768,
-            max_window_layers=4,  # 80
-            num_attention_heads=12,  # 64
-            num_hidden_layers=4,  # 80
-            num_key_value_heads=2,  # 8
-            rms_norm_eps=1e-6,  # 1e-5
-            rope_theta=1000000.0,
-            rope_scaling=dict(
-                type="mrope",
-                mrope_section=[16, 24, 24],  # (temporal, height, width)
-            ),
-            sliding_window=4096,
-            tie_word_embeddings=False,
-            use_cache=True,
-            vocab_size=32000,  # 152064
-            use_sliding_window=False,
-            vision_config={
-                "depth": 4,  # 32
-                "embed_dim": 1280,
-                "mlp_ratio": 4,
-                "num_heads": 16,
-                "in_chans": 3,
-                "hidden_size": 128,  # 1536
-                "patch_size": 14,
-                "spatial_merge_size": 2,
-                "spatial_patch_size": 14,
-                "temporal_patch_size": 2,
-            },
-            attn_implementation="sdpa",
-        ),
-    )
-
 
 def create_model(model_name="mini_llama3"):
     """
@@ -396,14 +309,9 @@ def run_mini_model(
     if with_liger is True:
         kwargs = {
             "rms_norm": True,
+            "rope": True,
+            "layer_norm": True,
         }
-        model_supports_rope = "qwen2_vl" not in model_name
-        if model_supports_rope:
-            kwargs["rope"] = True
-
-        model_supports_layer_norm = "qwen2_vl" in model_name
-        if model_supports_layer_norm:
-            kwargs["layer_norm"] = True
 
         if "gemma" in model_name:
             kwargs["geglu"] = True
@@ -514,43 +422,6 @@ def run_mini_model(
         #     marks=pytest.mark.skipif(
         #         not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
         #     ),
-        # ),
-        pytest.param(
-            "mini_qwen2_vl",
-            32,
-            1e-4,
-            torch.float32,
-            1e-8,
-            1e-5,
-            5e-3,
-            1e-5,
-            5e-3,
-            1e-5,
-            marks=pytest.mark.skipif(
-                not QWEN2_VL_AVAILABLE,
-                reason="Qwen2-VL not available in this version of transformers",
-            ),
-        ),
-        # pytest.param(
-        #     "mini_qwen2_vl",
-        #     32,
-        #     1e-4,
-        #     torch.bfloat16,
-        #     1e-3,
-        #     1e-2,
-        #     1e-1,
-        #     1e-2,
-        #     1e-2,
-        #     1e-2,
-        #     marks=[
-        #         pytest.mark.skipif(
-        #             not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
-        #         ),
-        #         pytest.mark.skipif(
-        #             not QWEN2_VL_AVAILABLE,
-        #             reason="Qwen2-VL not available in this version of transformers",
-        #         ),
-        #     ],
         # ),
         ("mini_phi3", 32, 1e-4, torch.float32, 1e-8, 1e-5, 5e-3, 1e-5, 5e-3, 1e-5),
         # pytest.param(

--- a/test/convergence/test_mini_models_multimodal.py
+++ b/test/convergence/test_mini_models_multimodal.py
@@ -147,6 +147,7 @@ if QWEN2_VL_AVAILABLE:
             vision_end_token_id=2,
             vision_token_id=3,
             image_token_id=4,
+            video_token_id=5,
             hidden_act="silu",
             hidden_size=1024,  # 8192
             initializer_range=0.02,
@@ -315,7 +316,8 @@ def run_mini_model_multimodal(
     if with_liger is True:
         kwargs = {
             "rms_norm": True,
-            "cross_entropy": True,
+            "fused_linear_cross_entropy": True,
+            "cross_entropy": False,
             "layer_norm": True,
         }
         model_supports_rope = "qwen2_vl" not in model_name

--- a/test/convergence/test_mini_models_multimodal.py
+++ b/test/convergence/test_mini_models_multimodal.py
@@ -147,7 +147,6 @@ if QWEN2_VL_AVAILABLE:
             vision_end_token_id=2,
             vision_token_id=3,
             image_token_id=4,
-            video_token_id=5,
             hidden_act="silu",
             hidden_size=1024,  # 8192
             initializer_range=0.02,


### PR DESCRIPTION
## Summary
Qwen2-VL tests are failing with AttributeErrors using the latest version of transformers. transformers has modified the Qwen2-VL modeling code and so we need to update to stay compatible.

https://github.com/linkedin/Liger-Kernel/issues/355

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
