### PR TITLE
Qwen2-VL Bug / Incompatibility Fixes

### DIFF
--- a/src/liger_kernel/transformers/model/qwen2_vl.py
+++ b/src/liger_kernel/transformers/model/qwen2_vl.py
@@ -2,6 +2,10 @@ from typing import List, Optional, Tuple, Union
 
 import torch
 from torch.nn import CrossEntropyLoss
+
+from liger_kernel.transformers.fused_linear_cross_entropy import (
+    LigerFusedLinearCrossEntropyLoss,
+)
 from transformers.models.qwen2_vl.modeling_qwen2_vl import (
     _CONFIG_FOR_DOC,
     QWEN2_VL_INPUTS_DOCSTRING,
@@ -10,10 +14,6 @@ from transformers.models.qwen2_vl.modeling_qwen2_vl import (
 from transformers.utils import (
     add_start_docstrings_to_model_forward,
     replace_return_docstrings,
-)
-
-from liger_kernel.transformers.fused_linear_cross_entropy import (
-    LigerFusedLinearCrossEntropyLoss,
 )
 
 
@@ -81,7 +81,6 @@ def lce_forward(
     "The image shows a street scene with a red stop sign in the foreground. In the background, there is a large red gate with Chinese characters ..."
     ```"""
     # FIXME: The code is outdated and not compatible with transformer >= 4.46.1
-
     output_attentions = (
         output_attentions
         if output_attentions is not None
@@ -100,23 +99,43 @@ def lce_forward(
         inputs_embeds = self.model.embed_tokens(input_ids)
         if pixel_values is not None:
             pixel_values = pixel_values.type(self.visual.get_dtype())
-            image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw).to(
-                inputs_embeds.device
+            image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
+            n_image_tokens = (input_ids == self.config.image_token_id).sum().item()
+            n_image_features = image_embeds.shape[0]
+            if n_image_tokens != n_image_features:
+                raise ValueError(
+                    f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
+                )
+            image_mask = (
+                (input_ids == self.config.image_token_id)
+                .unsqueeze(-1)
+                .expand_as(inputs_embeds)
+                .to(inputs_embeds.device)
             )
-            image_mask = input_ids == self.config.image_token_id
-            if self.training:
-                inputs_embeds = inputs_embeds.clone()
-            inputs_embeds[image_mask] = image_embeds
+            image_embeds = image_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+
         if pixel_values_videos is not None:
             pixel_values_videos = pixel_values_videos.type(self.visual.get_dtype())
-            video_embeds = self.visual(pixel_values_videos, grid_thw=video_grid_thw).to(
-                inputs_embeds.device
+            video_embeds = self.visual(pixel_values_videos, grid_thw=video_grid_thw)
+            n_video_tokens = (input_ids == self.config.video_token_id).sum().item()
+            n_video_features = video_embeds.shape[0]
+            if n_video_tokens != n_video_features:
+                raise ValueError(
+                    f"Video features and video tokens do not match: tokens: {n_video_tokens}, features {n_video_features}"
+                )
+            video_mask = (
+                (input_ids == self.config.video_token_id)
+                .unsqueeze(-1)
+                .expand_as(inputs_embeds)
+                .to(inputs_embeds.device)
             )
-            video_mask = input_ids == self.config.video_token_id
-            inputs_embeds[video_mask] = video_embeds
+            video_embeds = video_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
+
         if attention_mask is not None:
             attention_mask = attention_mask.to(inputs_embeds.device)
-    # The code is copied from https://github.com/huggingface/transformers/pull/33487
+
     if position_ids is None and input_ids is not None:
         position_ids, _ = self.get_rope_index(
             input_ids, image_grid_thw, video_grid_thw, attention_mask

--- a/src/liger_kernel/transformers/model/qwen2_vl.py
+++ b/src/liger_kernel/transformers/model/qwen2_vl.py
@@ -142,7 +142,7 @@ def lce_forward(
         # https://github.com/huggingface/transformers/issues/33401
         # While correct, this breaks equivalence with past versions of Qwen2-VL from
         # transformers and leads to failed tests or users noticing differences in results.
-        # TODO: remove the above conditional when liker-kernel drops support for transformers < 4.47.0
+        # TODO: remove above conditional when liger drops support for transformers<4.47.0
         if position_ids is None and input_ids is not None:
             position_ids, _ = self.get_rope_index(
                 input_ids, image_grid_thw, video_grid_thw, attention_mask

--- a/src/liger_kernel/transformers/model/qwen2_vl.py
+++ b/src/liger_kernel/transformers/model/qwen2_vl.py
@@ -82,7 +82,6 @@ def lce_forward(
     >>> tokenizer.batch_decode(generate_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)[0]
     "The image shows a street scene with a red stop sign in the foreground. In the background, there is a large red gate with Chinese characters ..."
     ```"""
-    # FIXME: The code is outdated and not compatible with transformer >= 4.46.1
     output_attentions = (
         output_attentions
         if output_attentions is not None

--- a/test/convergence/test_mini_models.py
+++ b/test/convergence/test_mini_models.py
@@ -1,20 +1,3 @@
-from test.utils import (
-    DEFAULT_DATASET_PATH,
-    MiniModelConfig,
-    assert_verbose_allclose,
-    revert_liger_kernel_to_gemma,
-    revert_liger_kernel_to_gemma2,
-    revert_liger_kernel_to_llama,
-    revert_liger_kernel_to_mistral,
-    revert_liger_kernel_to_mixtral,
-    revert_liger_kernel_to_mllama,
-    revert_liger_kernel_to_phi3,
-    revert_liger_kernel_to_qwen2,
-    revert_liger_kernel_to_qwen2_vl,
-    set_seed,
-    simple_collate_fn,
-)
-
 import pytest
 import torch
 from datasets import load_from_disk
@@ -37,6 +20,23 @@ from liger_kernel.transformers import (
     apply_liger_kernel_to_phi3,
     apply_liger_kernel_to_qwen2,
     apply_liger_kernel_to_qwen2_vl,
+)
+from test.utils import (
+    DEFAULT_DATASET_PATH,
+    MiniModelConfig,
+    assert_verbose_allclose,
+    revert_liger_kernel_to_gemma,
+    revert_liger_kernel_to_gemma2,
+    revert_liger_kernel_to_llama,
+    revert_liger_kernel_to_mistral,
+    revert_liger_kernel_to_mixtral,
+    revert_liger_kernel_to_mllama,
+    revert_liger_kernel_to_phi3,
+    revert_liger_kernel_to_qwen2,
+    revert_liger_kernel_to_qwen2_vl,
+    set_seed,
+    simple_collate_fn,
+    supports_bfloat16,
 )
 
 try:
@@ -332,6 +332,11 @@ if QWEN2_VL_AVAILABLE:
             attention_dropout=0.0,
             bos_token_id=1,  # 151643
             eos_token_id=2,  # 151645
+            vision_start_token_id=31995,
+            vision_end_token_id=31996,
+            vision_token_id=31997,
+            image_token_id=31998,
+            video_token_id=31999,
             hidden_act="silu",
             hidden_size=1536,  # 8192
             initializer_range=0.02,
@@ -516,22 +521,23 @@ def run_mini_model(
         #     ),
         # ),
         # FIXME qwen2 is broken and needs fix
-        # pytest.param(
-        #     "mini_qwen2_vl",
-        #     32,
-        #     1e-4,
-        #     torch.float32,
-        #     1e-8,
-        #     1e-5,
-        #     5e-3,
-        #     1e-5,
-        #     5e-3,
-        #     1e-5,
-        #     marks=pytest.mark.skipif(
-        #         not QWEN2_VL_AVAILABLE,
-        #         reason="Qwen2-VL not available in this version of transformers",
-        #     ),
-        # ),
+        # Note: broken with transformers 4.46.2 and 4.45.2
+        pytest.param(
+            "mini_qwen2_vl",
+            32,
+            1e-4,
+            torch.float32,
+            1e-8,
+            1e-5,
+            5e-3,
+            1e-5,
+            5e-3,
+            1e-5,
+            marks=pytest.mark.skipif(
+                not QWEN2_VL_AVAILABLE,
+                reason="Qwen2-VL not available in this version of transformers",
+            ),
+        ),
         # pytest.param(
         #     "mini_qwen2_vl",
         #     32,

--- a/test/convergence/test_mini_models.py
+++ b/test/convergence/test_mini_models.py
@@ -356,7 +356,7 @@ if QWEN2_VL_AVAILABLE:
                 mrope_section=[16, 24, 24],  # (temporal, height, width)
             ),
             sliding_window=4096,
-            tie_word_embeddings=True,
+            tie_word_embeddings=False,
             use_cache=True,
             vocab_size=32768,  # 152064  # >32k, Mistral-7B tokenizer vocab size
             use_sliding_window=False,
@@ -454,7 +454,6 @@ def run_mini_model(
 
 
 @pytest.mark.parametrize(
-    # FIXME enable bf16 tests after revert is fixed
     "model_name, num_steps, lr, dtype, loss_atol, loss_rtol, logits_atol, logits_rtol, param_atol, param_rtol",
     [
         ("mini_llama3", 32, 1e-4, torch.float32, 1e-8, 2e-5, 1e-4, 1e-5, 5e-3, 1e-5),
@@ -526,8 +525,6 @@ def run_mini_model(
                 not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
             ),
         ),
-        # FIXME qwen2 is broken and needs fix
-        # Note: broken with transformers 4.46.2 and 4.45.2
         pytest.param(
             "mini_qwen2_vl",
             32,

--- a/test/convergence/test_mini_models.py
+++ b/test/convergence/test_mini_models.py
@@ -525,13 +525,13 @@ def run_mini_model(
                 not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
             ),
         ),
-        pytest.param(
+        pytest.param(  # qwen2_vl requires slightly larger tolerances to pass this test after bug fix to qwen2_vl in transformers v4.47.0
             "mini_qwen2_vl",
             32,
             1e-4,
             torch.float32,
-            1e-8,
-            1e-5,
+            8e-6,  # 1e-8,
+            2e-5,  # 1e-5,
             5e-3,
             1e-5,
             5e-3,

--- a/test/convergence/test_mini_models_multimodal.py
+++ b/test/convergence/test_mini_models_multimodal.py
@@ -18,7 +18,7 @@ import pytest
 import torch
 from datasets import load_dataset
 from torch.utils.data import DataLoader
-from transformer import PreTrainedTokenizerFast
+from transformers import PreTrainedTokenizerFast
 
 from liger_kernel.transformers import (
     apply_liger_kernel_to_mllama,

--- a/test/convergence/test_mini_models_multimodal.py
+++ b/test/convergence/test_mini_models_multimodal.py
@@ -1,5 +1,18 @@
 import functools
 import os
+from test.utils import (
+    FAKE_CONFIGS_PATH,
+    UNTOKENIZED_DATASET_PATH,
+    MiniModelConfig,
+    assert_verbose_allclose,
+    load_tokenizer_config,
+    multimodal_collate_fn,
+    revert_liger_kernel_to_mllama,
+    revert_liger_kernel_to_qwen2_vl,
+    set_seed,
+    supports_bfloat16,
+    train_bpe_tokenizer,
+)
 
 import pytest
 import torch
@@ -10,18 +23,6 @@ from transformer import PreTrainedTokenizerFast
 from liger_kernel.transformers import (
     apply_liger_kernel_to_mllama,
     apply_liger_kernel_to_qwen2_vl,
-)
-from test.utils import (
-    FAKE_CONFIGS_PATH,
-    UNTOKENIZED_DATASET_PATH,
-    assert_verbose_allclose,
-    load_tokenizer_config,
-    multimodal_collate_fn,
-    revert_liger_kernel_to_mllama,
-    revert_liger_kernel_to_qwen2_vl,
-    set_seed,
-    supports_bfloat16,
-    train_bpe_tokenizer,
 )
 
 try:

--- a/test/convergence/test_mini_models_multimodal.py
+++ b/test/convergence/test_mini_models_multimodal.py
@@ -1,9 +1,19 @@
 import functools
 import os
+
+import pytest
+import torch
+from datasets import load_dataset
+from torch.utils.data import DataLoader
+from transformer import PreTrainedTokenizerFast
+
+from liger_kernel.transformers import (
+    apply_liger_kernel_to_mllama,
+    apply_liger_kernel_to_qwen2_vl,
+)
 from test.utils import (
     FAKE_CONFIGS_PATH,
     UNTOKENIZED_DATASET_PATH,
-    MiniModelConfig,
     assert_verbose_allclose,
     load_tokenizer_config,
     multimodal_collate_fn,
@@ -12,17 +22,6 @@ from test.utils import (
     set_seed,
     supports_bfloat16,
     train_bpe_tokenizer,
-)
-
-import pytest
-import torch
-from datasets import load_dataset
-from torch.utils.data import DataLoader
-from transformers import PreTrainedTokenizerFast
-
-from liger_kernel.transformers import (
-    apply_liger_kernel_to_mllama,
-    apply_liger_kernel_to_qwen2_vl,
 )
 
 try:
@@ -140,13 +139,14 @@ if QWEN2_VL_AVAILABLE:
         mini_model_config=Qwen2VLConfig(
             attention_dropout=0.0,
             # Token Ids and vocab size must match those in the tokenizer/processor
-            # https://huggingface.co/Qwen/Qwen2-VL-7B-Instruct/blob/main/config.json
+            # test/resources/fake_configs/Qwen/Qwen2-VL-7B-Instruct/tokenizer_config.json
             bos_token_id=0,
             eos_token_id=0,
             vision_start_token_id=1,
             vision_end_token_id=2,
             vision_token_id=3,
             image_token_id=4,
+            video_token_id=5,
             hidden_act="silu",
             hidden_size=1024,  # 8192
             initializer_range=0.02,

--- a/test/convergence/test_mini_models_with_logits.py
+++ b/test/convergence/test_mini_models_with_logits.py
@@ -1,20 +1,3 @@
-from test.utils import (
-    DEFAULT_DATASET_PATH,
-    MiniModelConfig,
-    assert_verbose_allclose,
-    revert_liger_kernel_to_gemma,
-    revert_liger_kernel_to_gemma2,
-    revert_liger_kernel_to_llama,
-    revert_liger_kernel_to_mistral,
-    revert_liger_kernel_to_mixtral,
-    revert_liger_kernel_to_mllama,
-    revert_liger_kernel_to_phi3,
-    revert_liger_kernel_to_qwen2,
-    revert_liger_kernel_to_qwen2_vl,
-    set_seed,
-    simple_collate_fn,
-)
-
 import pytest
 import torch
 from datasets import load_from_disk
@@ -37,6 +20,23 @@ from liger_kernel.transformers import (
     apply_liger_kernel_to_phi3,
     apply_liger_kernel_to_qwen2,
     apply_liger_kernel_to_qwen2_vl,
+)
+from test.utils import (
+    DEFAULT_DATASET_PATH,
+    MiniModelConfig,
+    assert_verbose_allclose,
+    revert_liger_kernel_to_gemma,
+    revert_liger_kernel_to_gemma2,
+    revert_liger_kernel_to_llama,
+    revert_liger_kernel_to_mistral,
+    revert_liger_kernel_to_mixtral,
+    revert_liger_kernel_to_mllama,
+    revert_liger_kernel_to_phi3,
+    revert_liger_kernel_to_qwen2,
+    revert_liger_kernel_to_qwen2_vl,
+    set_seed,
+    simple_collate_fn,
+    supports_bfloat16,
 )
 
 try:
@@ -332,6 +332,11 @@ if QWEN2_VL_AVAILABLE:
             attention_dropout=0.0,
             bos_token_id=1,  # 151643
             eos_token_id=2,  # 151645
+            vision_start_token_id=31995,
+            vision_end_token_id=31996,
+            vision_token_id=31997,
+            image_token_id=31998,
+            video_token_id=31999,
             hidden_act="silu",
             hidden_size=1536,  # 8192
             initializer_range=0.02,
@@ -516,43 +521,44 @@ def run_mini_model(
         #     ),
         # ),
         # FIXME qwen2 is broken and needs fix
-        # pytest.param(
-        #     "mini_qwen2_vl",
-        #     32,
-        #     1e-4,
-        #     torch.float32,
-        #     1e-8,
-        #     1e-5,
-        #     5e-3,
-        #     1e-5,
-        #     5e-3,
-        #     1e-5,
-        #     marks=pytest.mark.skipif(
-        #         not QWEN2_VL_AVAILABLE,
-        #         reason="Qwen2-VL not available in this version of transformers",
-        #     ),
-        # ),
-        # pytest.param(
-        #     "mini_qwen2_vl",
-        #     32,
-        #     1e-4,
-        #     torch.bfloat16,
-        #     1e-3,
-        #     1e-2,
-        #     1e-1,
-        #     1e-2,
-        #     1e-2,
-        #     1e-2,
-        #     marks=[
-        #         pytest.mark.skipif(
-        #             not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
-        #         ),
-        #         pytest.mark.skipif(
-        #             not QWEN2_VL_AVAILABLE,
-        #             reason="Qwen2-VL not available in this version of transformers",
-        #         ),
-        #     ],
-        # ),
+        # Note: works with transformers 4.46.2 and 4.45.2
+        pytest.param(
+            "mini_qwen2_vl",
+            32,
+            1e-4,
+            torch.float32,
+            1e-8,
+            1e-5,
+            5e-3,
+            1e-5,
+            5e-3,
+            1e-5,
+            marks=pytest.mark.skipif(
+                not QWEN2_VL_AVAILABLE,
+                reason="Qwen2-VL not available in this version of transformers",
+            ),
+        ),
+        pytest.param(
+            "mini_qwen2_vl",
+            32,
+            1e-4,
+            torch.bfloat16,
+            1e-3,
+            1e-2,
+            1e-1,
+            1e-2,
+            1e-2,
+            1e-2,
+            marks=[
+                pytest.mark.skipif(
+                    not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
+                ),
+                pytest.mark.skipif(
+                    not QWEN2_VL_AVAILABLE,
+                    reason="Qwen2-VL not available in this version of transformers",
+                ),
+            ],
+        ),
         ("mini_phi3", 32, 1e-4, torch.float32, 1e-8, 1e-5, 5e-3, 1e-5, 5e-3, 1e-5),
         # pytest.param(
         #     "mini_phi3",

--- a/test/convergence/test_mini_models_with_logits.py
+++ b/test/convergence/test_mini_models_with_logits.py
@@ -427,8 +427,6 @@ def run_mini_model(
 
         MINI_MODEL_SETUPS[model_name].liger_kernel_patch_func(**kwargs)
     else:
-        ...
-        # FIXME: disable revert because it will cause flce to not be patched
         MINI_MODEL_SETUPS[model_name].liger_kernel_patch_revert_func(**revert_kwargs)
 
     model = create_model(model_name).to(dtype).to("cuda")
@@ -455,7 +453,6 @@ def run_mini_model(
 
 
 @pytest.mark.parametrize(
-    # FIXME enable bf16 tests after revert is fixed
     "model_name, num_steps, lr, dtype, loss_atol, loss_rtol, logits_atol, logits_rtol, param_atol, param_rtol",
     [
         ("mini_llama3", 32, 1e-4, torch.float32, 1e-8, 2e-5, 1e-4, 1e-5, 5e-3, 1e-5),
@@ -527,8 +524,6 @@ def run_mini_model(
                 not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
             ),
         ),
-        # FIXME qwen2 is broken and needs fix
-        # Note: works with transformers 4.46.2 and 4.45.2
         pytest.param(
             "mini_qwen2_vl",
             32,

--- a/test/convergence/test_mini_models_with_logits.py
+++ b/test/convergence/test_mini_models_with_logits.py
@@ -1,3 +1,21 @@
+from test.utils import (
+    DEFAULT_DATASET_PATH,
+    MiniModelConfig,
+    assert_verbose_allclose,
+    revert_liger_kernel_to_gemma,
+    revert_liger_kernel_to_gemma2,
+    revert_liger_kernel_to_llama,
+    revert_liger_kernel_to_mistral,
+    revert_liger_kernel_to_mixtral,
+    revert_liger_kernel_to_mllama,
+    revert_liger_kernel_to_phi3,
+    revert_liger_kernel_to_qwen2,
+    revert_liger_kernel_to_qwen2_vl,
+    set_seed,
+    simple_collate_fn,
+    supports_bfloat16,
+)
+
 import pytest
 import torch
 from datasets import load_from_disk
@@ -20,23 +38,6 @@ from liger_kernel.transformers import (
     apply_liger_kernel_to_phi3,
     apply_liger_kernel_to_qwen2,
     apply_liger_kernel_to_qwen2_vl,
-)
-from test.utils import (
-    DEFAULT_DATASET_PATH,
-    MiniModelConfig,
-    assert_verbose_allclose,
-    revert_liger_kernel_to_gemma,
-    revert_liger_kernel_to_gemma2,
-    revert_liger_kernel_to_llama,
-    revert_liger_kernel_to_mistral,
-    revert_liger_kernel_to_mixtral,
-    revert_liger_kernel_to_mllama,
-    revert_liger_kernel_to_phi3,
-    revert_liger_kernel_to_qwen2,
-    revert_liger_kernel_to_qwen2_vl,
-    set_seed,
-    simple_collate_fn,
-    supports_bfloat16,
 )
 
 try:
@@ -330,13 +331,15 @@ if QWEN2_VL_AVAILABLE:
         model_class=Qwen2VLForConditionalGeneration,
         mini_model_config=Qwen2VLConfig(
             attention_dropout=0.0,
+            # bos and eos set to match the Mistral-7B tokenizer used to create the test dataset
+            # https://huggingface.co/mistralai/Mistral-7B-v0.1/blob/main/config.json
             bos_token_id=1,  # 151643
             eos_token_id=2,  # 151645
-            vision_start_token_id=31995,
-            vision_end_token_id=31996,
-            vision_token_id=31997,
-            image_token_id=31998,
-            video_token_id=31999,
+            vision_start_token_id=32765,  # vocab_size - 5
+            vision_end_token_id=32766,  # vocab_size - 4
+            vision_token_id=32767,  # vocab_size - 3
+            image_token_id=32768,  # vocab_size - 2
+            video_token_id=32769,  # vocab_size - 1
             hidden_act="silu",
             hidden_size=1536,  # 8192
             initializer_range=0.02,
@@ -355,7 +358,7 @@ if QWEN2_VL_AVAILABLE:
             sliding_window=4096,
             tie_word_embeddings=False,
             use_cache=True,
-            vocab_size=32000,  # 152064
+            vocab_size=32768,  # 152064  # >32k, Mistral-7B tokenizer vocab size
             use_sliding_window=False,
             vision_config={
                 "depth": 4,  # 32

--- a/test/resources/fake_configs/Qwen/Qwen2-VL-7B-Instruct/tokenizer_config.json
+++ b/test/resources/fake_configs/Qwen/Qwen2-VL-7B-Instruct/tokenizer_config.json
@@ -39,6 +39,14 @@
         "rstrip": false,
         "single_word": false,
         "special": true
+      },
+      "5": {
+        "content": "<|video_pad|>",
+        "lstrip": false,
+        "normalized": false,
+        "rstrip": false,
+        "single_word": false,
+        "special": true
       }
     },
     "additional_special_tokens": ["<|im_start|>", "<|im_end|>", "<|object_ref_start|>","<|object_ref_end|>","<|box_start|>","<|box_end|>","<|quad_start|>","<|quad_end|>","<|vision_start|>","<|vision_end|>","<|vision_pad|>","<|image_pad|>","<|video_pad|>"],


### PR DESCRIPTION
## Summary
Two fixes:
1. https://github.com/linkedin/Liger-Kernel/pull/276/files created a backwards-incompatible change. So that when users use transformers < 4.47.0.dev0 they will see different behavior from liger (which mimics behavior of 4.47.0.dev0). By adding a conditional we can support the behavior of all versions of transformers that include qwen2_vl.
2. Recent versions of qwen2_vl from transformers make various qwen2_vl specific tokens mandatory to specify, so those are now specified to avoid AttributeErrors.

## Testing Done
Tested locally against both transformers 4.46.2 and transformers 4.47.0.dev0 (from git+https://github.com/huggingface/transformers.git@52ea4aa589324bae43dfb1b6db70335da7b68654)

- Hardware Type: RTX 4090
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
