### PR TITLE
Fix incomplete RMSNorm patch

### DIFF
--- a/test/transformers/test_monkey_patch.py
+++ b/test/transformers/test_monkey_patch.py
@@ -268,6 +268,12 @@ def test_apply_liger_kernel_to_instance_for_llama():
                 layer.post_attention_layernorm.forward
             ) == inspect.getsource(LigerRMSNorm.forward)
 
+        # Ensure that the model patched with Liger modules can work properly
+        try:
+            print(dummy_model_instance)
+        except Exception as e:
+            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+
 
 @pytest.mark.skipif(not is_mllama_available(), reason="mllama module not available")
 def test_apply_liger_kernel_to_instance_for_mllama_for_conditional_generation():
@@ -382,6 +388,11 @@ def test_apply_liger_kernel_to_instance_for_mllama_for_conditional_generation():
                 layer.post_attention_layernorm.forward
             ) == inspect.getsource(LigerLayerNorm.forward)
 
+        try:
+            print(dummy_model_instance)
+        except Exception as e:
+            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+
 
 @pytest.mark.skipif(not is_mllama_available(), reason="mllama module not available")
 def test_apply_liger_kernel_to_instance_for_mllama_for_causal_lm():
@@ -440,6 +451,11 @@ def test_apply_liger_kernel_to_instance_for_mllama_for_causal_lm():
                 layer.post_attention_layernorm.forward
             ) == inspect.getsource(LigerRMSNorm.forward)
 
+        try:
+            print(dummy_model_instance)
+        except Exception as e:
+            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+
 
 def test_apply_liger_kernel_to_instance_for_mistral():
     # Ensure any monkey patching is cleaned up for subsequent tests
@@ -487,6 +503,11 @@ def test_apply_liger_kernel_to_instance_for_mistral():
             assert inspect.getsource(
                 layer.post_attention_layernorm.forward
             ) == inspect.getsource(LigerRMSNorm.forward)
+
+        try:
+            print(dummy_model_instance)
+        except Exception as e:
+            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
 
 
 def test_apply_liger_kernel_to_instance_for_mixtral():
@@ -540,6 +561,11 @@ def test_apply_liger_kernel_to_instance_for_mixtral():
                 layer.post_attention_layernorm.forward
             ) == inspect.getsource(LigerRMSNorm.forward)
 
+        try:
+            print(dummy_model_instance)
+        except Exception as e:
+            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+
 
 def test_apply_liger_kernel_to_instance_for_gemma():
     # Ensure any monkey patching is cleaned up for subsequent tests
@@ -587,6 +613,11 @@ def test_apply_liger_kernel_to_instance_for_gemma():
             assert inspect.getsource(
                 layer.post_attention_layernorm.forward
             ) == inspect.getsource(LigerRMSNorm.forward)
+
+        try:
+            print(dummy_model_instance)
+        except Exception as e:
+            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
 
 
 def test_apply_liger_kernel_to_instance_for_gemma2():
@@ -648,6 +679,11 @@ def test_apply_liger_kernel_to_instance_for_gemma2():
                 layer.post_feedforward_layernorm.forward
             ) == inspect.getsource(LigerRMSNorm.forward)
 
+        try:
+            print(dummy_model_instance)
+        except Exception as e:
+            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+
 
 def test_apply_liger_kernel_to_instance_for_qwen2():
     # Ensure any monkey patching is cleaned up for subsequent tests
@@ -695,6 +731,11 @@ def test_apply_liger_kernel_to_instance_for_qwen2():
             assert inspect.getsource(
                 layer.post_attention_layernorm.forward
             ) == inspect.getsource(LigerRMSNorm.forward)
+
+        try:
+            print(dummy_model_instance)
+        except Exception as e:
+            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_qwen2_vl_available(), reason="qwen2_vl module not available")
@@ -775,6 +816,11 @@ def test_apply_liger_kernel_to_instance_for_qwen2_vl():
                 LigerLayerNorm.forward
             )
 
+        try:
+            print(dummy_model_instance)
+        except Exception as e:
+            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+
 
 def test_apply_liger_kernel_to_instance_for_phi3():
     # Ensure any monkey patching is cleaned up for subsequent tests
@@ -822,3 +868,8 @@ def test_apply_liger_kernel_to_instance_for_phi3():
             assert inspect.getsource(
                 layer.post_attention_layernorm.forward
             ) == inspect.getsource(LigerRMSNorm.forward)
+
+        try:
+            print(dummy_model_instance)
+        except Exception as e:
+            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")


### PR DESCRIPTION
## Summary
Fix #383, #390.
RMSNorm wasn't fully patched to already-instantiated modules, missing `in_place` attribute when patching.

## Testing Done

Added an extra_expr test after patching an instantiated model
Before fix:
```
=============================================== short test summary info ================================================
FAILED test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_llama - Failed: An exception occured in extra_expr: AttributeError - 'LlamaRMSNorm' object has no attribute 'in_place'
FAILED test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_mllama_for_conditional_generation - Failed: An exception occured in extra_expr: AttributeError - 'MllamaTextRMSNorm' object has no attribute 'in_place'
FAILED test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_mllama_for_causal_lm - Failed: An exception occured in extra_expr: AttributeError - 'MllamaTextRMSNorm' object has no attribute 'in_place'
FAILED test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_mistral - Failed: An exception occured in extra_expr: AttributeError - 'MistralRMSNorm' object has no attribute 'in_place'
FAILED test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_mixtral - Failed: An exception occured in extra_expr: AttributeError - 'MixtralRMSNorm' object has no attribute 'in_place'
FAILED test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_gemma - Failed: An exception occured in extra_expr: AttributeError - 'GemmaRMSNorm' object has no attribute 'in_place'
FAILED test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_gemma2 - TypeError: _patch_rms_norm_module() got an unexpected keyword argument 'in_place'
FAILED test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2 - Failed: An exception occured in extra_expr: AttributeError - 'Qwen2RMSNorm' object has no attribute 'in_place'
FAILED test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2_vl - Failed: An exception occured in extra_expr: AttributeError - 'Qwen2RMSNorm' object has no attribute 'in_place'
FAILED test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_phi3 - Failed: An exception occured in extra_expr: AttributeError - 'Phi3RMSNorm' object has no attribute 'in_place'
======================================= 10 failed, 9 passed, 2 warnings in 3.57s =======================================
```
After fix:
```
╰─ python -m pytest test/transformers/test_monkey_patch.py
================================================= test session starts ==================================================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/tcc/Liger-Kernel
configfile: pyproject.toml
collected 19 items

test/transformers/test_monkey_patch.py::test_import_from_root PASSED                                             [  5%]
test/transformers/test_monkey_patch.py::test_apply_liger_kernel_no_supported_model_type
---------------------------------------------------- live log call -----------------------------------------------------
INFO     liger_kernel.transformers.monkey_patch:monkey_patch.py:827 There are currently no Liger kernels supported for model type: foobar.
PASSED                                                                                                           [ 10%]
test/transformers/test_monkey_patch.py::test_apply_liger_kernel_only_supported_model_type_called
---------------------------------------------------- live log call -----------------------------------------------------
INFO     liger_kernel.transformers.monkey_patch:monkey_patch.py:842 Applying Liger kernels for model type: llama with kwargs: {}
PASSED                                                                                                           [ 15%]
test/transformers/test_monkey_patch.py::test_apply_liger_kernel_only_passes_valid_kwargs
---------------------------------------------------- live log call -----------------------------------------------------
INFO     liger_kernel.transformers.monkey_patch:monkey_patch.py:842 Applying Liger kernels for model type: llama with kwargs: {'rope': False, 'fused_linear_cross_entropy': False, 'cross_entropy': True}
PASSED                                                                                                           [ 21%]
test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_no_supported_model_type
---------------------------------------------------- live log call -----------------------------------------------------
INFO     liger_kernel.transformers.monkey_patch:monkey_patch.py:863 Model type could not be determined from model config. No Liger kernels will be applied.
PASSED                                                                                                           [ 26%]
test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_only_supported_model_type_called
---------------------------------------------------- live log call -----------------------------------------------------
INFO     liger_kernel.transformers.monkey_patch:monkey_patch.py:884 Applying Liger kernels to model instance with model type: llama with kwargs: {}
PASSED                                                                                                           [ 31%]
test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_only_passes_valid_kwargs
---------------------------------------------------- live log call -----------------------------------------------------
INFO     liger_kernel.transformers.monkey_patch:monkey_patch.py:884 Applying Liger kernels to model instance with model type: llama with kwargs: {'rope': False, 'fused_linear_cross_entropy': False, 'cross_entropy': True}
PASSED                                                                                                           [ 36%]
test/transformers/test_monkey_patch.py::test_patching_apis_match_auto_mapping PASSED                             [ 42%]
test/transformers/test_monkey_patch.py::test_patching_apis_support_patching_model_instance PASSED                [ 47%]
test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_llama
---------------------------------------------------- live log call -----------------------------------------------------
INFO     liger_kernel.transformers.monkey_patch:monkey_patch.py:884 Applying Liger kernels to model instance with model type: llama with kwargs: {}
PASSED                                                                                                           [ 52%]
test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_mllama_for_conditional_generation
---------------------------------------------------- live log call -----------------------------------------------------
INFO     liger_kernel.transformers.monkey_patch:monkey_patch.py:884 Applying Liger kernels to model instance with model type: mllama with kwargs: {}
PASSED                                                                                                           [ 57%]
test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_mllama_for_causal_lm
---------------------------------------------------- live log call -----------------------------------------------------
INFO     liger_kernel.transformers.monkey_patch:monkey_patch.py:884 Applying Liger kernels to model instance with model type: mllama_text_model with kwargs: {}
PASSED                                                                                                           [ 63%]
test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_mistral
---------------------------------------------------- live log call -----------------------------------------------------
INFO     liger_kernel.transformers.monkey_patch:monkey_patch.py:884 Applying Liger kernels to model instance with model type: mistral with kwargs: {}
PASSED                                                                                                           [ 68%]
test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_mixtral
---------------------------------------------------- live log call -----------------------------------------------------
INFO     liger_kernel.transformers.monkey_patch:monkey_patch.py:884 Applying Liger kernels to model instance with model type: mixtral with kwargs: {}
PASSED                                                                                                           [ 73%]
test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_gemma
---------------------------------------------------- live log call -----------------------------------------------------
INFO     liger_kernel.transformers.monkey_patch:monkey_patch.py:884 Applying Liger kernels to model instance with model type: gemma with kwargs: {}
PASSED                                                                                                           [ 78%]
test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_gemma2
---------------------------------------------------- live log call -----------------------------------------------------
INFO     liger_kernel.transformers.monkey_patch:monkey_patch.py:884 Applying Liger kernels to model instance with model type: gemma2 with kwargs: {}
PASSED                                                                                                           [ 84%]
test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2
---------------------------------------------------- live log call -----------------------------------------------------
INFO     liger_kernel.transformers.monkey_patch:monkey_patch.py:884 Applying Liger kernels to model instance with model type: qwen2 with kwargs: {}
PASSED                                                                                                           [ 89%]
test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2_vl
---------------------------------------------------- live log call -----------------------------------------------------
INFO     liger_kernel.transformers.monkey_patch:monkey_patch.py:884 Applying Liger kernels to model instance with model type: qwen2_vl with kwargs: {}
PASSED                                                                                                           [ 94%]
test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_phi3
---------------------------------------------------- live log call -----------------------------------------------------
INFO     liger_kernel.transformers.monkey_patch:monkey_patch.py:884 Applying Liger kernels to model instance with model type: phi3 with kwargs: {}
PASSED                                                                                                           [100%]

=================================================== warnings summary ===================================================
.venv/lib/python3.10/site-packages/_pytest/config/__init__.py:1441
  /home/tcc/Liger-Kernel/.venv/lib/python3.10/site-packages/_pytest/config/__init__.py:1441: PytestConfigWarning: Unknown config option: asyncio_mode

    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

.venv/lib/python3.10/site-packages/accelerate/utils/other.py:220
  /home/tcc/Liger-Kernel/.venv/lib/python3.10/site-packages/accelerate/utils/other.py:220: DeprecationWarning: numpy.core is deprecated and has been renamed to numpy._core. The numpy._core namespace contains private NumPy internals and its use is discouraged, as NumPy internals can change without warning in any release. In practice, most real-world usage of numpy.core is to access functionality in the public NumPy API. If that is the case, use the public NumPy API. If not, you are using NumPy internals. If you would still like to access an internal attribute, use numpy._core.multiarray.
    np.core.multiarray._reconstruct,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================ 19 passed, 2 warnings in 2.11s ============================================
```

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
