### PR TITLE
[WIP]: Autotune Chunk Size

### DIFF
--- a/test/chunked_loss/test_orpo_loss.py
+++ b/test/chunked_loss/test_orpo_loss.py
@@ -173,6 +173,39 @@ class HF_ORPO_Loss:
         return loss
 
 
+def get_random_input_tensors(B, T, H, V, scalar, dtype, ignore_index, bias):
+    """
+    B: batch size
+    T: sequence length
+    H: hidden size
+    V: vocab size
+    scalar: scale factor for input
+    dtype: data type for input
+    ignore_index: ignore index for loss
+    bias: whether to include bias in the linear layer
+    """
+    B = 2 * B  # orpo loss requires B to be even
+
+    _input = torch.randn(B, T, H, device="cuda", dtype=dtype) * scalar
+    input1 = _input.detach().clone().requires_grad_(True)
+    input2 = _input.detach().clone().requires_grad_(True)
+
+    target = torch.randint(0, V, (B, T), device="cuda", dtype=torch.long)
+    num_elements_to_assign = torch.randint(1, B * T // 2, (1,)).item()
+    indices_to_assign = torch.randperm(B * T)[:num_elements_to_assign]
+    target.view(-1)[indices_to_assign] = ignore_index
+
+    _weight = torch.randn(V, H, device="cuda", dtype=dtype)
+    weight1 = _weight.detach().clone().requires_grad_(True)
+    weight2 = _weight.detach().clone().requires_grad_(True)
+
+    _bias = torch.randn(V, device="cuda", dtype=dtype)
+    bias1 = _bias.detach().clone().requires_grad_(True) if bias else None
+    bias2 = _bias.detach().clone().requires_grad_(True) if bias else None
+
+    return input1, weight1, target, bias1, input2, weight2, bias2
+
+
 @pytest.mark.parametrize(
     "B, T, H, V",
     [
@@ -190,40 +223,15 @@ class HF_ORPO_Loss:
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("ignore_index, beta", [(-100, 0.1), (42, 0.2)])
 def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, bias, ignore_index, beta):
-    B = 2 * B  # orpo loss requires B to be even
-
-    _input = torch.randn(B, T, H, device="cuda", dtype=dtype) * scalar
-    input1 = _input.detach().clone().requires_grad_(True)
-    input2 = _input.detach().clone().requires_grad_(True)
-
-    target = torch.randint(
-        0,
-        V,
-        (
-            B,
-            T,
-        ),
-        device="cuda",
-        dtype=torch.long,
+    input1, weight1, target, bias1, input2, weight2, bias2 = get_random_input_tensors(
+        B, T, H, V, scalar, dtype, ignore_index, bias
     )
-    # Assign some random number of elements as ignore_index
-    num_elements_to_assign = torch.randint(1, B * T // 2, (1,)).item()
-    indices_to_assign = torch.randperm(B * T)[:num_elements_to_assign]
-    target.view(-1)[indices_to_assign] = ignore_index
-
-    _weight = torch.randn(V, H, device="cuda", dtype=dtype)
-    weight1 = _weight.detach().clone().requires_grad_(True)
-    weight2 = _weight.detach().clone().requires_grad_(True)
-
-    _bias = torch.randn(V, device="cuda", dtype=dtype) if bias else None
-    bias1 = _bias.detach().clone().requires_grad_(True) if bias else None
-    bias2 = _bias.detach().clone().requires_grad_(True) if bias else None
 
     loss1 = HF_ORPO_Loss(ignore_index=ignore_index, beta=beta).get_batch_loss_metrics(
         input1, weight1, target, bias1
     )
     loss2 = LigerFusedLinearORPOFunction.apply(
-        input2, weight2, target, bias2, ignore_index, beta, True
+        input2, weight2, target, bias2, ignore_index, beta, True, True
     )
 
     assert_verbose_allclose(loss1, loss2, atol=atol, rtol=rtol)
@@ -235,3 +243,43 @@ def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, bias, ignore_index, 
     assert_verbose_allclose(weight1.grad, weight2.grad, atol=atol, rtol=rtol)
     if bias:
         assert_verbose_allclose(bias1.grad, bias2.grad, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize(
+    "B, T, H, V",
+    [
+        (1, 12, 36, 128),
+        (3, 47, 31, 123),  # random shape
+    ],
+)
+@pytest.mark.parametrize(
+    "scalar, dtype, atol, rtol",
+    [
+        (1.0, torch.bfloat16, 5e-2, 5e-1),
+        (1.0, torch.float32, 1e-5, 5e-4),
+    ],
+)
+@pytest.mark.parametrize("bias", [True, False])
+@pytest.mark.parametrize("ignore_index, beta", [(-100, 0.1)])
+def test_autotune(B, T, H, V, scalar, dtype, atol, rtol, bias, ignore_index, beta):
+
+    input1, weight1, target, bias1, input2, weight2, bias2 = get_random_input_tensors(
+        B, T, H, V, scalar, dtype, ignore_index, bias
+    )
+
+    loss1 = HF_ORPO_Loss(ignore_index=ignore_index, beta=beta).get_batch_loss_metrics(
+        input1, weight1, target, bias1
+    )
+    loss2 = LigerFusedLinearORPOFunction.apply(
+        input2, weight2, target, bias2, ignore_index, beta, True, True, True
+    )
+
+    assert_verbose_allclose(loss1, loss2, atol=atol, rtol=rtol)
+
+    loss1.backward()
+    loss2.backward()
+
+    assert torch.allclose(input1.grad, input2.grad, atol=atol, rtol=rtol)
+    assert torch.allclose(weight1.grad, weight2.grad, atol=atol, rtol=rtol)
+    if bias:
+        assert torch.allclose(bias1.grad, bias2.grad, atol=atol, rtol=rtol)


### PR DESCRIPTION
## Summary
Our chunked loss functions currently statically set the chunk size to 1. However, this might lead to underutilized gpu memory resources. In this PR we show how the chunk size can be dynamically set, based on the additional peak memory consumed by the forward pass of the chunked loss being used.


## Testing Done
On A100 80 GB SMX

Benchmarking shows very marginal improvement in speed compared to a static chunk size.
![Screenshot 2024-11-19 at 10 58 59 AM](https://github.com/user-attachments/assets/a90a35a2-e5b8-4e02-b4ea-78055b63f383)


![Screenshot 2024-11-19 at 10 46 43 AM](https://github.com/user-attachments/assets/98643d92-7463-477b-b684-b8c0e2cbc32c)

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness (wip)
- [X] run `make checkstyle` to ensure code style
- [X] run `make test-convergence` to ensure convergence
