### PR TITLE
add xpu support

### DIFF
--- a/benchmark/scripts/benchmark_cpo_loss.py
+++ b/benchmark/scripts/benchmark_cpo_loss.py
@@ -13,6 +13,10 @@ from utils import (
 )
 
 from liger_kernel.chunked_loss.cpo_loss import LigerFusedLinearCPOFunction
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
@@ -66,7 +70,6 @@ def bench_memory_fused_linear_cpo_loss(
     dtype = input.extra_benchmark_config["dtype"]
     provider = input.kernel_provider
 
-    device = "cuda"
     torch_lm_head_cpo = TorchLMHeadCPO(H=H, V=V, dtype=dtype).to(device)
     liger_lm_head_cpo = LigerLMHeadCPO(H=H, V=V, dtype=dtype).to(device)
 
@@ -106,8 +109,6 @@ def bench_speed_fused_linear_cpo_loss(
     dtype = input.extra_benchmark_config["dtype"]
     provider = input.kernel_provider
     mode = input.kernel_operation_mode
-
-    device = "cuda"
 
     torch_lm_head_cpo = TorchLMHeadCPO(H=H, V=V, dtype=dtype).to(device)
     liger_lm_head_cpo = LigerLMHeadCPO(H=H, V=V, dtype=dtype).to(device)

--- a/benchmark/scripts/benchmark_cross_entropy.py
+++ b/benchmark/scripts/benchmark_cross_entropy.py
@@ -11,6 +11,10 @@ from utils import (
 )
 
 from liger_kernel.transformers.cross_entropy import LigerCrossEntropyLoss
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 
 def bench_memory_cross_entropy(
@@ -24,8 +28,8 @@ def bench_memory_cross_entropy(
     B = input.extra_benchmark_config["B"]
     T = input.extra_benchmark_config["T"]
 
-    _input = torch.randn(B * T, V, requires_grad=True, device="cuda")
-    target = torch.randint(V, (B * T, 1), device="cuda").squeeze(1)
+    _input = torch.randn(B * T, V, requires_grad=True, device=device)
+    target = torch.randint(V, (B * T, 1), device=device).squeeze(1)
 
     def fwd():
         if provider == "liger":
@@ -57,8 +61,8 @@ def bench_speed_cross_entropy(
     B = input.extra_benchmark_config["B"]
     T = input.extra_benchmark_config["T"]
 
-    _input = torch.randn(B * T, V, requires_grad=True, device="cuda")
-    target = torch.randint(V, (B * T, 1), device="cuda").squeeze(1)
+    _input = torch.randn(B * T, V, requires_grad=True, device=device)
+    target = torch.randint(V, (B * T, 1), device=device).squeeze(1)
 
     def fwd():
         if provider == "liger":

--- a/benchmark/scripts/benchmark_dpo_loss.py
+++ b/benchmark/scripts/benchmark_dpo_loss.py
@@ -12,6 +12,10 @@ from utils import (
 )
 
 from liger_kernel.chunked_loss.dpo_loss import LigerFusedLinearDPOFunction
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 
 class TorchDPOLoss(torch.nn.Module):
@@ -79,7 +83,6 @@ def bench_memory_dpo_loss(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunO
     ignore_index = input.extra_benchmark_config["ignore_index"]
     provider = input.kernel_provider
 
-    device = "cuda"
     torch_dpo_loss = TorchDPOLoss(
         H=H, V=V, dtype=dtype, beta=beta, ignore_index=ignore_index, bias=bias
     ).to(device)
@@ -127,7 +130,6 @@ def bench_speed_dpo_loss(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOu
     provider = input.kernel_provider
     mode = input.kernel_operation_mode
 
-    device = "cuda"
     torch_dpo_loss = TorchDPOLoss(
         H=H, V=V, dtype=dtype, beta=beta, ignore_index=ignore_index, bias=bias
     ).to(device)

--- a/benchmark/scripts/benchmark_embedding.py
+++ b/benchmark/scripts/benchmark_embedding.py
@@ -11,6 +11,10 @@ from utils import (
 )
 
 from liger_kernel.transformers.experimental.embedding import LigerEmbedding
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 # NOTE: For torch compile, we will just use default inductor settings. No further customization
 # is needed.
@@ -25,8 +29,6 @@ def bench_speed_embedding(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunO
     T = input.extra_benchmark_config["T"]
     D = input.extra_benchmark_config["D"]
     dtype = input.extra_benchmark_config["dtype"]
-
-    device = "cuda"
 
     torch_emb = Embedding(V, D).to(device).to(dtype)
     liger_emb = LigerEmbedding(V, D).to(device).to(dtype)
@@ -67,8 +69,6 @@ def bench_memory_embedding(input: SingleBenchmarkRunInput) -> SingleBenchmarkRun
     T = input.extra_benchmark_config["T"]
     D = input.extra_benchmark_config["D"]
     dtype = input.extra_benchmark_config["dtype"]
-
-    device = "cuda"
 
     torch_emb = Embedding(V, D).to(device).to(dtype)
     liger_emb = LigerEmbedding(V, D).to(device).to(dtype)

--- a/benchmark/scripts/benchmark_fused_linear_cross_entropy.py
+++ b/benchmark/scripts/benchmark_fused_linear_cross_entropy.py
@@ -12,6 +12,10 @@ from utils import (
 from liger_kernel.transformers.fused_linear_cross_entropy import (
     LigerFusedLinearCrossEntropyLoss,
 )
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 
 class TorchLMHeadCE(torch.nn.Module):
@@ -65,7 +69,6 @@ def bench_memory_fused_linear_cross_entropy(
     dtype = input.extra_benchmark_config["dtype"]
     provider = input.kernel_provider
 
-    device = "cuda"
     torch_lm_head_ce = TorchLMHeadCE(H=H, V=V, dtype=dtype).to(device)
     liger_lm_head_ce = LigerLMHeadCE(H=H, V=V, dtype=dtype).to(device)
 
@@ -104,8 +107,6 @@ def bench_speed_fused_linear_cross_entropy(
     dtype = input.extra_benchmark_config["dtype"]
     provider = input.kernel_provider
     mode = input.kernel_operation_mode
-
-    device = "cuda"
 
     torch_lm_head_ce = TorchLMHeadCE(H=H, V=V, dtype=dtype).to(device)
     liger_lm_head_ce = LigerLMHeadCE(H=H, V=V, dtype=dtype).to(device)

--- a/benchmark/scripts/benchmark_fused_linear_jsd.py
+++ b/benchmark/scripts/benchmark_fused_linear_jsd.py
@@ -10,6 +10,10 @@ from utils import (
 )
 
 from liger_kernel.transformers.fused_linear_jsd import LigerFusedLinearJSD
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 
 class TorchJSD(torch.nn.Module):
@@ -134,7 +138,6 @@ def bench_memory_fused_linear_jsd(
     dtype = input.extra_benchmark_config["dtype"]
     provider = input.kernel_provider
 
-    device = "cuda"
     torch_lm_head_jsd = TorchLMHeadJSD(H=H, V=V, dtype=dtype, device=device).to(device)
     liger_lm_head_jsd = LigerLMHeadJSD(H=H, V=V, dtype=dtype, device=device).to(device)
 
@@ -183,7 +186,6 @@ def bench_speed_fused_linear_jsd(
     dtype = input.extra_benchmark_config["dtype"]
     provider = input.kernel_provider
 
-    device = "cuda"
     torch_lm_head_jsd = TorchLMHeadJSD(H=H, V=V, dtype=dtype, device=device).to(device)
     liger_lm_head_jsd = LigerLMHeadJSD(H=H, V=V, dtype=dtype, device=device).to(device)
 

--- a/benchmark/scripts/benchmark_geglu.py
+++ b/benchmark/scripts/benchmark_geglu.py
@@ -12,6 +12,10 @@ from utils import (
 )
 
 from liger_kernel.transformers.geglu import LigerGEGLUMLP
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 
 def bench_speed_geglu(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
@@ -31,7 +35,6 @@ def bench_speed_geglu(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutpu
     )
 
     x_shape = (bsz, seq_len, hidden_size)
-    device = "cuda"
 
     # initialize input
     x = torch.randn(*x_shape, device=device, dtype=dtype, requires_grad=True)
@@ -99,7 +102,6 @@ def bench_memory_geglu(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutp
     )
 
     x_shape = (bsz, seq_len, hidden_size)
-    device = "cuda"
     # initialize input
     x = torch.randn(*x_shape, device=device, dtype=dtype, requires_grad=True)
 

--- a/benchmark/scripts/benchmark_group_norm.py
+++ b/benchmark/scripts/benchmark_group_norm.py
@@ -10,6 +10,10 @@ from utils import (
 )
 
 from liger_kernel.transformers.group_norm import LigerGroupNorm
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 
 def bench_speed_group_norm(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
@@ -26,12 +30,12 @@ def bench_speed_group_norm(input: SingleBenchmarkRunInput) -> SingleBenchmarkRun
     x_shape = (M, C, H)
     triton_ln = LigerGroupNorm(
         num_channels=C, num_groups=C // channels_per_group, eps=eps
-    ).to("cuda")
+    ).to(device)
     torch_ln = torch.nn.GroupNorm(
         num_groups=C // channels_per_group, num_channels=C, eps=eps
-    ).to("cuda")
+    ).to(device)
 
-    x = torch.randn(x_shape, dtype=dtype, device="cuda")
+    x = torch.randn(x_shape, dtype=dtype, device=device)
     dy = torch.randn_like(x)
     x.requires_grad_(True)
 
@@ -83,12 +87,12 @@ def bench_memory_group_norm(input: SingleBenchmarkRunInput) -> SingleBenchmarkRu
     x_shape = (M, C, H)
     triton_ln = LigerGroupNorm(
         num_channels=C, num_groups=C // channels_per_group, eps=eps
-    ).to("cuda")
+    ).to(device)
     torch_ln = torch.nn.GroupNorm(
         num_groups=C // channels_per_group, num_channels=C, eps=eps
-    ).to("cuda")
+    ).to(device)
 
-    x = torch.randn(x_shape, dtype=dtype, device="cuda")
+    x = torch.randn(x_shape, dtype=dtype, device=device)
     dy = torch.randn_like(x)
     x.requires_grad_(True)
 

--- a/benchmark/scripts/benchmark_jsd.py
+++ b/benchmark/scripts/benchmark_jsd.py
@@ -10,6 +10,10 @@ from utils import (
 )
 
 from liger_kernel.transformers.jsd import LigerJSD
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 
 class TorchJSD(torch.nn.Module):
@@ -56,10 +60,10 @@ def bench_speed_jsd(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
     torch_jsd = TorchJSD()
     liger_jsd = LigerJSD()
 
-    _input = torch.randn(B * T, V, requires_grad=True, device="cuda").log_softmax(
+    _input = torch.randn(B * T, V, requires_grad=True, device=device).log_softmax(
         dim=-1
     )
-    target = torch.randn(B * T, V, device="cuda").log_softmax(dim=-1)
+    target = torch.randn(B * T, V, device=device).log_softmax(dim=-1)
 
     def fwd():
         if input.kernel_provider == "liger":
@@ -101,10 +105,10 @@ def bench_memory_jsd(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput
     V = input.x
     B, T = input.extra_benchmark_config["B"], input.extra_benchmark_config["T"]
 
-    _input = torch.randn(B * T, V, requires_grad=True, device="cuda").log_softmax(
+    _input = torch.randn(B * T, V, requires_grad=True, device=device).log_softmax(
         dim=-1
     )
-    target = torch.randn(B * T, V, device="cuda").log_softmax(dim=-1)
+    target = torch.randn(B * T, V, device=device).log_softmax(dim=-1)
 
     def fwd():
         if input.kernel_provider == "liger":

--- a/benchmark/scripts/benchmark_kl_div.py
+++ b/benchmark/scripts/benchmark_kl_div.py
@@ -11,6 +11,10 @@ from utils import (
 )
 
 from liger_kernel.transformers.kl_div import LigerKLDIVLoss
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 S, E = 12, 18
 
@@ -22,10 +26,10 @@ def bench_speed_kldiv(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutpu
     torch_kl_div = nn.KLDivLoss(reduction=reduction)
     liger_kl_div = LigerKLDIVLoss(reduction=reduction)
 
-    _input = torch.randn(B * T, V, requires_grad=True, device="cuda").log_softmax(
+    _input = torch.randn(B * T, V, requires_grad=True, device=device).log_softmax(
         dim=-1
     )
-    target = torch.randn(B * T, V, device="cuda").softmax(dim=-1)
+    target = torch.randn(B * T, V, device=device).softmax(dim=-1)
 
     def fwd():
         if input.kernel_provider == "liger":
@@ -68,10 +72,10 @@ def bench_memory_kldiv(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutp
     V = input.x
     B, T = input.extra_benchmark_config["B"], input.extra_benchmark_config["T"]
 
-    _input = torch.randn(B * T, V, requires_grad=True, device="cuda").log_softmax(
+    _input = torch.randn(B * T, V, requires_grad=True, device=device).log_softmax(
         dim=-1
     )
-    target = torch.randn(B * T, V, device="cuda").softmax(dim=-1)
+    target = torch.randn(B * T, V, device=device).softmax(dim=-1)
 
     def fwd():
         if input.kernel_provider == "liger":

--- a/benchmark/scripts/benchmark_layer_norm.py
+++ b/benchmark/scripts/benchmark_layer_norm.py
@@ -10,6 +10,10 @@ from utils import (
 )
 
 from liger_kernel.transformers.layer_norm import LigerLayerNorm
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 
 def bench_speed_layer_norm(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
@@ -22,10 +26,10 @@ def bench_speed_layer_norm(input: SingleBenchmarkRunInput) -> SingleBenchmarkRun
     dtype = extra_benchmark_config["dtype"]
 
     x_shape = (M, N)
-    triton_ln = LigerLayerNorm(hidden_size=N).to("cuda")
-    torch_ln = torch.nn.LayerNorm(N, eps=eps).to("cuda")
+    triton_ln = LigerLayerNorm(hidden_size=N).to(device)
+    torch_ln = torch.nn.LayerNorm(N, eps=eps).to(device)
 
-    x = torch.randn(x_shape, dtype=dtype, device="cuda")
+    x = torch.randn(x_shape, dtype=dtype, device=device)
     dy = torch.randn_like(x)
     x.requires_grad_(True)
 
@@ -73,10 +77,10 @@ def bench_memory_layer_norm(input: SingleBenchmarkRunInput) -> SingleBenchmarkRu
 
     x_shape = (M, N)
 
-    triton_ln = LigerLayerNorm(hidden_size=N).to("cuda")
-    torch_ln = torch.nn.LayerNorm(N, eps=eps).to("cuda")
+    triton_ln = LigerLayerNorm(hidden_size=N).to(device)
+    torch_ln = torch.nn.LayerNorm(N, eps=eps).to(device)
 
-    x = torch.randn(x_shape, dtype=dtype, device="cuda")
+    x = torch.randn(x_shape, dtype=dtype, device=device)
     dy = torch.randn_like(x)
     x.requires_grad_(True)
 

--- a/benchmark/scripts/benchmark_orpo_loss.py
+++ b/benchmark/scripts/benchmark_orpo_loss.py
@@ -13,6 +13,10 @@ from utils import (
 )
 
 from liger_kernel.chunked_loss.orpo_loss import LigerFusedLinearORPOFunction
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
@@ -66,7 +70,6 @@ def bench_memory_fused_linear_orpo_loss(
     dtype = input.extra_benchmark_config["dtype"]
     provider = input.kernel_provider
 
-    device = "cuda"
     torch_lm_head_orpo = TorchLMHeadORPO(H=H, V=V, dtype=dtype).to(device)
     liger_lm_head_orpo = LigerLMHeadORPO(H=H, V=V, dtype=dtype).to(device)
 
@@ -106,8 +109,6 @@ def bench_speed_fused_linear_orpo_loss(
     dtype = input.extra_benchmark_config["dtype"]
     provider = input.kernel_provider
     mode = input.kernel_operation_mode
-
-    device = "cuda"
 
     torch_lm_head_orpo = TorchLMHeadORPO(H=H, V=V, dtype=dtype).to(device)
     liger_lm_head_orpo = LigerLMHeadORPO(H=H, V=V, dtype=dtype).to(device)

--- a/benchmark/scripts/benchmark_qwen2vl_mrope.py
+++ b/benchmark/scripts/benchmark_qwen2vl_mrope.py
@@ -14,6 +14,10 @@ from utils import (
 )
 
 from liger_kernel.transformers.qwen2vl_mrope import liger_multimodal_rotary_pos_emb
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 
 def bench_speed_qwen2vl_mrope(
@@ -40,23 +44,23 @@ def bench_speed_qwen2vl_mrope(
     )
 
     head_dim = hidden_size // num_q_heads
-    rotary_emb = Qwen2VLRotaryEmbedding(head_dim, device="cuda")
+    rotary_emb = Qwen2VLRotaryEmbedding(head_dim, device=device)
     q = torch.randn(
         (1, seq_len, num_q_heads, head_dim),
-        device="cuda",
+        device=device,
         requires_grad=True,
         dtype=dtype,
     ).transpose(1, 2)
     k = torch.randn(
         (1, seq_len, num_kv_heads, head_dim),
-        device="cuda",
+        device=device,
         requires_grad=True,
         dtype=dtype,
     ).transpose(1, 2)
-    dq, dk = torch.randn_like(q, device="cuda", dtype=dtype), torch.randn_like(
-        k, device="cuda"
+    dq, dk = torch.randn_like(q, device=device, dtype=dtype), torch.randn_like(
+        k, device=device
     )
-    pos_ids = torch.arange(seq_len * 3, device="cuda", dtype=torch.long).view(3, 1, -1)
+    pos_ids = torch.arange(seq_len * 3, device=device, dtype=torch.long).view(3, 1, -1)
     cos, sin = rotary_emb(k, pos_ids)
 
     mrope_section_hw = head_dim * 3 // 16
@@ -133,23 +137,23 @@ def bench_memory_qwen2vl_mrope(
     )
 
     head_dim = hidden_size // num_q_heads
-    rotary_emb = Qwen2VLRotaryEmbedding(head_dim, device="cuda")
+    rotary_emb = Qwen2VLRotaryEmbedding(head_dim, device=device)
     q = torch.randn(
         (1, seq_len, num_q_heads, head_dim),
-        device="cuda",
+        device=device,
         requires_grad=True,
         dtype=dtype,
     ).transpose(1, 2)
     k = torch.randn(
         (1, seq_len, num_kv_heads, head_dim),
-        device="cuda",
+        device=device,
         requires_grad=True,
         dtype=dtype,
     ).transpose(1, 2)
-    dq, dk = torch.randn_like(q, device="cuda", dtype=dtype), torch.randn_like(
-        k, device="cuda"
+    dq, dk = torch.randn_like(q, device=device, dtype=dtype), torch.randn_like(
+        k, device=device
     )
-    pos_ids = torch.arange(seq_len * 3, device="cuda", dtype=torch.long).view(3, 1, -1)
+    pos_ids = torch.arange(seq_len * 3, device=device, dtype=torch.long).view(3, 1, -1)
     cos, sin = rotary_emb(k, pos_ids)
 
     mrope_section_hw = head_dim * 3 // 16

--- a/benchmark/scripts/benchmark_rms_norm.py
+++ b/benchmark/scripts/benchmark_rms_norm.py
@@ -11,6 +11,10 @@ from utils import (
 )
 
 from liger_kernel.transformers.rms_norm import LigerRMSNorm
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 
 class LlamaRMSNorm(nn.Module):
@@ -42,10 +46,10 @@ def bench_speed_rms_norm(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOu
 
     x_shape = (M, N)
 
-    triton_rms = LigerRMSNorm(hidden_size=N, eps=eps).to("cuda")
-    llama_rms = LlamaRMSNorm(hidden_size=N, eps=eps).to("cuda")
+    triton_rms = LigerRMSNorm(hidden_size=N, eps=eps).to(device)
+    llama_rms = LlamaRMSNorm(hidden_size=N, eps=eps).to(device)
 
-    x = torch.randn(x_shape, dtype=dtype, device="cuda")
+    x = torch.randn(x_shape, dtype=dtype, device=device)
     dy = torch.randn_like(x)
     x.requires_grad_(True)
 
@@ -104,10 +108,10 @@ def bench_memory_rms_norm(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunO
 
     x_shape = (M, N)
 
-    triton_rms = LigerRMSNorm(hidden_size=N, eps=eps).to("cuda")
-    llama_rms = LlamaRMSNorm(hidden_size=N, eps=eps).to("cuda")
+    triton_rms = LigerRMSNorm(hidden_size=N, eps=eps).to(device)
+    llama_rms = LlamaRMSNorm(hidden_size=N, eps=eps).to(device)
 
-    x = torch.randn(x_shape, dtype=dtype, device="cuda")
+    x = torch.randn(x_shape, dtype=dtype, device=device)
     dy = torch.randn_like(x)
     x.requires_grad_(True)
 

--- a/benchmark/scripts/benchmark_rope.py
+++ b/benchmark/scripts/benchmark_rope.py
@@ -14,6 +14,10 @@ from utils import (
 )
 
 from liger_kernel.transformers.rope import liger_rotary_pos_emb
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 
 def bench_speed_rope(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
@@ -38,23 +42,23 @@ def bench_speed_rope(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput
     )
 
     head_dim = hidden_size // num_q_heads
-    rotary_emb = LlamaRotaryEmbedding(head_dim, device="cuda")
+    rotary_emb = LlamaRotaryEmbedding(head_dim, device=device)
     q = torch.randn(
         (1, seq_len, num_q_heads, head_dim),
-        device="cuda",
+        device=device,
         requires_grad=True,
         dtype=dtype,
     ).transpose(1, 2)
     k = torch.randn(
         (1, seq_len, num_kv_heads, head_dim),
-        device="cuda",
+        device=device,
         requires_grad=True,
         dtype=dtype,
     ).transpose(1, 2)
-    dq, dk = torch.randn_like(q, device="cuda", dtype=dtype), torch.randn_like(
-        k, device="cuda"
+    dq, dk = torch.randn_like(q, device=device, dtype=dtype), torch.randn_like(
+        k, device=device
     )
-    pos_ids = torch.arange(seq_len, device="cuda", dtype=torch.long).unsqueeze(0)
+    pos_ids = torch.arange(seq_len, device=device, dtype=torch.long).unsqueeze(0)
     cos, sin = rotary_emb(k, pos_ids)
 
     def fwd():
@@ -122,23 +126,23 @@ def bench_memory_rope(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutpu
     )
 
     head_dim = hidden_size // num_q_heads
-    rotary_emb = LlamaRotaryEmbedding(head_dim, device="cuda")
+    rotary_emb = LlamaRotaryEmbedding(head_dim, device=device)
     q = torch.randn(
         (1, seq_len, num_q_heads, head_dim),
-        device="cuda",
+        device=device,
         requires_grad=True,
         dtype=dtype,
     ).transpose(1, 2)
     k = torch.randn(
         (1, seq_len, num_kv_heads, head_dim),
-        device="cuda",
+        device=device,
         requires_grad=True,
         dtype=dtype,
     ).transpose(1, 2)
-    dq, dk = torch.randn_like(q, device="cuda", dtype=dtype), torch.randn_like(
-        k, device="cuda"
+    dq, dk = torch.randn_like(q, device=device, dtype=dtype), torch.randn_like(
+        k, device=device
     )
-    pos_ids = torch.arange(seq_len, device="cuda", dtype=torch.long).unsqueeze(0)
+    pos_ids = torch.arange(seq_len, device=device, dtype=torch.long).unsqueeze(0)
     cos, sin = rotary_emb(k, pos_ids)
 
     def full():

--- a/benchmark/scripts/benchmark_swiglu.py
+++ b/benchmark/scripts/benchmark_swiglu.py
@@ -12,6 +12,10 @@ from utils import (
 )
 
 from liger_kernel.transformers.swiglu import LigerSwiGLUMLP
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 
 def bench_speed_swiglu(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
@@ -33,7 +37,6 @@ def bench_speed_swiglu(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutp
     )
 
     x_shape = (bsz, seq_len, hidden_size)
-    device = "cuda"
 
     # initialize input
     x = torch.randn(*x_shape, device=device, dtype=dtype, requires_grad=True)
@@ -103,7 +106,6 @@ def bench_memory_swiglu(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOut
     )
 
     x_shape = (bsz, seq_len, hidden_size)
-    device = "cuda"
 
     # initialize input
     x = torch.randn(*x_shape, device=device, dtype=dtype, requires_grad=True)

--- a/benchmark/scripts/utils.py
+++ b/benchmark/scripts/utils.py
@@ -10,6 +10,9 @@ from itertools import zip_longest
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
+from liger_kernel.utils import infer_device
+
+device = infer_device()
 
 LIGER_KERNEL_VERSION = version("liger-kernel")
 
@@ -88,10 +91,10 @@ def _test_memory(
     total_mem = []
 
     for _ in range(_iter):
-        torch.cuda.memory.reset_peak_memory_stats()
+        getattr(torch, device).memory.reset_peak_memory_stats()
         func()
         # Convert to MB
-        mem = torch.cuda.max_memory_allocated() / 2**20
+        mem = getattr(torch, device).max_memory_allocated() / 2**20
         total_mem.append(mem)
 
     total_mem = torch.tensor(total_mem, dtype=torch.float)
@@ -141,8 +144,9 @@ def get_gpu_name():
     """
     Returns the current GPU name, formatted to serve as a directory name
     """
-    if torch.cuda.is_available():
-        gpu_name = torch.cuda.get_device_name(torch.cuda.current_device())
+    torch_device = getattr(torch, device)
+    if torch_device.is_available():
+        gpu_name = torch_device.get_device_name(torch_device.current_device())
         return gpu_name
     else:
         raise Exception("Benchmarks can only be run on GPU.")

--- a/examples/lightning/training.py
+++ b/examples/lightning/training.py
@@ -15,6 +15,7 @@ from transformers.models.qwen2.modeling_qwen2 import Qwen2DecoderLayer
 from trl import DataCollatorForCompletionOnlyLM
 
 from liger_kernel.transformers import AutoLigerKernelForCausalLM
+from liger_kernel.utils import infer_device
 
 _RETAIN_COLUMNS = {"input_ids", "attention_mask", "labels"}
 QUESTION = "<Question>"
@@ -263,10 +264,11 @@ def train():
         strategy = "auto"
         precision = "bf16-true"
 
+    device = infer_device()
     trainer = pl.Trainer(
-        accelerator="cuda",
+        accelerator=device,
         strategy=strategy,
-        devices=torch.cuda.device_count() if args.num_gpu is None else args.num_gpu,
+        devices=getattr(torch, device).device_count() if args.num_gpu is None else args.num_gpu,
         default_root_dir=args.output_dir,
         log_every_n_steps=1,
         max_epochs=1,

--- a/src/liger_kernel/ops/layer_norm.py
+++ b/src/liger_kernel/ops/layer_norm.py
@@ -180,8 +180,13 @@ def layer_norm_backward(dY, X, W, B, Mean, RSTD):
     dY = dY.view(-1, dim)
     n_rows, n_cols = dY.shape
 
+    sm_count = 1
+    if X.device.type == "cuda":
+        sm_count = torch.cuda.get_device_properties(X.device).multi_processor_count
+    elif X.device.type == "xpu":
+        sm_count = torch.xpu.get_device_properties(X.device).gpu_subslice_count
+
     DX = torch.empty((n_rows, n_cols), dtype=X.dtype, device=X.device)
-    sm_count = torch.cuda.get_device_properties(X.device).multi_processor_count
     _DW = torch.empty((sm_count, n_cols), dtype=W.dtype, device=W.device)
     _DB = torch.empty((sm_count, n_cols), dtype=W.dtype, device=W.device)
 

--- a/src/liger_kernel/ops/rms_norm.py
+++ b/src/liger_kernel/ops/rms_norm.py
@@ -264,6 +264,7 @@ def rms_norm_backward(
     dY = dY.view(-1, dim)
     n_rows, n_cols = dY.shape
 
+    sm_count = 1
     if X.device.type == "cuda":
         sm_count = torch.cuda.get_device_properties(X.device).multi_processor_count
     elif X.device.type == "xpu":

--- a/src/liger_kernel/ops/utils.py
+++ b/src/liger_kernel/ops/utils.py
@@ -19,6 +19,7 @@ import torch
 import triton
 import triton.language as tl
 from packaging.version import Version
+from liger_kernel.utils import infer_device
 
 
 def is_hip() -> bool:
@@ -69,10 +70,11 @@ def compare_version(package: str, operator: Callable, target: str):
 
 
 def get_amp_custom_fwd_bwd() -> Callable:
+    device = infer_device()
     if compare_version("torch", operator.ge, "2.4.0"):
         return (
-            functools.partial(torch.amp.custom_fwd, device_type="cuda"),
-            functools.partial(torch.amp.custom_bwd, device_type="cuda"),
+            functools.partial(torch.amp.custom_fwd, device_type=device),
+            functools.partial(torch.amp.custom_bwd, device_type=device),
         )
     return torch.cuda.amp.custom_fwd, torch.cuda.amp.custom_bwd
 

--- a/src/liger_kernel/utils.py
+++ b/src/liger_kernel/utils.py
@@ -1,0 +1,13 @@
+import torch
+
+
+def infer_device():
+    """
+    Get current device name based on available devices
+    """
+    if torch.cuda.is_available():
+        return "cuda"
+    elif torch.xpu.is_available():
+        return "xpu"
+    else:
+        return "cpu"

--- a/test/chunked_loss/test_cpo_loss.py
+++ b/test/chunked_loss/test_cpo_loss.py
@@ -6,6 +6,10 @@ import torch
 import torch.nn.functional as F
 
 from liger_kernel.chunked_loss.cpo_loss import LigerFusedLinearCPOFunction
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 # set random seed globally
 set_seed()
@@ -87,7 +91,7 @@ def test_correctness(
 ):
     B = 2 * B  # cpo loss requires B to be even
 
-    _input = torch.randn(B, T, H, device="cuda", dtype=dtype) * scalar
+    _input = torch.randn(B, T, H, device=device, dtype=dtype) * scalar
     input1 = _input.detach().clone().requires_grad_(True)
     input2 = _input.detach().clone().requires_grad_(True)
 
@@ -98,7 +102,7 @@ def test_correctness(
             B,
             T,
         ),
-        device="cuda",
+        device=device,
         dtype=torch.long,
     )
     # Assign some random number of elements as ignore_index
@@ -106,11 +110,11 @@ def test_correctness(
     indices_to_assign = torch.randperm(B * T)[:num_elements_to_assign]
     target.view(-1)[indices_to_assign] = ignore_index
 
-    _weight = torch.randn(V, H, device="cuda", dtype=dtype)
+    _weight = torch.randn(V, H, device=device, dtype=dtype)
     weight1 = _weight.detach().clone().requires_grad_(True)
     weight2 = _weight.detach().clone().requires_grad_(True)
 
-    _bias = torch.randn(V, device="cuda", dtype=dtype) if bias else None
+    _bias = torch.randn(V, device=device, dtype=dtype) if bias else None
     bias1 = _bias.detach().clone().requires_grad_(True) if bias else None
     bias2 = _bias.detach().clone().requires_grad_(True) if bias else None
 

--- a/test/chunked_loss/test_dpo_loss.py
+++ b/test/chunked_loss/test_dpo_loss.py
@@ -5,6 +5,9 @@ import torch
 import torch.nn.functional as F
 
 from liger_kernel.chunked_loss.dpo_loss import LigerFusedLinearDPOFunction
+from liger_kernel.utils import infer_device
+
+device = infer_device()
 
 # set random seed globally
 set_seed()
@@ -58,7 +61,7 @@ class HF_DPO_Loss(HFAlignmentLoss):
 def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, bias, ignore_index, beta):
     B = 2 * B  # dpo loss requires B to be even
 
-    _input = torch.randn(B, T, H, device="cuda", dtype=dtype) * scalar
+    _input = torch.randn(B, T, H, device=device, dtype=dtype) * scalar
     input1 = _input.detach().clone().requires_grad_(True)
     input2 = _input.detach().clone().requires_grad_(True)
 
@@ -69,7 +72,7 @@ def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, bias, ignore_index, 
             B,
             T,
         ),
-        device="cuda",
+        device=device,
         dtype=torch.long,
     )
     # Assign some random number of elements as ignore_index
@@ -77,11 +80,11 @@ def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, bias, ignore_index, 
     indices_to_assign = torch.randperm(B * T)[:num_elements_to_assign]
     target.view(-1)[indices_to_assign] = ignore_index
 
-    _weight = torch.randn(V, H, device="cuda", dtype=dtype)
+    _weight = torch.randn(V, H, device=device, dtype=dtype)
     weight1 = _weight.detach().clone().requires_grad_(True)
     weight2 = _weight.detach().clone().requires_grad_(True)
 
-    _bias = torch.randn(V, device="cuda", dtype=dtype) if bias else None
+    _bias = torch.randn(V, device=device, dtype=dtype) if bias else None
     bias1 = _bias.detach().clone().requires_grad_(True) if bias else None
     bias2 = _bias.detach().clone().requires_grad_(True) if bias else None
 

--- a/test/chunked_loss/test_orpo_loss.py
+++ b/test/chunked_loss/test_orpo_loss.py
@@ -6,6 +6,9 @@ import torch
 import torch.nn.functional as F
 
 from liger_kernel.chunked_loss.orpo_loss import LigerFusedLinearORPOFunction
+from liger_kernel.utils import infer_device
+
+device = infer_device()
 
 # set random seed globally
 set_seed()
@@ -76,7 +79,7 @@ class HFORPOLoss(HFAlignmentLoss):
 def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, bias, ignore_index, beta):
     B = 2 * B  # orpo loss requires B to be even
 
-    _input = torch.randn(B, T, H, device="cuda", dtype=dtype) * scalar
+    _input = torch.randn(B, T, H, device=device, dtype=dtype) * scalar
     input1 = _input.detach().clone().requires_grad_(True)
     input2 = _input.detach().clone().requires_grad_(True)
 
@@ -87,7 +90,7 @@ def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, bias, ignore_index, 
             B,
             T,
         ),
-        device="cuda",
+        device=device,
         dtype=torch.long,
     )
     # Assign some random number of elements as ignore_index
@@ -95,11 +98,11 @@ def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, bias, ignore_index, 
     indices_to_assign = torch.randperm(B * T)[:num_elements_to_assign]
     target.view(-1)[indices_to_assign] = ignore_index
 
-    _weight = torch.randn(V, H, device="cuda", dtype=dtype)
+    _weight = torch.randn(V, H, device=device, dtype=dtype)
     weight1 = _weight.detach().clone().requires_grad_(True)
     weight2 = _weight.detach().clone().requires_grad_(True)
 
-    _bias = torch.randn(V, device="cuda", dtype=dtype) if bias else None
+    _bias = torch.randn(V, device=device, dtype=dtype) if bias else None
     bias1 = _bias.detach().clone().requires_grad_(True) if bias else None
     bias2 = _bias.detach().clone().requires_grad_(True) if bias else None
 

--- a/test/convergence/test_mini_models.py
+++ b/test/convergence/test_mini_models.py
@@ -60,6 +60,10 @@ try:
 except ImportError:
     QWEN2_VL_AVAILABLE = False
 
+from liger_kernel.utils import infer_device
+
+device = infer_device()
+
 MINI_MODEL_SETUPS = {
     "mini_llama3": MiniModelConfig(
         liger_kernel_patch_func=apply_liger_kernel_to_llama,
@@ -427,7 +431,7 @@ def run_mini_model(
     else:
         MINI_MODEL_SETUPS[model_name].liger_kernel_patch_revert_func(**revert_kwargs)
 
-    model = create_model(model_name).to(dtype).to("cuda")
+    model = create_model(model_name).to(dtype).to(device)
 
     train_dataset = load_from_disk(DEFAULT_DATASET_PATH)
     loader = DataLoader(

--- a/test/convergence/test_mini_models_multimodal.py
+++ b/test/convergence/test_mini_models_multimodal.py
@@ -58,6 +58,10 @@ try:
 except ImportError:
     MLLAMA_AVAILABLE = False
 
+from liger_kernel.utils import infer_device
+
+device = infer_device()
+
 torch.use_deterministic_algorithms(True)
 
 #  Only setting torch.use_deterministic_algorithms(True) throws the following error:
@@ -333,7 +337,7 @@ def run_mini_model_multimodal(
     else:
         MINI_MODEL_SETUPS[model_name].liger_kernel_patch_revert_func(**revert_kwargs)
 
-    model = create_model(model_name).to(dtype).to("cuda")
+    model = create_model(model_name).to(dtype).to(device)
     model.gradient_checkpointing_enable()
 
     train_dataset = create_multimodal_dataset(model_name)

--- a/test/convergence/test_mini_models_with_logits.py
+++ b/test/convergence/test_mini_models_with_logits.py
@@ -60,6 +60,10 @@ try:
 except ImportError:
     QWEN2_VL_AVAILABLE = False
 
+from liger_kernel.utils import infer_device
+
+device = infer_device()
+
 MINI_MODEL_SETUPS = {
     "mini_llama3": MiniModelConfig(
         liger_kernel_patch_func=apply_liger_kernel_to_llama,
@@ -427,7 +431,7 @@ def run_mini_model(
     else:
         MINI_MODEL_SETUPS[model_name].liger_kernel_patch_revert_func(**revert_kwargs)
 
-    model = create_model(model_name).to(dtype).to("cuda")
+    model = create_model(model_name).to(dtype).to(device)
     train_dataset = load_from_disk(DEFAULT_DATASET_PATH)
     loader = DataLoader(
         train_dataset, batch_size=16, shuffle=False, collate_fn=simple_collate_fn

--- a/test/transformers/test_cross_entropy.py
+++ b/test/transformers/test_cross_entropy.py
@@ -8,7 +8,10 @@ from torch.nn import CrossEntropyLoss
 from liger_kernel.ops.cross_entropy import LigerCrossEntropyFunction
 from liger_kernel.transformers.cross_entropy import LigerCrossEntropyLoss
 from liger_kernel.transformers.functional import liger_cross_entropy
+from liger_kernel.utils import infer_device
 
+
+device = infer_device()
 set_seed(42)
 
 
@@ -71,11 +74,11 @@ def _test_correctness_once(target_ce, B, T, V, reduction, scalar, dtype, atol, r
     torch.manual_seed(0)
     torch_ce = CrossEntropyLoss(reduction=reduction)
 
-    _tensor = torch.randn(B * T, V, device="cuda", dtype=dtype) * scalar
+    _tensor = torch.randn(B * T, V, device=device, dtype=dtype) * scalar
     _input = _tensor.detach().clone().requires_grad_(True)
     _input2 = _tensor.detach().clone().requires_grad_(True)
 
-    target = torch.randint(0, V, (B * T,), device="cuda", dtype=torch.long)
+    target = torch.randint(0, V, (B * T,), device=device, dtype=torch.long)
 
     output = torch_ce(_input, target)
     output2 = target_ce(_input2, target)
@@ -92,11 +95,11 @@ def _test_correctness_with_ignore_index_once(
 
     torch_ce = CrossEntropyLoss(ignore_index=ignore_index, reduction=reduction)
 
-    _tensor = torch.randn(B * T, V, device="cuda", dtype=dtype) * scalar
+    _tensor = torch.randn(B * T, V, device=device, dtype=dtype) * scalar
     _input = _tensor.detach().clone().requires_grad_(True)
     _input2 = _tensor.detach().clone().requires_grad_(True)
 
-    target = torch.randint(0, V, (B * T,), device="cuda", dtype=torch.long)
+    target = torch.randint(0, V, (B * T,), device=device, dtype=torch.long)
 
     # Assign some random number of elements as ignore_index
     num_elements_to_assign = torch.randint(
@@ -123,11 +126,11 @@ def _test_correctness_with_label_smoothing_once(
 
     torch_ce = CrossEntropyLoss(label_smoothing=label_smoothing)
 
-    _tensor = torch.randn(B * T, V, device="cuda", dtype=dtype) * scalar
+    _tensor = torch.randn(B * T, V, device=device, dtype=dtype) * scalar
     _input = _tensor.detach().clone().requires_grad_(True)
     _input2 = _tensor.detach().clone().requires_grad_(True)
 
-    target = torch.randint(0, V, (B * T,), device="cuda", dtype=torch.long)
+    target = torch.randint(0, V, (B * T,), device=device, dtype=torch.long)
 
     output = torch_ce(_input, target)
     output2 = target_ce(_input2, target)
@@ -147,11 +150,11 @@ def _test_correctness_with_label_smoothing_with_ignore_index_once(
         ignore_index=ignore_index, label_smoothing=label_smoothing
     )
 
-    _tensor = torch.randn(B * T, V, device="cuda", dtype=dtype) * scalar
+    _tensor = torch.randn(B * T, V, device=device, dtype=dtype) * scalar
     _input = _tensor.detach().clone().requires_grad_(True)
     _input2 = _tensor.detach().clone().requires_grad_(True)
 
-    target = torch.randint(0, V, (B * T,), device="cuda", dtype=torch.long)
+    target = torch.randint(0, V, (B * T,), device=device, dtype=torch.long)
 
     # Assign some random number of elements as ignore_index
     num_elements_to_assign = torch.randint(
@@ -178,12 +181,12 @@ def _test_correctness_with_softcap_once(
 
     torch_ce = CrossEntropyLoss(reduction=reduction)
 
-    _tensor = torch.randn(B * T, V, device="cuda", dtype=dtype) * scalar
+    _tensor = torch.randn(B * T, V, device=device, dtype=dtype) * scalar
     # upcasting to match liger's casting strategy
     _input = _tensor.to(torch.float32).detach().clone().requires_grad_(True)
     _input2 = _tensor.detach().clone().requires_grad_(True)
 
-    target = torch.randint(0, V, (B * T,), device="cuda", dtype=torch.long)
+    target = torch.randint(0, V, (B * T,), device=device, dtype=torch.long)
 
     # downcasting to original dtype
     output = torch_ce(softcap * torch.tanh(_input / softcap), target).to(dtype)
@@ -214,11 +217,11 @@ def _test_correctness_with_z_loss_once(
         dtype=dtype,
     )
 
-    _tensor = torch.randn(B * T, V, device="cuda", dtype=dtype) * scalar
+    _tensor = torch.randn(B * T, V, device=device, dtype=dtype) * scalar
     _input = _tensor.detach().clone().requires_grad_(True)
     _input2 = _tensor.detach().clone().requires_grad_(True)
 
-    target = torch.randint(0, V, (B * T,), device="cuda", dtype=torch.long)
+    target = torch.randint(0, V, (B * T,), device=device, dtype=torch.long)
     if return_z_loss:
         output, z_output = torch_ce(_input, target)
         output2, z_output2 = target_ce(_input2, target)
@@ -263,11 +266,11 @@ def _test_correctness_with_z_loss_with_other_params_once(
         dtype=dtype,
     )
 
-    _tensor = torch.randn(B * T, V, device="cuda", dtype=dtype) * scalar
+    _tensor = torch.randn(B * T, V, device=device, dtype=dtype) * scalar
     _input = _tensor.detach().clone().requires_grad_(True)
     _input2 = _tensor.detach().clone().requires_grad_(True)
 
-    target = torch.randint(0, V, (B * T,), device="cuda", dtype=torch.long)
+    target = torch.randint(0, V, (B * T,), device=device, dtype=torch.long)
 
     # Assign some random number of elements as ignore_index
     num_elements_to_assign = torch.randint(
@@ -302,11 +305,11 @@ def _test_correctness_not_last_layer_once(
 
     torch_ce = CrossEntropyLoss(reduction=reduction)
 
-    _tensor = torch.randn(B * T, V, device="cuda", dtype=dtype) * scalar
+    _tensor = torch.randn(B * T, V, device=device, dtype=dtype) * scalar
     _input = _tensor.detach().clone().requires_grad_(True)
     _input2 = _tensor.detach().clone().requires_grad_(True)
 
-    target = torch.randint(0, V, (B * T,), device="cuda", dtype=torch.long)
+    target = torch.randint(0, V, (B * T,), device=device, dtype=torch.long)
 
     output = torch_ce(_input, target)
     output2 = target_ce(_input2, target)
@@ -330,12 +333,12 @@ def _test_correctness_functional(
     rtol,
 ):
 
-    _input = torch.randn(B * T, V, device="cuda", dtype=dtype) * scalar
+    _input = torch.randn(B * T, V, device=device, dtype=dtype) * scalar
 
     x1 = _input.clone().requires_grad_(True)
     x2 = _input.clone().requires_grad_(True)
 
-    target = torch.randint(0, V, (B * T,), device="cuda", dtype=torch.long)
+    target = torch.randint(0, V, (B * T,), device=device, dtype=torch.long)
 
     y1, y1_z = liger_cross_entropy(
         x1,

--- a/test/transformers/test_embedding.py
+++ b/test/transformers/test_embedding.py
@@ -3,6 +3,9 @@ import torch
 from torch.nn import Embedding
 
 from liger_kernel.transformers.experimental.embedding import LigerEmbedding
+from liger_kernel.utils import infer_device
+
+device = infer_device()
 
 SLEEP_SECONDS = 0.1
 
@@ -27,7 +30,7 @@ SLEEP_SECONDS = 0.1
 @pytest.mark.parametrize(
     "dtype, atol, rtol, device",
     [
-        (torch.float32, 1e-6, 1e-5, "cuda"),
+        (torch.float32, 1e-6, 1e-5, device),
     ],
 )
 def test_embedding_correctness(

--- a/test/transformers/test_fused_linear_jsd.py
+++ b/test/transformers/test_fused_linear_jsd.py
@@ -7,6 +7,9 @@ import torch
 from liger_kernel.ops.fused_linear_jsd import LigerFusedLinearJSDFunction
 from liger_kernel.transformers.functional import liger_fused_linear_jsd
 from liger_kernel.transformers.fused_linear_jsd import LigerFusedLinearJSD
+from liger_kernel.utils import infer_device
+
+device = infer_device()
 
 set_seed(42)
 
@@ -108,7 +111,6 @@ class LigerLMHeadJSD(torch.nn.Module):
     ],
 )
 def test_correctness(B, T, H, V, scalar, dtype, beta, temperature, atol, rtol):
-    device = "cuda"
     torch_lm_head_jsd = TorchLMHeadJSD(
         H=H,
         V=V,
@@ -183,7 +185,6 @@ def test_correctness(B, T, H, V, scalar, dtype, beta, temperature, atol, rtol):
 def test_correctness_with_ignore_index(
     B, T, H, V, scalar, dtype, beta, ignore_index, temperature, atol, rtol
 ):
-    device = "cuda"
     torch_lm_head_jsd = TorchLMHeadJSD(
         H=H,
         V=V,
@@ -267,8 +268,6 @@ def test_correctness_with_ignore_index(
 def test_correctness_functional(
     B, T, H, V, scalar, dtype, beta, ignore_index, temperature, atol, rtol
 ):
-    device = "cuda"
-
     # init the linear in all FusedLinearJSDs with the same weights
     _weight = torch.rand(V, H // 2, device=device, dtype=dtype)
     _weight1 = _weight.detach().clone().requires_grad_(True)
@@ -346,7 +345,6 @@ def test_correctness_functional(
 def test_correctness_all_ignored(
     B, T, H, V, scalar, dtype, beta, ignore_index, temperature, atol, rtol
 ):
-    device = "cuda"
     torch_lm_head_jsd = TorchLMHeadJSD(
         H=H,
         V=V,
@@ -411,7 +409,6 @@ def test_amp(autocast_dtype, atol, rtol):
     ignore_index = -100
     temperature = 1.0
     beta = 0.5
-    device = "cuda"
     dtype = torch.float32
     torch_lm_head_jsd = TorchLMHeadJSD(
         H=H,
@@ -456,7 +453,7 @@ def test_amp(autocast_dtype, atol, rtol):
     ]  # Randomly select indices
     label[indices_to_assign] = ignore_index
 
-    with torch.autocast(device_type="cuda", dtype=autocast_dtype):
+    with torch.autocast(device_type=device, dtype=autocast_dtype):
         output1 = torch_lm_head_jsd(_input1, teacher_input, label)
         output2 = liger_lm_head_jsd(_input2, teacher_input, label)
 

--- a/test/transformers/test_geglu.py
+++ b/test/transformers/test_geglu.py
@@ -8,6 +8,9 @@ from transformers.models.llama.modeling_llama import LlamaMLP
 from liger_kernel.ops.geglu import LigerGELUMulFunction
 from liger_kernel.transformers.functional import liger_geglu
 from liger_kernel.transformers.geglu import LigerGEGLUMLP
+from liger_kernel.utils import infer_device
+
+device = infer_device()
 
 LLAMA_CONFIG = LlamaConfig(
     hidden_size=4096,
@@ -42,22 +45,22 @@ SLEEP_SECONDS = 0.1
     ],
 )
 def test_correctness(bsz, seq_len, hidden_size, intermediate_size, dtype, atol, rtol):
-    _input = torch.randn(bsz, seq_len, hidden_size, device="cuda", dtype=dtype)
+    _input = torch.randn(bsz, seq_len, hidden_size, device=device, dtype=dtype)
 
     x1 = _input.clone().requires_grad_(True)
     x2 = _input.clone().requires_grad_(True)
 
     # initialize weights
-    G = torch.randn(hidden_size, intermediate_size, device="cuda", dtype=dtype)
-    U = torch.randn(hidden_size, intermediate_size, device="cuda", dtype=dtype)
-    D = torch.randn(intermediate_size, hidden_size, device="cuda", dtype=dtype)
+    G = torch.randn(hidden_size, intermediate_size, device=device, dtype=dtype)
+    U = torch.randn(hidden_size, intermediate_size, device=device, dtype=dtype)
+    D = torch.randn(intermediate_size, hidden_size, device=device, dtype=dtype)
 
-    llama_mlp = LlamaMLP(config=LLAMA_CONFIG).to("cuda").to(dtype)
+    llama_mlp = LlamaMLP(config=LLAMA_CONFIG).to(device).to(dtype)
     llama_mlp.gate_proj.weight.data = G.T
     llama_mlp.up_proj.weight.data = U.T
     llama_mlp.down_proj.weight.data = D.T
 
-    liger_mlp = LigerGEGLUMLP(config=LLAMA_CONFIG).to("cuda").to(dtype)
+    liger_mlp = LigerGEGLUMLP(config=LLAMA_CONFIG).to(device).to(dtype)
     liger_mlp.gate_proj.weight.data = G.T
     liger_mlp.up_proj.weight.data = U.T
     liger_mlp.down_proj.weight.data = D.T
@@ -121,8 +124,8 @@ def test_correctness(bsz, seq_len, hidden_size, intermediate_size, dtype, atol, 
     ],
 )
 def test_correctness_functional(bsz, seq_len, size, dtype, atol, rtol):
-    _input = torch.randn(bsz, seq_len, size, device="cuda", dtype=dtype)
-    _b = torch.randn(bsz, seq_len, size, device="cuda", dtype=dtype)
+    _input = torch.randn(bsz, seq_len, size, device=device, dtype=dtype)
+    _b = torch.randn(bsz, seq_len, size, device=device, dtype=dtype)
 
     x1 = _input.clone().requires_grad_(True)
     x2 = _input.clone().requires_grad_(True)

--- a/test/transformers/test_group_norm.py
+++ b/test/transformers/test_group_norm.py
@@ -4,6 +4,9 @@ import pytest
 import torch
 
 from liger_kernel.transformers.group_norm import LigerGroupNorm
+from liger_kernel.utils import infer_device
+
+device = infer_device()
 
 random_batch_size = random.randint(1, 16)
 random_num_groups = random.randint(1, 32)
@@ -32,17 +35,17 @@ def test_liger_group_norm(
     torch.manual_seed(0)
 
     _tensor = torch.randn(
-        batch_size, num_channels, hidden_size, dtype=dtype, device="cuda"
+        batch_size, num_channels, hidden_size, dtype=dtype, device=device
     )
 
     liger_x = _tensor.clone().detach().requires_grad_(True)
     torch_x = _tensor.clone().detach().requires_grad_(True)
 
-    liger_ln = LigerGroupNorm(num_channels, num_groups, eps=1e-6).to(dtype).cuda()
+    liger_ln = LigerGroupNorm(num_channels, num_groups, eps=1e-6).to(dtype).to(device)
     torch_ln = (
         torch.nn.GroupNorm(num_channels=num_channels, num_groups=num_groups, eps=1e-6)
         .to(dtype)
-        .cuda()
+        .to(device)
     )
 
     with torch.no_grad():

--- a/test/transformers/test_jsd.py
+++ b/test/transformers/test_jsd.py
@@ -7,6 +7,9 @@ from torch.nn import KLDivLoss
 
 from liger_kernel.transformers.functional import liger_jsd
 from liger_kernel.transformers.jsd import LigerJSD, LigerJSDFunction
+from liger_kernel.utils import infer_device
+
+device = infer_device()
 
 set_seed(42)
 
@@ -84,7 +87,7 @@ def _test_correctness_once(
     atol,
     rtol,
     is_last_layer=True,
-    device="cuda",
+    device=device,
 ):
     torch_jsd = JSD(dtype=dtype)
 
@@ -126,7 +129,7 @@ def _test_correctness_with_beta_once(
     atol,
     rtol,
     is_last_layer=True,
-    device="cuda",
+    device=device,
 ):
     torch_jsd = JSD(beta=beta, dtype=dtype)
 
@@ -163,7 +166,7 @@ def _test_correctness_with_ignore_index_once(
     dtype,
     atol,
     rtol,
-    device="cuda",
+    device=device,
 ):
     torch_jsd = JSD(ignore_index=ignore_index, dtype=dtype)
 
@@ -198,7 +201,7 @@ def _test_correctness_with_ignore_index_once(
 
 
 def _test_correctness_functional(
-    B, T, V, beta, ignore_index, is_last_layer, dtype, atol, rtol, device="cuda"
+    B, T, V, beta, ignore_index, is_last_layer, dtype, atol, rtol, device=device
 ):
     input = torch.randn(
         B * T, V, device=device, dtype=dtype, requires_grad=True
@@ -292,7 +295,7 @@ def test_correctness_with_all_indices_ignored(
     dtype=torch.bfloat16,
     atol=1e-3,
     rtol=1e-3,
-    device="cuda",
+    device=device,
 ):
     ignore_index = -100
     torch_jsd = JSD(ignore_index=ignore_index, dtype=dtype)

--- a/test/transformers/test_kl_div.py
+++ b/test/transformers/test_kl_div.py
@@ -5,6 +5,9 @@ import torch
 from torch.nn import KLDivLoss
 
 from liger_kernel.transformers.kl_div import LigerKLDIVLoss
+from liger_kernel.utils import infer_device
+
+device = infer_device()
 
 _SHAPE_PARAMS = (
     "B, T, V",
@@ -43,7 +46,7 @@ def _test_correctness_once(
     reduction,
     log_target,
     is_last_layer=True,
-    device="cuda",
+    device=device,
 ):
     torch.manual_seed(0)
     torch_kldiv = KLDivLoss(reduction=reduction, log_target=log_target)

--- a/test/transformers/test_layer_norm.py
+++ b/test/transformers/test_layer_norm.py
@@ -4,6 +4,9 @@ import torch
 from liger_kernel.ops.layer_norm import LigerLayerNormFunction
 from liger_kernel.transformers.functional import liger_layer_norm
 from liger_kernel.transformers.layer_norm import LigerLayerNorm
+from liger_kernel.utils import infer_device
+
+device = infer_device()
 
 
 @pytest.mark.parametrize(
@@ -22,13 +25,13 @@ from liger_kernel.transformers.layer_norm import LigerLayerNorm
 def test_liger_layer_norm(batch_size, seq_len, hidden_size, dtype, atol, rtol):
     torch.manual_seed(0)
 
-    x = torch.randn(batch_size, seq_len, hidden_size, dtype=dtype, device="cuda")
+    x = torch.randn(batch_size, seq_len, hidden_size, dtype=dtype, device=device)
 
     liger_x = x.clone().requires_grad_(True)
     torch_x = x.clone().requires_grad_(True)
 
-    liger_ln = LigerLayerNorm(hidden_size, eps=1e-6).to(dtype).cuda()
-    torch_ln = torch.nn.LayerNorm(hidden_size, eps=1e-6).to(dtype).cuda()
+    liger_ln = LigerLayerNorm(hidden_size, eps=1e-6).to(dtype).to(device)
+    torch_ln = torch.nn.LayerNorm(hidden_size, eps=1e-6).to(dtype).to(device)
 
     with torch.no_grad():
         torch_ln.weight.copy_(liger_ln.weight)
@@ -68,17 +71,17 @@ def test_liger_layer_norm_functional(
 ):
     torch.manual_seed(0)
 
-    input = torch.randn(batch_size, seq_len, hidden_size, dtype=dtype, device="cuda")
+    input = torch.randn(batch_size, seq_len, hidden_size, dtype=dtype, device=device)
 
     x1 = input.clone().requires_grad_(True)
     x2 = input.clone().requires_grad_(True)
 
-    w = torch.randn(hidden_size, device="cuda", dtype=dtype)
+    w = torch.randn(hidden_size, device=device, dtype=dtype)
 
     w1 = w.clone().requires_grad_(True)
     w2 = w.clone().requires_grad_(True)
 
-    b = torch.randn(hidden_size, device="cuda", dtype=dtype)
+    b = torch.randn(hidden_size, device=device, dtype=dtype)
 
     b1 = b.clone().requires_grad_(True)
     b2 = b.clone().requires_grad_(True)

--- a/test/transformers/test_mm_int8int2.py
+++ b/test/transformers/test_mm_int8int2.py
@@ -6,6 +6,9 @@ from liger_kernel.ops.experimental.mm_int8int2 import (
     pack_weights,
     unpack_weights,
 )
+from liger_kernel.utils import infer_device
+
+device = infer_device()
 
 
 # input_features = size*4 when the weight matrix is unpacked
@@ -38,7 +41,7 @@ from liger_kernel.ops.experimental.mm_int8int2 import (
 @pytest.mark.parametrize(
     "atol, rtol, device",
     [
-        (1e-2, 1e-2, "cuda"),
+        (1e-2, 1e-2, device),
     ],
 )
 def test_kernel_correctness(
@@ -95,7 +98,7 @@ def test_kernel_correctness(
 @pytest.mark.parametrize(
     "device",
     [
-        "cuda",
+        device,
     ],
 )
 def test_unpack_pack_correctness(out_features, size, device):

--- a/test/transformers/test_qwen2vl_mrope.py
+++ b/test/transformers/test_qwen2vl_mrope.py
@@ -16,6 +16,10 @@ except Exception:
 from liger_kernel.ops.qwen2vl_mrope import LigerQwen2VLMRopeFunction
 from liger_kernel.transformers.functional import liger_qwen2vl_mrope
 from liger_kernel.transformers.qwen2vl_mrope import liger_multimodal_rotary_pos_emb
+from liger_kernel.utils import infer_device
+
+
+device = infer_device()
 
 
 @pytest.mark.skipif(
@@ -49,16 +53,16 @@ from liger_kernel.transformers.qwen2vl_mrope import liger_multimodal_rotary_pos_
 def test_correctness(
     bsz, seq_len, num_q_heads, num_kv_heads, head_dim, mrope_section, dtype, atol, rtol
 ):
-    rotary_emb = Qwen2VLRotaryEmbedding(head_dim, device="cuda")
+    rotary_emb = Qwen2VLRotaryEmbedding(head_dim, device=device)
 
     _tensor_q = (
-        torch.randn((bsz, seq_len, num_q_heads, head_dim), device="cuda")
+        torch.randn((bsz, seq_len, num_q_heads, head_dim), device=device)
         .transpose(1, 2)
         .to(dtype)
     )
 
     _tensor_k = (
-        torch.randn((bsz, seq_len, num_kv_heads, head_dim), device="cuda")
+        torch.randn((bsz, seq_len, num_kv_heads, head_dim), device=device)
         .transpose(1, 2)
         .to(dtype)
     )
@@ -70,7 +74,7 @@ def test_correctness(
     k2 = _tensor_k.clone().requires_grad_(True)
 
     # NOTE: this position ids distribution is different from the real one, just to test op correctness
-    pos_ids = torch.arange(seq_len * 3, device="cuda", dtype=torch.long).view(3, 1, -1)
+    pos_ids = torch.arange(seq_len * 3, device=device, dtype=torch.long).view(3, 1, -1)
     cos, sin = rotary_emb(k1, pos_ids)
 
     # validate forward pass
@@ -81,8 +85,8 @@ def test_correctness(
 
     # validate backward pass
     dq, dk = (
-        torch.randn_like(hf_q, device="cuda"),
-        torch.randn_like(hf_k, device="cuda").to(dtype),
+        torch.randn_like(hf_q, device=device),
+        torch.randn_like(hf_k, device=device).to(dtype),
     )
 
     q1_grad, k1_grad = torch.autograd.grad(
@@ -116,8 +120,8 @@ def test_correctness(
 def test_functional_correctness(
     bsz, seq_len, num_q_heads, num_kv_heads, head_dim, mrope_section, dtype, atol, rtol
 ):
-    _q = torch.randn((bsz, num_q_heads, seq_len, head_dim), device="cuda", dtype=dtype)
-    _k = torch.randn((bsz, num_kv_heads, seq_len, head_dim), device="cuda", dtype=dtype)
+    _q = torch.randn((bsz, num_q_heads, seq_len, head_dim), device=device, dtype=dtype)
+    _k = torch.randn((bsz, num_kv_heads, seq_len, head_dim), device=device, dtype=dtype)
 
     q1 = _q.clone().requires_grad_(True)
     q2 = _q.clone().requires_grad_(True)
@@ -125,9 +129,9 @@ def test_functional_correctness(
     k1 = _k.clone().requires_grad_(True)
     k2 = _k.clone().requires_grad_(True)
 
-    rotary_emb = Qwen2VLRotaryEmbedding(head_dim, device="cuda")
+    rotary_emb = Qwen2VLRotaryEmbedding(head_dim, device=device)
 
-    pos_ids = torch.arange(seq_len * 3, device="cuda", dtype=torch.long).view(3, 1, -1)
+    pos_ids = torch.arange(seq_len * 3, device=device, dtype=torch.long).view(3, 1, -1)
     cos, sin = rotary_emb(k1, pos_ids)
 
     functional_q, functional_k = liger_qwen2vl_mrope(q1, k1, cos, sin, mrope_section)

--- a/test/transformers/test_rms_norm.py
+++ b/test/transformers/test_rms_norm.py
@@ -13,10 +13,13 @@ import torch.nn as nn
 from liger_kernel.ops.rms_norm import LigerRMSNormFunction
 from liger_kernel.transformers.functional import liger_rms_norm
 from liger_kernel.transformers.rms_norm import LigerRMSNorm
+from liger_kernel.utils import infer_device
+
+device = infer_device()
 
 set_seed(42)
 torch.use_deterministic_algorithms(True)
-device = infer_device()
+
 #  Only setting torch.use_deterministic_algorithms(True) might throw the following error:
 #  RuntimeError: Deterministic behavior was enabled with either `torch.use_deterministic_algorithms(True)` or `at::Context::setDeterministicAlgorithms(true)`,
 #  but this operation is not deterministic because it uses CuBLAS and you have CUDA >= 10.2. To enable deterministic behavior in this case, you must set an

--- a/test/transformers/test_rope.py
+++ b/test/transformers/test_rope.py
@@ -10,6 +10,9 @@ from transformers.models.llama.modeling_llama import (
 from liger_kernel.ops.rope import LigerRopeFunction
 from liger_kernel.transformers.functional import liger_rope
 from liger_kernel.transformers.rope import liger_rotary_pos_emb
+from liger_kernel.utils import infer_device
+
+device = infer_device()
 
 SLEEP_SECONDS = 0.1
 
@@ -46,16 +49,16 @@ SLEEP_SECONDS = 0.1
 def test_correctness(
     bsz, seq_len, num_q_heads, num_kv_heads, head_dim, dtype, atol, rtol
 ):
-    rotary_emb = LlamaRotaryEmbedding(head_dim, device="cuda")
+    rotary_emb = LlamaRotaryEmbedding(head_dim, device=device)
 
     _tensor_q = (
-        torch.randn((bsz, seq_len, num_q_heads, head_dim), device="cuda")
+        torch.randn((bsz, seq_len, num_q_heads, head_dim), device=device)
         .transpose(1, 2)
         .to(dtype)
     )
 
     _tensor_k = (
-        torch.randn((bsz, seq_len, num_kv_heads, head_dim), device="cuda")
+        torch.randn((bsz, seq_len, num_kv_heads, head_dim), device=device)
         .transpose(1, 2)
         .to(dtype)
     )
@@ -66,7 +69,7 @@ def test_correctness(
     q2 = _tensor_q.clone().requires_grad_(True)
     k2 = _tensor_k.clone().requires_grad_(True)
 
-    pos_ids = torch.arange(seq_len, device="cuda", dtype=torch.long).unsqueeze(0)
+    pos_ids = torch.arange(seq_len, device=device, dtype=torch.long).unsqueeze(0)
     cos, sin = rotary_emb(k1, pos_ids)
 
     # validate forward pass
@@ -77,8 +80,8 @@ def test_correctness(
 
     # validate backward pass
     dq, dk = (
-        torch.randn_like(hf_q, device="cuda"),
-        torch.randn_like(hf_k, device="cuda").to(dtype),
+        torch.randn_like(hf_q, device=device),
+        torch.randn_like(hf_k, device=device).to(dtype),
     )
 
     q1_grad, k1_grad = torch.autograd.grad(
@@ -111,8 +114,8 @@ def test_correctness(
 def test_functional_correctness(
     bsz, seq_len, num_q_heads, num_kv_heads, head_dim, dtype, atol, rtol
 ):
-    _q = torch.randn((bsz, num_q_heads, seq_len, head_dim), device="cuda", dtype=dtype)
-    _k = torch.randn((bsz, num_kv_heads, seq_len, head_dim), device="cuda", dtype=dtype)
+    _q = torch.randn((bsz, num_q_heads, seq_len, head_dim), device=device, dtype=dtype)
+    _k = torch.randn((bsz, num_kv_heads, seq_len, head_dim), device=device, dtype=dtype)
 
     q1 = _q.clone().requires_grad_(True)
     q2 = _q.clone().requires_grad_(True)
@@ -120,9 +123,9 @@ def test_functional_correctness(
     k1 = _k.clone().requires_grad_(True)
     k2 = _k.clone().requires_grad_(True)
 
-    rotary_emb = LlamaRotaryEmbedding(head_dim, device="cuda")
+    rotary_emb = LlamaRotaryEmbedding(head_dim, device=device)
 
-    pos_ids = torch.arange(seq_len, device="cuda", dtype=torch.long).unsqueeze(0)
+    pos_ids = torch.arange(seq_len, device=device, dtype=torch.long).unsqueeze(0)
     cos, sin = rotary_emb(k1, pos_ids)
 
     functional_q, functional_k = liger_rope(q1, k1, cos, sin)

--- a/test/transformers/test_swiglu.py
+++ b/test/transformers/test_swiglu.py
@@ -10,6 +10,9 @@ from transformers.models.phi3.modeling_phi3 import Phi3MLP
 from liger_kernel.ops.swiglu import LigerSiLUMulFunction
 from liger_kernel.transformers.functional import liger_swiglu
 from liger_kernel.transformers.swiglu import LigerPhi3SwiGLUMLP, LigerSwiGLUMLP
+from liger_kernel.utils import infer_device
+
+device = infer_device()
 
 LLAMA_CONFIG = LlamaConfig(
     hidden_size=4096,
@@ -52,22 +55,22 @@ SLEEP_SECONDS = 0.1
 def test_correctness_llamamlp(
     bsz, seq_len, hidden_size, intermediate_size, dtype, atol, rtol
 ):
-    _input = torch.randn(bsz, seq_len, hidden_size, device="cuda", dtype=dtype)
+    _input = torch.randn(bsz, seq_len, hidden_size, device=device, dtype=dtype)
 
     x1 = _input.clone().requires_grad_(True)
     x2 = _input.clone().requires_grad_(True)
 
     # initialize weights
-    G = torch.randn(hidden_size, intermediate_size, device="cuda", dtype=dtype)
-    U = torch.randn(hidden_size, intermediate_size, device="cuda", dtype=dtype)
-    D = torch.randn(intermediate_size, hidden_size, device="cuda", dtype=dtype)
+    G = torch.randn(hidden_size, intermediate_size, device=device, dtype=dtype)
+    U = torch.randn(hidden_size, intermediate_size, device=device, dtype=dtype)
+    D = torch.randn(intermediate_size, hidden_size, device=device, dtype=dtype)
 
-    llama_mlp = LlamaMLP(config=LLAMA_CONFIG).to("cuda").to(dtype)
+    llama_mlp = LlamaMLP(config=LLAMA_CONFIG).to(device).to(dtype)
     llama_mlp.gate_proj.weight.data = G.T
     llama_mlp.up_proj.weight.data = U.T
     llama_mlp.down_proj.weight.data = D.T
 
-    liger_mlp = LigerSwiGLUMLP(config=LLAMA_CONFIG).to("cuda").to(dtype)
+    liger_mlp = LigerSwiGLUMLP(config=LLAMA_CONFIG).to(device).to(dtype)
     liger_mlp.gate_proj.weight.data = G.T
     liger_mlp.up_proj.weight.data = U.T
     liger_mlp.down_proj.weight.data = D.T
@@ -132,20 +135,20 @@ def test_correctness_llamamlp(
 def test_correctness_phi3mlp(
     bsz, seq_len, hidden_size, intermediate_size, dtype, atol, rtol
 ):
-    _input = torch.randn(bsz, seq_len, hidden_size, device="cuda", dtype=dtype)
+    _input = torch.randn(bsz, seq_len, hidden_size, device=device, dtype=dtype)
 
     x1 = _input.clone().requires_grad_(True)
     x2 = _input.clone().requires_grad_(True)
 
     # initialize weights
-    GU = torch.randn(hidden_size, intermediate_size * 2, device="cuda", dtype=dtype)
-    D = torch.randn(intermediate_size, hidden_size, device="cuda", dtype=dtype)
+    GU = torch.randn(hidden_size, intermediate_size * 2, device=device, dtype=dtype)
+    D = torch.randn(intermediate_size, hidden_size, device=device, dtype=dtype)
 
-    phi3_mlp = Phi3MLP(config=PHI3_CONFIG).to("cuda").to(dtype)
+    phi3_mlp = Phi3MLP(config=PHI3_CONFIG).to(device).to(dtype)
     phi3_mlp.gate_up_proj.weight.data = GU.T
     phi3_mlp.down_proj.weight.data = D.T
 
-    liger_mlp = LigerPhi3SwiGLUMLP(config=PHI3_CONFIG).to("cuda").to(dtype)
+    liger_mlp = LigerPhi3SwiGLUMLP(config=PHI3_CONFIG).to(device).to(dtype)
     liger_mlp.gate_up_proj.weight.data = GU.T
     liger_mlp.down_proj.weight.data = D.T
 
@@ -193,8 +196,8 @@ def test_correctness_phi3mlp(
     ],
 )
 def test_correctness_functional(bsz, seq_len, size, dtype, atol, rtol):
-    _input = torch.randn(bsz, seq_len, size, device="cuda", dtype=dtype)
-    _b = torch.randn(bsz, seq_len, size, device="cuda", dtype=dtype)
+    _input = torch.randn(bsz, seq_len, size, device=device, dtype=dtype)
+    _b = torch.randn(bsz, seq_len, size, device=device, dtype=dtype)
 
     x1 = _input.clone().requires_grad_(True)
     x2 = _input.clone().requires_grad_(True)

--- a/test/utils.py
+++ b/test/utils.py
@@ -15,21 +15,9 @@ from tokenizers.pre_tokenizers import Whitespace
 from tokenizers.trainers import BpeTrainer
 from transformers import PretrainedConfig, PreTrainedModel
 from transformers.tokenization_utils_base import BatchEncoding
+from liger_kernel.utils import infer_device
 
-
-def infer_device():
-    """
-    Get current device name based on available devices
-    """
-    if torch.cuda.is_available():
-        return "cuda"
-    elif torch.xpu.is_available():
-        return "xpu"
-    else:
-        return "cpu"
-
-
-torch_device = infer_device()
+device = infer_device()
 
 
 def set_seed(seed=42):
@@ -43,7 +31,7 @@ def set_seed(seed=42):
     # PyTorch random seed
     torch.manual_seed(seed)
 
-    if torch_device == "cuda":
+    if device == "cuda":
         # If you are using CUDA
         torch.cuda.manual_seed(seed)
         torch.cuda.manual_seed_all(seed)  # if you are using multi-GPU.
@@ -51,8 +39,8 @@ def set_seed(seed=42):
         # PyTorch backend settings
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
-    elif torch_device == "xpu":
-        # If you ware using intel GPU
+    elif device == "xpu":
+        # If you are using XPU
         torch.xpu.manual_seed(seed)
         torch.xpu.manual_seed_all(seed)
 
@@ -225,9 +213,9 @@ def train_bpe_tokenizer(special_tokens: List[str], unk_token: str = "<|unk|>"):
 
 
 def supports_bfloat16():
-    if torch_device == "cuda":
+    if device == "cuda":
         return torch.cuda.get_device_capability() >= (8, 0)  # Ampere and newer
-    elif torch_device == "xpu":
+    elif device == "xpu":
         return True
     else:
         return False


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Adds xpu support so all tests, benchmarks etc. run on XPUs or Intel GPUs. 

## Details
`infer_device()` function is moved to a separate file and in any file where previously "cuda" was needed, `infer_device` is imported and "cuda" is replaced with return value of a call to `infer_device()`

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
A100 80GB PCIe, RTX 3060, Intel Data Center GPU Max 1550
<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [x] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
