### PR TITLE
Implement softcapping in fused jsd

### DIFF
--- a/src/liger_kernel/transformers/fused_linear_jsd.py
+++ b/src/liger_kernel/transformers/fused_linear_jsd.py
@@ -68,7 +68,7 @@ class LigerFusedLinearJSD(torch.nn.Module):
     ```
     """
 
-    def __init__(self, jsd_beta=0.5, ignore_index=-100, temperature=1.0):
+    def __init__(self, jsd_beta=0.5, ignore_index=-100, temperature=1.0, softcap=0.0):
         super().__init__()
         assert (
             jsd_beta > 0 and jsd_beta < 1
@@ -77,6 +77,7 @@ class LigerFusedLinearJSD(torch.nn.Module):
         self.jsd_beta = jsd_beta
         self.temperature = temperature
         self.ignore_index = ignore_index
+        self.softcap = softcap
 
     def forward(
         self,
@@ -95,4 +96,5 @@ class LigerFusedLinearJSD(torch.nn.Module):
             self.jsd_beta,
             self.ignore_index,
             self.temperature,
+            self.softcap,
         )


### PR DESCRIPTION
## Summary
Implements `softcap` in the fused linear jsd, so it can be used for `gemma2` models

## Details
Assumes same softcap for teacher and student model

## Testing Done
- added tests for softcapping in `test_fused_linear_jsd.py`

- Hardware Type: L40S
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
