### PR TITLE
add reference model logps to chunkedloss interface and fix dpo loss fn

### DIFF
--- a/src/liger_kernel/chunked_loss/dpo_loss.py
+++ b/src/liger_kernel/chunked_loss/dpo_loss.py
@@ -9,15 +9,25 @@ from liger_kernel.chunked_loss.fused_linear_preference import (
 class LigerFusedLinearDPOFunction(LigerFusedLinearPreferenceBase):
 
     @staticmethod
-    def preference_loss_fn(chosen_logps, rejected_logps, beta=0.1):
+    def preference_loss_fn(chosen_logps, rejected_logps, ref_chosen_logps=None, ref_rejected_logps=None, beta=0.1):
         """
         Compute DPO loss (Direct Preference Optimization).
         Args:
             chosen_logps (torch.Tensor): Avg log probabilities of chosen tokens. Shape: (batch_size,).
             rejected_logps (torch.Tensor): Avg log probabilities of rejected tokens. Shape: (batch_size,).
+            ref_chosen_logps (torch.Tensor, optional): Reference log probabilities of chosen tokens. Shape: (batch_size,).
+            ref_rejected_logps (torch.Tensor, optional): Reference log probabilities of rejected tokens. Shape: (batch_size,).
             beta (float): Weight for the direct preference loss.
         """
-        logits_diff = beta * (chosen_logps - rejected_logps)
+        if ref_chosen_logps is None:
+            ref_chosen_logps = torch.tensor(0.0, device=chosen_logps.device)
+        if ref_rejected_logps is None:
+            ref_rejected_logps = torch.tensor(0.0, device=rejected_logps.device)
+
+        chosen_logratios = chosen_logps - ref_chosen_logps
+        rejected_logratios = rejected_logps - ref_rejected_logps
+
+        logits_diff = beta * (chosen_logratios - rejected_logratios)
         losses = -F.logsigmoid(logits_diff)
         return losses.sum()
 
@@ -28,10 +38,13 @@ class LigerFusedLinearDPOFunction(LigerFusedLinearPreferenceBase):
         weight,
         target,
         bias=None,
+        ref_weight=None,
+        ref_bias=None,
         ignore_index=-100,
         beta=0.1,
         compute_nll_loss=True,
         compiled=True,
+        use_ref_model=True,
     ):
         """
         Fused linear layer with DPO (Direct Preference Optimization) loss.
@@ -48,6 +61,9 @@ class LigerFusedLinearDPOFunction(LigerFusedLinearPreferenceBase):
             beta=beta,
             compute_nll_loss=compute_nll_loss,
             compiled=compiled,
+            use_ref_model=use_ref_model,
+            ref_weight=ref_weight,
+            ref_bias=ref_bias,
         )
 
     @staticmethod
@@ -55,7 +71,7 @@ class LigerFusedLinearDPOFunction(LigerFusedLinearPreferenceBase):
         # Get gradients for _input, weight, bias, and target from the base class
         grads = LigerFusedLinearPreferenceBase.backward(ctx, grad_output)[:4]
         # Return these gradients, followed by None for the remaining inputs
-        return *grads, None, None, None, None
+        return *grads, None, None, None, None, None, None, None
 
 
 class LigerFusedLinearDPOLoss(torch.nn.Module):
@@ -69,26 +85,34 @@ class LigerFusedLinearDPOLoss(torch.nn.Module):
         beta: float = 0.1,
         compute_nll_loss: bool = True,
         compiled: bool = True,
+        use_ref_model: bool = False,
     ):
         """
         Args:
             ignore_index (int): Index to ignore in the loss.
             beta (float): Weight for the odds ratio loss.
+            compute_nll_loss (bool): Whether to compute the NLL loss.
+            compiled (bool): Whether to use the torch compiled kernel.
+            use_ref_model (bool): Whether to use a reference model for the DPO loss.
         """
         super().__init__()
         self.ignore_index = ignore_index
         self.beta = beta
         self.compute_nll_loss = compute_nll_loss
         self.compiled = compiled
+        self.use_ref_model = use_ref_model
 
-    def forward(self, lin_weight, _input, target, bias=None):
+    def forward(self, lin_weight, _input, target, bias=None, ref_weight=None, ref_bias=None):
         return LigerFusedLinearDPOFunction.apply(
             _input,
             lin_weight,
             target,
             bias,
+            ref_weight,
+            ref_bias,
             self.ignore_index,
             self.beta,
             self.compute_nll_loss,
             self.compiled,
+            self.use_ref_model,
         )

--- a/src/liger_kernel/chunked_loss/dpo_loss.py
+++ b/src/liger_kernel/chunked_loss/dpo_loss.py
@@ -9,7 +9,13 @@ from liger_kernel.chunked_loss.fused_linear_preference import (
 class LigerFusedLinearDPOFunction(LigerFusedLinearPreferenceBase):
 
     @staticmethod
-    def preference_loss_fn(chosen_logps, rejected_logps, ref_chosen_logps=None, ref_rejected_logps=None, beta=0.1):
+    def preference_loss_fn(
+        chosen_logps,
+        rejected_logps,
+        ref_chosen_logps=None,
+        ref_rejected_logps=None,
+        beta=0.1,
+    ):
         """
         Compute DPO loss (Direct Preference Optimization).
         Args:
@@ -102,7 +108,9 @@ class LigerFusedLinearDPOLoss(torch.nn.Module):
         self.compiled = compiled
         self.use_ref_model = use_ref_model
 
-    def forward(self, lin_weight, _input, target, bias=None, ref_weight=None, ref_bias=None):
+    def forward(
+        self, lin_weight, _input, target, bias=None, ref_weight=None, ref_bias=None
+    ):
         return LigerFusedLinearDPOFunction.apply(
             _input,
             lin_weight,

--- a/src/liger_kernel/chunked_loss/fused_linear_preference.py
+++ b/src/liger_kernel/chunked_loss/fused_linear_preference.py
@@ -19,28 +19,37 @@ class LigerFusedLinearPreferenceBase(torch.autograd.Function):
         raise NotImplementedError("Preference loss function must be implemented.")
 
     @staticmethod
-    def get_ref_logps(
-        input_chunk, ref_weight, target_chunk, ref_bias=None, ignore_index=-100
+    def chunk_forward(
+        input_chunk, weight, target_chunk, bias=None, ignore_index=-100, compute_nll_loss=True
     ):
-        with torch.no_grad():
-            ref_logits_chunk = input_chunk @ ref_weight.t()
-            if ref_bias is not None:
-                ref_logits_chunk = ref_logits_chunk + ref_bias
-            ref_log_probs_chunk = F.log_softmax(ref_logits_chunk.float(), dim=-1)
+        len_chosen_chunk = target_chunk.shape[0] // 2
+        logits_chunk = input_chunk @ weight.t()
+        if bias is not None:
+            logits_chunk = logits_chunk + bias
+        log_probs_chunk = F.log_softmax(logits_chunk.float(), dim=-1)
+        
+        chosen_nll_loss = 0.0
+        if compute_nll_loss:
+            chosen_nll_loss = F.nll_loss(
+                    log_probs_chunk[:len_chosen_chunk].view(-1, log_probs_chunk.shape[-1]),
+                    target_chunk[:len_chosen_chunk].view(-1),
+                    reduction="sum",
+                    ignore_index=ignore_index,
+                )
 
-            loss_mask = target_chunk != ignore_index
-            label_chunk = torch.where(loss_mask, target_chunk, 0)
+        loss_mask = target_chunk != ignore_index
+        label_chunk = torch.where(loss_mask, target_chunk, 0)
 
-            ref_per_token_logps = ref_log_probs_chunk.gather(
-                -1, label_chunk.unsqueeze(-1)
-            ).squeeze(-1)
-            ref_average_log_prob = (ref_per_token_logps * loss_mask).sum(
-                -1
-            ) / loss_mask.sum(-1)
+        per_token_logps = log_probs_chunk.gather(
+            -1, label_chunk.unsqueeze(-1)
+        ).squeeze(-1)
+        average_log_prob = (per_token_logps * loss_mask).sum(
+            -1
+        ) / loss_mask.sum(-1)
 
-            ref_chosen_logps = ref_average_log_prob[: input_chunk.shape[0] // 2]
-            ref_rejected_logps = ref_average_log_prob[input_chunk.shape[0] // 2 :]
-        return ref_chosen_logps, ref_rejected_logps
+        chosen_logps = average_log_prob[: len_chosen_chunk]
+        rejected_logps = average_log_prob[len_chosen_chunk :]
+        return chosen_logps, rejected_logps, chosen_nll_loss
 
     @staticmethod
     def forward(
@@ -216,47 +225,31 @@ class LigerFusedLinearPreferenceBase(torch.autograd.Function):
             ref_bias (torch.Tensor, optional): Reference bias tensor. Shape: (vocab_size,).
             loss_kwargs (dict): Additional arguments for the loss function.
         """
-        len_chosen_chunk = target_chunk.shape[0] // 2
-
-        logits_chunk = input_chunk @ weight.t()  # chunk_size x V
-        if bias is not None:
-            logits_chunk = logits_chunk + bias
-        log_probs_chunk = F.log_softmax(logits_chunk.float(), dim=-1)
-
-        chosen_nll_loss = 0.0
-        if compute_nll_loss:
-            chosen_nll_loss = F.nll_loss(
-                log_probs_chunk[:len_chosen_chunk].view(-1, log_probs_chunk.shape[-1]),
-                target_chunk[:len_chosen_chunk].view(-1),
-                reduction="sum",
-                ignore_index=ignore_index,
-            )
-            chosen_nll_loss = (
+        chosen_logps, rejected_logps, chosen_nll_loss = LigerFusedLinearPreferenceBase.chunk_forward(
+            input_chunk,
+            weight,
+            target_chunk,
+            bias=bias,
+            ignore_index=ignore_index,
+            compute_nll_loss=compute_nll_loss,
+        )
+        chosen_nll_loss = (
                 chosen_nll_loss
                 / (full_target[: full_target.shape[0] // 2] != ignore_index).sum()
             )
 
-        loss_mask = target_chunk != ignore_index
-        label_chunk = torch.where(loss_mask, target_chunk, 0)
-
-        per_token_logps = log_probs_chunk.gather(-1, label_chunk.unsqueeze(-1)).squeeze(
-            -1
-        )
-        average_log_prob = (per_token_logps * loss_mask).sum(-1) / loss_mask.sum(-1)
-
-        chosen_logps = average_log_prob[:len_chosen_chunk]
-        rejected_logps = average_log_prob[len_chosen_chunk:]
-
         if use_ref_model:
-            ref_chosen_logps, ref_rejected_logps = (
-                LigerFusedLinearPreferenceBase.get_ref_logps(
-                    input_chunk,
-                    ref_weight,
-                    target_chunk,
-                    ref_bias=ref_bias,
-                    ignore_index=ignore_index,
+            with torch.no_grad():
+                ref_chosen_logps, ref_rejected_logps, _ = (
+                    LigerFusedLinearPreferenceBase.chunk_forward(
+                        input_chunk,
+                        ref_weight,
+                        target_chunk,
+                        ref_bias,
+                        ignore_index=ignore_index,
+                        compute_nll_loss=False,
+                    )
                 )
-            )
             loss_kwargs["ref_chosen_logps"] = ref_chosen_logps
             loss_kwargs["ref_rejected_logps"] = ref_rejected_logps
 

--- a/test/chunked_loss/test_dpo_loss.py
+++ b/test/chunked_loss/test_dpo_loss.py
@@ -19,8 +19,12 @@ class HFDPOLoss(HFAlignmentLoss):
     Reference: https://github.com/huggingface/trl/blob/main/trl/trainer/orpo_trainer.py
     """
 
-    def __init__(self, ignore_index: int = -100, beta: float = 0.1, use_ref_model: bool = True):
-        super().__init__(beta=beta, ignore_index=ignore_index, use_ref_model=use_ref_model)
+    def __init__(
+        self, ignore_index: int = -100, beta: float = 0.1, use_ref_model: bool = True
+    ):
+        super().__init__(
+            beta=beta, ignore_index=ignore_index, use_ref_model=use_ref_model
+        )
 
     def alignment_loss(
         self,
@@ -69,7 +73,9 @@ class TorchLMHeadDPO(torch.nn.Module):
         ).get_batch_loss_metrics
 
     def forward(self, x, y):
-        return self.dpo_loss(self.lin.weight, x, y, self.lin.bias, self.ref_lin.weight, self.ref_lin.bias)
+        return self.dpo_loss(
+            self.lin.weight, x, y, self.lin.bias, self.ref_lin.weight, self.ref_lin.bias
+        )
 
 
 class LigerLMHeadDPO(torch.nn.Module):
@@ -90,10 +96,14 @@ class LigerLMHeadDPO(torch.nn.Module):
         self.ref_lin = torch.nn.Linear(
             in_features=H, out_features=V, bias=ref_bias, dtype=dtype
         )
-        self.dpo_loss = LigerFusedLinearDPOLoss(ignore_index=ignore_index, beta=beta, use_ref_model=True)
+        self.dpo_loss = LigerFusedLinearDPOLoss(
+            ignore_index=ignore_index, beta=beta, use_ref_model=True
+        )
 
     def forward(self, x, y):
-        return self.dpo_loss(self.lin.weight, x, y, self.lin.bias, self.ref_lin.weight, self.ref_lin.bias)
+        return self.dpo_loss(
+            self.lin.weight, x, y, self.lin.bias, self.ref_lin.weight, self.ref_lin.bias
+        )
 
 
 @pytest.mark.parametrize(
@@ -113,7 +123,9 @@ class LigerLMHeadDPO(torch.nn.Module):
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("ref_bias", [True, False])
 @pytest.mark.parametrize("ignore_index, beta", [(-100, 0.1), (42, 0.2)])
-def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, bias, ref_bias, ignore_index, beta):
+def test_correctness(
+    B, T, H, V, scalar, dtype, atol, rtol, bias, ref_bias, ignore_index, beta
+):
     B = 2 * B  # dpo loss requires B to be even
 
     torch_lm_head_dpo = TorchLMHeadDPO(
@@ -138,8 +150,8 @@ def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, bias, ref_bias, igno
     torch_lm_head_dpo.lin.weight.data = liger_lm_head_dpo.lin.weight.data = torch.randn(
         V, H, device="cuda", dtype=dtype
     )
-    torch_lm_head_dpo.ref_lin.weight.data = liger_lm_head_dpo.ref_lin.weight.data = torch.randn(
-        V, H, device="cuda", dtype=dtype
+    torch_lm_head_dpo.ref_lin.weight.data = liger_lm_head_dpo.ref_lin.weight.data = (
+        torch.randn(V, H, device="cuda", dtype=dtype)
     )
 
     if bias:
@@ -147,8 +159,8 @@ def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, bias, ref_bias, igno
             V, device="cuda", dtype=dtype
         )
     if ref_bias:
-        torch_lm_head_dpo.ref_lin.bias.data = liger_lm_head_dpo.ref_lin.bias.data = torch.randn(
-            V, device="cuda", dtype=dtype
+        torch_lm_head_dpo.ref_lin.bias.data = liger_lm_head_dpo.ref_lin.bias.data = (
+            torch.randn(V, device="cuda", dtype=dtype)
         )
 
     _input = torch.randn(B, T, H, device="cuda", dtype=dtype) * scalar
@@ -244,8 +256,12 @@ def test_correctness_functional(B, T, H, V, scalar, dtype, atol, rtol, bias, ref
     ref_bias1 = _ref_bias.detach().clone().requires_grad_(True) if ref_bias else None
     ref_bias2 = _ref_bias.detach().clone().requires_grad_(True) if ref_bias else None
 
-    loss1 = LigerFusedLinearDPOFunction.apply(input1, weight1, target, bias1, ref_weight1, ref_bias1)
-    loss2 = liger_fused_linear_dpo(input2, weight2, target, bias2, ref_weight2, ref_bias2)
+    loss1 = LigerFusedLinearDPOFunction.apply(
+        input1, weight1, target, bias1, ref_weight1, ref_bias1
+    )
+    loss2 = liger_fused_linear_dpo(
+        input2, weight2, target, bias2, ref_weight2, ref_bias2
+    )
 
     assert_verbose_allclose(loss1, loss2, atol=atol, rtol=rtol)
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -355,7 +355,13 @@ def revert_liger_kernel_to_phi3(model_config: MiniModelConfig):
 
 class HFAlignmentLoss:
 
-    def __init__(self, alpha: float = 1.0, beta: float = 0.1, ignore_index: int = -100, use_ref_model: bool = False):
+    def __init__(
+        self,
+        alpha: float = 1.0,
+        beta: float = 0.1,
+        ignore_index: int = -100,
+        use_ref_model: bool = False,
+    ):
         self.alpha = alpha
         self.beta = beta
         self.ignore_index = ignore_index
@@ -414,8 +420,13 @@ class HFAlignmentLoss:
         ref_logits = _input @ ref_weight.t()
         if ref_bias is not None:
             ref_logits = ref_logits + ref_bias
-        ref_all_logps = self.get_batch_logps(ref_logits, target, average_log_prob=average_log_prob)
-        return ref_all_logps[:_input.shape[0] // 2], ref_all_logps[_input.shape[0] // 2:]
+        ref_all_logps = self.get_batch_logps(
+            ref_logits, target, average_log_prob=average_log_prob
+        )
+        return (
+            ref_all_logps[: _input.shape[0] // 2],
+            ref_all_logps[_input.shape[0] // 2 :],
+        )
 
     def concatenated_forward(
         self,
@@ -503,7 +514,9 @@ class HFAlignmentLoss:
             )
             loss_kwargs["ref_chosen_logps"] = ref_chosen_logps
             loss_kwargs["ref_rejected_logps"] = ref_rejected_logps
-        losses = self.alignment_loss(policy_chosen_logps, policy_rejected_logps, **loss_kwargs)
+        losses = self.alignment_loss(
+            policy_chosen_logps, policy_rejected_logps, **loss_kwargs
+        )
         # full loss
         loss = policy_nll_loss * self.alpha - losses.mean()
         return loss


### PR DESCRIPTION
accomodate reference model logps in chunked loss interface and make dpo loss use reference model logps in its loss function
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
as title
<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
