### PR TITLE
Fix `get_batch_loss_metrics` comments

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -483,7 +483,7 @@ class HFAlignmentLoss:
         ref_bias: torch.FloatTensor = None,
         average_log_prob: bool = True,
     ):
-        """Compute the ORPO loss and other metrics for the given batch of inputs for train or test."""
+        """Compute the loss metrics for the given batch of inputs for train or test."""
 
         forward_output = self.concatenated_forward(
             _input, weight, target, bias, average_log_prob


### PR DESCRIPTION
## Summary

Remove misleading docstring in `get_batch_loss_metrics()` of `test/utils.py`.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: A10G
- [ ] run `make test` to ensure correctness
- [X] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
