### PR TITLE
Switch amd-ci to use MI300X runner

### DIFF
--- a/.github/workflows/amd-ci.yml
+++ b/.github/workflows/amd-ci.yml
@@ -21,7 +21,7 @@ name: GitHub Actions CI (AMD)
 
 jobs:
   checkstyle:
-    runs-on: ubuntu-latest
+    runs-on: linux-mi300-gpu-1
 
     steps:
     - name: Checkout code

--- a/.github/workflows/amd-ci.yml
+++ b/.github/workflows/amd-ci.yml
@@ -1,23 +1,23 @@
 name: GitHub Actions CI (AMD)
 
-# on:
-#   push:
-#     branches:
-#       - main
-#     paths:
-#       - "src/**"
-#       - "test/**"
-#   pull_request:
-#     branches:
-#       - main
-#     paths:
-#       - "src/**"
-#       - "test/**"
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "test/**"
+  pull_request:
+    # branches:
+    #   - main
+    # paths:
+    #   - "src/**"
+    #   - "test/**"
 
-# concurrency:
-#   # This causes it to cancel previous in-progress actions on the same PR / branch,
-#   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-#   cancel-in-progress: true
+concurrency:
+  # This causes it to cancel previous in-progress actions on the same PR / branch,
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   checkstyle:


### PR DESCRIPTION
This commit switches the amd-ci workflow to use MI300x gpu provided by AMD for testing coverage.
