### PR TITLE
[AMD] [CI] Added Dockerfile and AMD-CI test workflow

### DIFF
--- a/.github/workflows/amd-ci.yml
+++ b/.github/workflows/amd-ci.yml
@@ -53,12 +53,21 @@ jobs:
       with:
         python-version: '3.10'
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e ".[dev]"
+    - name: Check Docker Version
+      run: docker version
 
-    - name: Run tests
+    - name: Build Liger-Kernel CI Docker image
+      run: docker build -t liger-kernel-ci -f Dockerfile.rocm .
+
+    - name: Run the tests
       run: |
-        make test
-        make test-convergence
+        sudo docker run \
+          --network=host \
+          --group-add=video \
+          --ipc=host \
+          --cap-add=SYS_PTRACE \
+          --security-opt seccomp=unconfined \
+          --device /dev/kfd \
+          --device /dev/dri \
+          liger-kernel-ci \
+          /bin/bash -c "make test; make test-convergence"

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -1,0 +1,73 @@
+# Default ROCm 6.2 base image
+ARG BASE_IMAGE="rocm/pytorch:rocm6.2.3_ubuntu22.04_py3.10_pytorch_release_2.3.0_triton_llvm_reg_issue"
+
+### Base image build stage
+FROM $BASE_IMAGE AS base
+
+# Install some basic utilities
+RUN apt-get update && apt-get install python3 python3-pip -y
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    sudo \
+    git \
+    bzip2 \
+    libx11-6 \
+    build-essential \
+    wget \
+    unzip \
+    tmux \
+    ccache \
+ && rm -rf /var/lib/apt/lists/*
+
+# When launching the container, mount the code directory to /liger-kernel-workspace
+ARG APP_MOUNT=/liger-kernel-workspace
+WORKDIR ${APP_MOUNT}
+
+RUN python3 -m pip install --upgrade pip
+# Remove sccache so it doesn't interfere with ccache
+# TODO: implement sccache support across components
+RUN apt-get purge -y sccache; python3 -m pip uninstall -y sccache; rm -f "$(which sccache)"
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install triton==3.1.0 transformers==4.46.3
+
+ENV LLVM_SYMBOLIZER_PATH=/opt/rocm/llvm/bin/llvm-symbolizer
+ENV PATH=$PATH:/opt/rocm/bin:/libtorch/bin:
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib/:/libtorch/lib:
+ENV CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/libtorch/include:/libtorch/include/torch/csrc/api/include/:/opt/rocm/include/:
+
+ENV PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH}
+ENV CCACHE_DIR=/root/.cache/ccache
+
+
+### AMD-SMI build stage
+FROM base AS build_amdsmi
+# Build amdsmi wheel always
+RUN cd /opt/rocm/share/amd_smi \
+    && python3 -m pip wheel . --wheel-dir=/install
+
+
+### Final Liger-Kernel build stage
+FROM base AS final
+# Import the Liger-Kernel development directory from the build context
+COPY . .
+ARG GIT_REPO_CHECK=0
+RUN --mount=type=bind,source=.git,target=.git \
+    if [ "$GIT_REPO_CHECK" != 0 ]; then bash tools/check_repo.sh ; fi
+
+RUN python3 -m pip install --upgrade pip
+
+RUN --mount=type=cache,target=${CCACHE_DIR} \
+    --mount=type=bind,source=.git,target=.git \
+    --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install -e .[dev]
+
+# Copy amdsmi wheel into final image
+RUN --mount=type=bind,from=build_amdsmi,src=/install,target=/install \
+    mkdir -p libs \
+    && cp /install/*.whl libs \
+    # Preemptively uninstall to avoid same-version no-installs
+    && python3 -m pip uninstall -y amdsmi;
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
This is a PR to suggests the use of Docker Images to run the Liger Kernel CI on AMD Machine.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Details
When running the `docker run` you might need to run with `sudo`. In this version, I have not included it. If you find problem using AMD GPU within the docker container. Please add back the `sudo`. E.g.
```bash
sudo docker run \
   --network=host \
   --group-add=video \
   --ipc=host \
   --cap-add=SYS_PTRACE \
   --security-opt seccomp=unconfined \
   --device /dev/kfd \
   --device /dev/dri \
   liger-ci \
   /bin/bash -c "make test-convergence; make test"
```

## Additional Details

The `transformers` version has been pinned to `4.46.3` as there is a API changes in the later version of `transformers`. E.g. I have tested with `transformers==4.47.0` and the following error occured.
```bash
FAILED test/convergence/test_mini_models_multimodal.py::test_mini_model_multimodal[mini_qwen2_vl-32-0.0001-dtype0-1e-08-1e-05-0.005-1e-05-0.005-1e-05] - AttributeError: 'Qwen2VLConfig' object has no attribute 'video_token_id'. Did you mean: 'vision_token_id'?
FAILED test/convergence/test_mini_models_multimodal.py::test_mini_model_multimodal[mini_qwen2_vl-32-0.0001-dtype1-0.001-0.01-0.1-0.01-0.01-0.01] - AttributeError: 'Qwen2VLConfig' object has no attribute 'video_token_id'. Did you mean: 'vision_token_id'?
FAILED test/convergence/test_mini_models_no_logits.py::test_mini_model[mini_qwen2_vl-32-0.0001-dtype6-1e-08-1e-05-0.005-1e-05-0.005-1e-05] - AttributeError: 'Qwen2VLConfig' object has no attribute 'image_token_id'. Did you mean: 'pad_token_id'?
FAILED test/convergence/test_mini_models_no_logits.py::test_mini_model[mini_qwen2_vl-32-0.0001-dtype7-0.001-0.01-0.1-0.01-0.01-0.01] - AttributeError: 'Qwen2VLConfig' object has no attribute 'image_token_id'. Did you mean: 'pad_token_id'?
```

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
