### PR TITLE
Fix All `chunked_loss` Benchmark Scripts

### DIFF
--- a/benchmark/scripts/benchmark_cpo_loss.py
+++ b/benchmark/scripts/benchmark_cpo_loss.py
@@ -19,26 +19,6 @@ device = infer_device()
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 
-class TorchLMHeadCPO(torch.nn.Module):
-    """Ground truth implementation of the linear fused with torch based cross entropy loss.
-
-    :param H: hidden size
-    :param V: vocab size
-    :param ignore_index: index to ignore
-    :param reduction: reduction method
-    """
-
-    def __init__(self, H: int, V: int, dtype: torch.dtype, ignore_index: int = -100):
-        from test.chunked_loss.test_cpo_loss import HFCPOLoss
-
-        super().__init__()
-        self.lin = torch.nn.Linear(in_features=H, out_features=V, bias=False, dtype=dtype)
-        self.cpo_loss = HFCPOLoss().get_batch_loss_metrics
-
-    def forward(self, x, y):
-        return self.cpo_loss(x, self.lin.weight, y)
-
-
 class LigerLMHeadCPO(torch.nn.Module):
     def __init__(self, H: int, V: int, dtype: torch.dtype, ignore_index: int = -100):
         super().__init__()
@@ -57,6 +37,8 @@ class LigerLMHeadCPO(torch.nn.Module):
 def bench_memory_fused_linear_cpo_loss(
     input: SingleBenchmarkRunInput,
 ) -> SingleBenchmarkRunOutput:
+    from test.chunked_loss.test_cpo_loss import TorchLMHeadCPO
+
     B = input.x
     T = input.extra_benchmark_config["T"]
     H = input.extra_benchmark_config["H"]
@@ -77,8 +59,9 @@ def bench_memory_fused_linear_cpo_loss(
             return torch_lm_head_cpo(_input, target)
 
     def full():
-        y = fwd()
-        y.backward()
+        losses = fwd()
+        loss = losses[0]
+        loss.backward()
 
     mem_50, mem_20, mem_80 = _test_memory(full, _iter=10, quantiles=QUANTILES)
     return SingleBenchmarkRunOutput(
@@ -96,6 +79,8 @@ def bench_memory_fused_linear_cpo_loss(
 def bench_speed_fused_linear_cpo_loss(
     input: SingleBenchmarkRunInput,
 ) -> SingleBenchmarkRunOutput:
+    from test.chunked_loss.test_cpo_loss import TorchLMHeadCPO
+
     B = input.x
     T = input.extra_benchmark_config["T"]
     H = input.extra_benchmark_config["H"]
@@ -123,10 +108,10 @@ def bench_speed_fused_linear_cpo_loss(
             quantiles=QUANTILES,
         )
     elif mode == "backward":
-        y = fwd()
+        losses = fwd()
 
         ms_50, ms_20, ms_80 = triton.testing.do_bench(
-            lambda: y.backward(retain_graph=True),
+            lambda: losses[0].backward(retain_graph=True),
             grad_to_none=[_input],
             rep=100,
             quantiles=QUANTILES,
@@ -134,8 +119,9 @@ def bench_speed_fused_linear_cpo_loss(
     elif mode == "full":
 
         def full():
-            y = fwd()
-            y.backward()
+            losses = fwd()
+            loss = losses[0]
+            loss.backward()
 
         ms_50, ms_20, ms_80 = triton.testing.do_bench(
             full,

--- a/benchmark/scripts/benchmark_orpo_loss.py
+++ b/benchmark/scripts/benchmark_orpo_loss.py
@@ -19,16 +19,6 @@ device = infer_device()
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 
-class LigerLMHeadORPO(torch.nn.Module):
-    def __init__(self, H: int, V: int, dtype: torch.dtype, ignore_index: int = -100):
-        super().__init__()
-        self.lin = torch.nn.Linear(in_features=H, out_features=V, bias=False, dtype=dtype)
-        self.orpo_loss = LigerFusedLinearORPOFunction.apply
-
-    def forward(self, x, y):
-        return self.orpo_loss(x, self.lin.weight, y)
-
-
 #############################################################################
 # Test the memory consumption of the linear fused cross entropy loss
 #############################################################################
@@ -37,7 +27,7 @@ class LigerLMHeadORPO(torch.nn.Module):
 def bench_memory_fused_linear_orpo_loss(
     input: SingleBenchmarkRunInput,
 ) -> SingleBenchmarkRunOutput:
-    from test.chunked_loss.test_orpo_loss import TorchLMHeadORPO
+    from test.chunked_loss.test_orpo_loss import LigerLMHeadORPO, TorchLMHeadORPO
 
     B = input.x
     T = input.extra_benchmark_config["T"]
@@ -46,8 +36,12 @@ def bench_memory_fused_linear_orpo_loss(
     dtype = input.extra_benchmark_config["dtype"]
     provider = input.kernel_provider
 
-    torch_lm_head_orpo = TorchLMHeadORPO(H=H, V=V, dtype=dtype).to(device)
-    liger_lm_head_orpo = LigerLMHeadORPO(H=H, V=V, dtype=dtype).to(device)
+    torch_lm_head_orpo = lambda x, target: TorchLMHeadORPO(H=H, V=V, dtype=dtype).to(
+        device
+    )(x, target)[0]
+    liger_lm_head_orpo = lambda x, target: LigerLMHeadORPO(H=H, V=V, dtype=dtype).to(
+        device
+    )(x, target)[0]
 
     _input = torch.randn(B, T, H, requires_grad=True, dtype=dtype, device=device)
     target = torch.randint(V, (B, T), dtype=torch.long, device=device)
@@ -59,9 +53,8 @@ def bench_memory_fused_linear_orpo_loss(
             return torch_lm_head_orpo(_input, target)
 
     def full():
-        losses = fwd()
-        loss = losses[0]
-        loss.backward()
+        y = fwd()
+        y.backward()
 
     mem_50, mem_20, mem_80 = _test_memory(full, _iter=10, quantiles=QUANTILES)
     return SingleBenchmarkRunOutput(
@@ -79,7 +72,7 @@ def bench_memory_fused_linear_orpo_loss(
 def bench_speed_fused_linear_orpo_loss(
     input: SingleBenchmarkRunInput,
 ) -> SingleBenchmarkRunOutput:
-    from test.chunked_loss.test_orpo_loss import TorchLMHeadORPO
+    from test.chunked_loss.test_orpo_loss import LigerLMHeadORPO, TorchLMHeadORPO
 
     B = input.x
     T = input.extra_benchmark_config["T"]
@@ -89,8 +82,12 @@ def bench_speed_fused_linear_orpo_loss(
     provider = input.kernel_provider
     mode = input.kernel_operation_mode
 
-    torch_lm_head_orpo = TorchLMHeadORPO(H=H, V=V, dtype=dtype).to(device)
-    liger_lm_head_orpo = LigerLMHeadORPO(H=H, V=V, dtype=dtype).to(device)
+    torch_lm_head_orpo = lambda x, target: TorchLMHeadORPO(H=H, V=V, dtype=dtype).to(
+        device
+    )(x, target)[0]
+    liger_lm_head_orpo = lambda x, target: LigerLMHeadORPO(H=H, V=V, dtype=dtype).to(
+        device
+    )(x, target)[0]
 
     _input = torch.randn(B, T, H, requires_grad=True, dtype=dtype, device=device)
     target = torch.randint(V, (B, T), dtype=torch.long, device=device)
@@ -108,10 +105,10 @@ def bench_speed_fused_linear_orpo_loss(
             quantiles=QUANTILES,
         )
     elif mode == "backward":
-        losses = fwd()
+        y = fwd()
 
         ms_50, ms_20, ms_80 = triton.testing.do_bench(
-            lambda: losses[0].backward(retain_graph=True),
+            lambda: y.backward(retain_graph=True),
             grad_to_none=[_input],
             rep=100,
             quantiles=QUANTILES,
@@ -119,9 +116,8 @@ def bench_speed_fused_linear_orpo_loss(
     elif mode == "full":
 
         def full():
-            losses = fwd()
-            loss = losses[0]
-            loss.backward()
+            y = fwd()
+            y.backward()
 
         ms_50, ms_20, ms_80 = triton.testing.do_bench(
             full,

--- a/benchmark/scripts/benchmark_simpo_loss.py
+++ b/benchmark/scripts/benchmark_simpo_loss.py
@@ -19,16 +19,6 @@ device = infer_device()
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 
-class LigerLMHeadSimPO(torch.nn.Module):
-    def __init__(self, H: int, V: int, dtype: torch.dtype, ignore_index: int = -100):
-        super().__init__()
-        self.lin = torch.nn.Linear(in_features=H, out_features=V, bias=False, dtype=dtype)
-        self.simpo_loss = LigerFusedLinearSimPOFunction.apply
-
-    def forward(self, x, y):
-        return self.simpo_loss(x, self.lin.weight, y)
-
-
 #############################################################################
 # Test the memory consumption of the linear fused cross entropy loss
 #############################################################################
@@ -37,7 +27,7 @@ class LigerLMHeadSimPO(torch.nn.Module):
 def bench_memory_fused_linear_simpo_loss(
     input: SingleBenchmarkRunInput,
 ) -> SingleBenchmarkRunOutput:
-    from test.chunked_loss.test_simpo_loss import TorchLMHeadCPO
+    from test.chunked_loss.test_simpo_loss import LigerLMHeadSimPO, TorchLMHeadCPO
 
     B = input.x
     T = input.extra_benchmark_config["T"]
@@ -46,8 +36,12 @@ def bench_memory_fused_linear_simpo_loss(
     dtype = input.extra_benchmark_config["dtype"]
     provider = input.kernel_provider
 
-    torch_lm_head_simpo = TorchLMHeadCPO(H=H, V=V, dtype=dtype).to(device)
-    liger_lm_head_simpo = LigerLMHeadSimPO(H=H, V=V, dtype=dtype).to(device)
+    torch_lm_head_simpo = lambda x, target: TorchLMHeadCPO(H=H, V=V, dtype=dtype).to(
+        device
+    )(x, target)[0]
+    liger_lm_head_simpo = lambda x, target: LigerLMHeadSimPO(H=H, V=V, dtype=dtype).to(
+        device
+    )(x, target)[0]
 
     _input = torch.randn(B, T, H, requires_grad=True, dtype=dtype, device=device)
     target = torch.randint(V, (B, T), dtype=torch.long, device=device)
@@ -59,9 +53,8 @@ def bench_memory_fused_linear_simpo_loss(
             return torch_lm_head_simpo(_input, target)
 
     def full():
-        losses = fwd()
-        loss = losses[0]
-        loss.backward()
+        y = fwd()
+        y.backward()
 
     mem_50, mem_20, mem_80 = _test_memory(full, _iter=10, quantiles=QUANTILES)
     return SingleBenchmarkRunOutput(
@@ -79,7 +72,7 @@ def bench_memory_fused_linear_simpo_loss(
 def bench_speed_fused_linear_simpo_loss(
     input: SingleBenchmarkRunInput,
 ) -> SingleBenchmarkRunOutput:
-    from test.chunked_loss.test_simpo_loss import TorchLMHeadCPO
+    from test.chunked_loss.test_simpo_loss import LigerLMHeadSimPO, TorchLMHeadCPO
 
     B = input.x
     T = input.extra_benchmark_config["T"]
@@ -89,8 +82,12 @@ def bench_speed_fused_linear_simpo_loss(
     provider = input.kernel_provider
     mode = input.kernel_operation_mode
 
-    torch_lm_head_simpo = TorchLMHeadCPO(H=H, V=V, dtype=dtype).to(device)
-    liger_lm_head_simpo = LigerLMHeadSimPO(H=H, V=V, dtype=dtype).to(device)
+    torch_lm_head_simpo = lambda x, target: TorchLMHeadCPO(H=H, V=V, dtype=dtype).to(
+        device
+    )(x, target)[0]
+    liger_lm_head_simpo = lambda x, target: LigerLMHeadSimPO(H=H, V=V, dtype=dtype).to(
+        device
+    )(x, target)[0]
 
     _input = torch.randn(B, T, H, requires_grad=True, dtype=dtype, device=device)
     target = torch.randint(V, (B, T), dtype=torch.long, device=device)
@@ -108,10 +105,10 @@ def bench_speed_fused_linear_simpo_loss(
             quantiles=QUANTILES,
         )
     elif mode == "backward":
-        losses = fwd()
+        y = fwd()
 
         ms_50, ms_20, ms_80 = triton.testing.do_bench(
-            lambda: losses[0].backward(retain_graph=True),
+            lambda: y.backward(retain_graph=True),
             grad_to_none=[_input],
             rep=100,
             quantiles=QUANTILES,
@@ -119,9 +116,8 @@ def bench_speed_fused_linear_simpo_loss(
     elif mode == "full":
 
         def full():
-            losses = fwd()
-            loss = losses[0]
-            loss.backward()
+            y = fwd()
+            y.backward()
 
         ms_50, ms_20, ms_80 = triton.testing.do_bench(
             full,

--- a/benchmark/scripts/benchmark_simpo_loss.py
+++ b/benchmark/scripts/benchmark_simpo_loss.py
@@ -19,26 +19,6 @@ device = infer_device()
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 
-class TorchLMHeadSimPO(torch.nn.Module):
-    """Ground truth implementation of the linear fused with torch based cross entropy loss.
-
-    :param H: hidden size
-    :param V: vocab size
-    :param ignore_index: index to ignore
-    :param reduction: reduction method
-    """
-
-    def __init__(self, H: int, V: int, dtype: torch.dtype, ignore_index: int = -100):
-        from test.chunked_loss.test_cpo_loss import HFCPOLoss
-
-        super().__init__()
-        self.lin = torch.nn.Linear(in_features=H, out_features=V, bias=False, dtype=dtype)
-        self.simpo_loss = HFCPOLoss(loss_type="simpo").get_batch_loss_metrics
-
-    def forward(self, x, y):
-        return self.simpo_loss(x, self.lin.weight, y)
-
-
 class LigerLMHeadSimPO(torch.nn.Module):
     def __init__(self, H: int, V: int, dtype: torch.dtype, ignore_index: int = -100):
         super().__init__()
@@ -57,6 +37,8 @@ class LigerLMHeadSimPO(torch.nn.Module):
 def bench_memory_fused_linear_simpo_loss(
     input: SingleBenchmarkRunInput,
 ) -> SingleBenchmarkRunOutput:
+    from test.chunked_loss.test_simpo_loss import TorchLMHeadCPO
+
     B = input.x
     T = input.extra_benchmark_config["T"]
     H = input.extra_benchmark_config["H"]
@@ -64,7 +46,7 @@ def bench_memory_fused_linear_simpo_loss(
     dtype = input.extra_benchmark_config["dtype"]
     provider = input.kernel_provider
 
-    torch_lm_head_simpo = TorchLMHeadSimPO(H=H, V=V, dtype=dtype).to(device)
+    torch_lm_head_simpo = TorchLMHeadCPO(H=H, V=V, dtype=dtype).to(device)
     liger_lm_head_simpo = LigerLMHeadSimPO(H=H, V=V, dtype=dtype).to(device)
 
     _input = torch.randn(B, T, H, requires_grad=True, dtype=dtype, device=device)
@@ -77,8 +59,9 @@ def bench_memory_fused_linear_simpo_loss(
             return torch_lm_head_simpo(_input, target)
 
     def full():
-        y = fwd()
-        y.backward()
+        losses = fwd()
+        loss = losses[0]
+        loss.backward()
 
     mem_50, mem_20, mem_80 = _test_memory(full, _iter=10, quantiles=QUANTILES)
     return SingleBenchmarkRunOutput(
@@ -96,6 +79,8 @@ def bench_memory_fused_linear_simpo_loss(
 def bench_speed_fused_linear_simpo_loss(
     input: SingleBenchmarkRunInput,
 ) -> SingleBenchmarkRunOutput:
+    from test.chunked_loss.test_simpo_loss import TorchLMHeadCPO
+
     B = input.x
     T = input.extra_benchmark_config["T"]
     H = input.extra_benchmark_config["H"]
@@ -104,7 +89,7 @@ def bench_speed_fused_linear_simpo_loss(
     provider = input.kernel_provider
     mode = input.kernel_operation_mode
 
-    torch_lm_head_simpo = TorchLMHeadSimPO(H=H, V=V, dtype=dtype).to(device)
+    torch_lm_head_simpo = TorchLMHeadCPO(H=H, V=V, dtype=dtype).to(device)
     liger_lm_head_simpo = LigerLMHeadSimPO(H=H, V=V, dtype=dtype).to(device)
 
     _input = torch.randn(B, T, H, requires_grad=True, dtype=dtype, device=device)
@@ -123,10 +108,10 @@ def bench_speed_fused_linear_simpo_loss(
             quantiles=QUANTILES,
         )
     elif mode == "backward":
-        y = fwd()
+        losses = fwd()
 
         ms_50, ms_20, ms_80 = triton.testing.do_bench(
-            lambda: y.backward(retain_graph=True),
+            lambda: losses[0].backward(retain_graph=True),
             grad_to_none=[_input],
             rep=100,
             quantiles=QUANTILES,
@@ -134,8 +119,9 @@ def bench_speed_fused_linear_simpo_loss(
     elif mode == "full":
 
         def full():
-            y = fwd()
-            y.backward()
+            losses = fwd()
+            loss = losses[0]
+            loss.backward()
 
         ms_50, ms_20, ms_80 = triton.testing.do_bench(
             full,


### PR DESCRIPTION
## Summary

With recent updates, we need to align the APIs used in the benchmark script to ensure consistency.

Code changes:

- Fix `.backward()` pass in `backward` and `full` mode. 
- Reuse `TorchLMHead` from `chunked_loss` tests.

## Testing Done

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [X] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
