### PR TITLE
update ci icon on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,16 @@
             </a>
         </td>
         <td style="padding: 10px;">
-            <a href="https://github.com/linkedin/Liger-Kernel/actions/workflows/ci.yml">
-                <img src="https://github.com/linkedin/Liger-Kernel/actions/workflows/ci.yml/badge.svg?event=schedule" alt="Build">
-            </a>
+            <div style="display: block;">
+                <a href="https://github.com/linkedin/Liger-Kernel/actions/workflows/nvi-ci.yml">
+                    <img src="https://github.com/linkedin/Liger-Kernel/actions/workflows/nvi-ci.yml/badge.svg?event=schedule" alt="Build">
+                </a>
+            </div>
+            <div style="display: block;">
+                <a href="https://github.com/linkedin/Liger-Kernel/actions/workflows/amd-ci.yml">
+                    <img src="https://github.com/linkedin/Liger-Kernel/actions/workflows/amd-ci.yml/badge.svg" alt="Build">
+                </a>
+            </div>
         </td>
     </tr>
 </table>


### PR DESCRIPTION
## Summary
Update to support CI link on README page for both AMD and Intel.

Preview image on my fork
<img width="869" alt="image" src="https://github.com/user-attachments/assets/16cf6813-82a9-4b53-98a6-f105709be932">

## Testing Done
No testing required

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
