### PR TITLE
Fix Normalization Term in Distillation Loss 

### DIFF
--- a/src/liger_kernel/chunked_loss/fused_linear_distillation.py
+++ b/src/liger_kernel/chunked_loss/fused_linear_distillation.py
@@ -105,7 +105,9 @@ class LigerFusedLinearDistillationBase(torch.autograd.Function):
 
         hard_loss /= full_target.shape[0] // student_input_chunk.shape[0]
 
-        soft_loss = distillation_loss_fn(student_logits_chunk, teacher_logits_chunk, temperature)
+        soft_loss = distillation_loss_fn(
+            student_logits_chunk, teacher_logits_chunk, temperature
+        )
         soft_loss /= full_target.shape[0] // student_input_chunk.shape[0]
 
         loss = weight_hard_loss * hard_loss + weight_soft_loss * soft_loss

--- a/src/liger_kernel/chunked_loss/fused_linear_distillation.py
+++ b/src/liger_kernel/chunked_loss/fused_linear_distillation.py
@@ -47,7 +47,7 @@ class LigerFusedLinearDistillationBase(torch.autograd.Function):
             ce_loss = F.nll_loss(
                 student_log_probs_chunk.view(-1, student_log_probs_chunk.shape[-1]),
                 target_chunk.view(-1),
-                reduction="sum",
+                reduction="mean",
                 ignore_index=ignore_index,
             )
 
@@ -103,10 +103,10 @@ class LigerFusedLinearDistillationBase(torch.autograd.Function):
             )
         )
 
-        hard_loss /= full_target.shape[0]
+        hard_loss /= full_target.shape[0] // student_input_chunk.shape[0]
 
         soft_loss = distillation_loss_fn(student_logits_chunk, teacher_logits_chunk, temperature)
-        soft_loss /= full_target.shape[0]
+        soft_loss /= full_target.shape[0] // student_input_chunk.shape[0]
 
         loss = weight_hard_loss * hard_loss + weight_soft_loss * soft_loss
         return loss, (soft_loss, hard_loss, student_logits_chunk, teacher_logits_chunk)


### PR DESCRIPTION
## Summary

Based on this modification https://github.com/linkedin/Liger-Kernel/pull/432/commits/e381569d6c88283490887d76de70a824bb463b0c#r1875638713 introduced by @shivam15s.

I believe it's more accurate to compute chunked loss by normalizing it based on the "number of `chunks`". Please correct me if I'm mistaken—thanks!

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
