### PR TITLE
Revert Workaround of Disabling QWEN2_VL in Convergence Tests

### DIFF
--- a/test/convergence/test_mini_models_multimodal.py
+++ b/test/convergence/test_mini_models_multimodal.py
@@ -16,9 +16,7 @@ from test.utils import (
 
 import pytest
 import torch
-import transformers
 from datasets import load_dataset
-from packaging import version
 from torch.utils.data import DataLoader
 from transformers import PreTrainedTokenizerFast
 

--- a/test/convergence/test_mini_models_multimodal.py
+++ b/test/convergence/test_mini_models_multimodal.py
@@ -380,9 +380,8 @@ def run_mini_model_multimodal(
             5e-3,
             1e-5,
             marks=pytest.mark.skipif(
-                not QWEN2_VL_AVAILABLE
-                or version.parse(transformers.__version__) >= version.parse("4.47.0"),
-                reason="Qwen2-VL not available in this version of transformers or transformers version >= 4.47.0",
+                not QWEN2_VL_AVAILABLE,
+                reason="Qwen2-VL not available in this version of transformers",
             ),
         ),
         pytest.param(
@@ -401,10 +400,8 @@ def run_mini_model_multimodal(
                     not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
                 ),
                 pytest.mark.skipif(
-                    not QWEN2_VL_AVAILABLE
-                    or version.parse(transformers.__version__)
-                    >= version.parse("4.47.0"),
-                    reason="Qwen2-VL not available in this version of transformers or transformers version >= 4.47.0",
+                    not QWEN2_VL_AVAILABLE,
+                    reason="Qwen2-VL not available in this version of transformers",
                 ),
             ],
         ),

--- a/test/convergence/test_mini_models_with_logits.py
+++ b/test/convergence/test_mini_models_with_logits.py
@@ -18,9 +18,7 @@ from test.utils import (
 
 import pytest
 import torch
-import transformers
 from datasets import load_from_disk
-from packaging import version
 from torch.utils.data import DataLoader
 from transformers.models.gemma import GemmaConfig, GemmaForCausalLM
 from transformers.models.gemma2 import Gemma2Config, Gemma2ForCausalLM

--- a/test/convergence/test_mini_models_with_logits.py
+++ b/test/convergence/test_mini_models_with_logits.py
@@ -540,9 +540,8 @@ def run_mini_model(
             5e-3,
             1e-5,
             marks=pytest.mark.skipif(
-                not QWEN2_VL_AVAILABLE
-                or version.parse(transformers.__version__) >= version.parse("4.47.0"),
-                reason="Qwen2-VL not available in this version of transformers or transformers version >= 4.47.0",
+                not QWEN2_VL_AVAILABLE,
+                reason="Qwen2-VL not available in this version of transformers",
             ),
         ),
         pytest.param(
@@ -561,10 +560,8 @@ def run_mini_model(
                     not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
                 ),
                 pytest.mark.skipif(
-                    not QWEN2_VL_AVAILABLE
-                    or version.parse(transformers.__version__)
-                    >= version.parse("4.47.0"),
-                    reason="Qwen2-VL not available in this version of transformers or transformers version >= 4.47.0",
+                    not QWEN2_VL_AVAILABLE,
+                    reason="Qwen2-VL not available in this version of transformers",
                 ),
             ],
         ),


### PR DESCRIPTION
## Summary

After fix https://github.com/linkedin/Liger-Kernel/pull/464

We can revert some changes in

- https://github.com/linkedin/Liger-Kernel/pull/463
- https://github.com/linkedin/Liger-Kernel/pull/459

Which are workarounds of

https://github.com/linkedin/Liger-Kernel/issues/461

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [X] run `make checkstyle` to ensure code style
- [X] run `make test-convergence` to ensure convergence
