### PR TITLE
preference loss sign is inverted and leads to negative loss

### DIFF
--- a/src/liger_kernel/chunked_loss/fused_linear_preference.py
+++ b/src/liger_kernel/chunked_loss/fused_linear_preference.py
@@ -408,7 +408,7 @@ class LigerFusedLinearPreferenceBase(torch.autograd.Function):
         else:
             preference_loss, aux_outputs = preference_loss_outputs, []
 
-        loss = alpha * chosen_nll_loss - preference_loss
+        loss = alpha * chosen_nll_loss + preference_loss
         return_vars = (
             chosen_logps,
             rejected_logps,

--- a/test/utils.py
+++ b/test/utils.py
@@ -511,7 +511,7 @@ class HFAlignmentLoss:
         else:
             losses, aggregated_aux_outputs = alignment_loss_outputs, []
         # full loss
-        loss = policy_nll_loss * self.alpha - losses.mean()
+        loss = policy_nll_loss * self.alpha + losses.mean()
         return_vars = (
             policy_chosen_logps,
             policy_rejected_logps,


### PR DESCRIPTION
## Summary
In testing cases where there is no alpha/NLL loss used, the loss becomes negative, which is probably not the intended behavior. see https://github.com/huggingface/trl/blob/main/trl/trainer/dpo_trainer.py#L1234

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
