### PR TITLE
annotate tl constexpr values

### DIFF
--- a/src/liger_kernel/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cross_entropy.py
@@ -17,8 +17,8 @@ if compare_version("triton", operator.ge, "3.0.0"):
 else:
     from triton.language.math import tanh
 
-_TRUE: tl.constexpr = 1
-_FALSE: tl.constexpr = 0
+_TRUE: tl.constexpr = tl.constexpr(1)
+_FALSE: tl.constexpr = tl.constexpr(0)
 
 
 @triton.jit

--- a/src/liger_kernel/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cross_entropy.py
@@ -17,8 +17,8 @@ if compare_version("triton", operator.ge, "3.0.0"):
 else:
     from triton.language.math import tanh
 
-_TRUE = tl.constexpr(1)
-_FALSE = tl.constexpr(0)
+_TRUE: tl.constexpr = 1
+_FALSE: tl.constexpr = 0
 
 
 @triton.jit

--- a/src/liger_kernel/ops/kl_div.py
+++ b/src/liger_kernel/ops/kl_div.py
@@ -23,10 +23,10 @@ MAX_FUSED_SIZE = 65536 // 4  # 65536 // 4 or 8 works the best
 
 REDUCTION_LITERAL = Literal["none", "sum", "mean", "batchmean"]
 
-_REDUCTION_MODE_NONE: tl.constexpr = 0
-_REDUCTION_MODE_SUM: tl.constexpr = 1
-_REDUCTION_MODE_MEAN: tl.constexpr = 2
-_REDUCTION_MODE_BATCHMEAN: tl.constexpr = 3
+_REDUCTION_MODE_NONE: tl.constexpr = tl.constexpr(0)
+_REDUCTION_MODE_SUM: tl.constexpr = tl.constexpr(1)
+_REDUCTION_MODE_MEAN: tl.constexpr = tl.constexpr(2)
+_REDUCTION_MODE_BATCHMEAN: tl.constexpr = tl.constexpr(3)
 
 _str_to_reduction_mode = {
     "none": _REDUCTION_MODE_NONE.value,

--- a/src/liger_kernel/ops/kl_div.py
+++ b/src/liger_kernel/ops/kl_div.py
@@ -23,10 +23,10 @@ MAX_FUSED_SIZE = 65536 // 4  # 65536 // 4 or 8 works the best
 
 REDUCTION_LITERAL = Literal["none", "sum", "mean", "batchmean"]
 
-_REDUCTION_MODE_NONE = tl.constexpr(0)
-_REDUCTION_MODE_SUM = tl.constexpr(1)
-_REDUCTION_MODE_MEAN = tl.constexpr(2)
-_REDUCTION_MODE_BATCHMEAN = tl.constexpr(3)
+_REDUCTION_MODE_NONE: tl.constexpr = 0
+_REDUCTION_MODE_SUM: tl.constexpr = 1
+_REDUCTION_MODE_MEAN: tl.constexpr = 2
+_REDUCTION_MODE_BATCHMEAN: tl.constexpr = 3
 
 _str_to_reduction_mode = {
     "none": _REDUCTION_MODE_NONE.value,

--- a/src/liger_kernel/ops/rms_norm.py
+++ b/src/liger_kernel/ops/rms_norm.py
@@ -35,9 +35,9 @@ else:
     from triton.language.math import rsqrt
 
 
-_CASTING_MODE_NONE: tl.constexpr = -1
-_CASTING_MODE_LLAMA: tl.constexpr = 0
-_CASTING_MODE_GEMMA: tl.constexpr = 1
+_CASTING_MODE_NONE: tl.constexpr = tl.constexpr(-1)
+_CASTING_MODE_LLAMA: tl.constexpr = tl.constexpr(0)
+_CASTING_MODE_GEMMA: tl.constexpr = tl.constexpr(1)
 
 
 @triton.jit

--- a/src/liger_kernel/ops/rms_norm.py
+++ b/src/liger_kernel/ops/rms_norm.py
@@ -35,9 +35,9 @@ else:
     from triton.language.math import rsqrt
 
 
-_CASTING_MODE_NONE = tl.constexpr(-1)
-_CASTING_MODE_LLAMA = tl.constexpr(0)
-_CASTING_MODE_GEMMA = tl.constexpr(1)
+_CASTING_MODE_NONE: tl.constexpr = -1
+_CASTING_MODE_LLAMA: tl.constexpr = 0
+_CASTING_MODE_GEMMA: tl.constexpr = 1
 
 
 @triton.jit


### PR DESCRIPTION
## Summary

Annotates tl.constexpr
## Details

When using torch.compile I get the error

```
   File "/tmp/torchinductor_root/5h/c5hmywscvfp53un2gehng5syunj2ibukwyyzqs3b3caewyhxjuff.py", line 89, in <module>                                                       
     _CASTING_MODE_LLAMA = constexpr[0]   
                           ^^^^^^^^^      
 NameError: name 'constexpr' is not defined                                                                                                                              
```

This was fixed upstream, but it's in 2.6.0, so not stable yet. Converting this to an annotated expression resolves the issue.                                  

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
