### PR TITLE
Fix Unit Test error brought by Transformer Breaking Changes

### DIFF
--- a/benchmark/scripts/benchmark_rope.py
+++ b/benchmark/scripts/benchmark_rope.py
@@ -32,7 +32,6 @@ def bench_speed_rope(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput
     seq_len = extra_benchmark_config["seq_len"] if "seq_len" in extra_benchmark_config else input.x
 
     head_dim = hidden_size // num_q_heads
-    llama_config = LlamaConfig(head_dim=head_dim)
 
     if transformers_version < "4.48.0":
         # LlamaRotaryEmbedding constructor signature changed in transformers 4.48.0

--- a/benchmark/scripts/benchmark_rope.py
+++ b/benchmark/scripts/benchmark_rope.py
@@ -35,7 +35,7 @@ def bench_speed_rope(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput
 
     if transformers_version < "4.48.0":
         # LlamaRotaryEmbedding constructor signature changed in transformers 4.48.0
-        rotary_emb = LlamaRotaryEmbedding(head_dim=head_dim, device=device)
+        rotary_emb = LlamaRotaryEmbedding(head_dim, device=device)
     else:
         llama_config = LlamaConfig(head_dim=head_dim)
         rotary_emb = LlamaRotaryEmbedding(llama_config, device=device)
@@ -116,7 +116,7 @@ def bench_memory_rope(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutpu
 
     if transformers_version < "4.48.0":
         # LlamaRotaryEmbedding constructor signature changed in transformers 4.48.0
-        rotary_emb = LlamaRotaryEmbedding(head_dim=head_dim, device=device)
+        rotary_emb = LlamaRotaryEmbedding(head_dim, device=device)
     else:
         llama_config = LlamaConfig(head_dim=head_dim)
         rotary_emb = LlamaRotaryEmbedding(llama_config, device=device)

--- a/benchmark/scripts/benchmark_rope.py
+++ b/benchmark/scripts/benchmark_rope.py
@@ -1,6 +1,7 @@
 import torch
 import triton
 
+from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding
 from transformers.models.llama.modeling_llama import apply_rotary_pos_emb
 from utils import QUANTILES
@@ -30,7 +31,8 @@ def bench_speed_rope(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput
     seq_len = extra_benchmark_config["seq_len"] if "seq_len" in extra_benchmark_config else input.x
 
     head_dim = hidden_size // num_q_heads
-    rotary_emb = LlamaRotaryEmbedding(head_dim, device=device)
+    llama_config = LlamaConfig(head_dim=head_dim)
+    rotary_emb = LlamaRotaryEmbedding(llama_config, device=device)
     q = torch.randn(
         (1, seq_len, num_q_heads, head_dim),
         device=device,
@@ -105,7 +107,8 @@ def bench_memory_rope(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutpu
     seq_len = extra_benchmark_config["seq_len"] if "seq_len" in extra_benchmark_config else input.x
 
     head_dim = hidden_size // num_q_heads
-    rotary_emb = LlamaRotaryEmbedding(head_dim, device=device)
+    llama_config = LlamaConfig(head_dim=head_dim)
+    rotary_emb = LlamaRotaryEmbedding(llama_config, device=device)
     q = torch.randn(
         (1, seq_len, num_q_heads, head_dim),
         device=device,

--- a/test/transformers/test_rope.py
+++ b/test/transformers/test_rope.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from test.utils import supports_bfloat16
+from transformers import __version__ as transformers_version
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding
 from transformers.models.llama.modeling_llama import apply_rotary_pos_emb
@@ -58,8 +59,12 @@ def test_correctness(
     atol,
     rtol,
 ):
-    llama_config = LlamaConfig(head_dim=head_dim)
-    rotary_emb = LlamaRotaryEmbedding(llama_config, device=device)
+    if transformers_version < "4.48.0":
+        # LlamaRotaryEmbedding constructor signature changed in transformers 4.48.0
+        rotary_emb = LlamaRotaryEmbedding(head_dim=head_dim, device=device)
+    else:
+        llama_config = LlamaConfig(head_dim=head_dim)
+        rotary_emb = LlamaRotaryEmbedding(llama_config, device=device)
 
     _tensor_q = torch.randn((bsz, seq_len, num_q_heads, head_dim), device=device).transpose(1, 2).to(dtype)
 

--- a/test/transformers/test_rope.py
+++ b/test/transformers/test_rope.py
@@ -61,7 +61,7 @@ def test_correctness(
 ):
     if transformers_version < "4.48.0":
         # LlamaRotaryEmbedding constructor signature changed in transformers 4.48.0
-        rotary_emb = LlamaRotaryEmbedding(head_dim=head_dim, device=device)
+        rotary_emb = LlamaRotaryEmbedding(head_dim, device=device)
     else:
         llama_config = LlamaConfig(head_dim=head_dim)
         rotary_emb = LlamaRotaryEmbedding(llama_config, device=device)
@@ -142,7 +142,7 @@ def test_functional_correctness(
 
     if transformers_version < "4.48.0":
         # LlamaRotaryEmbedding constructor signature changed in transformers 4.48.0
-        rotary_emb = LlamaRotaryEmbedding(head_dim=head_dim, device=device)
+        rotary_emb = LlamaRotaryEmbedding(head_dim, device=device)
     else:
         llama_config = LlamaConfig(head_dim=head_dim)
         rotary_emb = LlamaRotaryEmbedding(llama_config, device=device)

--- a/test/transformers/test_rope.py
+++ b/test/transformers/test_rope.py
@@ -140,8 +140,12 @@ def test_functional_correctness(
     k1 = _k.clone().requires_grad_(True)
     k2 = _k.clone().requires_grad_(True)
 
-    llama_config = LlamaConfig(head_dim=head_dim)
-    rotary_emb = LlamaRotaryEmbedding(llama_config, device=device)
+    if transformers_version < "4.48.0":
+        # LlamaRotaryEmbedding constructor signature changed in transformers 4.48.0
+        rotary_emb = LlamaRotaryEmbedding(head_dim=head_dim, device=device)
+    else:
+        llama_config = LlamaConfig(head_dim=head_dim)
+        rotary_emb = LlamaRotaryEmbedding(llama_config, device=device)
 
     pos_ids = torch.arange(seq_len, device=device, dtype=torch.long).unsqueeze(0)
     if expand_position_ids:

--- a/test/transformers/test_rope.py
+++ b/test/transformers/test_rope.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from test.utils import supports_bfloat16
+from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding
 from transformers.models.llama.modeling_llama import apply_rotary_pos_emb
 
@@ -57,7 +58,8 @@ def test_correctness(
     atol,
     rtol,
 ):
-    rotary_emb = LlamaRotaryEmbedding(head_dim, device=device)
+    llama_config = LlamaConfig(head_dim=head_dim)
+    rotary_emb = LlamaRotaryEmbedding(llama_config, device=device)
 
     _tensor_q = torch.randn((bsz, seq_len, num_q_heads, head_dim), device=device).transpose(1, 2).to(dtype)
 
@@ -133,7 +135,8 @@ def test_functional_correctness(
     k1 = _k.clone().requires_grad_(True)
     k2 = _k.clone().requires_grad_(True)
 
-    rotary_emb = LlamaRotaryEmbedding(head_dim, device=device)
+    llama_config = LlamaConfig(head_dim=head_dim)
+    rotary_emb = LlamaRotaryEmbedding(llama_config, device=device)
 
     pos_ids = torch.arange(seq_len, device=device, dtype=torch.long).unsqueeze(0)
     if expand_position_ids:


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
There is a breaking changes from HF Transformers that will break out unit test:

https://github.com/huggingface/transformers/blame/137965ca7d0b453b22806c0a5fffc51fde821c33/src/transformers/models/llama/modeling_llama.py#L85

For example, it broke my [PR about KTO Loss](https://github.com/linkedin/Liger-Kernel/pull/475) which has nothing to do with `FAILED test/transformers/test_rope.py::test_correctness`

https://github.com/linkedin/Liger-Kernel/actions/runs/12779518445/job/35624270834?pr=475


<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
Unit Test is done
<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
