### PR TITLE
[Fix] Fix the type hint of `test_utils::concatenated_forward`

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 import numpy as np
@@ -467,10 +468,10 @@ class HFAlignmentLoss:
         _input: torch.FloatTensor,
         weight: torch.FloatTensor,
         target: torch.LongTensor,
-        bias: torch.FloatTensor | None = None,
+        bias: Optional[torch.FloatTensor] = None,
         average_log_prob: bool = True,
         preference_labels: torch.Tensor = None,
-        nll_target: torch.LongTensor | None = None,
+        nll_target: Optional[torch.LongTensor] = None,
     ) -> Tuple[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.FloatTensor]:
         """Run the given model on the given batch of inputs, concatenating the chosen and rejected inputs together.
 


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->

Fix the type hint of two func args from `Tensor | None=None` to `Optional[Tensor]=None`, the former typing hint is only working for python 3.10+, switching it back to `Optional` to fit for 3.9 and below python versions.
<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
