### PR TITLE
Fix DPO unit test fail and refactor

### DIFF
--- a/src/liger_kernel/chunked_loss/dpo_loss.py
+++ b/src/liger_kernel/chunked_loss/dpo_loss.py
@@ -45,8 +45,8 @@ class LigerFusedLinearDPOFunction(LigerFusedLinearPreferenceBase):
         chosen_logratios = chosen_logps - ref_chosen_logps
         rejected_logratios = rejected_logps - ref_rejected_logps
 
-        chosen_rewards = beta * (chosen_logps - ref_chosen_logps)
-        rejected_rewards = beta * (rejected_logps - ref_rejected_logps)
+        chosen_rewards = beta * chosen_logratios
+        rejected_rewards = beta * rejected_logratios
 
         logits_diff = beta * (chosen_logratios - rejected_logratios)
         loss = -F.logsigmoid(logits_diff).sum() / (full_target.shape[0] // 2)

--- a/test/chunked_loss/test_dpo_loss.py
+++ b/test/chunked_loss/test_dpo_loss.py
@@ -233,7 +233,7 @@ def test_correctness(
     for i in range(len(aggregated_aux_outputs1)):
         if i > 4 and dtype == torch.bfloat16:
             # numerical instability in bf16 for chosen_rewards and rejected_rewards
-            # temporary fix
+            # temporary fix. TODO: investigate how to reduce numercial instabiltiy issue
             assert_verbose_allclose(
                 aggregated_aux_outputs1[i],
                 aggregated_aux_outputs2[i],

--- a/test/chunked_loss/test_dpo_loss.py
+++ b/test/chunked_loss/test_dpo_loss.py
@@ -238,7 +238,7 @@ def test_correctness(
                 aggregated_aux_outputs1[i],
                 aggregated_aux_outputs2[i],
                 atol=5e-1,
-                rtol=5e-1,
+                rtol=rtol,
             )
             continue
         assert_verbose_allclose(


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
#521 introduced a unit test failure caused by the numerical issue in bf16. 

This PR relaxes the atol for `chosen_rewards` and `rejected_rewards` only. 
Note: It's just a temporary fix for ci. 

This PR also removes duplicated calculations on both terms.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
