### PR TITLE
Infer correct device for AMD HIP device

### DIFF
--- a/src/liger_kernel/utils.py
+++ b/src/liger_kernel/utils.py
@@ -5,12 +5,10 @@ def infer_device():
     """
     Get current device name based on available devices
     """
-    if torch.cuda.is_available():
+    if torch.cuda.is_available():  # Works for both Nvidia and AMD
         return "cuda"
     elif torch.xpu.is_available():
         return "xpu"
-    elif torch.hip.is_available():
-        return "hip"
     else:
         return "cpu"
 


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
In AMD HIP, it is using CUDA as device name instead of "hip"

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
build and test on AMD device

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
