### PR TITLE
Compare means of aggregated outputs in KTO tests

### DIFF
--- a/test/chunked_loss/test_kto_loss.py
+++ b/test/chunked_loss/test_kto_loss.py
@@ -389,12 +389,35 @@ def test_correctness_functional(B, T, H, V, scalar, dtype, atol, rtol, bias, ref
 
     assert len(aggregated_aux_outputs1) == len(aggregated_aux_outputs2)
 
-    if dtype==torch.float32:
-        for i in range(len(aggregated_aux_outputs1)):
-            assert_verbose_allclose(
-                aggregated_aux_outputs1[i],
-                aggregated_aux_outputs2[i],
-            )
+    # chosen_logps
+    chosen_logps_mean1 = aggregated_aux_outputs1[0] / ((num_chosen_samples * T * V) + 1e-20)
+    chosen_logps_mean2 = aggregated_aux_outputs2[0] / ((num_chosen_samples * T * V) + 1e-20)
+    assert_verbose_allclose(chosen_logps_mean1, chosen_logps_mean2, atol=atol, rtol=rtol)
+
+    # chosen_logits
+    chosen_logits_mean1 = aggregated_aux_outputs1[2] / ((num_chosen_samples * T * V) + 1e-20)
+    chosen_logits_mean2 = aggregated_aux_outputs2[2] / ((num_chosen_samples * T * V) + 1e-20)
+    assert_verbose_allclose(chosen_logits_mean1, chosen_logits_mean2, atol=atol, rtol=rtol)
+
+    # chosen_rewards
+    chosen_rewards_mean1 = aggregated_aux_outputs1[4] / ((num_chosen_samples * T * V) + 1e-20)
+    chosen_rewards_mean2 = aggregated_aux_outputs2[4] / ((num_chosen_samples * T * V) + 1e-20)
+    assert_verbose_allclose(chosen_rewards_mean1, chosen_rewards_mean2, atol=atol, rtol=rtol)
+
+    # rejected_logps
+    rejected_logps_mean1 = aggregated_aux_outputs1[1] / ((num_rejected_samples * T * V) + 1e-20)
+    rejected_logps_mean2 = aggregated_aux_outputs2[1] / ((num_rejected_samples * T * V) + 1e-20)
+    assert_verbose_allclose(rejected_logps_mean1, rejected_logps_mean2, atol=atol, rtol=rtol)
+
+    # rejected_logits
+    rejected_logits_mean1 = aggregated_aux_outputs1[3] / ((num_rejected_samples * T * V) + 1e-20)
+    rejected_logits_mean2 = aggregated_aux_outputs2[3] / ((num_rejected_samples * T * V) + 1e-20)
+    assert_verbose_allclose(rejected_logits_mean1, rejected_logits_mean2, atol=atol, rtol=rtol)
+
+    # rejected_rewards
+    rejected_rewards_mean1 = aggregated_aux_outputs1[5] / ((num_rejected_samples * T * V) + 1e-20)
+    rejected_rewards_mean2 = aggregated_aux_outputs2[5] / ((num_rejected_samples * T * V) + 1e-20)
+    assert_verbose_allclose(rejected_rewards_mean1, rejected_rewards_mean2, atol=atol, rtol=rtol)
 
     loss1.backward()
     loss2.backward()

--- a/test/chunked_loss/test_kto_loss.py
+++ b/test/chunked_loss/test_kto_loss.py
@@ -179,7 +179,7 @@ def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, bias, ref_bias, igno
     # Used to indicate preferred sequences (1) vs non-preferred sequences (0)
     preference_labels = torch.randint(2, (B,), dtype=torch.bool, device=device, requires_grad=False)
     num_chosen_samples = preference_labels.sum()
-    num_rejected_samples =  len(preference_labels) - num_chosen_samples
+    num_rejected_samples = len(preference_labels) - num_chosen_samples
 
     # Precomputed KL divergence between policy and reference distributions
     kl = torch.randn(1, device=device, dtype=dtype)
@@ -248,7 +248,7 @@ def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, bias, ref_bias, igno
     assert_verbose_allclose(loss1, loss2, atol=atol, rtol=rtol)
 
     assert len(aggregated_aux_outputs1) == len(aggregated_aux_outputs2)
-    
+
     # chosen_logps
     chosen_logps_mean1 = aggregated_aux_outputs1[0] / ((num_chosen_samples * T * V) + 1e-20)
     chosen_logps_mean2 = aggregated_aux_outputs2[0] / ((num_chosen_samples * T * V) + 1e-20)
@@ -326,8 +326,8 @@ def test_correctness_functional(B, T, H, V, scalar, dtype, atol, rtol, bias, ref
     # Used to indicate preferred sequences (1) vs non-preferred sequences (0)
     preference_labels = torch.randint(2, (B,), dtype=torch.bool, device=device)
     num_chosen_samples = preference_labels.sum()
-    num_rejected_samples =  len(preference_labels) - num_chosen_samples
-    
+    num_rejected_samples = len(preference_labels) - num_chosen_samples
+
     # Precomputed KL divergence between policy and reference distributions
     kl = torch.randn(1, device=device, dtype=dtype)
 

--- a/test/chunked_loss/test_kto_loss.py
+++ b/test/chunked_loss/test_kto_loss.py
@@ -164,20 +164,22 @@ class LigerLMHeadKTO(torch.nn.Module):
     ],
 )
 @pytest.mark.parametrize(
-    "scalar, dtype, atol, rtol, atol_aux, rtol_aux",
+    "scalar, dtype, atol, rtol",
     [
-        (1.0, torch.bfloat16, 5e-2, 5e-1, 5e-1, 5e-1),
-        (1.0, torch.float32, 1e-5, 5e-4, 1e-5, 5e-4),
+        (1.0, torch.bfloat16, 5e-2, 5e-1),
+        (1.0, torch.float32, 1e-5, 5e-4),
     ],
 )
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("ref_bias", [True, False])
 @pytest.mark.parametrize("ignore_index, beta", [(-100, 0.1), (42, 0.2)])
-def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, atol_aux, rtol_aux, bias, ref_bias, ignore_index, beta):
+def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, bias, ref_bias, ignore_index, beta):
     # Preference labels shape: [B]
     # Create binary preference labels (0 or 1) for each sequence in the batch
     # Used to indicate preferred sequences (1) vs non-preferred sequences (0)
     preference_labels = torch.randint(2, (B,), dtype=torch.bool, device=device, requires_grad=False)
+    num_chosen_samples = preference_labels.sum()
+    num_rejected_samples =  len(preference_labels) - num_chosen_samples
 
     # Precomputed KL divergence between policy and reference distributions
     kl = torch.randn(1, device=device, dtype=dtype)
@@ -246,14 +248,36 @@ def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, atol_aux, rtol_aux, 
     assert_verbose_allclose(loss1, loss2, atol=atol, rtol=rtol)
 
     assert len(aggregated_aux_outputs1) == len(aggregated_aux_outputs2)
+    
+    # chosen_logps
+    chosen_logps_mean1 = aggregated_aux_outputs1[0] / ((num_chosen_samples * T * V) + 1e-20)
+    chosen_logps_mean2 = aggregated_aux_outputs2[0] / ((num_chosen_samples * T * V) + 1e-20)
+    assert_verbose_allclose(chosen_logps_mean1, chosen_logps_mean2, atol=atol, rtol=rtol)
 
-    for i in range(len(aggregated_aux_outputs1)):
-        assert_verbose_allclose(
-            aggregated_aux_outputs1[i],
-            aggregated_aux_outputs2[i],
-            atol=atol_aux,
-            rtol=rtol_aux,
-        )
+    # chosen_logits
+    chosen_logits_mean1 = aggregated_aux_outputs1[2] / ((num_chosen_samples * T * V) + 1e-20)
+    chosen_logits_mean2 = aggregated_aux_outputs2[2] / ((num_chosen_samples * T * V) + 1e-20)
+    assert_verbose_allclose(chosen_logits_mean1, chosen_logits_mean2, atol=atol, rtol=rtol)
+
+    # chosen_rewards
+    chosen_rewards_mean1 = aggregated_aux_outputs1[4] / ((num_chosen_samples * T * V) + 1e-20)
+    chosen_rewards_mean2 = aggregated_aux_outputs2[4] / ((num_chosen_samples * T * V) + 1e-20)
+    assert_verbose_allclose(chosen_rewards_mean1, chosen_rewards_mean2, atol=atol, rtol=rtol)
+
+    # rejected_logps
+    rejected_logps_mean1 = aggregated_aux_outputs1[1] / ((num_rejected_samples * T * V) + 1e-20)
+    rejected_logps_mean2 = aggregated_aux_outputs2[1] / ((num_rejected_samples * T * V) + 1e-20)
+    assert_verbose_allclose(rejected_logps_mean1, rejected_logps_mean2, atol=atol, rtol=rtol)
+
+    # rejected_logits
+    rejected_logits_mean1 = aggregated_aux_outputs1[3] / ((num_rejected_samples * T * V) + 1e-20)
+    rejected_logits_mean2 = aggregated_aux_outputs2[3] / ((num_rejected_samples * T * V) + 1e-20)
+    assert_verbose_allclose(rejected_logits_mean1, rejected_logits_mean2, atol=atol, rtol=rtol)
+
+    # rejected_rewards
+    rejected_rewards_mean1 = aggregated_aux_outputs1[5] / ((num_rejected_samples * T * V) + 1e-20)
+    rejected_rewards_mean2 = aggregated_aux_outputs2[5] / ((num_rejected_samples * T * V) + 1e-20)
+    assert_verbose_allclose(rejected_rewards_mean1, rejected_rewards_mean2, atol=atol, rtol=rtol)
 
     loss1.backward()
     loss2.backward()
@@ -288,15 +312,15 @@ def test_correctness(B, T, H, V, scalar, dtype, atol, rtol, atol_aux, rtol_aux, 
     ],
 )
 @pytest.mark.parametrize(
-    "scalar, dtype, atol, rtol, atol_aux, rtol_aux",
+    "scalar, dtype, atol, rtol",
     [
-        (1.0, torch.bfloat16, 5e-2, 5e-1, 5e-1, 5e-1),
-        (1.0, torch.float32, 1e-5, 5e-4, 1e-5, 5e-4),
+        (1.0, torch.bfloat16, 5e-2, 5e-1),
+        (1.0, torch.float32, 1e-5, 5e-4),
     ],
 )
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("ref_bias", [True, False])
-def test_correctness_functional(B, T, H, V, scalar, dtype, atol, rtol, atol_aux, rtol_aux, bias, ref_bias):
+def test_correctness_functional(B, T, H, V, scalar, dtype, atol, rtol, bias, ref_bias):
     # Preference labels shape: [B]
     # Create binary preference labels (0 or 1) for each sequence in the batch
     # Used to indicate preferred sequences (1) vs non-preferred sequences (0)
@@ -365,13 +389,12 @@ def test_correctness_functional(B, T, H, V, scalar, dtype, atol, rtol, atol_aux,
 
     assert len(aggregated_aux_outputs1) == len(aggregated_aux_outputs2)
 
-    for i in range(len(aggregated_aux_outputs1)):
-        assert_verbose_allclose(
-            aggregated_aux_outputs1[i],
-            aggregated_aux_outputs2[i],
-            atol=atol_aux,
-            rtol=rtol_aux,
-        )
+    if dtype==torch.float32:
+        for i in range(len(aggregated_aux_outputs1)):
+            assert_verbose_allclose(
+                aggregated_aux_outputs1[i],
+                aggregated_aux_outputs2[i],
+            )
 
     loss1.backward()
     loss2.backward()

--- a/test/chunked_loss/test_kto_loss.py
+++ b/test/chunked_loss/test_kto_loss.py
@@ -325,7 +325,9 @@ def test_correctness_functional(B, T, H, V, scalar, dtype, atol, rtol, bias, ref
     # Create binary preference labels (0 or 1) for each sequence in the batch
     # Used to indicate preferred sequences (1) vs non-preferred sequences (0)
     preference_labels = torch.randint(2, (B,), dtype=torch.bool, device=device)
-
+    num_chosen_samples = preference_labels.sum()
+    num_rejected_samples =  len(preference_labels) - num_chosen_samples
+    
     # Precomputed KL divergence between policy and reference distributions
     kl = torch.randn(1, device=device, dtype=dtype)
 


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
This change modifies the testing code to compare the mean of aggregated outputs in kto tests. This prevents the problem of error accumulation when we sum the metrics.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type:  H100-80GB-HBM3
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
