### PR TITLE
Support Dynamic Tanh (DyT)

### DIFF
--- a/benchmark/benchmarks_visualizer.py
+++ b/benchmark/benchmarks_visualizer.py
@@ -8,8 +8,8 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
 
-DATA_PATH = "data/all_benchmark_data.csv"
-VISUALIZATIONS_PATH = "visualizations/"
+DATA_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "data/all_benchmark_data.csv"))
+VISUALIZATIONS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "visualizations/"))
 
 
 @dataclass

--- a/benchmark/scripts/benchmark_dyt.py
+++ b/benchmark/scripts/benchmark_dyt.py
@@ -22,11 +22,11 @@ def bench_speed_dyt(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
     from test.transformers.test_dyt import LigerDyT
     from test.transformers.test_dyt import TorchDyT
 
-    hidden_size = input.x
+    BT = input.x
     provider = input.kernel_provider
     mode = input.kernel_operation_mode
     extra_benchmark_config = input.extra_benchmark_config
-    BT = extra_benchmark_config["BT"]
+    hidden_size = extra_benchmark_config["hidden_size"]
     dtype = extra_benchmark_config["dtype"]
 
     x_shape = (BT, hidden_size)
@@ -79,10 +79,10 @@ def bench_memory_dyt(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput
     from test.transformers.test_dyt import LigerDyT
     from test.transformers.test_dyt import TorchDyT
 
-    hidden_size = input.x
+    BT = input.x
     provider = input.kernel_provider
     extra_benchmark_config = input.extra_benchmark_config
-    BT = extra_benchmark_config["BT"]
+    hidden_size = extra_benchmark_config["hidden_size"]
     dtype = extra_benchmark_config["dtype"]
 
     x_shape = (BT, hidden_size)
@@ -119,11 +119,11 @@ if __name__ == "__main__":
 
     common_configs = {
         "kernel_name": "dyt",
-        "x_name": "hidden_size",
-        "x_label": "hidden size",
+        "x_name": "BT",
+        "x_label": "batch_size * seq_len",
         "x_values": [2**i for i in range(10, 15)],
         "kernel_providers": ["liger", "torch", "torch_compile"],
-        "extra_benchmark_configs": [{"BT": 4096, "dtype": torch.float32}],
+        "extra_benchmark_configs": [{"hidden_size": 4096, "dtype": torch.float32}],
         "overwrite": args.overwrite,
     }
 

--- a/benchmark/scripts/benchmark_dyt.py
+++ b/benchmark/scripts/benchmark_dyt.py
@@ -1,0 +1,147 @@
+import os
+import sys
+
+import torch
+import triton
+
+from utils import QUANTILES
+from utils import SingleBenchmarkRunInput
+from utils import SingleBenchmarkRunOutput
+from utils import _test_memory
+from utils import parse_benchmark_script_args
+from utils import run_benchmarks
+
+from liger_kernel.utils import infer_device
+
+device = infer_device()
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+
+def bench_speed_dyt(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
+    from test.transformers.test_dyt import LigerDyT
+    from test.transformers.test_dyt import TorchDyT
+
+    hidden_size = input.x
+    provider = input.kernel_provider
+    mode = input.kernel_operation_mode
+    extra_benchmark_config = input.extra_benchmark_config
+    BT = extra_benchmark_config["BT"]
+    dtype = extra_benchmark_config["dtype"]
+
+    x_shape = (BT, hidden_size)
+    torch_y = lambda x: TorchDyT(hidden_size=hidden_size).to(device)(x)
+    torch_compile_y = lambda x: torch.compile(
+        TorchDyT(hidden_size=hidden_size).to(device)
+    )(x)
+    triton_y = lambda x: LigerDyT(hidden_size=hidden_size).to(device)(x)
+
+    x = torch.randn(x_shape, dtype=dtype, device=device)
+    dy = torch.randn_like(x)
+    x.requires_grad_(True)
+
+    def fwd():
+        if provider == "liger":
+            return triton_y(x)
+        elif provider == "torch":
+            return torch_y(x)
+        elif provider == "torch_compile":
+            return torch_compile_y(x)
+
+    if mode == "forward":
+        ms_50, ms_20, ms_80 = triton.testing.do_bench(
+            fwd, quantiles=QUANTILES, grad_to_none=[x], rep=500
+        )
+    elif mode == "backward":
+        y = fwd()
+        ms_50, ms_20, ms_80 = triton.testing.do_bench(
+            lambda: y.backward(dy, retain_graph=True),
+            quantiles=QUANTILES,
+            grad_to_none=[x],
+            rep=500,
+        )
+    elif mode == "full":
+
+        def full():
+            y = fwd()
+            y.backward(dy)
+
+        ms_50, ms_20, ms_80 = triton.testing.do_bench(
+            full, quantiles=QUANTILES, grad_to_none=[x], rep=500
+        )
+
+    return SingleBenchmarkRunOutput(
+        y_20=ms_20,
+        y_50=ms_50,
+        y_80=ms_80,
+    )
+
+
+def bench_memory_dyt(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
+    from test.transformers.test_dyt import LigerDyT
+    from test.transformers.test_dyt import TorchDyT
+
+    hidden_size = input.x
+    provider = input.kernel_provider
+    extra_benchmark_config = input.extra_benchmark_config
+    BT = extra_benchmark_config["BT"]
+    dtype = extra_benchmark_config["dtype"]
+
+    x_shape = (BT, hidden_size)
+    torch_y = lambda x: TorchDyT(hidden_size=hidden_size).to(device)(x)
+    torch_compile_y = lambda x: torch.compile(
+        TorchDyT(hidden_size=hidden_size).to(device)
+    )(x)
+    triton_y = lambda x: LigerDyT(hidden_size=hidden_size).to(device)(x)
+
+    x = torch.randn(x_shape, dtype=dtype, device=device)
+    dy = torch.randn_like(x)
+    x.requires_grad_(True)
+
+    def fwd():
+        if provider == "liger":
+            return triton_y(x)
+        elif provider == "torch":
+            return torch_y(x)
+        elif provider == "torch_compile":
+            return torch_compile_y(x)
+
+    def full():
+        y = fwd()
+        y.backward(dy, retain_graph=True)
+
+    mem_50, mem_20, mem_80 = _test_memory(full, quantiles=QUANTILES)
+    return SingleBenchmarkRunOutput(
+        y_20=mem_20,
+        y_50=mem_50,
+        y_80=mem_80,
+    )
+
+
+if __name__ == "__main__":
+    args = parse_benchmark_script_args()
+
+    common_configs = {
+        "kernel_name": "dyt",
+        "x_name": "hidden_size",
+        "x_label": "hidden size",
+        "x_values": [2**i for i in range(10, 15)],
+        "kernel_providers": ["liger", "torch", "torch_compile"],
+        "extra_benchmark_configs": [{"BT": 4096, "dtype": torch.float32}],
+        "overwrite": args.overwrite,
+    }
+
+    run_benchmarks(
+        bench_test_fn=bench_speed_dyt,
+        kernel_operation_modes=["forward", "backward", "full"],
+        metric_name="speed",
+        metric_unit="ms",
+        **common_configs,
+    )
+    run_benchmarks(
+        bench_test_fn=bench_memory_dyt,
+        kernel_operation_modes=["full"],
+        metric_name="memory",
+        metric_unit="MB",
+        **common_configs,
+    )

--- a/benchmark/scripts/benchmark_dyt.py
+++ b/benchmark/scripts/benchmark_dyt.py
@@ -47,9 +47,7 @@ def bench_speed_dyt(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
             return torch_compile_dyt(x)
 
     if mode == "forward":
-        ms_50, ms_20, ms_80 = triton.testing.do_bench(
-            fwd, quantiles=QUANTILES, grad_to_none=[x], rep=500
-        )
+        ms_50, ms_20, ms_80 = triton.testing.do_bench(fwd, quantiles=QUANTILES, grad_to_none=[x], rep=500)
     elif mode == "backward":
         y = fwd()
         ms_50, ms_20, ms_80 = triton.testing.do_bench(
@@ -64,9 +62,7 @@ def bench_speed_dyt(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
             y = fwd()
             y.backward(dy)
 
-        ms_50, ms_20, ms_80 = triton.testing.do_bench(
-            full, quantiles=QUANTILES, grad_to_none=[x], rep=500
-        )
+        ms_50, ms_20, ms_80 = triton.testing.do_bench(full, quantiles=QUANTILES, grad_to_none=[x], rep=500)
 
     return SingleBenchmarkRunOutput(
         y_20=ms_20,

--- a/benchmark/scripts/benchmark_dyt.py
+++ b/benchmark/scripts/benchmark_dyt.py
@@ -30,11 +30,9 @@ def bench_speed_dyt(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
     dtype = extra_benchmark_config["dtype"]
 
     x_shape = (BT, hidden_size)
-    torch_y = lambda x: TorchDyT(hidden_size=hidden_size).to(device)(x)
-    torch_compile_y = lambda x: torch.compile(
-        TorchDyT(hidden_size=hidden_size).to(device)
-    )(x)
-    triton_y = lambda x: LigerDyT(hidden_size=hidden_size).to(device)(x)
+    torch_dyt = TorchDyT(hidden_size=hidden_size).to(device)
+    torch_compile_dyt = torch.compile(TorchDyT(hidden_size=hidden_size).to(device))
+    triton_dyt = LigerDyT(hidden_size=hidden_size).to(device)
 
     x = torch.randn(x_shape, dtype=dtype, device=device)
     dy = torch.randn_like(x)
@@ -42,11 +40,11 @@ def bench_speed_dyt(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
 
     def fwd():
         if provider == "liger":
-            return triton_y(x)
+            return triton_dyt(x)
         elif provider == "torch":
-            return torch_y(x)
+            return torch_dyt(x)
         elif provider == "torch_compile":
-            return torch_compile_y(x)
+            return torch_compile_dyt(x)
 
     if mode == "forward":
         ms_50, ms_20, ms_80 = triton.testing.do_bench(
@@ -88,11 +86,9 @@ def bench_memory_dyt(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput
     dtype = extra_benchmark_config["dtype"]
 
     x_shape = (BT, hidden_size)
-    torch_y = lambda x: TorchDyT(hidden_size=hidden_size).to(device)(x)
-    torch_compile_y = lambda x: torch.compile(
-        TorchDyT(hidden_size=hidden_size).to(device)
-    )(x)
-    triton_y = lambda x: LigerDyT(hidden_size=hidden_size).to(device)(x)
+    torch_dyt = TorchDyT(hidden_size=hidden_size).to(device)
+    torch_compile_dyt = torch.compile(TorchDyT(hidden_size=hidden_size).to(device))
+    triton_dyt = LigerDyT(hidden_size=hidden_size).to(device)
 
     x = torch.randn(x_shape, dtype=dtype, device=device)
     dy = torch.randn_like(x)
@@ -100,11 +96,11 @@ def bench_memory_dyt(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput
 
     def fwd():
         if provider == "liger":
-            return triton_y(x)
+            return triton_dyt(x)
         elif provider == "torch":
-            return torch_y(x)
+            return torch_dyt(x)
         elif provider == "torch_compile":
-            return torch_compile_y(x)
+            return torch_compile_dyt(x)
 
     def full():
         y = fwd()

--- a/src/liger_kernel/ops/dyt.py
+++ b/src/liger_kernel/ops/dyt.py
@@ -33,6 +33,9 @@ def _dyt_fwd_kernel(
     BLOCK_SIZE: tl.constexpr,
 ):
     """
+    Reference:
+    https://arxiv.org/abs/2503.10622
+
     Shapes:
         - x: (BT, C)
         - alpha: (1)
@@ -73,6 +76,9 @@ def _dyt_bwd_kernel(
     BLOCK_SIZE: tl.constexpr,
 ):
     """
+    Reference:
+    https://arxiv.org/abs/2503.10622
+
     Shapes:
         - x: (BT, C)
         - alpha: (1)

--- a/src/liger_kernel/ops/dyt.py
+++ b/src/liger_kernel/ops/dyt.py
@@ -8,7 +8,6 @@ from liger_kernel.ops.utils import calculate_settings
 from liger_kernel.ops.utils import compare_version
 from liger_kernel.ops.utils import ensure_contiguous
 from liger_kernel.ops.utils import infer_device
-from liger_kernel.ops.utils import is_hip
 
 if compare_version("triton", operator.ge, "3.0.0"):
     try:
@@ -78,7 +77,6 @@ def _dyt_bwd_kernel(
         - x: (BT, C)
         - alpha: (1)
         - gamma: (C)
-        - beta: (C)
         - dx: (BT, C)
         - dy: (BT, C)
         - dgamma: (sm_count, C)

--- a/src/liger_kernel/ops/dyt.py
+++ b/src/liger_kernel/ops/dyt.py
@@ -1,0 +1,214 @@
+import operator
+
+import torch
+import triton
+import triton.language as tl
+
+from liger_kernel.ops.utils import calculate_settings
+from liger_kernel.ops.utils import compare_version
+from liger_kernel.ops.utils import ensure_contiguous
+from liger_kernel.ops.utils import infer_device
+from liger_kernel.ops.utils import is_hip
+
+if compare_version("triton", operator.ge, "3.0.0"):
+    try:
+        # typical import path with dispatch available
+        from triton.language.extra.libdevice import tanh
+    except ModuleNotFoundError:
+        # for working with NGC containers
+        from triton.language.extra.cuda.libdevice import tanh
+else:
+    from triton.language.math import tanh
+
+
+@triton.jit
+def _dyt_fwd_kernel(
+    x_ptr,
+    x_row_stride,
+    alpha_ptr,
+    gamma_ptr,
+    beta_ptr,
+    y_ptr,
+    y_row_stride,
+    n_cols,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    Shapes:
+        - x: (BT, C)
+        - alpha: (1)
+        - gamma: (C)
+        - beta: (C)
+    """
+    row_idx = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_cols
+
+    x_ptr += row_idx * x_row_stride
+    y_ptr += row_idx * y_row_stride
+
+    alpha = tl.load(alpha_ptr)
+    gamma = tl.load(gamma_ptr + offsets, mask=mask)
+    beta = tl.load(beta_ptr + offsets, mask=mask)
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = gamma * tanh((alpha * x).cast(tl.float32)) + beta
+    tl.store(y_ptr + offsets, y, mask=mask)
+
+
+@triton.jit
+def _dyt_bwd_kernel(
+    x_ptr,
+    x_row_stride,
+    dy_ptr,
+    dy_row_stride,
+    dx_ptr,
+    dx_row_stride,
+    alpha_ptr,
+    dalpha_ptr,
+    gamma_ptr,
+    dgamma_ptr,
+    dgamma_row_stride,
+    n_cols,
+    ROWS_PER_PROGRAM: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    Shapes:
+        - x: (BT, C)
+        - alpha: (1)
+        - gamma: (C)
+        - beta: (C)
+    """
+    # d(gamma * tanh(alpha * x) + beta) / dx
+    # = gamma * (1 - tanh^2(alpha * x)) * alpha
+    # d(gamma * tanh(alpha * x) + beta) / dalpha
+    # = gamma * (1 - tanh^2(alpha * x)) * x
+    # d(gamma * tanh(alpha * x) + beta) / dgamma
+    # = tanh(alpha * x)
+    # d(gamma * tanh(alpha * x)) / dbeta = 1
+    pid = tl.program_id(0)
+
+    row_start = pid * ROWS_PER_PROGRAM
+    row_end = min((pid + 1) * ROWS_PER_PROGRAM, tl.num_programs(0))
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_cols
+
+    dalpha = tl.zeros((1,), dtype=tl.float32)
+    dgamma = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+
+    x_ptr += row_start * x_row_stride
+    dy_ptr += row_start * dy_row_stride
+    alpha = tl.load(alpha_ptr)
+    gamma = tl.load(gamma_ptr + offsets, mask=mask, other=0.0)
+
+    for _ in tl.range(row_start, row_end):
+        dy = tl.load(dy_ptr + offsets, mask=mask, other=0.0)
+        x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+        tanh_ax = tanh((alpha * x).cast(tl.float32))
+        sech2_ax = 1 - tanh_ax * tanh_ax
+
+        dx = dy * gamma * sech2_ax * alpha
+        dalpha += tl.sum(dy * gamma * sech2_ax * x)
+        dgamma += dy * tanh_ax
+        tl.store(dx_ptr + offsets, dx, mask=mask)
+
+        dy_ptr += dy_row_stride
+        x_ptr += x_row_stride
+        dx_ptr += dx_row_stride
+
+    tl.store(dgamma_ptr + pid * dgamma_row_stride + offsets, dgamma, mask=mask)
+    tl.store(dalpha_ptr + pid, dalpha)
+
+    pass
+
+
+def liger_dyt_fwd(x, alpha, gamma, beta):
+    shape = x.shape
+    dim = shape[-1]
+    x = x.view(-1, dim)
+    n_rows, n_cols = x.shape
+    y = torch.empty_like(x)
+    BLOCK_SIZE, num_warps = calculate_settings(n_cols)
+    _dyt_fwd_kernel[(n_rows,)](
+        x_ptr=x,
+        alpha_ptr=alpha,
+        gamma_ptr=gamma,
+        beta_ptr=beta,
+        y_ptr=y,
+        x_row_stride=x.stride(0),
+        y_row_stride=y.stride(0),
+        n_cols=n_cols,
+        BLOCK_SIZE=BLOCK_SIZE,
+        num_warps=num_warps,
+    )
+    return y.view(*shape)
+
+
+def liger_dyt_bwd(dy, x, alpha, gamma):
+    shape = dy.shape
+    dtype = x.dtype
+    dim = shape[-1]
+    dy = dy.view(-1, dim)
+    x = x.view(-1, dim)
+    n_rows, n_cols = dy.shape
+    BLOCK_SIZE, num_warps = calculate_settings(n_cols)
+    sm_count = 1
+    device = infer_device()
+    if device == "cuda":
+        sm_count = torch.cuda.get_device_properties(x.device).multi_processor_count
+    elif device == "xpu":
+        sm_count = torch.xpu.get_device_properties(X.device).gpu_subslice_count
+    if n_cols > BLOCK_SIZE:
+        raise RuntimeError(
+            f"Feature dimension {dim} exceeds maximum supported size of {BLOCK_SIZE}. Consider using a smaller feature dimension."
+        )
+
+    dx = torch.empty_like(x, dtype=torch.float32)
+    _dalpha = torch.empty((sm_count,), dtype=torch.float32)
+    _dgamma = torch.empty((sm_count, n_cols), dtype=torch.float32)
+
+    grid = (sm_count,)
+    rows_per_program = triton.cdiv(n_rows, sm_count)
+    _dyt_bwd_kernel[grid](
+        x_ptr=x,
+        x_row_stride=x.stride(0),
+        dy_ptr=dy,
+        dy_row_stride=dy.stride(0),
+        dx_ptr=dx,
+        dx_row_stride=dx.stride(0),
+        alpha_ptr=alpha,
+        dalpha_ptr=_dalpha,
+        gamma_ptr=gamma,
+        dgamma_ptr=_dgamma,
+        dgamma_row_stride=_dgamma.stride(0),
+        n_cols=n_cols,
+        ROWS_PER_PROGRAM=rows_per_program,
+        BLOCK_SIZE=BLOCK_SIZE,
+        num_warps=num_warps,
+    )
+    dalpha = _dalpha.sum().to(dtype)
+    dgamma = _dgamma.sum(dim=0).to(dtype)
+    dbeta = dy.sum(dim=0).to(dtype)
+    return dx.view(*shape), dalpha, dgamma, dbeta
+
+
+class LigerDyTFunction(torch.autograd.Function):
+    @staticmethod
+    @ensure_contiguous
+    def forward(ctx, x, alpha, gamma, beta):
+        y = liger_dyt_fwd(x, alpha, gamma, beta)
+        ctx.save_for_backward(x, alpha, gamma)
+        return y
+
+    @staticmethod
+    @ensure_contiguous
+    def backward(ctx, grad_output):
+        x, alpha, gamma = ctx.saved_tensors
+        dx, dalpha, dgamma, dbeta = liger_dyt_bwd(
+            grad_output,
+            x,
+            alpha,
+            gamma,
+        )
+
+        return (dx, dalpha, dgamma, dbeta)

--- a/src/liger_kernel/transformers/__init__.py
+++ b/src/liger_kernel/transformers/__init__.py
@@ -1,5 +1,6 @@
 from liger_kernel.transformers.auto_model import AutoLigerKernelForCausalLM  # noqa: F401
 from liger_kernel.transformers.cross_entropy import LigerCrossEntropyLoss  # noqa: F401
+from liger_kernel.transformers.dyt import LigerDyT  # noqa: F401
 from liger_kernel.transformers.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyLoss  # noqa: F401
 from liger_kernel.transformers.fused_linear_jsd import LigerFusedLinearJSD  # noqa: F401
 from liger_kernel.transformers.geglu import LigerGEGLUMLP  # noqa: F401

--- a/src/liger_kernel/transformers/dyt.py
+++ b/src/liger_kernel/transformers/dyt.py
@@ -5,16 +5,16 @@ from liger_kernel.ops.dyt import LigerDyTFunction
 
 
 class LigerDyT(nn.Module):
-    def __init__(self, C, init_alpha):
+    def __init__(self, hidden_size, init_alpha=0.5):
         super().__init__()
-        self.C = C
+        self.hidden_size = hidden_size
         self.init_alpha = init_alpha
         self.alpha = nn.Parameter(torch.ones(1) * init_alpha)
-        self.gamma = nn.Parameter(torch.ones(C))
-        self.beta = nn.Parameter(torch.zeros(C))
+        self.gamma = nn.Parameter(torch.ones(hidden_size))
+        self.beta = nn.Parameter(torch.zeros(hidden_size))
 
     def forward(self, x):
         return LigerDyTFunction.apply(x, self.alpha, self.gamma, self.beta)
 
     def extra_repr(self):
-        return f"{self.C}, init_alpha={self.init_alpha}"
+        return f"{self.hidden_size}, init_alpha={self.init_alpha}"

--- a/src/liger_kernel/transformers/dyt.py
+++ b/src/liger_kernel/transformers/dyt.py
@@ -1,0 +1,20 @@
+import torch
+import torch.nn as nn
+
+from liger_kernel.ops.dyt import LigerDyTFunction
+
+
+class LigerDyT(nn.Module):
+    def __init__(self, C, init_alpha):
+        super().__init__()
+        self.C = C
+        self.init_alpha = init_alpha
+        self.alpha = nn.Parameter(torch.ones(1) * init_alpha)
+        self.gamma = nn.Parameter(torch.ones(C))
+        self.beta = nn.Parameter(torch.zeros(C))
+
+    def forward(self, x):
+        return LigerDyTFunction.apply(x, self.alpha, self.gamma, self.beta)
+
+    def extra_repr(self):
+        return f"{self.C}, init_alpha={self.init_alpha}"

--- a/src/liger_kernel/transformers/functional.py
+++ b/src/liger_kernel/transformers/functional.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from liger_kernel.ops.cross_entropy import LigerCrossEntropyFunction
+from liger_kernel.ops.dyt import LigerDyTFunction
 from liger_kernel.ops.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyFunction
 from liger_kernel.ops.fused_linear_jsd import LigerFusedLinearJSDFunction
 from liger_kernel.ops.geglu import LigerGELUMulFunction
@@ -192,3 +193,7 @@ def liger_rope(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
 
 def liger_swiglu(a, b):
     return LigerSiLUMulFunction.apply(a, b)
+
+
+def liger_dyt(x, alpha, gamma, beta):
+    return LigerDyTFunction.apply(x, alpha, gamma, beta)

--- a/test/transformers/test_dyt.py
+++ b/test/transformers/test_dyt.py
@@ -54,16 +54,12 @@ def test_liger_dyt_correctness(B, T, hidden_size, init_alpha, dtype, atol, rtol)
     gamma = torch.randn(hidden_size, device=device, dtype=dtype)
     beta = torch.randn(hidden_size, device=device, dtype=dtype)
 
-    torch_dyt = (
-        TorchDyT(hidden_size=hidden_size, init_alpha=init_alpha).to(device).to(dtype)
-    )
+    torch_dyt = TorchDyT(hidden_size=hidden_size, init_alpha=init_alpha).to(device).to(dtype)
     torch_dyt.alpha.data = alpha.clone()
     torch_dyt.gamma.data = gamma.clone()
     torch_dyt.beta.data = beta.clone()
 
-    liger_dyt = (
-        LigerDyT(hidden_size=hidden_size, init_alpha=init_alpha).to(device).to(dtype)
-    )
+    liger_dyt = LigerDyT(hidden_size=hidden_size, init_alpha=init_alpha).to(device).to(dtype)
     liger_dyt.alpha.data = alpha.clone()
     liger_dyt.gamma.data = gamma.clone()
     liger_dyt.beta.data = beta.clone()
@@ -78,15 +74,9 @@ def test_liger_dyt_correctness(B, T, hidden_size, init_alpha, dtype, atol, rtol)
     liger_output.backward(grad_output)
 
     assert_verbose_allclose(x1.grad, x2.grad, rtol=rtol, atol=atol)
-    assert_verbose_allclose(
-        torch_dyt.alpha.grad, liger_dyt.alpha.grad, rtol=rtol, atol=atol
-    )
-    assert_verbose_allclose(
-        torch_dyt.gamma.grad, liger_dyt.gamma.grad, rtol=rtol, atol=atol
-    )
-    assert_verbose_allclose(
-        torch_dyt.beta.grad, liger_dyt.beta.grad, rtol=rtol, atol=atol
-    )
+    assert_verbose_allclose(torch_dyt.alpha.grad, liger_dyt.alpha.grad, rtol=rtol, atol=atol)
+    assert_verbose_allclose(torch_dyt.gamma.grad, liger_dyt.gamma.grad, rtol=rtol, atol=atol)
+    assert_verbose_allclose(torch_dyt.beta.grad, liger_dyt.beta.grad, rtol=rtol, atol=atol)
 
 
 @pytest.mark.parametrize(
@@ -108,9 +98,7 @@ def test_liger_dyt_correctness(B, T, hidden_size, init_alpha, dtype, atol, rtol)
             torch.bfloat16,
             1e-8,
             5e-2,
-            marks=pytest.mark.skipif(
-                not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
-            ),
+            marks=pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this GPU"),
         ),
     ],
 )

--- a/test/transformers/test_dyt.py
+++ b/test/transformers/test_dyt.py
@@ -1,0 +1,97 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from test.utils import assert_verbose_allclose
+from test.utils import infer_device
+from test.utils import set_seed
+from test.utils import supports_bfloat16
+
+from liger_kernel.transformers.dyt import LigerDyT
+
+
+class TorchDyT(nn.Module):
+    def __init__(self, C, init_alpha, dtype):
+        super().__init__()
+        self.alpha = nn.Parameter(torch.ones(1) * init_alpha)
+        self.gamma = nn.Parameter(torch.ones(C))
+        self.beta = nn.Parameter(torch.zeros(C))
+        self.dtype = dtype
+
+    def forward(self, x):
+        return (
+            self.gamma * torch.tanh((self.alpha * x).to(torch.float32)) + self.beta
+        ).to(self.dtype)
+
+
+set_seed(42)
+device = infer_device()
+
+
+@pytest.mark.parametrize("init_alpha", [0.5, 0.2, 1.0])
+@pytest.mark.parametrize(
+    "B, T, C",
+    [
+        (2, 16, 32),
+        # (2, 2048, 2048),
+        # # weird shapes
+        # (9, 41, 341),
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype, atol, rtol",
+    [
+        # atol is for small values: they have more difference, so set atol higher
+        # rtol is for larger values: they are very close, so set rtol lower
+        (torch.float32, 1e-5, 1e-5),
+        pytest.param(
+            torch.bfloat16,
+            1e-8,
+            5e-2,
+            marks=pytest.mark.skipif(
+                not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
+            ),
+        ),
+    ],
+)
+def test_correctness(B, T, C, init_alpha, dtype, atol, rtol):
+    _input = torch.randn(B, T, C, device=device, dtype=dtype)
+
+    x1 = _input.clone().requires_grad_(True)
+    x2 = _input.clone().requires_grad_(True)
+
+    # initialize weights
+    alpha = torch.randn(1, device=device, dtype=dtype)
+    gamma = torch.randn(C, device=device, dtype=dtype)
+    beta = torch.randn(C, device=device, dtype=dtype)
+
+    torch_dyt = TorchDyT(C=C, init_alpha=init_alpha, dtype=dtype).to(device).to(dtype)
+    torch_dyt.alpha.data = alpha.clone()
+    torch_dyt.gamma.data = gamma.clone()
+    torch_dyt.beta.data = beta.clone()
+
+    liger_dyt = LigerDyT(C=C, init_alpha=init_alpha).to(device).to(dtype)
+    liger_dyt.alpha.data = alpha.clone()
+    liger_dyt.gamma.data = gamma.clone()
+    liger_dyt.beta.data = beta.clone()
+
+    torch_output = torch_dyt(x1)
+    liger_output = liger_dyt(x2)
+
+    assert_verbose_allclose(torch_output, liger_output, rtol=rtol, atol=atol)
+
+    return
+    grad_output = torch.randn_like(_input)
+    torch_output.backward(grad_output)
+    liger_output.backward(grad_output)
+
+    assert_verbose_allclose(x1.grad, x2.grad, rtol=rtol, atol=atol)
+    assert_verbose_allclose(
+        torch_dyt.alpha.grad, liger_dyt.alpha.grad, rtol=rtol, atol=atol
+    )
+    assert_verbose_allclose(
+        torch_dyt.gamma.grad, liger_dyt.gamma.grad, rtol=rtol, atol=atol
+    )
+    assert_verbose_allclose(
+        torch_dyt.beta.grad, liger_dyt.beta.grad, rtol=rtol, atol=atol
+    )

--- a/test/transformers/test_dyt.py
+++ b/test/transformers/test_dyt.py
@@ -7,15 +7,17 @@ from test.utils import infer_device
 from test.utils import set_seed
 from test.utils import supports_bfloat16
 
+from liger_kernel.ops.dyt import LigerDyTFunction
 from liger_kernel.transformers.dyt import LigerDyT
+from liger_kernel.transformers.functional import liger_dyt
 
 
 class TorchDyT(nn.Module):
-    def __init__(self, C, init_alpha, dtype):
+    def __init__(self, hidden_size, init_alpha, dtype):
         super().__init__()
         self.alpha = nn.Parameter(torch.ones(1) * init_alpha)
-        self.gamma = nn.Parameter(torch.ones(C))
-        self.beta = nn.Parameter(torch.zeros(C))
+        self.gamma = nn.Parameter(torch.ones(hidden_size))
+        self.beta = nn.Parameter(torch.zeros(hidden_size))
         self.dtype = dtype
 
     def forward(self, x):
@@ -28,7 +30,58 @@ device = infer_device()
 
 @pytest.mark.parametrize("init_alpha", [0.5, 0.2, 1.0])
 @pytest.mark.parametrize(
-    "B, T, C",
+    "B, T, hidden_size",
+    [
+        (2, 8, 4096),
+        (4, 16, 2048),
+        (1, 1, 1023),  # Minimal batch/seq with near power-of-2 hidden
+        (3, 7, 256),  # Prime numbers for batch/seq
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype, atol, rtol",
+    [
+        (torch.float32, 1e-5, 1e-5),
+    ],
+)
+def test_liger_dyt_correctness(B, T, hidden_size, init_alpha, dtype, atol, rtol):
+    _input = torch.randn(B, T, hidden_size, device=device, dtype=dtype)
+
+    x1 = _input.clone().requires_grad_(True)
+    x2 = _input.clone().requires_grad_(True)
+
+    # initialize weights
+    alpha = torch.randn(1, device=device, dtype=dtype)
+    gamma = torch.randn(hidden_size, device=device, dtype=dtype)
+    beta = torch.randn(hidden_size, device=device, dtype=dtype)
+
+    torch_dyt = TorchDyT(hidden_size=hidden_size, init_alpha=init_alpha, dtype=dtype).to(device).to(dtype)
+    torch_dyt.alpha.data = alpha.clone()
+    torch_dyt.gamma.data = gamma.clone()
+    torch_dyt.beta.data = beta.clone()
+
+    liger_dyt = LigerDyT(hidden_size=hidden_size, init_alpha=init_alpha).to(device).to(dtype)
+    liger_dyt.alpha.data = alpha.clone()
+    liger_dyt.gamma.data = gamma.clone()
+    liger_dyt.beta.data = beta.clone()
+
+    torch_output = torch_dyt(x1)
+    liger_output = liger_dyt(x2)
+
+    assert_verbose_allclose(torch_output, liger_output, rtol=rtol, atol=atol)
+
+    grad_output = torch.randn_like(_input)
+    torch_output.backward(grad_output)
+    liger_output.backward(grad_output)
+
+    assert_verbose_allclose(x1.grad, x2.grad, rtol=rtol, atol=atol)
+    assert_verbose_allclose(torch_dyt.alpha.grad, liger_dyt.alpha.grad, rtol=rtol, atol=atol)
+    assert_verbose_allclose(torch_dyt.gamma.grad, liger_dyt.gamma.grad, rtol=rtol, atol=atol)
+    assert_verbose_allclose(torch_dyt.beta.grad, liger_dyt.beta.grad, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize(
+    "B, T, hidden_size",
     [
         (2, 8, 4096),
         (4, 16, 2048),
@@ -50,37 +103,35 @@ device = infer_device()
         ),
     ],
 )
-def test_correctness(B, T, C, init_alpha, dtype, atol, rtol):
-    _input = torch.randn(B, T, C, device=device, dtype=dtype)
+def test_liger_dyt_functional(B, T, hidden_size, dtype, atol, rtol):
+    _input = torch.randn(B, T, hidden_size, device=device, dtype=dtype)
 
     x1 = _input.clone().requires_grad_(True)
     x2 = _input.clone().requires_grad_(True)
 
     # initialize weights
     alpha = torch.randn(1, device=device, dtype=dtype)
-    gamma = torch.randn(C, device=device, dtype=dtype)
-    beta = torch.randn(C, device=device, dtype=dtype)
+    gamma = torch.randn(hidden_size, device=device, dtype=dtype)
+    beta = torch.randn(hidden_size, device=device, dtype=dtype)
 
-    torch_dyt = TorchDyT(C=C, init_alpha=init_alpha, dtype=dtype).to(device).to(dtype)
-    torch_dyt.alpha.data = alpha.clone()
-    torch_dyt.gamma.data = gamma.clone()
-    torch_dyt.beta.data = beta.clone()
+    alpha1 = alpha.clone().requires_grad_(True)
+    gamma1 = gamma.clone().requires_grad_(True)
+    beta1 = beta.clone().requires_grad_(True)
 
-    liger_dyt = LigerDyT(C=C, init_alpha=init_alpha).to(device).to(dtype)
-    liger_dyt.alpha.data = alpha.clone()
-    liger_dyt.gamma.data = gamma.clone()
-    liger_dyt.beta.data = beta.clone()
+    alpha2 = alpha.clone().requires_grad_(True)
+    gamma2 = gamma.clone().requires_grad_(True)
+    beta2 = beta.clone().requires_grad_(True)
 
-    torch_output = torch_dyt(x1)
-    liger_output = liger_dyt(x2)
+    output1 = liger_dyt(x1, alpha=alpha1, gamma=gamma1, beta=beta1)
+    output2 = LigerDyTFunction.apply(x2, alpha2, gamma2, beta2)
 
-    assert_verbose_allclose(torch_output, liger_output, rtol=rtol, atol=atol)
+    assert_verbose_allclose(output1, output2, rtol=rtol, atol=atol)
 
     grad_output = torch.randn_like(_input)
-    torch_output.backward(grad_output)
-    liger_output.backward(grad_output)
+    output1.backward(grad_output, retain_graph=True)
+    output2.backward(grad_output, retain_graph=True)
 
     assert_verbose_allclose(x1.grad, x2.grad, rtol=rtol, atol=atol)
-    assert_verbose_allclose(torch_dyt.alpha.grad, liger_dyt.alpha.grad, rtol=rtol, atol=atol)
-    assert_verbose_allclose(torch_dyt.gamma.grad, liger_dyt.gamma.grad, rtol=rtol, atol=atol)
-    assert_verbose_allclose(torch_dyt.beta.grad, liger_dyt.beta.grad, rtol=rtol, atol=atol)
+    assert_verbose_allclose(alpha1.grad, alpha2.grad, rtol=rtol, atol=atol)
+    assert_verbose_allclose(gamma1.grad, gamma2.grad, rtol=rtol, atol=atol)
+    assert_verbose_allclose(beta1.grad, beta2.grad, rtol=rtol, atol=atol)

--- a/test/transformers/test_dyt.py
+++ b/test/transformers/test_dyt.py
@@ -19,9 +19,7 @@ class TorchDyT(nn.Module):
         self.dtype = dtype
 
     def forward(self, x):
-        return (
-            self.gamma * torch.tanh((self.alpha * x).to(torch.float32)) + self.beta
-        ).to(self.dtype)
+        return (self.gamma * torch.tanh((self.alpha * x).to(torch.float32)) + self.beta).to(self.dtype)
 
 
 set_seed(42)
@@ -48,9 +46,7 @@ device = infer_device()
             torch.bfloat16,
             1e-8,
             5e-2,
-            marks=pytest.mark.skipif(
-                not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
-            ),
+            marks=pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this GPU"),
         ),
     ],
 )
@@ -85,12 +81,6 @@ def test_correctness(B, T, C, init_alpha, dtype, atol, rtol):
     liger_output.backward(grad_output)
 
     assert_verbose_allclose(x1.grad, x2.grad, rtol=rtol, atol=atol)
-    assert_verbose_allclose(
-        torch_dyt.alpha.grad, liger_dyt.alpha.grad, rtol=rtol, atol=atol
-    )
-    assert_verbose_allclose(
-        torch_dyt.gamma.grad, liger_dyt.gamma.grad, rtol=rtol, atol=atol
-    )
-    assert_verbose_allclose(
-        torch_dyt.beta.grad, liger_dyt.beta.grad, rtol=rtol, atol=atol
-    )
+    assert_verbose_allclose(torch_dyt.alpha.grad, liger_dyt.alpha.grad, rtol=rtol, atol=atol)
+    assert_verbose_allclose(torch_dyt.gamma.grad, liger_dyt.gamma.grad, rtol=rtol, atol=atol)
+    assert_verbose_allclose(torch_dyt.beta.grad, liger_dyt.beta.grad, rtol=rtol, atol=atol)

--- a/test/transformers/test_dyt.py
+++ b/test/transformers/test_dyt.py
@@ -32,10 +32,10 @@ device = infer_device()
 @pytest.mark.parametrize(
     "B, T, C",
     [
-        (2, 16, 32),
-        # (2, 2048, 2048),
-        # # weird shapes
-        # (9, 41, 341),
+        (2, 8, 4096),
+        (4, 16, 2048),
+        (1, 1, 1023),  # Minimal batch/seq with near power-of-2 hidden
+        (3, 7, 256),  # Prime numbers for batch/seq
     ],
 )
 @pytest.mark.parametrize(

--- a/test/transformers/test_dyt.py
+++ b/test/transformers/test_dyt.py
@@ -80,7 +80,6 @@ def test_correctness(B, T, C, init_alpha, dtype, atol, rtol):
 
     assert_verbose_allclose(torch_output, liger_output, rtol=rtol, atol=atol)
 
-    return
     grad_output = torch.randn_like(_input)
     torch_output.backward(grad_output)
     liger_output.backward(grad_output)


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Resolves #607 

## Details

Benchmarking on RTX4090
<details> <summary> Environment Report </summary>
Operating System: Linux-6.1.0-0.deb11.21-amd64-x86_64-with-glibc2.31
Python version: 3.11.10
Liger Kernel version: 0.5.5
PyTorch version: 2.6.0+cu124
CUDA version: 12.4
HIP(ROCm) version: Not available
Triton version: 3.2.0
Transformers version: 4.50.0
XPU version: XPU Not Available

</details>

<details> <summary> Benchmark data </summary>

```bash
**************************************
     BENCHMARKING SPEED for DYT
**************************************
********** Benchmark Data **********
[
  {
    "kernel_name": "dyt",
    "kernel_provider": "liger",
    "metric_name": "speed",
    "metric_unit": "ms",
    "gpu_name": "NVIDIA GeForce RTX 4090",
    "x_name": "BT",
    "x_label": "batch_size * seq_len",
    "x_values": [
      1024,
      2048,
      4096,
      8192,
      16384
    ],
    "y_values_50": [
      0.04198399931192398,
      0.08089599758386612,
      0.15462400019168854,
      0.30003198981285095,
      0.591871976852417
    ],
    "y_values_20": [
      0.04095999896526337,
      0.0798719972372055,
      0.15360000729560852,
      0.29900801181793213,
      0.5908480286598206
    ],
    "y_values_80": [
      0.043007999658584595,
      0.08191999793052673,
      0.15564799308776855,
      0.30105599761009216,
      0.5926719903945923
    ],
    "timestamp": "2025-03-21 18:41:05",
    "kernel_operation_mode": "forward",
    "extra_benchmark_config_str": "{\"hidden_size\": 4096, \"dtype\": \"torch.float32\"}",
    "liger_version": "0.5.5"
  },
  {
    "kernel_name": "dyt",
    "kernel_provider": "torch",
    "metric_name": "speed",
    "metric_unit": "ms",
    "gpu_name": "NVIDIA GeForce RTX 4090",
    "x_name": "BT",
    "x_label": "batch_size * seq_len",
    "x_values": [
      1024,
      2048,
      4096,
      8192,
      16384
    ],
    "y_values_50": [
      0.08294399827718735,
      0.16784000396728516,
      0.5908480286598206,
      1.1724799871444702,
      2.333695888519287
    ],
    "y_values_20": [
      0.08191999793052673,
      0.1669120043516159,
      0.5898240208625793,
      1.171455979347229,
      2.332479953765869
    ],
    "y_values_80": [
      0.08297599852085114,
      0.16879360377788544,
      0.591871976852417,
      1.1744128465652466,
      2.3347198963165283
    ],
    "timestamp": "2025-03-21 18:41:07",
    "kernel_operation_mode": "forward",
    "extra_benchmark_config_str": "{\"hidden_size\": 4096, \"dtype\": \"torch.float32\"}",
    "liger_version": "0.5.5"
  },
  {
    "kernel_name": "dyt",
    "kernel_provider": "torch_compile",
    "metric_name": "speed",
    "metric_unit": "ms",
    "gpu_name": "NVIDIA GeForce RTX 4090",
    "x_name": "BT",
    "x_label": "batch_size * seq_len",
    "x_values": [
      1024,
      2048,
      4096,
      8192,
      16384
    ],
    "y_values_50": [
      0.04198399931192398,
      0.07577600330114365,
      0.1504639983177185,
      0.2969599962234497,
      0.5867519974708557
    ],
    "y_values_20": [
      0.04095999896526337,
      0.07577600330114365,
      0.14950400590896606,
      0.2959359884262085,
      0.5857279896736145
    ],
    "y_values_80": [
      0.04198399931192398,
      0.07680000364780426,
      0.15052799880504608,
      0.2979840040206909,
      0.5877760052680969
    ],
    "timestamp": "2025-03-21 18:41:12",
    "kernel_operation_mode": "forward",
    "extra_benchmark_config_str": "{\"hidden_size\": 4096, \"dtype\": \"torch.float32\"}",
    "liger_version": "0.5.5"
  },
  {
    "kernel_name": "dyt",
    "kernel_provider": "liger",
    "metric_name": "speed",
    "metric_unit": "ms",
    "gpu_name": "NVIDIA GeForce RTX 4090",
    "x_name": "BT",
    "x_label": "batch_size * seq_len",
    "x_values": [
      1024,
      2048,
      4096,
      8192,
      16384
    ],
    "y_values_50": [
      0.09728000313043594,
      0.17817600071430206,
      0.34303998947143555,
      0.6574079990386963,
      1.235967993736267
    ],
    "y_values_20": [
      0.09625600278377533,
      0.17715199291706085,
      0.3420160114765167,
      0.6563839912414551,
      1.2349439859390259
    ],
    "y_values_80": [
      0.09830400347709656,
      0.17919999361038208,
      0.34303998947143555,
      0.6584320068359375,
      1.2369920015335083
    ],
    "timestamp": "2025-03-21 18:41:14",
    "kernel_operation_mode": "backward",
    "extra_benchmark_config_str": "{\"hidden_size\": 4096, \"dtype\": \"torch.float32\"}",
    "liger_version": "0.5.5"
  },
  {
    "kernel_name": "dyt",
    "kernel_provider": "torch",
    "metric_name": "speed",
    "metric_unit": "ms",
    "gpu_name": "NVIDIA GeForce RTX 4090",
    "x_name": "BT",
    "x_label": "batch_size * seq_len",
    "x_values": [
      1024,
      2048,
      4096,
      8192,
      16384
    ],
    "y_values_50": [
      0.16383999586105347,
      0.4638719856739044,
      1.1233279705047607,
      2.3736319541931152,
      4.687871932983398
    ],
    "y_values_20": [
      0.16383999586105347,
      0.46371200680732727,
      1.1212799549102783,
      2.372607946395874,
      4.685823917388916
    ],
    "y_values_80": [
      0.16486400365829468,
      0.46489599347114563,
      1.124351978302002,
      2.3755135536193848,
      4.689919948577881
    ],
    "timestamp": "2025-03-21 18:41:17",
    "kernel_operation_mode": "backward",
    "extra_benchmark_config_str": "{\"hidden_size\": 4096, \"dtype\": \"torch.float32\"}",
    "liger_version": "0.5.5"
  },
  {
    "kernel_name": "dyt",
    "kernel_provider": "torch_compile",
    "metric_name": "speed",
    "metric_unit": "ms",
    "gpu_name": "NVIDIA GeForce RTX 4090",
    "x_name": "BT",
    "x_label": "batch_size * seq_len",
    "x_values": [
      1024,
      2048,
      4096,
      8192,
      16384
    ],
    "y_values_50": [
      0.11059200018644333,
      0.21606400609016418,
      0.44543999433517456,
      0.9502720236778259,
      1.9487040042877197
    ],
    "y_values_20": [
      0.10956799983978271,
      0.21606400609016418,
      0.44441598653793335,
      0.9492480158805847,
      1.947648048400879
    ],
    "y_values_80": [
      0.11059200018644333,
      0.2170879989862442,
      0.44543999433517456,
      0.9512959718704224,
      1.950719952583313
    ],
    "timestamp": "2025-03-21 18:41:19",
    "kernel_operation_mode": "backward",
    "extra_benchmark_config_str": "{\"hidden_size\": 4096, \"dtype\": \"torch.float32\"}",
    "liger_version": "0.5.5"
  },
  {
    "kernel_name": "dyt",
    "kernel_provider": "liger",
    "metric_name": "speed",
    "metric_unit": "ms",
    "gpu_name": "NVIDIA GeForce RTX 4090",
    "x_name": "BT",
    "x_label": "batch_size * seq_len",
    "x_values": [
      1024,
      2048,
      4096,
      8192,
      16384
    ],
    "y_values_50": [
      0.11878400295972824,
      0.24371199309825897,
      0.4843519926071167,
      0.9461759924888611,
      1.815551996231079
    ],
    "y_values_20": [
      0.11776000261306763,
      0.24268800020217896,
      0.4833280146121979,
      0.9451519846916199,
      1.8135039806365967
    ],
    "y_values_80": [
      0.11980800330638885,
      0.24473600089550018,
      0.4864000082015991,
      0.9472000002861023,
      1.8165760040283203
    ],
    "timestamp": "2025-03-21 18:41:21",
    "kernel_operation_mode": "full",
    "extra_benchmark_config_str": "{\"hidden_size\": 4096, \"dtype\": \"torch.float32\"}",
    "liger_version": "0.5.5"
  },
  {
    "kernel_name": "dyt",
    "kernel_provider": "torch",
    "metric_name": "speed",
    "metric_unit": "ms",
    "gpu_name": "NVIDIA GeForce RTX 4090",
    "x_name": "BT",
    "x_label": "batch_size * seq_len",
    "x_values": [
      1024,
      2048,
      4096,
      8192,
      16384
    ],
    "y_values_50": [
      0.21401600539684296,
      0.6164479851722717,
      1.7192959785461426,
      3.54201602935791,
      7.015423774719238
    ],
    "y_values_20": [
      0.21299199759960175,
      0.6154239773750305,
      1.7182079553604126,
      3.540569543838501,
      7.014400005340576
    ],
    "y_values_80": [
      0.21401600539684296,
      0.6184960007667542,
      1.721343994140625,
      3.5440640449523926,
      7.017471790313721
    ],
    "timestamp": "2025-03-21 18:41:24",
    "kernel_operation_mode": "full",
    "extra_benchmark_config_str": "{\"hidden_size\": 4096, \"dtype\": \"torch.float32\"}",
    "liger_version": "0.5.5"
  },
  {
    "kernel_name": "dyt",
    "kernel_provider": "torch_compile",
    "metric_name": "speed",
    "metric_unit": "ms",
    "gpu_name": "NVIDIA GeForce RTX 4090",
    "x_name": "BT",
    "x_label": "batch_size * seq_len",
    "x_values": [
      1024,
      2048,
      4096,
      8192,
      16384
    ],
    "y_values_50": [
      0.13209599256515503,
      0.28672000765800476,
      0.5887680053710938,
      1.2411680221557617,
      2.5333759784698486
    ],
    "y_values_20": [
      0.131071999669075,
      0.28672000765800476,
      0.5877760052680969,
      1.240505576133728,
      2.5323519706726074
    ],
    "y_values_80": [
      0.13209599256515503,
      0.2877439856529236,
      0.5888000130653381,
      1.2431360483169556,
      2.535423994064331
    ],
    "timestamp": "2025-03-21 18:41:26",
    "kernel_operation_mode": "full",
    "extra_benchmark_config_str": "{\"hidden_size\": 4096, \"dtype\": \"torch.float32\"}",
    "liger_version": "0.5.5"
  }
]
**************************************
     BENCHMARKING MEMORY for DYT
**************************************
********** Benchmark Data **********
[
  {
    "kernel_name": "dyt",
    "kernel_provider": "liger",
    "metric_name": "memory",
    "metric_unit": "MB",
    "gpu_name": "NVIDIA GeForce RTX 4090",
    "x_name": "BT",
    "x_label": "batch_size * seq_len",
    "x_values": [
      1024,
      2048,
      4096,
      8192,
      16384
    ],
    "y_values_50": [
      114.15966796875,
      226.15966796875,
      418.15966796875,
      738.15966796875,
      1378.15966796875
    ],
    "y_values_20": [
      114.15966796875,
      226.15966796875,
      418.15966796875,
      738.15966796875,
      1378.15966796875
    ],
    "y_values_80": [
      114.15966796875,
      226.15966796875,
      418.15966796875,
      738.15966796875,
      1378.15966796875
    ],
    "timestamp": "2025-03-21 18:41:26",
    "kernel_operation_mode": "full",
    "extra_benchmark_config_str": "{\"hidden_size\": 4096, \"dtype\": \"torch.float32\"}",
    "liger_version": "0.5.5"
  },
  {
    "kernel_name": "dyt",
    "kernel_provider": "torch",
    "metric_name": "memory",
    "metric_unit": "MB",
    "gpu_name": "NVIDIA GeForce RTX 4090",
    "x_name": "BT",
    "x_label": "batch_size * seq_len",
    "x_values": [
      1024,
      2048,
      4096,
      8192,
      16384
    ],
    "y_values_50": [
      144.14306640625,
      288.14306640625,
      544.14306640625,
      1024.12939453125,
      2048.1298828125
    ],
    "y_values_20": [
      144.14306640625,
      288.14306640625,
      544.14306640625,
      1024.12939453125,
      2048.1298828125
    ],
    "y_values_80": [
      144.14306640625,
      288.14306640625,
      544.14306640625,
      1024.12939453125,
      2048.1298828125
    ],
    "timestamp": "2025-03-21 18:41:26",
    "kernel_operation_mode": "full",
    "extra_benchmark_config_str": "{\"hidden_size\": 4096, \"dtype\": \"torch.float32\"}",
    "liger_version": "0.5.5"
  },
  {
    "kernel_name": "dyt",
    "kernel_provider": "torch_compile",
    "metric_name": "memory",
    "metric_unit": "MB",
    "gpu_name": "NVIDIA GeForce RTX 4090",
    "x_name": "BT",
    "x_label": "batch_size * seq_len",
    "x_values": [
      1024,
      2048,
      4096,
      8192,
      16384
    ],
    "y_values_50": [
      80.15869140625,
      160.15869140625,
      320.15869140625,
      640.15869140625,
      1280.15869140625
    ],
    "y_values_20": [
      80.15869140625,
      160.15869140625,
      320.15869140625,
      640.15869140625,
      1280.15869140625
    ],
    "y_values_80": [
      80.15869140625,
      160.15869140625,
      320.15869140625,
      640.15869140625,
      1280.15869140625
    ],
    "timestamp": "2025-03-21 18:41:26",
    "kernel_operation_mode": "full",
    "extra_benchmark_config_str": "{\"hidden_size\": 4096, \"dtype\": \"torch.float32\"}",
    "liger_version": "0.5.5"
  }
]
```
</details>

## Speed (hidden_size = 4096, dtype = fp32)
### forward
![image](https://github.com/user-attachments/assets/b4ba2cd3-3fd9-4497-8802-08ea58232b53)

### backward
![image](https://github.com/user-attachments/assets/37d670b5-f278-4d1e-ba64-582db16e0c77)

### full
![image](https://github.com/user-attachments/assets/b6828478-e9aa-41da-89d3-cdfa9b7cde91)

## Memory (hidden_size = 4096, dtype = fp32)
### full
![image](https://github.com/user-attachments/assets/03d552b9-9330-403a-8aad-0f1f8854809e)

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
