### PR TITLE
Fix incorrect module patching when using LoRA with modules_to_save

### DIFF
--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -52,6 +52,8 @@ def _bind_method_to_module(module, method_name: str, new_method: Callable):
 
 
 def _patch_rms_norm_module(module, offset=0.0, eps=1e-6, casting_mode="llama", in_place=True):
+    # Check if the module is a PEFT ModulesToSaveWrapper
+    # If it is, we need to patch the modules_to_save.default and original_modules
     if PEFT_AVAILABLE and isinstance(module, peft.utils.other.ModulesToSaveWrapper):
         module.modules_to_save.default.offset = offset
         module.modules_to_save.default.casting_mode = casting_mode
@@ -78,6 +80,8 @@ def _patch_rms_norm_module(module, offset=0.0, eps=1e-6, casting_mode="llama", i
 
 
 def _patch_layer_norm_module(module, eps=1e-6):
+    # Check if the module is a PEFT ModulesToSaveWrapper
+    # If it is, we need to patch the modules_to_save.default and original_modules
     if PEFT_AVAILABLE and isinstance(module, peft.utils.other.ModulesToSaveWrapper):
         module.hidden_size = module.normalized_shape
         _bind_method_to_module(module, "forward", LigerLayerNorm.forward)


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Fix #631 

Tests and convergence tests are passed.
## Details
Without this PR, `_apply_liger_kernel_to_instance` patches the wrong module when using LoRA with `modules_to_save`.
It patches the entire `ModulesToSaveWrapper`, which causes the error when the training starts.
```python
(norm): ModulesToSaveWrapper(
    (original_module): Qwen2RMSNorm((896,), eps=1e-06, offset=0.0, in_place=True)
    (modules_to_save): ModuleDict(
        (default): Qwen2RMSNorm((896,), eps=1e-06, offset=0.0, in_place=True)
    )
)
```
This PR patches the `original_module` and `default` when it detects `ModulesToSaveWrapper`

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [x] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
