### PR TITLE
Fix incorrect condition comment in log_target calculation

### DIFF
--- a/src/liger_kernel/ops/kl_div.py
+++ b/src/liger_kernel/ops/kl_div.py
@@ -185,9 +185,9 @@ class LigerKLDivLossFunction(torch.autograd.Function):
     Class implementing the forward and backward pass for the KL Divergence Loss using Triton, as defined by the following formula:
     ```python
     if log_target:
-        loss = target * (target.log() - input)
-    else:
         loss = target.exp() * (target - input)
+    else:
+        loss = target * (target.log() - input)
     ```,
     then the loss is reduced according to the `reduction` parameter.
     as defined in the PyTorch documentation: https://pytorch.org/docs/stable/generated/torch.nn.KLDivLoss.html


### PR DESCRIPTION
## Summary
This PR fixes an incorrect comment in the `log_target` condition calculation. The original comments had the conditions reversed of LigerKLDivLossFunction. 

- When `log_target=False`, the actual computation is `target * (target.log() - input)`
- When `log_target=True`, the actual computation is `target.exp() * (target - input)`

This change corrects the comments to accurately reflect the implementation (documentation-only change).

## Details
The comment correction improves code clarity and prevents potential confusion for developers. No functional changes are made.

## Testing Done
**Not required** - This is a documentation-only change that:
1. Doesn't modify any executable code
2. Doesn't affect any existing functionality
3. Only fixes inaccurate comments

<!-- Removed testing checklist as it's not applicable for doc changes -->
