### PR TITLE
Zhasun/grpo add ref logits

### DIFF
--- a/src/liger_kernel/chunked_loss/fused_linear_rlhf.py
+++ b/src/liger_kernel/chunked_loss/fused_linear_rlhf.py
@@ -24,6 +24,7 @@ class LigerFusedLinearRLHFBase(torch.autograd.Function):
         attention_mask,
         advantages,
         bias=None,
+        ref_log_probs=None,
         ref_input=None,
         ref_weight=None,
         ref_bias=None,
@@ -47,6 +48,7 @@ class LigerFusedLinearRLHFBase(torch.autograd.Function):
             attention_mask: Attention mask tensor
             advantages: Advantages tensor
             bias: Bias tensor
+            ref_log_probs: Reference model log probs tensor
             ref_input: Reference model input tensor
             ref_weight: Reference model weight tensor
             ref_bias: Reference model bias tensor
@@ -85,6 +87,7 @@ class LigerFusedLinearRLHFBase(torch.autograd.Function):
             selected_token_ids_chunk,
             attention_mask_chunk,
             advantages_chunk,
+            ref_log_probs_chunk,
             ref_input_chunk,
             old_per_token_logps_chunk,
         ):
@@ -97,8 +100,9 @@ class LigerFusedLinearRLHFBase(torch.autograd.Function):
                 attention_mask_chunk,  # arg 3
                 advantages_chunk,  # arg 4
                 bias,  # arg 5
-                ref_input_chunk=ref_input_chunk,  # arg 6
-                old_per_token_logps_chunk=old_per_token_logps_chunk,  # arg 7
+                ref_log_probs_chunk=ref_log_probs_chunk, # arg 6
+                ref_input_chunk=ref_input_chunk,  # arg 7
+                old_per_token_logps_chunk=old_per_token_logps_chunk,  # arg 8
             )
 
         def accumulate_chunk(
@@ -106,6 +110,7 @@ class LigerFusedLinearRLHFBase(torch.autograd.Function):
             selected_token_ids_chunk,
             attention_mask_chunk,
             advantages_chunk,
+            ref_log_probs_chunk=None,
             ref_input_chunk=None,
             old_per_token_logps_chunk=None,
         ):
@@ -114,6 +119,7 @@ class LigerFusedLinearRLHFBase(torch.autograd.Function):
                 selected_token_ids_chunk,
                 attention_mask_chunk,
                 advantages_chunk,
+                ref_log_probs_chunk,
                 ref_input_chunk,
                 old_per_token_logps_chunk,
             )
@@ -150,7 +156,9 @@ class LigerFusedLinearRLHFBase(torch.autograd.Function):
         _selected_token_ids_chunks = torch.chunk(selected_token_ids, chunks=chunks, dim=0)
         _attention_mask_chunks = torch.chunk(attention_mask, chunks=chunks, dim=0)
         _advantages_chunks = torch.chunk(advantages, chunks=chunks, dim=0)
-        _ref_input_chunks = torch.chunk(ref_input, chunks=chunks, dim=0) if use_ref_model else [None] * chunks
+        _ref_log_probs_chunks = torch.chunk(ref_log_probs, chunks=chunks, dim=0) if use_ref_model and ref_log_probs is not None else [None] * chunks
+        # if ref_log_probs is not none, then we don't need ref_input to calculate the log probs
+        _ref_input_chunks = torch.chunk(ref_input, chunks=chunks, dim=0) if use_ref_model and ref_log_probs is None else [None] * chunks
         _old_per_token_logps_chunks = (
             torch.chunk(old_per_token_logps, chunks=chunks, dim=0)
             if old_per_token_logps is not None
@@ -162,6 +170,7 @@ class LigerFusedLinearRLHFBase(torch.autograd.Function):
             selected_token_ids_chunk,
             attention_mask_chunk,
             advantages_chunk,
+            ref_log_probs_chunk,
             ref_input_chunk,
             old_per_token_logps_chunk,
         ) in zip(
@@ -169,6 +178,7 @@ class LigerFusedLinearRLHFBase(torch.autograd.Function):
             _selected_token_ids_chunks,
             _attention_mask_chunks,
             _advantages_chunks,
+            _ref_log_probs_chunks,
             _ref_input_chunks,
             _old_per_token_logps_chunks,
         ):
@@ -176,7 +186,9 @@ class LigerFusedLinearRLHFBase(torch.autograd.Function):
             torch._dynamo.mark_dynamic(input_chunk, 1)
             torch._dynamo.mark_dynamic(selected_token_ids_chunk, 1)
             torch._dynamo.mark_dynamic(attention_mask_chunk, 1)
-            if use_ref_model:
+            if use_ref_model and ref_log_probs_chunk is not None:
+                torch._dynamo.mark_dynamic(ref_log_probs_chunk, 1)
+            elif use_ref_model:
                 torch._dynamo.mark_dynamic(ref_input_chunk, 1)
             else:
                 ref_input_chunk = None
@@ -190,6 +202,7 @@ class LigerFusedLinearRLHFBase(torch.autograd.Function):
                 selected_token_ids_chunk,
                 attention_mask_chunk,
                 advantages_chunk,
+                ref_log_probs_chunk,
                 ref_input_chunk,
                 old_per_token_logps_chunk,
             )
@@ -218,6 +231,7 @@ class LigerFusedLinearRLHFBase(torch.autograd.Function):
         attention_mask_chunk,
         advantages_chunk,
         bias=None,
+        ref_log_probs_chunk=None,
         ref_input_chunk=None,
         ref_weight=None,
         ref_bias=None,
@@ -236,11 +250,14 @@ class LigerFusedLinearRLHFBase(torch.autograd.Function):
 
         # Get reference log probabilities if needed
         ref_log_probs = None
-        if use_ref_model and ref_input_chunk is not None:
-            with torch.no_grad():
-                ref_log_probs, _ = LigerFusedLinearRLHFBase.chunk_forward(
-                    ref_input_chunk, ref_weight, bias=ref_bias, temperature=temperature
-                )
+        if use_ref_model:
+            if ref_log_probs_chunk is not None:
+                ref_log_probs = ref_log_probs_chunk
+            elif ref_input_chunk is not None:
+                with torch.no_grad():
+                    ref_log_probs, _ = LigerFusedLinearRLHFBase.chunk_forward(
+                        ref_input_chunk, ref_weight, bias=ref_bias, temperature=temperature
+                    )
 
         # Compute chunk loss and metrics using the provided loss function
         chunk_loss, chunk_metrics = rlhf_loss_fn(
@@ -290,6 +307,7 @@ class LigerFusedLinearRLHFBase(torch.autograd.Function):
             None,  # grad_attention_mask
             None,  # grad_advantages
             grad_bias,
+            None,  # grad_ref_log_probs
             None,  # grad_ref_input
             None,  # grad_ref_weight
             None,  # grad_ref_bias

--- a/test/chunked_loss/test_grpo_loss.py
+++ b/test/chunked_loss/test_grpo_loss.py
@@ -46,6 +46,7 @@ class TorchLMHeadGRPO(torch.nn.Module):
         selected_token_ids,  # Shape: [batch_size, seq_len]
         attention_mask,  # Shape: [batch_size, seq_len]
         advantages,  # Shape: [batch_size,]
+        ref_log_probs=None, #Shape: [batch_size, seq_len, vocab_size]
         ref_input=None,  # Shape: [batch_size, seq_len, hidden_size]
         old_per_token_logps=None,
     ):
@@ -132,6 +133,7 @@ class LigerLMHeadGRPO(torch.nn.Module):
         selected_token_ids,
         attention_mask,
         advantages,
+        ref_log_probs=None,
         ref_input=None,
         old_per_token_logps=None,
     ):
@@ -143,6 +145,7 @@ class LigerLMHeadGRPO(torch.nn.Module):
             attention_mask,  # attention_mask
             advantages,  # advantages
             self.lin.bias,  # bias
+            ref_log_probs, # ref_log_probs
             ref_input,  # ref_input
             self.ref_lin.weight,  # ref_weight
             self.ref_lin.bias,  # ref_bias
@@ -265,6 +268,7 @@ def test_correctness(
         selected_token_ids,
         attention_mask,
         advantages,
+        ref_log_probs=None,
         ref_input=ref_input,
         old_per_token_logps=old_per_token_logps,
     )
@@ -273,6 +277,7 @@ def test_correctness(
         selected_token_ids,
         attention_mask,
         advantages,
+        ref_log_probs=None,
         ref_input=ref_input,
         old_per_token_logps=old_per_token_logps,
     )
@@ -393,6 +398,7 @@ def test_functional_correctness(
     else:
         old_per_token_logps = None
 
+    ref_log_probs = None
     loss1, aux1 = liger_fused_linear_grpo(
         input1,
         weight1,
@@ -400,6 +406,7 @@ def test_functional_correctness(
         attention_mask,
         advantages,
         bias1,
+        ref_log_probs,
         ref_input,
         ref_weight1,
         ref_bias1,
@@ -420,6 +427,7 @@ def test_functional_correctness(
         attention_mask,
         advantages,
         bias2,
+        ref_log_probs,
         ref_input,
         ref_weight2,
         ref_bias2,


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Add the ref_log_probs as input. and if the log probs is not none, we don't need to re-calculate it using ref_input.

Add it in corresponding unit test as well.
<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [X] run `make test` to ensure correctness
- [X] run `make checkstyle` to ensure code style
- [X] run `make test-convergence` to ensure convergence
