### PR TITLE
[kl_div] Modified block and warp sizes for improved performance

### DIFF
--- a/src/liger_kernel/ops/kl_div.py
+++ b/src/liger_kernel/ops/kl_div.py
@@ -116,7 +116,11 @@ def _kldiv_kernel_backward(
 
 def kldiv_forward_triton(y_pred, y_true, log_target, reduction, eps):  # [BT, V]
     BT, V = y_pred.shape
-    BLOCK_SIZE = min(8192, triton.next_power_of_2(V)) if infer_device() == "xpu" else min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
+    BLOCK_SIZE = (
+        min(8192, triton.next_power_of_2(V))
+        if infer_device() == "xpu"
+        else min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
+    )
     num_warps = 32 if infer_device() == "xpu" else get_num_warps(BLOCK_SIZE)
 
     grid = (BT,)
@@ -155,7 +159,11 @@ def kldiv_forward_triton(y_pred, y_true, log_target, reduction, eps):  # [BT, V]
 
 def kldiv_backward_triton(target, grad_output, new_grads, log_target):
     BT, V = target.shape
-    BLOCK_SIZE = min(8192, triton.next_power_of_2(V)) if infer_device() == "xpu" else min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
+    BLOCK_SIZE = (
+        min(8192, triton.next_power_of_2(V))
+        if infer_device() == "xpu"
+        else min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
+    )
     num_warps = 32 if infer_device() == "xpu" else get_num_warps(BLOCK_SIZE)
 
     grid = (BT,)

--- a/src/liger_kernel/ops/kl_div.py
+++ b/src/liger_kernel/ops/kl_div.py
@@ -117,7 +117,7 @@ def _kldiv_kernel_backward(
 def kldiv_forward_triton(y_pred, y_true, log_target, reduction, eps):  # [BT, V]
     BT, V = y_pred.shape
     BLOCK_SIZE = min(8192, triton.next_power_of_2(V)) if infer_device() == "xpu" else min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
-    num_warps = 32 if infer_device() == "xpu" else triton.next_power_of_2(V)
+    num_warps = 32 if infer_device() == "xpu" else get_num_warps(BLOCK_SIZE)
 
     grid = (BT,)
     reduction = _str_to_reduction_mode[reduction]
@@ -156,7 +156,7 @@ def kldiv_forward_triton(y_pred, y_true, log_target, reduction, eps):  # [BT, V]
 def kldiv_backward_triton(target, grad_output, new_grads, log_target):
     BT, V = target.shape
     BLOCK_SIZE = min(8192, triton.next_power_of_2(V)) if infer_device() == "xpu" else min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
-    num_warps = 32 if infer_device() == "xpu" else triton.next_power_of_2(V)
+    num_warps = 32 if infer_device() == "xpu" else get_num_warps(BLOCK_SIZE)
 
     grid = (BT,)
 

--- a/src/liger_kernel/ops/kl_div.py
+++ b/src/liger_kernel/ops/kl_div.py
@@ -116,7 +116,7 @@ def _kldiv_kernel_backward(
 
 def kldiv_forward_triton(y_pred, y_true, log_target, reduction, eps):  # [BT, V]
     BT, V = y_pred.shape
-    BLOCK_SIZE = 8192 if infer_device() == "xpu" else min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
+    BLOCK_SIZE = min(8192, triton.next_power_of_2(V)) if infer_device() == "xpu" else min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
     num_warps = 32 if infer_device() == "xpu" else triton.next_power_of_2(V)
 
     grid = (BT,)
@@ -155,7 +155,7 @@ def kldiv_forward_triton(y_pred, y_true, log_target, reduction, eps):  # [BT, V]
 
 def kldiv_backward_triton(target, grad_output, new_grads, log_target):
     BT, V = target.shape
-    BLOCK_SIZE = 8192 if infer_device() == "xpu" else min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
+    BLOCK_SIZE = min(8192, triton.next_power_of_2(V)) if infer_device() == "xpu" else min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
     num_warps = 32 if infer_device() == "xpu" else triton.next_power_of_2(V)
 
     grid = (BT,)

--- a/src/liger_kernel/ops/kl_div.py
+++ b/src/liger_kernel/ops/kl_div.py
@@ -6,6 +6,7 @@ import triton.language as tl
 
 from liger_kernel.ops.utils import ensure_contiguous
 from liger_kernel.ops.utils import is_hip
+from liger_kernel.utils import infer_device
 
 
 def get_num_warps(BLOCK_SIZE):
@@ -19,6 +20,11 @@ def get_num_warps(BLOCK_SIZE):
 
     return num_warps
 
+# Tuning for XPU and CUDA devices
+def _get_block_and_warp_sizes():
+    BLOCK_SIZE = 8192 if infer_device() == "xpu" else min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
+    num_warps = 32 if infer_device() == "xpu" else triton.next_power_of_2(V)
+    return BLOCK_SIZE, num_warps   
 
 MAX_FUSED_SIZE = 65536 // 4  # 65536 // 4 or 8 works the best
 
@@ -115,9 +121,7 @@ def _kldiv_kernel_backward(
 
 def kldiv_forward_triton(y_pred, y_true, log_target, reduction, eps):  # [BT, V]
     BT, V = y_pred.shape
-
-    BLOCK_SIZE = min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
-    num_warps = get_num_warps(BLOCK_SIZE)
+    BLOCK_SIZE, num_warps = _get_block_and_warp_sizes()
 
     grid = (BT,)
     reduction = _str_to_reduction_mode[reduction]
@@ -155,9 +159,7 @@ def kldiv_forward_triton(y_pred, y_true, log_target, reduction, eps):  # [BT, V]
 
 def kldiv_backward_triton(target, grad_output, new_grads, log_target):
     BT, V = target.shape
-
-    BLOCK_SIZE = min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
-    num_warps = get_num_warps(BLOCK_SIZE)
+    BLOCK_SIZE, num_warps = _get_block_and_warp_sizes()
 
     grid = (BT,)
 


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->

This change is related to performance tuning on the Intel Max 1550 GPUs. By keeping the block and warp sizes the same in the forward and backward Triton kernels, the performance improves by 2-3%.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

Testing was done by comparing the run times between the `main` branch and my tuned changes

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: Intel Max GPU 1550
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence

Note: For the test-convergence, `test_mini_model_multimodal[mini_gemma3-32-0.0001-dtype6-1e-08-1e-05-0.005-1e-05-0.005-1e-05]` failed before my changes were included. This test failed due to a minor mismatch of the results: 
```
Mismatch at index (0, 2): tensor1[(0, 2)] = 1.842089295387268, tensor2[(0, 2)] = 1.8420593738555908
```

