### PR TITLE
backward compatible initialization

### DIFF
--- a/src/liger_kernel/chunked_loss/grpo_loss.py
+++ b/src/liger_kernel/chunked_loss/grpo_loss.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import torch
 
 from liger_kernel.chunked_loss.fused_linear_ppo import LigerFusedLinearPPOBase
@@ -204,7 +206,7 @@ class LigerFusedLinearGRPOLoss(torch.nn.Module):
         epsilon_low: float = 0.2,
         epsilon_high: float = 0.2,
         loss_type: str = "bnpo",
-        max_completion_length: int | None = None,
+        max_completion_length: Optional[int] = None,
         temperature: float = 1.0,
     ):
         """


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
#662 initialized the argument in a way that is not compatible with python3.9 so changing it to a backward compatible initialization.
This unblocks TRL PR https://github.com/huggingface/trl/pull/3260
<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
