### PR TITLE
update setup.py for installation on xpu

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ def get_default_dependencies():
     elif platform == "xpu":
         return [
             "torch>=2.6.0",
-            "pytorch-triton-xpu>=3.2.0",
         ]
 
 


### PR DESCRIPTION
## Summary
We want to remove `pytorch-triton-xpu` from the setup.py file, because it gets installed automatically with torch>=2.6.0 when using the below installation:
```bash
pip install -e .[dev] --extra-index-url https://download.pytorch.org/whl/test/xpu
```
So no need to explicitly mention it there.  
