### PR TITLE
Support GLM-4 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ loss.backward()
 | Phi3 & Phi3.5       | `liger_kernel.transformers.apply_liger_kernel_to_phi3`     | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy         |
 | Granite 3.0 & 3.1   | `liger_kernel.transformers.apply_liger_kernel_to_granite`     | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss |
 | OLMo2   | `liger_kernel.transformers.apply_liger_kernel_to_olmo2`     | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy |
+| GLM-4   | `liger_kernel.transformers.apply_liger_kernel_to_glm4`     | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy |
 
 
 ## Low-level APIs

--- a/src/liger_kernel/transformers/__init__.py
+++ b/src/liger_kernel/transformers/__init__.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from liger_kernel.transformers.monkey_patch import apply_liger_kernel_to_gemma2  # noqa: F401
     from liger_kernel.transformers.monkey_patch import apply_liger_kernel_to_gemma3  # noqa: F401
     from liger_kernel.transformers.monkey_patch import apply_liger_kernel_to_gemma3_text  # noqa: F401
+    from liger_kernel.transformers.monkey_patch import apply_liger_kernel_to_glm4  # noqa: F401
     from liger_kernel.transformers.monkey_patch import apply_liger_kernel_to_granite  # noqa: F401
     from liger_kernel.transformers.monkey_patch import apply_liger_kernel_to_llama  # noqa: F401
     from liger_kernel.transformers.monkey_patch import apply_liger_kernel_to_llava  # noqa: F401
@@ -79,6 +80,7 @@ def __getattr__(name: str):
         "apply_liger_kernel_to_gemma2",
         "apply_liger_kernel_to_gemma3",
         "apply_liger_kernel_to_gemma3_text",
+        "apply_liger_kernel_to_glm4",
         "apply_liger_kernel_to_granite",
         "apply_liger_kernel_to_llama",
         "apply_liger_kernel_to_llava",
@@ -129,6 +131,7 @@ if _TRANSFORMERS_AVAILABLE:
             "apply_liger_kernel_to_gemma2",
             "apply_liger_kernel_to_gemma3",
             "apply_liger_kernel_to_gemma3_text",
+            "apply_liger_kernel_to_glm4",
             "apply_liger_kernel_to_granite",
             "apply_liger_kernel_to_llama",
             "apply_liger_kernel_to_llava",

--- a/src/liger_kernel/transformers/model/glm4.py
+++ b/src/liger_kernel/transformers/model/glm4.py
@@ -89,14 +89,16 @@ def lce_forward(
 
     hidden_states = outputs[0]
 
+    shift_labels = loss_kwargs.pop("shift_labels", None)
     logits = None
     loss = None
     # if in training mode, don't materialize logits
-    if self.training and (labels is not None):
+    if self.training and (labels is not None or shift_labels is not None):
         loss = LigerForCausalLMLoss(
             hidden_states=hidden_states,
             lm_head_weight=self.lm_head.weight,
             labels=labels,
+            shift_labels=shift_labels,
             hidden_size=self.config.hidden_size,
             **loss_kwargs,
         )

--- a/src/liger_kernel/transformers/model/glm4.py
+++ b/src/liger_kernel/transformers/model/glm4.py
@@ -1,0 +1,121 @@
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
+
+import torch
+
+from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers.models.glm4.modeling_glm4 import _CONFIG_FOR_DOC
+from transformers.models.glm4.modeling_glm4 import GLM4_INPUTS_DOCSTRING
+from transformers.utils import add_start_docstrings_to_model_forward
+from transformers.utils import replace_return_docstrings
+from transformers.utils.deprecation import deprecate_kwarg
+
+from liger_kernel.transformers.model.loss_utils import LigerForCausalLMLoss
+
+
+@deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
+@add_start_docstrings_to_model_forward(GLM4_INPUTS_DOCSTRING)
+@replace_return_docstrings(output_type=CausalLMOutputWithPast, config_class=_CONFIG_FOR_DOC)
+def lce_forward(
+    self,
+    input_ids: torch.LongTensor = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values: Optional[List[torch.FloatTensor]] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    labels: Optional[torch.LongTensor] = None,
+    use_cache: Optional[bool] = None,
+    output_attentions: Optional[bool] = None,
+    output_hidden_states: Optional[bool] = None,
+    return_dict: Optional[bool] = None,
+    cache_position: Optional[torch.LongTensor] = None,
+    logits_to_keep: Union[int, torch.Tensor] = 0,
+    **loss_kwargs,
+) -> Union[Tuple, CausalLMOutputWithPast]:
+    r"""
+    Args:
+        labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
+            config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
+            (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+        logits_to_keep (`int` or `torch.Tensor`, *optional*):
+            If an `int`, compute logits for the last `logits_to_keep` tokens. If `0`, calculate logits for all
+            `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+            token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
+            If a `torch.Tensor`, must be 1D corresponding to the indices to keep in the sequence length dimension.
+            This is useful when using packed tensor format (single dimension for batch and sequence length).
+
+    Returns:
+
+    Example:
+
+    ```python
+    >>> from transformers import AutoTokenizer, Glm4ForCausalLM
+
+    >>> model = Glm4ForCausalLM.from_pretrained("THUDM/GLM-4-9B-0414")
+    >>> tokenizer = AutoTokenizer.from_pretrained("THUDM/GLM-4-9B-0414")
+
+    >>> prompt = "Hey, are you conscious? Can you talk to me?"
+    >>> inputs = tokenizer(prompt, return_tensors="pt")
+
+    >>> # Generate
+    >>> generate_ids = model.generate(inputs.input_ids, max_length=30)
+    >>> tokenizer.batch_decode(generate_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)[0]
+    'Hey, are you conscious? Can you talk to me?\nI’m not sure if you’re conscious of this, but I’m'
+    ```
+    """
+    output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+    output_hidden_states = (
+        output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+    )
+    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+    # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
+    outputs = self.model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        past_key_values=past_key_values,
+        inputs_embeds=inputs_embeds,
+        use_cache=use_cache,
+        output_attentions=output_attentions,
+        output_hidden_states=output_hidden_states,
+        return_dict=return_dict,
+        cache_position=cache_position,
+    )
+
+    hidden_states = outputs[0]
+
+    logits = None
+    loss = None
+    # if in training mode, don't materialize logits
+    if self.training and (labels is not None):
+        loss = LigerForCausalLMLoss(
+            hidden_states=hidden_states,
+            lm_head_weight=self.lm_head.weight,
+            labels=labels,
+            hidden_size=self.config.hidden_size,
+            **loss_kwargs,
+        )
+
+    else:  # if in inference mode materialize logits
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
+        if labels is not None:
+            loss = self.loss_function(
+                logits=logits,
+                labels=labels,
+                vocab_size=self.config.vocab_size,
+                **loss_kwargs,
+            )
+
+    return CausalLMOutputWithPast(
+        loss=loss,
+        logits=logits,
+        past_key_values=outputs.past_key_values,
+        hidden_states=outputs.hidden_states,
+        attentions=outputs.attentions,
+    )

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -17,6 +17,7 @@ from liger_kernel.transformers.model.gemma import lce_forward as gemma_lce_forwa
 from liger_kernel.transformers.model.gemma import lce_forward_deprecated as gemma_lce_forward_deprecated
 from liger_kernel.transformers.model.gemma2 import lce_forward as gemma2_lce_forward
 from liger_kernel.transformers.model.gemma2 import lce_forward_deprecated as gemma2_lce_forward_deprected
+from liger_kernel.transformers.model.glm4 import lce_forward as glm4_lce_forward
 from liger_kernel.transformers.model.llama import lce_forward as llama_lce_forward
 from liger_kernel.transformers.model.llama import lce_forward_deprecated as llama_lce_forward_deprecated
 from liger_kernel.transformers.model.llava import lce_forward as llava_lce_forward
@@ -1319,12 +1320,76 @@ def apply_liger_kernel_to_olmo2(
                 _patch_rms_norm_module(decoder_layer.post_feedforward_layernorm, in_place=False)
 
 
+def apply_liger_kernel_to_glm4(
+    rope: bool = False,
+    cross_entropy: bool = False,
+    fused_linear_cross_entropy: bool = True,
+    rms_norm: bool = True,
+    swiglu: bool = True,
+    model: PreTrainedModel = None,
+) -> None:
+    """
+    Apply Liger kernels to replace original implementation in HuggingFace GLM-4 models.
+
+    Args:
+        rope (bool): Whether to apply Liger's rotary position embedding. Default is False.
+        cross_entropy (bool): Whether to apply Liger's cross entropy loss. Default is False.
+        fused_linear_cross_entropy (bool):
+            Whether to apply Liger's fused linear cross entropy loss. Default is True.
+            `cross_entropy` and `fused_linear_cross_entropy` cannot both be True.
+            If `fused_linear_cross_entropy` is True, the logits will not be materialized but more memory efficient.
+        rms_norm (bool): Whether to apply Liger's RMSNorm. Default is True.
+        swiglu (bool): Whether to apply Liger's SwiGLU Glm4MLP. Default is True.
+        model (PreTrainedModel): The model instance to apply Liger kernels to, if the model has already been
+        loaded. Default is None.
+    """
+    assert not (cross_entropy and fused_linear_cross_entropy), (
+        "cross_entropy and fused_linear_cross_entropy cannot both be True."
+    )
+
+    from transformers.models.glm4 import modeling_glm4
+    from transformers.models.glm4.modeling_glm4 import Glm4Model
+
+    if rope:
+        raise NotImplementedError("liger_rotary_pos_emb is not available for Glm4 models.")
+    if rms_norm:
+        modeling_glm4.Glm4RMSNorm = partial(LigerRMSNorm, in_place=False)
+    if swiglu:
+        modeling_glm4.Glm4MLP = LigerPhi3SwiGLUMLP
+    if cross_entropy:
+        from transformers.loss.loss_utils import nn
+
+        nn.functional.cross_entropy = liger_cross_entropy
+    if fused_linear_cross_entropy:
+        modeling_glm4.Glm4ForCausalLM.forward = glm4_lce_forward
+
+    if model is not None:
+        # The model instance already exists, so we need to additionally patch the
+        # instance variables that reference already-instantiated modules
+
+        # get the base model from the model instance
+        base_model: Glm4Model = getattr(model, model.base_model_prefix, model)
+
+        if rms_norm:
+            _patch_rms_norm_module(base_model.norm, in_place=False)
+
+        for decoder_layer in base_model.layers:
+            if swiglu:
+                _patch_swiglu_module(decoder_layer.mlp, LigerPhi3SwiGLUMLP)
+            if rms_norm:
+                _patch_rms_norm_module(decoder_layer.input_layernorm, in_place=False)
+                _patch_rms_norm_module(decoder_layer.post_attention_layernorm, in_place=False)
+                _patch_rms_norm_module(decoder_layer.post_self_attn_layernorm, in_place=False)
+                _patch_rms_norm_module(decoder_layer.post_mlp_layernorm, in_place=False)
+
+
 # Model type corresponds to the keys defined in transformers/models/auto/modeling_auto.py
 MODEL_TYPE_TO_APPLY_LIGER_FN = {
     "gemma": apply_liger_kernel_to_gemma,
     "gemma2": apply_liger_kernel_to_gemma2,
     "gemma3_text": apply_liger_kernel_to_gemma3_text,
     "gemma3": apply_liger_kernel_to_gemma3,
+    "glm4": apply_liger_kernel_to_glm4,
     "llama": apply_liger_kernel_to_llama,
     "llava": apply_liger_kernel_to_llava,
     "granite": apply_liger_kernel_to_granite,

--- a/test/convergence/bf16/test_mini_models.py
+++ b/test/convergence/bf16/test_mini_models.py
@@ -21,6 +21,7 @@ from transformers.models.qwen2 import Qwen2ForCausalLM
 from liger_kernel.transformers import apply_liger_kernel_to_gemma
 from liger_kernel.transformers import apply_liger_kernel_to_gemma2
 from liger_kernel.transformers import apply_liger_kernel_to_gemma3_text
+from liger_kernel.transformers import apply_liger_kernel_to_glm4
 from liger_kernel.transformers import apply_liger_kernel_to_granite
 from liger_kernel.transformers import apply_liger_kernel_to_llama
 from liger_kernel.transformers import apply_liger_kernel_to_llava
@@ -38,6 +39,7 @@ from test.utils import assert_verbose_allclose
 from test.utils import revert_liger_kernel_to_gemma
 from test.utils import revert_liger_kernel_to_gemma2
 from test.utils import revert_liger_kernel_to_gemma3_text
+from test.utils import revert_liger_kernel_to_glm4
 from test.utils import revert_liger_kernel_to_granite
 from test.utils import revert_liger_kernel_to_llama
 from test.utils import revert_liger_kernel_to_llava
@@ -106,6 +108,14 @@ try:
 except ImportError:
     OLMO2_AVAILABLE = False
 
+try:
+    # Glm4 is only available in transformers>=4.51.3
+    from transformers.models.glm4.configuration_glm4 import Glm4Config
+    from transformers.models.glm4.modeling_glm4 import Glm4ForCausalLM
+
+    GLM4_AVAILABLE = True
+except ImportError:
+    GLM4_AVAILABLE = False
 
 try:
     from transformers.models.gemma3.configuration_gemma3 import Gemma3TextConfig
@@ -644,6 +654,37 @@ if OLMO2_AVAILABLE:
         ),
     )
 
+if GLM4_AVAILABLE:
+    MINI_MODEL_SETUPS["mini_glm4"] = MiniModelConfig(
+        liger_kernel_patch_func=apply_liger_kernel_to_glm4,
+        liger_kernel_patch_revert_func=revert_liger_kernel_to_glm4,
+        model_class=Glm4ForCausalLM,
+        mini_model_config=Glm4Config(
+            bos_token_id=1,  # None
+            eos_token_id=2,  # 151329, 151336, 151338
+            pad_token_id=2,  # 151329
+            partial_rotary_factor=0.5,
+            cross_attention_layers=None,
+            dropout=0,
+            hidden_act="silu",
+            hidden_size=1024,  # 6144
+            initializer_range=0.02,
+            intermediate_size=2048,  # 14336
+            max_position_embeddings=4096,  # 32768
+            num_attention_heads=8,  # 48
+            num_hidden_layers=4,  # 61
+            num_key_value_heads=2,
+            rms_norm_eps=1e-5,
+            rope_scaling=None,
+            rope_theta=500_000,
+            tie_word_embeddings=False,
+            use_cache=True,
+            vocab_size=32000,  # 151552
+            attention_bias=True,
+            attn_implementation="sdpa",  # default value, pytorch native attention
+        ),
+    )
+
 
 def create_model(model_name="mini_llama3"):
     """
@@ -678,6 +719,9 @@ def run_mini_model(
             "rope": True,
             "rms_norm": True,
         }
+
+        if "glm4" in model_name:
+            kwargs["rope"] = False
 
         model_supports_layer_norm = "qwen2_vl" in model_name
         if model_supports_layer_norm:
@@ -887,6 +931,25 @@ def run_mini_model(
                 pytest.mark.skipif(
                     not OLMO2_AVAILABLE,
                     reason="OLMO2 not available in this version of transformers",
+                ),
+            ],
+        ),
+        pytest.param(
+            "mini_glm4",
+            32,
+            1e-4,
+            torch.bfloat16,
+            1e-3,
+            1e-2,
+            1e-1,
+            1e-2,
+            1e-2,
+            1e-2,
+            marks=[
+                pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this GPU"),
+                pytest.mark.skipif(
+                    not GLM4_AVAILABLE,
+                    reason="Glm4 not available in this version of transformers",
                 ),
             ],
         ),

--- a/test/convergence/bf16/test_mini_models_with_logits.py
+++ b/test/convergence/bf16/test_mini_models_with_logits.py
@@ -21,6 +21,7 @@ from transformers.models.qwen2 import Qwen2ForCausalLM
 from liger_kernel.transformers import apply_liger_kernel_to_gemma
 from liger_kernel.transformers import apply_liger_kernel_to_gemma2
 from liger_kernel.transformers import apply_liger_kernel_to_gemma3_text
+from liger_kernel.transformers import apply_liger_kernel_to_glm4
 from liger_kernel.transformers import apply_liger_kernel_to_granite
 from liger_kernel.transformers import apply_liger_kernel_to_llama
 from liger_kernel.transformers import apply_liger_kernel_to_llava
@@ -38,6 +39,7 @@ from test.utils import assert_verbose_allclose
 from test.utils import revert_liger_kernel_to_gemma
 from test.utils import revert_liger_kernel_to_gemma2
 from test.utils import revert_liger_kernel_to_gemma3_text
+from test.utils import revert_liger_kernel_to_glm4
 from test.utils import revert_liger_kernel_to_granite
 from test.utils import revert_liger_kernel_to_llama
 from test.utils import revert_liger_kernel_to_llava
@@ -106,6 +108,14 @@ try:
 except ImportError:
     OLMO2_AVAILABLE = False
 
+try:
+    # Glm4 is only available in transformers>=4.51.3
+    from transformers.models.glm4.configuration_glm4 import Glm4Config
+    from transformers.models.glm4.modeling_glm4 import Glm4ForCausalLM
+
+    GLM4_AVAILABLE = True
+except ImportError:
+    GLM4_AVAILABLE = False
 
 try:
     from transformers.models.gemma3.configuration_gemma3 import Gemma3TextConfig
@@ -377,7 +387,6 @@ if GEMMA3_AVAILABLE:
         ),
     )
 
-
 if MLLAMA_AVAILABLE:
     MINI_MODEL_SETUPS["mini_mllama"] = MiniModelConfig(
         liger_kernel_patch_func=apply_liger_kernel_to_mllama,
@@ -645,6 +654,37 @@ if OLMO2_AVAILABLE:
         ),
     )
 
+if GLM4_AVAILABLE:
+    MINI_MODEL_SETUPS["mini_glm4"] = MiniModelConfig(
+        liger_kernel_patch_func=apply_liger_kernel_to_glm4,
+        liger_kernel_patch_revert_func=revert_liger_kernel_to_glm4,
+        model_class=Glm4ForCausalLM,
+        mini_model_config=Glm4Config(
+            bos_token_id=1,  # None
+            eos_token_id=2,  # 151329, 151336, 151338
+            pad_token_id=2,  # 151329
+            partial_rotary_factor=0.5,
+            cross_attention_layers=None,
+            dropout=0,
+            hidden_act="silu",
+            hidden_size=1024,  # 6144
+            initializer_range=0.02,
+            intermediate_size=2048,  # 14336
+            max_position_embeddings=4096,  # 32768
+            num_attention_heads=8,  # 48
+            num_hidden_layers=4,  # 61
+            num_key_value_heads=2,
+            rms_norm_eps=1e-5,
+            rope_scaling=None,
+            rope_theta=500_000,
+            tie_word_embeddings=False,
+            use_cache=True,
+            vocab_size=32000,  # 151552
+            attention_bias=True,
+            attn_implementation="sdpa",  # default value, pytorch native attention
+        ),
+    )
+
 
 def create_model(model_name="mini_llama3"):
     """
@@ -679,6 +719,9 @@ def run_mini_model(
             "rope": True,
             "rms_norm": True,
         }
+
+        if "glm4" in model_name:
+            kwargs["rope"] = False
 
         model_supports_layer_norm = "qwen2_vl" in model_name
         if model_supports_layer_norm:
@@ -930,6 +973,25 @@ def run_mini_model(
                 pytest.mark.skipif(
                     not OLMO2_AVAILABLE,
                     reason="OLMO2 not available in this version of transformers",
+                ),
+            ],
+        ),
+        pytest.param(
+            "mini_glm4",
+            32,
+            1e-4,
+            torch.bfloat16,
+            1e-3,
+            1e-2,
+            1e-1,
+            1e-2,
+            1e-2,
+            1e-2,
+            marks=[
+                pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this GPU"),
+                pytest.mark.skipif(
+                    not GLM4_AVAILABLE,
+                    reason="Glm4 not available in this version of transformers",
                 ),
             ],
         ),

--- a/test/convergence/fp32/test_mini_models.py
+++ b/test/convergence/fp32/test_mini_models.py
@@ -21,6 +21,7 @@ from transformers.models.qwen2 import Qwen2ForCausalLM
 from liger_kernel.transformers import apply_liger_kernel_to_gemma
 from liger_kernel.transformers import apply_liger_kernel_to_gemma2
 from liger_kernel.transformers import apply_liger_kernel_to_gemma3_text
+from liger_kernel.transformers import apply_liger_kernel_to_glm4
 from liger_kernel.transformers import apply_liger_kernel_to_granite
 from liger_kernel.transformers import apply_liger_kernel_to_llama
 from liger_kernel.transformers import apply_liger_kernel_to_llava
@@ -38,6 +39,7 @@ from test.utils import assert_verbose_allclose
 from test.utils import revert_liger_kernel_to_gemma
 from test.utils import revert_liger_kernel_to_gemma2
 from test.utils import revert_liger_kernel_to_gemma3_text
+from test.utils import revert_liger_kernel_to_glm4
 from test.utils import revert_liger_kernel_to_granite
 from test.utils import revert_liger_kernel_to_llama
 from test.utils import revert_liger_kernel_to_llava
@@ -105,6 +107,14 @@ try:
 except ImportError:
     OLMO2_AVAILABLE = False
 
+try:
+    # Glm4 is only available in transformers>=4.51.3
+    from transformers.models.glm4.configuration_glm4 import Glm4Config
+    from transformers.models.glm4.modeling_glm4 import Glm4ForCausalLM
+
+    GLM4_AVAILABLE = True
+except ImportError:
+    GLM4_AVAILABLE = False
 
 try:
     from transformers.models.gemma3.configuration_gemma3 import Gemma3TextConfig
@@ -583,6 +593,37 @@ if OLMO2_AVAILABLE:
         ),
     )
 
+if GLM4_AVAILABLE:
+    MINI_MODEL_SETUPS["mini_glm4"] = MiniModelConfig(
+        liger_kernel_patch_func=apply_liger_kernel_to_glm4,
+        liger_kernel_patch_revert_func=revert_liger_kernel_to_glm4,
+        model_class=Glm4ForCausalLM,
+        mini_model_config=Glm4Config(
+            bos_token_id=1,  # None
+            eos_token_id=2,  # 151329, 151336, 151338
+            pad_token_id=2,  # 151329
+            partial_rotary_factor=0.5,
+            cross_attention_layers=None,
+            dropout=0,
+            hidden_act="silu",
+            hidden_size=1024,  # 6144
+            initializer_range=0.02,
+            intermediate_size=2048,  # 14336
+            max_position_embeddings=32768,
+            num_attention_heads=8,  # 48
+            num_hidden_layers=4,  # 61
+            num_key_value_heads=2,
+            rms_norm_eps=1e-5,
+            rope_scaling=None,
+            rope_theta=500_000,
+            tie_word_embeddings=False,
+            use_cache=True,
+            vocab_size=32000,  # 151552
+            attention_bias=True,
+            attn_implementation="sdpa",  # default value, pytorch native attention
+        ),
+    )
+
 if LLAVA_AVAILABLE:
     # https://huggingface.co/llava-hf/llava-1.5-7b-hf
     MINI_MODEL_SETUPS["mini_llava"] = MiniModelConfig(
@@ -676,6 +717,9 @@ def run_mini_model(
             "rope": True,
             "rms_norm": True,
         }
+
+        if "glm4" in model_name:
+            kwargs["rope"] = False
 
         model_supports_layer_norm = "qwen2_vl" in model_name
         if model_supports_layer_norm:
@@ -818,6 +862,22 @@ def run_mini_model(
             marks=pytest.mark.skipif(
                 not OLMO2_AVAILABLE,
                 reason="OLMO2 not available in this version of transformers",
+            ),
+        ),
+        pytest.param(
+            "mini_glm4",
+            32,
+            1e-4,
+            torch.float32,
+            1e-8,
+            1e-5,
+            5e-3,
+            1e-5,
+            5e-3,
+            1e-5,
+            marks=pytest.mark.skipif(
+                not GLM4_AVAILABLE,
+                reason="Glm4 not available in this version of transformers",
             ),
         ),
         ("mini_phi3", 32, 1e-4, torch.float32, 1e-8, 1e-5, 5e-3, 1e-5, 5e-3, 1e-5),

--- a/test/convergence/fp32/test_mini_models_with_logits.py
+++ b/test/convergence/fp32/test_mini_models_with_logits.py
@@ -21,6 +21,7 @@ from transformers.models.qwen2 import Qwen2ForCausalLM
 from liger_kernel.transformers import apply_liger_kernel_to_gemma
 from liger_kernel.transformers import apply_liger_kernel_to_gemma2
 from liger_kernel.transformers import apply_liger_kernel_to_gemma3_text
+from liger_kernel.transformers import apply_liger_kernel_to_glm4
 from liger_kernel.transformers import apply_liger_kernel_to_granite
 from liger_kernel.transformers import apply_liger_kernel_to_llama
 from liger_kernel.transformers import apply_liger_kernel_to_llava
@@ -38,6 +39,7 @@ from test.utils import assert_verbose_allclose
 from test.utils import revert_liger_kernel_to_gemma
 from test.utils import revert_liger_kernel_to_gemma2
 from test.utils import revert_liger_kernel_to_gemma3_text
+from test.utils import revert_liger_kernel_to_glm4
 from test.utils import revert_liger_kernel_to_granite
 from test.utils import revert_liger_kernel_to_llama
 from test.utils import revert_liger_kernel_to_llava
@@ -96,7 +98,6 @@ try:
 except ImportError:
     LLAVA_AVAILABLE = False
 
-
 try:
     # OLMO2 is only available in transformers>=4.47.0
     from transformers.models.olmo2.configuration_olmo2 import Olmo2Config
@@ -106,6 +107,14 @@ try:
 except ImportError:
     OLMO2_AVAILABLE = False
 
+try:
+    # Glm4 is only available in transformers>=4.51.3
+    from transformers.models.glm4.configuration_glm4 import Glm4Config
+    from transformers.models.glm4.modeling_glm4 import Glm4ForCausalLM
+
+    GLM4_AVAILABLE = True
+except ImportError:
+    GLM4_AVAILABLE = False
 
 try:
     from transformers.models.gemma3.configuration_gemma3 import Gemma3TextConfig
@@ -644,6 +653,37 @@ if OLMO2_AVAILABLE:
         ),
     )
 
+if GLM4_AVAILABLE:
+    MINI_MODEL_SETUPS["mini_glm4"] = MiniModelConfig(
+        liger_kernel_patch_func=apply_liger_kernel_to_glm4,
+        liger_kernel_patch_revert_func=revert_liger_kernel_to_glm4,
+        model_class=Glm4ForCausalLM,
+        mini_model_config=Glm4Config(
+            bos_token_id=1,  # None
+            eos_token_id=2,  # 151329, 151336, 151338
+            pad_token_id=2,  # 151329
+            partial_rotary_factor=0.5,
+            cross_attention_layers=None,
+            dropout=0,
+            hidden_act="silu",
+            hidden_size=1024,  # 6144
+            initializer_range=0.02,
+            intermediate_size=2048,  # 14336
+            max_position_embeddings=4096,  # 32768
+            num_attention_heads=8,  # 48
+            num_hidden_layers=4,  # 61
+            num_key_value_heads=2,
+            rms_norm_eps=1e-5,
+            rope_scaling=None,
+            rope_theta=500_000,
+            tie_word_embeddings=False,
+            use_cache=True,
+            vocab_size=32000,  # 151552
+            attention_bias=True,
+            attn_implementation="sdpa",  # default value, pytorch native attention
+        ),
+    )
+
 
 def create_model(model_name="mini_llama3"):
     """
@@ -678,6 +718,9 @@ def run_mini_model(
             "rope": True,
             "rms_norm": True,
         }
+
+        if "glm4" in model_name:
+            kwargs["rope"] = False
 
         model_supports_layer_norm = "qwen2_vl" in model_name
         if model_supports_layer_norm:
@@ -819,6 +862,22 @@ def run_mini_model(
             marks=pytest.mark.skipif(
                 not OLMO2_AVAILABLE,
                 reason="OLMO2 not available in this version of transformers",
+            ),
+        ),
+        pytest.param(
+            "mini_glm4",
+            32,
+            1e-4,
+            torch.float32,
+            1e-8,
+            1e-5,
+            5e-3,
+            1e-5,
+            5e-3,
+            1e-5,
+            marks=pytest.mark.skipif(
+                not GLM4_AVAILABLE,
+                reason="Glm4 not available in this version of transformers",
             ),
         ),
         ("mini_phi3", 32, 1e-4, torch.float32, 1e-8, 1e-5, 5e-3, 1e-5, 5e-3, 1e-5),

--- a/test/transformers/test_monkey_patch.py
+++ b/test/transformers/test_monkey_patch.py
@@ -62,6 +62,15 @@ def is_olmo2_available():
         return False
 
 
+def is_glm4_available():
+    try:
+        import transformers.models.glm4  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 def is_gemma3_available():
     try:
         import transformers.models.gemma3  # noqa: F401
@@ -78,6 +87,7 @@ def test_import_from_root():
         from liger_kernel.transformers import apply_liger_kernel_to_gemma2  # noqa: F401
         from liger_kernel.transformers import apply_liger_kernel_to_gemma3  # noqa: F401
         from liger_kernel.transformers import apply_liger_kernel_to_gemma3_text  # noqa: F401
+        from liger_kernel.transformers import apply_liger_kernel_to_glm4  # noqa: F401
         from liger_kernel.transformers import apply_liger_kernel_to_llama  # noqa: F401
         from liger_kernel.transformers import apply_liger_kernel_to_mistral  # noqa: F401
         from liger_kernel.transformers import apply_liger_kernel_to_mixtral  # noqa: F401
@@ -959,6 +969,48 @@ def test_apply_liger_kernel_to_instance_for_olmo2():
             assert inspect.getsource(layer.post_feedforward_layernorm.forward) == inspect.getsource(
                 LigerRMSNorm.forward
             )
+
+        try:
+            print(dummy_model_instance)
+        except Exception as e:
+            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+
+
+@pytest.mark.skipif(not is_glm4_available(), reason="glm4 module not available")
+def test_apply_liger_kernel_to_instance_for_glm4():
+    # Ensure any monkey patching is cleaned up for subsequent tests
+    with patch("transformers.models.glm4.modeling_glm4"):
+        # Instantiate a dummy model
+        config = transformers.models.glm4.configuration_glm4.Glm4Config(
+            torch_dtype=torch.bfloat16,
+            rms_norm_eps=1e-5,
+            hidden_size=32,
+            intermediate_size=64,
+            hidden_act="silu",
+            num_hidden_layers=2,
+        )
+        dummy_model_instance = AutoModelForCausalLM.from_config(config)
+
+        # Check that model instance variables are not yet patched with Liger modules
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
+        for layer in dummy_model_instance.model.layers:
+            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(LigerPhi3SwiGLUMLP.forward)
+            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_self_attn_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_mlp_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+
+        # Test applying kernels to the model instance
+        _apply_liger_kernel_to_instance(model=dummy_model_instance)
+
+        # Check that the model's instance variables were correctly patched with Liger modules
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
+        for layer in dummy_model_instance.model.layers:
+            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerPhi3SwiGLUMLP.forward)
+            assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_self_attn_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_mlp_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
 
         try:
             print(dummy_model_instance)

--- a/test/utils.py
+++ b/test/utils.py
@@ -428,6 +428,18 @@ def revert_liger_kernel_to_olmo2(model_config: MiniModelConfig):
     print("Liger kernel patches have been reverted.")
 
 
+def revert_liger_kernel_to_glm4(model_config: MiniModelConfig):
+    """
+    Revert all Liger kernel patches applied to Glm4.
+    """
+
+    from transformers.models.glm4 import modeling_glm4
+
+    importlib.reload(modeling_glm4)
+    model_config.model_class = modeling_glm4.Glm4ForCausalLM
+    print("Liger kernel patches have been reverted.")
+
+
 def revert_liger_kernel_to_llava(model_config: MiniModelConfig):
     """
     Revert all Liger kernel patches applied to llava.


### PR DESCRIPTION
## Summary
This PR adds support for integrating Liger kernels into GLM-4 models. Fixes #679 

Notes:
- GLM-4 models use a different implementation of the `apply_rotary_pos_emb` function, therefore using `liger_rotary_pos_emb` is not implemented for now.
- GLM-4 models use the same MLP implemetation as Phi-3

## Testing Done

- Hardware Type: H100-80G-SXM5
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
