### PR TITLE
[dpo] set default average_log_prob to False

### DIFF
--- a/src/liger_kernel/chunked_loss/dpo_loss.py
+++ b/src/liger_kernel/chunked_loss/dpo_loss.py
@@ -128,7 +128,7 @@ class LigerFusedLinearDPOLoss(torch.nn.Module):
         compute_nll_loss: bool = False,
         compiled: bool = True,
         use_ref_model: bool = True,
-        average_log_prob: bool = True,
+        average_log_prob: bool = False,
         chunk_size: int = 1,
     ):
         """

--- a/test/chunked_loss/test_dpo_loss.py
+++ b/test/chunked_loss/test_dpo_loss.py
@@ -95,6 +95,7 @@ class TorchLMHeadDPO(torch.nn.Module):
             ref_x,
             self.ref_lin.weight,
             self.ref_lin.bias,
+            average_log_prob=True,
         )
 
 
@@ -118,6 +119,7 @@ class LigerLMHeadDPO(torch.nn.Module):
             beta=beta,
             use_ref_model=True,
             compute_nll_loss=compute_nll_loss,
+            average_log_prob=True,
         )
 
     def forward(self, x, ref_x, y):


### PR DESCRIPTION
## Summary
Match default with this (https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/chunked_loss/dpo_loss.py#L71)
Not sure but set it to False looks right according to paper?

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
