### PR TITLE
Visualizer Update

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -16,14 +16,32 @@ Follow these steps to benchmark and visualize kernel performance:
    ```
 
 3. Visualize results
-   - Use the visualization script with appropriate parameters
-   
-   Example: Visualizing KTO Loss benchmark results
+   - Use the visualization script with optional modes:
+
+     * To target specific mode(s), pass `--kernel-operation-mode` one or more values.
+     * If you omit `--kernel-operation-mode`, the script will:
+       - For `speed` metrics: generate plots for all available modes (forward/backward/full).
+       - For `memory` metrics: generate only the `full` plot.
+
+   Examples:
+   1. Specific modes (speed):
    ```bash
    python benchmarks_visualizer.py \
        --kernel-name kto_loss \
-       --metric-name memory \
-       --kernel-operation-mode full
+       --metric-name speed \
+       --kernel-operation-mode forward backward
+   ```
+   2. All modes (speed):
+   ```bash
+   python benchmarks_visualizer.py \
+       --kernel-name kto_loss \
+       --metric-name speed
+   ```
+   3. Memory (always full):
+   ```bash
+   python benchmarks_visualizer.py \
+       --kernel-name kto_loss \
+       --metric-name memory
    ```
 
 4. View results

--- a/benchmark/benchmarks_visualizer.py
+++ b/benchmark/benchmarks_visualizer.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 
 from argparse import ArgumentParser
 from dataclasses import dataclass
@@ -50,8 +51,9 @@ def parse_args() -> VisualizationsConfig:
     parser.add_argument(
         "--kernel-operation-mode",
         type=str,
-        required=True,
-        help="Kernel operation mode to visualize (forward/backward/full)",
+        nargs="*",
+        default=None,
+        help="Kernel operation modes to visualize (forward/backward/full). If not provided, generate for all available modes.",
     )
     parser.add_argument("--display", action="store_true", help="Display the visualization")
     parser.add_argument(
@@ -61,8 +63,7 @@ def parse_args() -> VisualizationsConfig:
     )
 
     args = parser.parse_args()
-
-    return VisualizationsConfig(**dict(args._get_kwargs()))
+    return args
 
 
 def load_data(config: VisualizationsConfig) -> pd.DataFrame:
@@ -142,7 +143,10 @@ def plot_data(df: pd.DataFrame, config: VisualizationsConfig):
     plt.ylabel(ylabel)
     plt.tight_layout()
 
-    out_path = os.path.join(VISUALIZATIONS_PATH, f"{config.kernel_name}_{config.metric_name}.png")
+    out_path = os.path.join(
+        VISUALIZATIONS_PATH,
+        f"{config.kernel_name}_{config.metric_name}_{config.kernel_operation_mode}.png",
+    )
 
     if config.display:
         plt.show()
@@ -155,9 +159,31 @@ def plot_data(df: pd.DataFrame, config: VisualizationsConfig):
 
 
 def main():
-    config = parse_args()
-    df = load_data(config)
-    plot_data(df, config)
+    args = parse_args()
+    all_df = pd.read_csv(DATA_PATH)
+    all_df["extra_benchmark_config"] = all_df["extra_benchmark_config_str"].apply(json.loads)
+
+    if args.metric_name == "memory":
+        modes = ["full"]
+    elif args.kernel_operation_mode:
+        modes = args.kernel_operation_mode
+    else:
+        filtered = all_df[(all_df["kernel_name"] == args.kernel_name) & (all_df["metric_name"] == args.metric_name)]
+        modes = filtered["kernel_operation_mode"].unique().tolist()
+        if not modes:
+            print(f"No data found for kernel '{args.kernel_name}' and metric '{args.metric_name}'.", file=sys.stderr)
+            sys.exit(1)
+
+    for mode in modes:
+        config = VisualizationsConfig(
+            kernel_name=args.kernel_name,
+            metric_name=args.metric_name,
+            kernel_operation_mode=mode,
+            display=args.display,
+            overwrite=args.overwrite,
+        )
+        df = load_data(config)
+        plot_data(df, config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…peration mode

## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
visualizer now supports optional kernel operation mode (with support for partial operation mode visualization generation). By default all kernel operation modes for the given metric name will be generated. Memory metric name is a special case, because we only expect "full" operation mode.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: RTX 3090
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
