### PR TITLE
Fix to publish docs on pushes to main branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Publish documentation
 on:
   push:
     branches:
-      - gh-pages
+      - main
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
## Summary
- I believe we need to publish docs on pushes to `main` branch, not `gh-pages` (`mkdocs gh-deploy --force` itself pushes to `gh-pages`)
- To resolve https://github.com/linkedin/Liger-Kernel/issues/641

## Testing Done
None

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
