### PR TITLE
Update ReadMe and make the Documentation Deployment more robust

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,4 +25,4 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: pip install mkdocs-material 
-      - run: mkdocs gh-deploy --force
+      - run: mkdocs gh-deploy --force --site-dir doc_site/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,4 +25,4 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: pip install mkdocs-material 
-      - run: mkdocs gh-deploy --force --site-dir doc_site/
+      - run: mkdocs gh-deploy --force 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,4 +25,4 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: pip install mkdocs-material 
-      - run: mkdocs gh-deploy --force 
+      - run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@
 
 We've also added optimized Post-Training kernels that deliver **up to 80% memory savings** for alignment and distillation tasks. We support losses like DPO, CPO, ORPO, SimPO, KTO, JSD, and many more. Check out [how we optimize the memory](https://x.com/hsu_byron/status/1866577403918917655).
 
+You can view the documentation site for additional installation, usage examples, and API references:https://linkedin.github.io/Liger-Kernel/
+
 ## Supercharge Your Model with Liger Kernel
 
 ![Banner](https://raw.githubusercontent.com/linkedin/Liger-Kernel/main/docs/images/banner.GIF)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Liger-Kernel Docs
 site_dir: 'doc_site'
-# site_url: https://linkedin.github.io/Liger-Kernel/
-# site_author: LinkedIn
+site_url: https://linkedin.github.io/Liger-Kernel/
+site_author: LinkedIn
 site_description: Efficient Triton Kernels for LLM Training
 theme:
   name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Liger-Kernel Docs
-site_dir: './doc_site'
+site_dir: 'doc_site'
 # site_url: https://linkedin.github.io/Liger-Kernel/
 # site_author: LinkedIn
 site_description: Efficient Triton Kernels for LLM Training

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,4 @@
 site_name: Liger-Kernel Docs
-site_dir: 'doc_site'
 site_url: https://linkedin.github.io/Liger-Kernel/
 site_author: LinkedIn
 site_description: Efficient Triton Kernels for LLM Training


### PR DESCRIPTION
## Summary
After #724, the documentation site is not being deployed to gh pages, this PR aims to fix the same.

Could you please review?

cc: @shimizust

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
