### PR TITLE
Fix gemma3 monkey patch tests

### DIFF
--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -911,7 +911,7 @@ def apply_liger_kernel_to_gemma3(
                 fused_linear_cross_entropy=False,
                 rms_norm=rms_norm,
                 geglu=geglu,
-                model=model.model.language_model,
+                model=model.language_model,
             )
 
         else:

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -905,9 +905,6 @@ def apply_liger_kernel_to_gemma3(
             if rms_norm:
                 _patch_rms_norm_module_for_gemma3(model.multi_modal_projector.mm_soft_emb_norm)
 
-            # Print instance of model.model.language_model
-            print(f"instance of model.model.language_model: {model.model.language_model}")
-            print(f"model_type of model.model.language_model: {model.model.language_model.config.model_type}")
             apply_liger_kernel_to_gemma3_text(
                 rope=rope,
                 cross_entropy=False,
@@ -1618,7 +1615,7 @@ def _apply_liger_kernel_to_instance(model: PreTrainedModel, **kwargs) -> None:
         - kwargs: keyword arguments that are passed to the corresponding apply_liger_kernel_to_* function.
     """
     model_type = getattr(model, "config", None) and getattr(model.config, "model_type", None)
-    print(f"model_type (apply_liger_kernel_to_instance): {model_type}")
+
     if not model_type:
         logger.info("Model type could not be determined from model config. No Liger kernels will be applied.")
         return
@@ -1628,9 +1625,6 @@ def _apply_liger_kernel_to_instance(model: PreTrainedModel, **kwargs) -> None:
         return
 
     apply_fn = MODEL_TYPE_TO_APPLY_LIGER_FN[model_type]
-    # Get the name of the apply_fn
-    apply_fn_name = apply_fn.__name__
-    print(f"apply_fn_name (apply_liger_kernel_to_instance): {apply_fn_name}")
     apply_fn_signature = inspect.signature(apply_fn)
 
     # Filter out the keyword arguments that are not supported by the apply function

--- a/test/transformers/test_monkey_patch.py
+++ b/test/transformers/test_monkey_patch.py
@@ -687,7 +687,7 @@ def test_apply_liger_kernel_to_instance_for_gemma3_conditional_generation():
             intermediate_size=64,
         )
         config = transformers.models.gemma3.configuration_gemma3.Gemma3Config(text_config, vision_config)
-        print(f"config.model_type: {config.model_type}")
+
         dummy_model_instance = Gemma3ForConditionalGeneration._from_config(config)
         assert isinstance(dummy_model_instance, Gemma3ForConditionalGeneration)
 

--- a/test/transformers/test_monkey_patch.py
+++ b/test/transformers/test_monkey_patch.py
@@ -667,7 +667,7 @@ def test_apply_liger_kernel_to_instance_for_gemma3_text():
 
 
 @pytest.mark.skipif(not is_gemma3_available(), reason="gemma3 module not available")
-def test_apply_liger_kernel_to_instance_for_gemma3():
+def test_apply_liger_kernel_to_instance_for_gemma3_conditional_generation():
     # Ensure any monkey patching is cleaned up for subsequent tests
 
     with patch("transformers.models.gemma3.modeling_gemma3"):
@@ -687,8 +687,9 @@ def test_apply_liger_kernel_to_instance_for_gemma3():
             intermediate_size=64,
         )
         config = transformers.models.gemma3.configuration_gemma3.Gemma3Config(text_config, vision_config)
+        print(f"config.model_type: {config.model_type}")
         dummy_model_instance = Gemma3ForConditionalGeneration._from_config(config)
-
+        print(f"dummy_model_instance config.model_type: {dummy_model_instance.config.model_type}")
         assert isinstance(dummy_model_instance, Gemma3ForConditionalGeneration)
 
         # Check that model instance variables are not yet patched with Liger modules
@@ -704,11 +705,11 @@ def test_apply_liger_kernel_to_instance_for_gemma3():
             dummy_model_instance.multi_modal_projector.mm_soft_emb_norm.forward
         ) != inspect.getsource(LigerRMSNorm.forward)
 
-        assert inspect.getsource(dummy_model_instance.language_model.model.norm.forward) != inspect.getsource(
+        assert inspect.getsource(dummy_model_instance.language_model.norm.forward) != inspect.getsource(
             LigerRMSNorm.forward
         )
 
-        for layer in dummy_model_instance.language_model.model.layers:
+        for layer in dummy_model_instance.language_model.layers:
             assert inspect.getsource(layer.mlp.forward) != inspect.getsource(LigerGEGLUMLP.forward)
             assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
@@ -736,10 +737,10 @@ def test_apply_liger_kernel_to_instance_for_gemma3():
             dummy_model_instance.multi_modal_projector.mm_soft_emb_norm.forward
         ) == inspect.getsource(LigerRMSNorm.forward)
 
-        assert inspect.getsource(dummy_model_instance.language_model.model.norm.forward) == inspect.getsource(
+        assert inspect.getsource(dummy_model_instance.language_model.norm.forward) == inspect.getsource(
             LigerRMSNorm.forward
         )
-        for layer in dummy_model_instance.language_model.model.layers:
+        for layer in dummy_model_instance.language_model.layers:
             assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerGEGLUMLP.forward)
             assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)

--- a/test/transformers/test_monkey_patch.py
+++ b/test/transformers/test_monkey_patch.py
@@ -689,7 +689,6 @@ def test_apply_liger_kernel_to_instance_for_gemma3_conditional_generation():
         config = transformers.models.gemma3.configuration_gemma3.Gemma3Config(text_config, vision_config)
         print(f"config.model_type: {config.model_type}")
         dummy_model_instance = Gemma3ForConditionalGeneration._from_config(config)
-        print(f"dummy_model_instance config.model_type: {dummy_model_instance.config.model_type}")
         assert isinstance(dummy_model_instance, Gemma3ForConditionalGeneration)
 
         # Check that model instance variables are not yet patched with Liger modules


### PR DESCRIPTION
## Summary
With transformers >= 4.52.0, there was some refactoring of gemma3 model code. Patching should still work for previous transformers version, but gemma3 tests won't pass for older transformers versions. Not sure we want to maintain that logic in the tests.

For reference:

- Before (transformers <=4.51.3):
```
Gemma3ForConditionalGeneration
 - language_model (Gemma3ForCausalLM)
    - model (Gemma3TextModel)
       - layers/norm/etc.
```

- After:
```
Gemma3ForConditionalGeneration
- model (Gemma3Model)
   - language_model (Gemma3TextModel)
      - layers/norm/etc.
- language_model (for backwards-compatibility, points to model.language_model (Gemma3TextModel))
```

Fixing part of #729

## Testing Done
Gemma3 monkey patch tests pass
```
pytest test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_gemma3_conditional_generation
pytest test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_gemma3_text 
```

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
