### PR TITLE
fix: Fix llava

### DIFF
--- a/src/liger_kernel/transformers/model/llava.py
+++ b/src/liger_kernel/transformers/model/llava.py
@@ -310,20 +310,11 @@ def lce_forward(
         )
 
     else:
-        logits = self.lm_head(hidden_states)
+        logits = self.lm_head(kept_hidden_states)
         if labels is not None:
-            # Upcast to float if we need to compute the loss to avoid potential precision issues
-            logits = logits.float()
-            # Shift so that tokens < n predict n
-            shift_logits = logits[..., :-1, :].contiguous()
-            shift_labels = labels[..., 1:].contiguous()
-            # Flatten the tokens
-            loss_fct = CrossEntropyLoss()
-            shift_logits = shift_logits.view(-1, self.config.vocab_size)
-            shift_labels = shift_labels.view(-1)
-            # Enable model parallelism
-            shift_labels = shift_labels.to(shift_logits.device)
-            loss = loss_fct(shift_logits, shift_labels)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **lm_kwargs
+            )
 
 
     if not return_dict:

--- a/src/liger_kernel/transformers/model/llava.py
+++ b/src/liger_kernel/transformers/model/llava.py
@@ -11,6 +11,7 @@ from transformers.utils import is_torchdynamo_compiling
 from transformers.utils.deprecation import deprecate_kwarg
 
 from liger_kernel.transformers.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyLoss
+from liger_kernel.transformers.model.loss_utils import LigerForCausalLMLoss
 
 
 def lce_forward_deprecated(
@@ -292,103 +293,68 @@ def lce_forward(
         else self.config.vision_feature_select_strategy
     )
 
-    if (input_ids is None) ^ (inputs_embeds is not None):
-        raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-
-    if pixel_values is not None and inputs_embeds is not None:
-        raise ValueError(
-            "You cannot specify both pixel_values and inputs_embeds at the same time, and must specify either one"
-        )
-
-    if inputs_embeds is None:
-        inputs_embeds = self.get_input_embeddings()(input_ids)
-
-    if pixel_values is not None:
-        image_features = self.get_image_features(
-            pixel_values=pixel_values,
-            vision_feature_layer=vision_feature_layer,
-            vision_feature_select_strategy=vision_feature_select_strategy,
-            image_sizes=image_sizes,
-        )
-
-        special_image_mask = (input_ids == self.config.image_token_index).unsqueeze(-1)
-        special_image_mask = special_image_mask.expand_as(inputs_embeds).to(inputs_embeds.device)
-        if not is_torchdynamo_compiling() and inputs_embeds[special_image_mask].numel() != image_features.numel():
-            n_image_tokens = (input_ids == self.config.image_token_index).sum()
-            n_image_features = image_features.shape[0] * image_features.shape[1]
-            raise ValueError(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-            )
-        image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
-        inputs_embeds = inputs_embeds.masked_scatter(special_image_mask, image_features)
-
-    outputs = self.language_model.model(
+    outputs = self.model(
+        input_ids=input_ids,
+        pixel_values=pixel_values,
         attention_mask=attention_mask,
         position_ids=position_ids,
         past_key_values=past_key_values,
         inputs_embeds=inputs_embeds,
+        vision_feature_layer=vision_feature_layer,
+        vision_feature_select_strategy=vision_feature_select_strategy,
         use_cache=use_cache,
         output_attentions=output_attentions,
         output_hidden_states=output_hidden_states,
-        return_dict=return_dict,
+        return_dict=True,
         cache_position=cache_position,
-        logits_to_keep=logits_to_keep,
+        image_sizes=image_sizes,
         **lm_kwargs,
     )
     hidden_states = outputs[0]
+    # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+    slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+    kept_hidden_states = hidden_states[:, slice_indices, :]
 
-    loss = None
+    shift_labels = lm_kwargs.pop("shift_labels", None)
     logits = None
+    loss = None
 
-    # Overwrite skip_logits, since llava never materializes logits
-    skip_logits = labels is not None
+    if skip_logits and labels is None and shift_labels is None:
+        raise ValueError("skip_logits is True, but labels and shift_labels are None")
+
+    if skip_logits is None:
+        # By default, if in training mode, don't materialize logits
+        skip_logits = self.training and (labels is not None or shift_labels is not None)
 
     if skip_logits:
-        # Shift so that tokens < n predict n
-        if attention_mask is not None:
-            # we use the input attention mask to shift the logits and labels, because it is 2D.
-            # we also crop attn mask in case it is longer, which happens in PrefixTuning with peft
-            shift_attention_mask = attention_mask[:, -(hidden_states.shape[1] - 1) :].to(hidden_states.device)
-            shift_hidden_states = hidden_states[..., :-1, :][
-                shift_attention_mask.to(hidden_states.device) != 0
-            ].contiguous()
-            shift_labels = labels[..., 1:][shift_attention_mask.to(labels.device) != 0].contiguous()
-        else:
-            shift_hidden_states = hidden_states[..., :-1, :].contiguous()
-            shift_labels = labels[..., 1:].contiguous()
-
-        lce = LigerFusedLinearCrossEntropyLoss()
-        loss = lce(
-            self.language_model.lm_head.weight,
-            shift_hidden_states.view(-1, shift_hidden_states.size(-1)),
-            shift_labels.view(-1).to(shift_hidden_states.device),
+        loss = LigerForCausalLMLoss(
+            hidden_states=kept_hidden_states,
+            lm_head_weight=self.lm_head.weight,
+            labels=labels,
+            shift_labels=shift_labels,
+            hidden_size=self.config.text_config.hidden_size,
+            **lm_kwargs,
         )
+
     else:
-        logits = self.language_model.lm_head(hidden_states)
+        logits = self.lm_head(hidden_states)
         if labels is not None:
             # Upcast to float if we need to compute the loss to avoid potential precision issues
             logits = logits.float()
-            shift_logits = logits[..., :-1, :]
-            shift_labels = labels[..., 1:]
-            if attention_mask is not None:
-                # we use the input attention mask to shift the logits and labels, because it is 2D.
-                # we also crop attn mask in case it is longer, which happens in PrefixTuning with peft
-                shift_attention_mask = attention_mask[:, -shift_logits.shape[1] :].to(logits.device)
-                shift_logits = shift_logits[shift_attention_mask.to(logits.device) != 0].contiguous()
-                shift_labels = shift_labels[shift_attention_mask.to(shift_labels.device) != 0].contiguous()
-            else:
-                shift_logits = shift_logits.contiguous()
-                shift_labels = shift_labels.contiguous()
+            # Shift so that tokens < n predict n
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
             # Flatten the tokens
             loss_fct = CrossEntropyLoss()
+            shift_logits = shift_logits.view(-1, self.config.vocab_size)
+            shift_labels = shift_labels.view(-1)
+            # Enable model parallelism
+            shift_labels = shift_labels.to(shift_logits.device)
+            loss = loss_fct(shift_logits, shift_labels)
 
-            flat_logits = shift_logits.view(-1, self.config.text_config.vocab_size)
-            flat_labels = shift_labels.view(-1).to(shift_logits.device)
-            loss = loss_fct(flat_logits, flat_labels)
 
     if not return_dict:
-        # NOTE: This part has not been tested.
-        output = outputs[1:]
+        output = (logits,) + outputs[1:]
         return (loss,) + output if loss is not None else output
 
     return LlavaCausalLMOutputWithPast(
@@ -397,5 +363,5 @@ def lce_forward(
         past_key_values=outputs.past_key_values,
         hidden_states=outputs.hidden_states,
         attentions=outputs.attentions,
-        image_hidden_states=image_features if pixel_values is not None else None,
+        image_hidden_states=outputs.image_hidden_states,
     )

--- a/src/liger_kernel/transformers/model/llava.py
+++ b/src/liger_kernel/transformers/model/llava.py
@@ -7,7 +7,6 @@ import torch
 
 from torch.nn import CrossEntropyLoss
 from transformers.models.llava.modeling_llava import LlavaCausalLMOutputWithPast
-from transformers.utils import is_torchdynamo_compiling
 from transformers.utils.deprecation import deprecate_kwarg
 
 from liger_kernel.transformers.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyLoss

--- a/src/liger_kernel/transformers/model/llava.py
+++ b/src/liger_kernel/transformers/model/llava.py
@@ -7,7 +7,6 @@ import torch
 
 from torch.nn import CrossEntropyLoss
 from transformers.models.llava.modeling_llava import LlavaCausalLMOutputWithPast
-from transformers.utils.deprecation import deprecate_kwarg
 
 from liger_kernel.transformers.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyLoss
 from liger_kernel.transformers.model.loss_utils import LigerForCausalLMLoss

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -428,13 +428,11 @@ def apply_liger_kernel_to_mllama(
         if isinstance(model, MllamaForConditionalGeneration):
             language_model: MllamaForCausalLM = model.language_model
             vision_model: MllamaVisionModel = model.vision_model
-            text_model: MllamaTextModel = language_model.model
-        elif isinstance(model, MllamaForCausalLM):
-            text_model = model.model
+            text_model: MllamaTextModel = language_model
+        elif isinstance(model, MllamaForCausalLM) or isinstance(model, MllamaTextModel):
+            text_model = model.model if isinstance(model,MllamaForCausalLM) else model
             vision_model = None
-        elif isinstance(model, MllamaTextModel):
-            text_model = model
-            vision_model = None
+
         else:
             raise ValueError(f"Unsupported Mllama model type: {type(model)}")
 

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -434,6 +434,7 @@ def apply_liger_kernel_to_mllama(
             vision_model = None
         elif isinstance(model, MllamaTextModel):
             text_model = model
+            vision_model = None
 
         else:
             raise ValueError(f"Unsupported Mllama model type: {type(model)}")

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -314,13 +314,14 @@ def apply_liger_kernel_to_llava(
         logger.warning(TRANSFORMER_DEPRECATION_WARNING)
         modeling_llava.nn.CrossEntropyLoss = LigerCrossEntropyLoss
     if fused_linear_cross_entropy:
-        if transformer_version >= version.parse("4.49.0"):
+        if transformer_version >= version.parse("4.52.0"):
             modeling_llava.LlavaForConditionalGeneration.forward = llava_lce_forward
+        elif transformer_version >= version.parse("4.49.0") and transformer_version < version.parse("4.52.0"): 
+            modeling_llava.LlavaForConditionalGeneration.forward = llava_lce_forward_deprecated
         else:  # if version < 4.49.0
             logger.warning(
-                "Support for transformers versions < 4.49.0 will soon be discontinued due to issues with incorrect legacy processing. \n Please consider upgrading to avoid potential issues. See details: https://github.com/huggingface/transformers/pull/35526"
+                "The latest version of Liger does not support transformers < 4.49.0 for llava. Please downgrade your liger version or upgrade your transformer version."
             )
-            modeling_llava.LlavaForConditionalGeneration.forward = llava_lce_forward_deprecated
 
     if model is not None:
         text_model_name, vision_model_name = model.config.text_config.model_type, model.config.vision_config.model_type

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -429,9 +429,11 @@ def apply_liger_kernel_to_mllama(
             language_model: MllamaForCausalLM = model.language_model
             vision_model: MllamaVisionModel = model.vision_model
             text_model: MllamaTextModel = language_model
-        elif isinstance(model, MllamaForCausalLM) or isinstance(model, MllamaTextModel):
-            text_model = model.model if isinstance(model,MllamaForCausalLM) else model
+        elif isinstance(model, MllamaForCausalLM):
+            text_model = model.model
             vision_model = None
+        elif isinstance(model, MllamaTextModel):
+            text_model = model
 
         else:
             raise ValueError(f"Unsupported Mllama model type: {type(model)}")

--- a/test/transformers/test_monkey_patch.py
+++ b/test/transformers/test_monkey_patch.py
@@ -348,10 +348,10 @@ def test_apply_liger_kernel_to_instance_for_mllama_for_conditional_generation():
         assert isinstance(dummy_model_instance, MllamaForConditionalGeneration)
 
         # Check that model instance variables are not yet patched with Liger modules
-        assert inspect.getsource(dummy_model_instance.language_model.model.norm.forward) != inspect.getsource(
+        assert inspect.getsource(dummy_model_instance.language_model.norm.forward) != inspect.getsource(
             LigerRMSNorm.forward
         )
-        for layer in dummy_model_instance.language_model.model.layers:
+        for layer in dummy_model_instance.language_model.layers:
             assert inspect.getsource(layer.mlp.forward) != inspect.getsource(LigerSwiGLUMLP.forward)
             assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
@@ -377,10 +377,10 @@ def test_apply_liger_kernel_to_instance_for_mllama_for_conditional_generation():
         _apply_liger_kernel_to_instance(model=dummy_model_instance)
 
         # Check that the model's instance variables were correctly patched with Liger modules
-        assert inspect.getsource(dummy_model_instance.language_model.model.norm.forward) == inspect.getsource(
+        assert inspect.getsource(dummy_model_instance.language_model.norm.forward) == inspect.getsource(
             LigerRMSNorm.forward
         )
-        for layer in dummy_model_instance.language_model.model.layers:
+        for layer in dummy_model_instance.language_model.layers:
             assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerSwiGLUMLP.forward)
             assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Resolve a part of #723 
<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
Convergence Test:
bf16/test_mini_models:
```
python -m pytest test/convergence/bf16/test_mini_models.py -k llava
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.10.14, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/jobuser/Liger-Kernel
configfile: pyproject.toml
plugins: xdist-3.7.0, rerunfailures-15.1, anyio-4.9.0, lipy-config-base-32.9.0, lipy-fabric-36.1.5, lipy-test-9.1.34, datadir-1.6.1
collecting ... 
------------------------------------------------------------------------------------- live log collection -------------------------------------------------------------------------------------
INFO     datasets:config.py:54 PyTorch version 2.7.0 available.
collected 16 items / 15 deselected / 1 selected                                                                                                                                               

test/convergence/bf16/test_mini_models.py::test_mini_model[mini_llava-32-0.0001-dtype1-0.001-0.01-0.1-0.01-0.01-0.01] PASSED                                                            [100%]

```

bf16/test_mini_models_multimodal:
```
python -m pytest test/convergence/bf16/test_mini_models_multimodal.py -k llava
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.10.14, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/jobuser/Liger-Kernel
configfile: pyproject.toml
plugins: xdist-3.7.0, rerunfailures-15.1, anyio-4.9.0, lipy-config-base-32.9.0, lipy-fabric-36.1.5, lipy-test-9.1.34, datadir-1.6.1
collecting ... 
------------------------------------------------------------------------------------- live log collection -------------------------------------------------------------------------------------
INFO     datasets:config.py:54 PyTorch version 2.7.0 available.
collected 7 items / 6 deselected / 1 selected                                                                                                                                                 

test/convergence/bf16/test_mini_models_multimodal.py::test_mini_model_multimodal[mini_llava-32-0.0001-dtype1-0.001-0.01-0.1-0.01-0.01-0.01] PASSED
```
fp32/test_mini_models:
```
python -m pytest test/convergence/fp32/test_mini_models.py -k llava
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.10.14, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/jobuser/Liger-Kernel
configfile: pyproject.toml
plugins: xdist-3.7.0, rerunfailures-15.1, anyio-4.9.0, lipy-config-base-32.9.0, lipy-fabric-36.1.5, lipy-test-9.1.34, datadir-1.6.1
collecting ... 
------------------------------------------------------------------------------------- live log collection -------------------------------------------------------------------------------------
INFO     datasets:config.py:54 PyTorch version 2.7.0 available.
collected 17 items / 16 deselected / 1 selected                                                                                                                                               

test/convergence/fp32/test_mini_models.py::test_mini_model[mini_llava-32-0.0001-dtype1-1e-08-1e-05-0.005-1e-05-0.005-1e-05] PASSED                                                      [100%]
```

fp32/test_mini_models_multimodal:
```
python -m pytest test/convergence/fp32/test_mini_models_multimodal.py -k llava
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.10.14, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/jobuser/Liger-Kernel
configfile: pyproject.toml
plugins: xdist-3.7.0, rerunfailures-15.1, anyio-4.9.0, lipy-config-base-32.9.0, lipy-fabric-36.1.5, lipy-test-9.1.34, datadir-1.6.1
collecting ... 
------------------------------------------------------------------------------------- live log collection -------------------------------------------------------------------------------------
INFO     datasets:config.py:54 PyTorch version 2.7.0 available.
collected 7 items / 6 deselected / 1 selected                                                                                                                                                 

test/convergence/fp32/test_mini_models_multimodal.py::test_mini_model_multimodal[mini_llava-32-0.0001-dtype1-1e-08-1e-05-0.005-1e-05-0.005-1e-05] PASSED                                [100%]
```

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
