### PR TITLE
Adding a test to run one benchmark when anything is pushed to the main branch

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,31 @@
+name: Benchmarks
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    env:
+      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install modal
+
+      - name: Run benchmarks on GPU
+        run: |
+          modal run dev.modal.benchmarks

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+concurrency:
+  # This causes it to cancel previous in-progress actions on the same PR / branch,
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   benchmarks:
     runs-on: ubuntu-latest

--- a/dev/modal/benchmarks.py
+++ b/dev/modal/benchmarks.py
@@ -24,4 +24,4 @@ def liger_benchmarks():
         shell=True,
         cwd=REMOTE_ROOT_PATH,
     )
-    subprocess.run(["make run-benchmarks"], check=True, shell=True, cwd=REMOTE_ROOT_PATH)
+    subprocess.run(["python benchmark/scripts/benchmark_kto_loss.py"], check=True, shell=True, cwd=REMOTE_ROOT_PATH)

--- a/dev/modal/benchmarks.py
+++ b/dev/modal/benchmarks.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+import modal
+
+ROOT_PATH = Path(__file__).parent.parent.parent
+REMOTE_ROOT_PATH = "/root/liger-kernel"
+PYTHON_VERSION = "3.12"
+
+image = modal.Image.debian_slim(python_version=PYTHON_VERSION).pip_install("uv")
+
+app = modal.App("liger_benchmarks", image=image)
+
+# mount: add local files to the remote container
+repo = image.add_local_dir(ROOT_PATH, remote_path=REMOTE_ROOT_PATH)
+
+
+@app.function(gpu="A10G", image=repo, timeout=60 * 45)
+def liger_benchmarks():
+    import subprocess
+
+    subprocess.run(
+        ["uv pip install -e '.[dev]' --system"],
+        check=True,
+        shell=True,
+        cwd=REMOTE_ROOT_PATH,
+    )
+    subprocess.run(["make run-benchmarks"], check=True, shell=True, cwd=REMOTE_ROOT_PATH)


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Trying to run just the KTO loss for now for testing purposes. It will run after any thing is pushed to the main branch
<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
