### PR TITLE
fix: import tanh

### DIFF
--- a/src/liger_kernel/ops/dyt.py
+++ b/src/liger_kernel/ops/dyt.py
@@ -4,8 +4,6 @@ import torch
 import triton
 import triton.language as tl
 
-from triton.language.extra.libdevice import tanh
-
 from liger_kernel.ops.utils import compare_version
 from liger_kernel.ops.utils import ensure_contiguous
 from liger_kernel.ops.utils import infer_device


### PR DESCRIPTION
## Summary
For triton version less than `3.0.0`, `tanh` function must be imported from `triton.language.math`. There is a duplicated import in the file `dyt.py` before checking the triton version and thus needs to be removed.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
