### PR TITLE
fix vocab_size path for gemma3

### DIFF
--- a/src/liger_kernel/transformers/model/gemma3.py
+++ b/src/liger_kernel/transformers/model/gemma3.py
@@ -208,7 +208,7 @@ def multimodal_forward(
     is_training = token_type_ids is not None and labels is not None
 
     # Replace image id woth PAD if the image token if OOV, to avoid index-errors
-    if input_ids is not None and self.config.image_token_index >= self.vocab_size:
+    if input_ids is not None and self.config.image_token_index >= self.config.text_config.vocab_size:
         special_image_mask = input_ids == self.config.image_token_index
         llm_input_ids = input_ids.clone()
         llm_input_ids[special_image_mask] = 0


### PR DESCRIPTION
## Summary
using `self.vocab_size` for the multimodal forward likely never worked or was deprecated in a transformers change.
