### PR TITLE
fix(geglu, swiglu): match the casting in MLP layer for bfloat16

### DIFF
--- a/src/liger_kernel/ops/geglu.py
+++ b/src/liger_kernel/ops/geglu.py
@@ -40,7 +40,7 @@ def _geglu_tanh_forward_kernel(a, b, c, stride, n_cols: tl.constexpr, BLOCK_SIZE
     tanh_arg = sqrt_2_over_pi * (a_row + 0.044715 * a_cubed)
     tanh_result = tanh(tanh_arg)
     geglu_a = 0.5 * a_row * (1 + tanh_result)
-    c_row = geglu_a * b_row
+    c_row = geglu_a.cast(b_row.dtype) * b_row
     tl.store(c + col_offsets, c_row, mask=mask)
 
 

--- a/src/liger_kernel/ops/swiglu.py
+++ b/src/liger_kernel/ops/swiglu.py
@@ -26,7 +26,7 @@ def _swiglu_forward_kernel(a_ptr, b_ptr, c_ptr, stride, n_cols: tl.constexpr, BL
     # sigmoid requires type float32
     a_row = tl.load(a_ptr + col_offsets, mask=mask, other=0).to(tl.float32)
     b_row = tl.load(b_ptr + col_offsets, mask=mask, other=0)
-    c_row = silu(a_row) * b_row
+    c_row = silu(a_row).cast(b_row.dtype) * b_row
     tl.store(c_ptr + col_offsets, c_row, mask=mask)
 
 


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Most MLPs are defined as:
```python
def forward(self, x):
    down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
    return down_proj
```
, where `self.act_fn` is [`torch.nn.GELU(approximate='tanh')`](https://github.com/huggingface/transformers/blob/25cd65ac43ee1a96cef4692bda0b110d1e3c6903/src/transformers/activations.py#L27)

However, in [LigerGELUMLP kernel](https://github.com/linkedin/Liger-Kernel/blob/08906d3d9cad77fcced2b9f6db0a385eff154f03/src/liger_kernel/ops/geglu.py#L22-L44), after upcasting `x` to float32, all computation are performed in float32. It can result in a huge discrepancy between original and patched models in bfloat16 scenario.

Here's the casting comparison:

Most Huggingface models' MLP
```python
def forward(self, x):
	ori_dtype = x.dtype
	# casting back before multiplying up projection
    down_proj = self.down_proj(gelu(self.gate_proj(x).float()).to(ori_dtype) * self.up_proj(x))
    return down_proj
```
LigerGEGLUMLP before this PR
```python
def forward(self, x):
    ori_dtype = x.dtype
	# casting back after multiplying up projection
    down_proj = self.down_proj((gelu(self.gate_proj(x).float()) * self.up_proj(x)).to(ori_dtype))
    return down_proj
```

This PR fixes the casting timing to match the former behavior.


Edit: Same fix can apply to `SwiGLUMLP` as well.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
