### PR TITLE
Update gemma3 logprobs_rtol

### DIFF
--- a/test/convergence/bf16/test_mini_models_multimodal.py
+++ b/test/convergence/bf16/test_mini_models_multimodal.py
@@ -1022,7 +1022,7 @@ def run_mini_model_multimodal(
             5e-2,
             5e-2,
             1e-1,
-            1e-2,
+            1e-1,
             1e-2,
             1e-2,
             marks=[


### PR DESCRIPTION
## Summary

- Relax logprobs_rtol for gemma3 back to original value as it's failing on CI

## Testing Done

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
