### PR TITLE
Release 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "liger_kernel"
-version = "0.5.10"
+version = "0.6.0"
 description = "Efficient Triton kernels for LLM Training"
 urls = { "Homepage" = "https://github.com/linkedin/Liger-Kernel" }
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
## Summary

- Releasing minor version bump 0.6.0 primarily to indicate backwards-incompatible support for monkey patching latest transformers (>=4.52.0) VLM models

## Testing Done

- Hardware Type: A10G
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
