### PR TITLE
Add `automatically-request-copilot-review.yaml` workflow

### DIFF
--- a/.github/workflows/automatically-request-copilot-review.yaml
+++ b/.github/workflows/automatically-request-copilot-review.yaml
@@ -1,0 +1,24 @@
+name: Automatic Copilot Code Review
+
+on:
+  pull_request:
+    types:
+      - opened            # brand-new PRs
+      - ready_for_review  # PR drafts marked "Ready for review"
+      - reopened          # PRs that were closed then reopened
+      - synchronize       # PRs updated with new commits
+
+jobs:
+  add-copilot-to-pr-reviews:
+    name: "Add Copilot to PR reviews"
+    if: ${{ github.event.pull_request.draft == false }}   # skip still-draft PRs
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN_COPILOT_REVIEW }}   # gh CLI picks this up automatically
+
+    steps:
+      - name: Install gh-copilot-review extension
+        run: gh extension install ChrisCarini/gh-copilot-review
+
+      - name: Ask Copilot to review this PR
+        run: gh copilot-review "${{ github.event.pull_request.html_url }}"


### PR DESCRIPTION
# Summary
  
This PR adds a GitHub Actions workflow to automatically request Copilot code reviews for pull requests in **linkedin/Liger-Kernel**.

## Changes
  
- Added `.github/workflows/automatically-request-copilot-review.yaml`
- The workflow will automatically request Copilot reviews on all PRs

## ⚠️ ⚠️ ⚠️ ACTION REQUIRED ⚠️ ⚠️ ⚠️
 
You still need to create a GitHub Personal Access Token (PAT) and add it to the repository secrets for this GitHub repository!

1. [Click here to create **_a classic GitHub PAT_** with the correct scopes (`repo`)](https://github.com/settings/tokens/new?scopes=repo&description=GH_TOKEN_COPILOT_REVIEW%20-%20For%20Automatic%20Copilot%20Code%20Reviews)
    - **Note:** You will have to select an `Expiration` value you feel is reasonable from a usability + security perspective given the necessary scopes and usage.
    - **Note2:** Creating a fine-grained PAT with the permission(s) documented https://github.com/ChrisCarini/gh-copilot-review?tab=readme-ov-file#token-permissions is a better option, from a security standpoint.
2. You will need to set a repository secret named `GH_TOKEN_COPILOT_REVIEW` for all the desired repositories
3. Once the secret named `GH_TOKEN_COPILOT_REVIEW` is added, please merge in the PR after getting the necessary approval(s).

## How it works

When a pull request is opened or updated in the **linkedin/Liger-Kernel** product, this workflow will:
1. Checkout the repository
2. Automatically request a Copilot review using the configured token
    - **Note:** Whoever created the PAT will show up as the one requesting the review from Copilot.