### PR TITLE
Update Dev Dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,7 @@ def get_optional_dependencies():
         "dev": [
             "transformers>=4.49.0",
             "matplotlib>=3.7.2",
-            "flake8>=4.0.1.1",
-            "black>=24.4.2",
-            "isort>=5.13.2",
+            "ruff.=0.12.0",
             "pytest>=7.1.2",
             "pytest-xdist",
             "pytest-cov",
@@ -43,7 +41,6 @@ def get_optional_dependencies():
             "pytest-rerunfailures",
             "datasets>=2.19.2",
             "seaborn",
-            "mkdocs",
             "mkdocs-material",
             "torchvision>=0.20",
         ]


### PR DESCRIPTION
## Summary
Fixes #885

As described in the issue, this PR updates the linting deps to only include ruff. I've also removed mkdocs, as mkdocs-material pre-installs mkdocs as well. Could you please review?

cc: @vaibhavjindal, @shimizust

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
