### PR TITLE
Fixed AMD CI issue #793

### DIFF
--- a/.github/workflows/amd-ci.yml
+++ b/.github/workflows/amd-ci.yml
@@ -64,7 +64,8 @@ jobs:
       run: |
         rocm-smi
         python -m pip install --upgrade pip
-        pip install -e .[dev] --extra-index-url https://download.pytorch.org/whl/nightly/rocm${{ matrix.rocm_version }}
+        pip install -e .[dev]
+        pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm${{ matrix.rocm_version }}/
     
     - name: List Python Environments
       run: python -m pip list

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ y = orpo_loss(lm_head.weight, x, target)
 - `triton >= 3.0.0` Install from pypi. (e.g. `pip install triton==3.0.0`)
 
 ```bash
-# Need to pass the url when installing
-pip install -e .[dev] --extra-index-url https://download.pytorch.org/whl/nightly/rocm6.2
+pip install -e .[dev]
+pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.3/
 ```
 
 ### Optional Dependencies

--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ pip install -e .
 
 # Setup Development Dependencies
 pip install -e ".[dev]"
+
+# NOTE -> For AMD users only
+pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.3/
 ```
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ def get_default_dependencies():
         ]
     elif platform == "rocm":
         return [
-            "torch>=2.6.0.dev",
             "triton>=3.0.0",
         ]
     elif platform == "xpu":


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->

This PR fixes #793 The AMD CI for `Liger-Kernel` was failing due to PyTorch ROCm not being installed correctly. The CI was installing a CUDA build instead of ROCm because PyPI packages were taking precedence over the extraindexurl nightly ROCm index URL. This caused the error:

```
and getattr(torch, infer_device()).get_device_properties(0).total_memory < 36e9,  
E   AttributeError: module 'torch.cpu' has no attribute 'get_device_properties'
```
Since CUDA PyTorch couldn't detect the GPU on the AMD Device.

This change updates the README and setup so that AMD users explicitly install the ROCm nightly PyTorch after the dev requirements, ensuring the correct ROCm build is used and torch can detect GPU.

---


## Details

1. **Intel CI issues remain unresolved.**

2. AMD users now need to run one additional step to (as updated in readme to downalod rocm torch, I tried using index-url instead of extra-index-url that helped to downalod correct version but still installed cuda version because of precedence so its better to manually downalod as specified in readme):

```
pip install -e .[dev]  
pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.3/
 
```
 This ensures the ROCm build overrides any CUDA installations from PyPI. 

---

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

Ran:

`python -m pytest test/transformers/test_tvd.py -v  `
(was earlier giving  AttributeError: module 'torch.cpu' has no attribute 'get_device_properties' , now all testcase passed)

<img width="1440" height="778" alt="testcasepassed" src="https://github.com/user-attachments/assets/ec1f9d81-2afa-45d2-9b29-ccbacccf257f" />
<img width="1440" height="774" alt="alltestcaserun" src="https://github.com/user-attachments/assets/5a427ebf-f8e4-4d38-bbf0-0bd9012504bc" />


All test cases passed on AMD MI300X.

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: AMD MI300X
- [x] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
