### PR TITLE
fix(llama4): Get correct swiglu patch target for llama4 moe layer

### DIFF
--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -480,7 +480,6 @@ def apply_liger_kernel_to_llama4(
     from transformers.models.llama4 import modeling_llama4
     from transformers.models.llama4.modeling_llama4 import Llama4ForCausalLM
     from transformers.models.llama4.modeling_llama4 import Llama4ForConditionalGeneration
-    from transformers.models.llama4.modeling_llama4 import Llama4TextMLP
     from transformers.models.llama4.modeling_llama4 import Llama4TextModel
     from transformers.models.llama4.modeling_llama4 import Llama4VisionModel
 
@@ -523,10 +522,10 @@ def apply_liger_kernel_to_llama4(
                 _patch_rms_norm_module(text_model.norm)
             for decoder_layer in text_model.layers:
                 if swiglu:
-                    if isinstance(decoder_layer.feed_forward, Llama4TextMLP):
-                        _patch_swiglu_module(decoder_layer.feed_forward, LigerSwiGLUMLP)
-                    else:  # Llama4TextMoe
+                    if decoder_layer.is_moe_layer:
                         _patch_swiglu_module(decoder_layer.feed_forward.shared_expert, LigerSwiGLUMLP)
+                    else:
+                        _patch_swiglu_module(decoder_layer.feed_forward, LigerSwiGLUMLP)
                 if rms_norm:
                     _patch_rms_norm_module(decoder_layer.input_layernorm)
                     _patch_rms_norm_module(decoder_layer.post_attention_layernorm)


### PR DESCRIPTION
## Summary

Resolves https://github.com/linkedin/Liger-Kernel/issues/905. Also updates incorrect default in docstring.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
### Unit testing

I wasn't sure what a good test would be to catch regressions - updated llama4 monkeypatch tests to assert that the expected target module (`layer.feed_forward.shared_expert`) is in fact an instance of `Llama4TextMLP`. Also added a similar test for a dummy model with no moe layers with the expectation that `layer.feed_forward` is an instance of `Llama4TextMLP` and patched correctly. Open to other suggestions though.

### Manual testing

Confirmed that with this branch installed, I am able to finetune Llama-4-Scout-17B-16E-Instruct with SFTTrainer with `use_liger_kernel=True`.

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: H100 SXM5 80GB
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence

@Tcc0403 Thanks!