### PR TITLE
Copy and paste benchmarks before and after gh-pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,6 @@ permissions:
   contents: write
 jobs:
   deploy:
-    if: False
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,4 +29,36 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: pip install mkdocs-material mkdocstrings[python]
-      - run: mkdocs gh-deploy --force
+      # ====== Backup the benchmarks from gh-pages ======
+      # This is necessary because the benchmarks are not included in the documentation build process.
+      # So we need to backup the benchmarks from gh-pages and restore them after the documentation is built.
+      - name: Backup benchmarks from gh-pages
+        run: |
+          git fetch origin gh-pages
+          # create worktree bound to local gh-pages, tracking origin/gh-pages
+          git branch -f gh-pages origin/gh-pages || true
+          mkdir -p ghp && git worktree add ghp gh-pages || true
+          if [ -d ghp/benchmarks ]; then
+            tar -C ghp -czf /tmp/benchmarks.tgz benchmarks
+          fi
+          # IMPORTANT: remove worktree so gh-pages isn't checked out anywhere
+          git worktree remove ghp --force || true
+          echo "Backed up benchmarks from gh-pages"
+      # ====== Deploy the documentation ======
+      - name: Deploy documentation
+        run: mkdocs gh-deploy --force
+      # ====== Restore the benchmarks onto gh-pages ======
+      # This is necessary because the benchmarks are not included in the documentation build process.
+      # So we need to restore the benchmarks onto gh-pages after the documentation is built.
+      - name: Restore benchmarks onto gh-pages
+        run: |
+          # Refresh remote tracking and recreate a clean worktree
+          git fetch origin gh-pages
+          git worktree add -B gh-pages ghp origin/gh-pages
+          if [ -f /tmp/benchmarks.tgz ]; then
+            tar -C ghp -xzf /tmp/benchmarks.tgz
+            git -C ghp add -A
+            git -C ghp commit -m "Restore benchmarks after gh-deploy" || echo "No changes"
+            git -C ghp push origin gh-pages
+          fi
+          git worktree remove ghp --force || true

--- a/docs/acknowledgement.md
+++ b/docs/acknowledgement.md
@@ -9,7 +9,6 @@
 We referenced or used the following projects:
 
 
-
 | # | Project                                                                                      | Description                                                                             | Location                                                                                                                         | License                                                                              |
 |---|----------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
 | 1 | [Unsloth](https://github.com/unslothai/unsloth/blob/fd753fed99ed5f10ef8a9b7139588d9de9ddecfb/unsloth/kernels/utils.py#L43)                              | `calculate_settings` to determine block size and warp; We reuse it for Norm and MLP     | [Liger Kernel Utils](https://github.com/linkedin/Liger-Kernel/blob/e249eee723978bf8610ff1ea2297d048a2417e20/src/liger_kernel/ops/utils.py#L23) | [Apache](https://github.com/unslothai/unsloth/blob/fd753fed99ed5f10ef8a9b7139588d9de9ddecfb/LICENSE) |


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Copy the benchmark data from gh-pages before every mkdocs deployment and paste it after the deployment. This helps in keeping the benchmark data after every mkdocs deployment.

Fixes: https://github.com/linkedin/Liger-Kernel/issues/875
<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
