### PR TITLE
[Test][XPU] Added gpu cache cleaning for XPU devices

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,9 @@ import torch
 
 
 @pytest.fixture(autouse=True)
-def clear_cuda_cache():
+def clear_gpu_cache():
     yield
-    torch.cuda.empty_cache()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    elif torch.xpu.is_available():
+        torch.xpu.empty_cache()


### PR DESCRIPTION
## Summary
Enable GPU cache cleaning for XPU devices


## Details
I discovered this issue while working on https://github.com/intel/intel-xpu-backend-for-triton/issues/5292 Basically testing on XPU was hanging indefinitely, but it was not due to a specific test. Hanging only occurred if many tests were run sequentially. In my local experiments on Intel Data Center GPU Max 1100 this patch resolves hanging issue.

The patch is small and unlikely to cause problems for cuda.

## Testing Done
`pytest test` with Intel Data Center GPU Max 1100

- Hardware Type: Intel Data Center GPU Max 1100
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
