### PR TITLE
Increase time limit for modal tests

### DIFF
--- a/dev/modal/tests.py
+++ b/dev/modal/tests.py
@@ -14,7 +14,7 @@ app = modal.App("liger_tests", image=image)
 repo = image.add_local_dir(ROOT_PATH, remote_path=REMOTE_ROOT_PATH)
 
 
-@app.function(gpu="H100!", image=repo, timeout=60 * 60)
+@app.function(gpu="H100!", image=repo, timeout=90 * 60)
 def liger_tests():
     import subprocess
 

--- a/dev/modal/tests_bwd.py
+++ b/dev/modal/tests_bwd.py
@@ -14,7 +14,7 @@ app = modal.App("liger_tests_bwd", image=image)
 repo = image.add_local_dir(ROOT_PATH, remote_path=REMOTE_ROOT_PATH)
 
 
-@app.function(gpu="H100!", image=repo, timeout=60 * 60)
+@app.function(gpu="H100!", image=repo, timeout=90 * 60)
 def liger_bwd_tests():
     import subprocess
 


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Modal tests on nvidia gpus failing becuase of time limit errors: https://github.com/linkedin/Liger-Kernel/actions/runs/19472103084/job/55721981739.

This PR increases the timeout to 90 mins to fix this.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
