### PR TITLE
[NPU]: refine geglu memory_multiplier based on UB analysis

### DIFF
--- a/src/liger_kernel/ops/backends/_ascend/ub_manager.py
+++ b/src/liger_kernel/ops/backends/_ascend/ub_manager.py
@@ -241,7 +241,7 @@ def compute_default_tiling_strategy(
         dtype_size: Size of data type in bytes (e.g., 2 for float16, 4 for float32).
             Must be provided. If None or <= 0, defaults to 4 (float32).
         memory_multiplier: Memory multiplier for estimating peak memory usage.
-            - For GEGLU: typically 10.0 for backward, 7.0 for forward
+            - For GEGLU: typically 10.0 for backward, 4.0 for forward
             - For ROPE: typically 3.0
             If None, defaults to 10.0 (conservative estimate).
         shapes: Tuple of full shapes. Each shape is a tuple of dimension sizes.


### PR DESCRIPTION
Update geglu forward and backward passes to use dtype-specific memory_multiplier values based on detailed buffer analysis:

- Forward: 4.0 (float16) or 3.0 (float32), was fixed 7.0
- Backward: 10.0 (float16) or 6.0 (float32), was fixed 10.0

Analysis distinguishes UB buffers from register-optimized temporaries and identifies peak memory usage at line 103 for backward pass.

This improves UB memory estimation accuracy and prevents overflow.

- Hardware Type: <Ascend910B4>
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
