### PR TITLE
fix: replace HybridCache with Cache in gemma2 and gemma3

### DIFF
--- a/src/liger_kernel/transformers/model/gemma2.py
+++ b/src/liger_kernel/transformers/model/gemma2.py
@@ -7,7 +7,7 @@ from typing import Union
 import torch
 
 from torch.nn import CrossEntropyLoss
-from transformers.cache_utils import HybridCache
+from transformers.cache_utils import Cache
 from transformers.modeling_outputs import CausalLMOutputWithPast
 from transformers.utils.deprecation import deprecate_kwarg
 
@@ -24,7 +24,7 @@ def lce_forward_deprecated(
     input_ids: torch.LongTensor = None,
     attention_mask: Optional[torch.Tensor] = None,
     position_ids: Optional[torch.LongTensor] = None,
-    past_key_values: Optional[HybridCache] = None,
+    past_key_values: Optional[Cache] = None,
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,
@@ -149,7 +149,7 @@ def lce_forward(
     input_ids: torch.LongTensor = None,
     attention_mask: Optional[torch.Tensor] = None,
     position_ids: Optional[torch.LongTensor] = None,
-    past_key_values: Optional[HybridCache] = None,
+    past_key_values: Optional[Cache] = None,
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,

--- a/src/liger_kernel/transformers/model/gemma3.py
+++ b/src/liger_kernel/transformers/model/gemma3.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 
 from transformers.cache_utils import Cache
-from transformers.cache_utils import HybridCache
+from transformers.cache_utils import Cache
 from transformers.utils import logging
 
 from liger_kernel.transformers.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyLoss
@@ -23,7 +23,7 @@ def causal_forward(
     input_ids: torch.LongTensor = None,
     attention_mask: Optional[torch.Tensor] = None,
     position_ids: Optional[torch.LongTensor] = None,
-    past_key_values: Optional[HybridCache] = None,
+    past_key_values: Optional[Cache] = None,
     inputs_embeds: Optional[torch.FloatTensor] = None,
     labels: Optional[torch.LongTensor] = None,
     use_cache: Optional[bool] = None,


### PR DESCRIPTION
`HybridCache` has been deprecated, and is now removed, see https://github.com/huggingface/transformers/pull/43168, causing 

```
  trl/trainer/dpo_trainer.py:500: in __init__
      super().__init__(
  .venv/lib/python3.12/site-packages/transformers/trainer.py:479: in __init__
      from liger_kernel.transformers import _apply_liger_kernel_to_instance
  .venv/lib/python3.12/site-packages/liger_kernel/transformers/__init__.py:140: in __getattr__
      module = importlib.import_module("liger_kernel.transformers.monkey_patch")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  /__w/_tool/Python/3.12.12/x64/lib/python3.12/importlib/__init__.py:90: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  .venv/lib/python3.12/site-packages/liger_kernel/transformers/monkey_patch.py:21: in <module>
      from liger_kernel.transformers.model.gemma2 import lce_forward as gemma2_lce_forward
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  
      import logging
      
      from typing import Optional
      from typing import Tuple
      from typing import Union
      
      import torch
      
      from torch.nn import CrossEntropyLoss
  >   from transformers.cache_utils import HybridCache
  E   ImportError: cannot import name 'HybridCache' from 'transformers.cache_utils' (/__w/trl/trl/.venv/lib/python3.12/site-packages/transformers/cache_utils.py)
  
  .venv/lib/python3.12/site-packages/liger_kernel/transformers/model/gemma2.py:10: ImportError
```

This PR fixes this issue