### PR TITLE
Enable `benchmark_tvd.py` for xpu devices

### DIFF
--- a/benchmark/scripts/benchmark_tvd.py
+++ b/benchmark/scripts/benchmark_tvd.py
@@ -9,6 +9,9 @@ from utils import parse_benchmark_script_args
 from utils import run_benchmarks
 
 from liger_kernel.transformers.tvd import LigerTVDLoss
+from liger_kernel.utils import infer_device
+
+device = infer_device()
 
 
 class TorchTVDLoss(torch.nn.Module):
@@ -40,8 +43,8 @@ def bench_speed_tvd(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
     torch_tvd = TorchTVDLoss(reduction=reduction)
     liger_tvd = LigerTVDLoss(reduction=reduction)
 
-    _input = torch.randn(B * T, V, requires_grad=True, device="cuda").softmax(dim=-1)
-    target = torch.randn(B * T, V, device="cuda").softmax(dim=-1)
+    _input = torch.randn(B * T, V, requires_grad=True, device=device).softmax(dim=-1)
+    target = torch.randn(B * T, V, device=device).softmax(dim=-1)
 
     def fwd():
         if input.kernel_provider == "liger":
@@ -82,8 +85,8 @@ def bench_memory_tvd(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput
     V = input.x
     B, T = input.extra_benchmark_config["B"], input.extra_benchmark_config["T"]
 
-    _input = torch.randn(B * T, V, requires_grad=True, device="cuda").softmax(dim=-1)
-    target = torch.randn(B * T, V, device="cuda").softmax(dim=-1)
+    _input = torch.randn(B * T, V, requires_grad=True, device=device).softmax(dim=-1)
+    target = torch.randn(B * T, V, device=device).softmax(dim=-1)
 
     def fwd():
         if input.kernel_provider == "liger":


### PR DESCRIPTION
## Summary
Use general device instead of hardcoded "cuda" for `benchmark_tvd.py`.

## Testing Done
Launched modified benchmark of XPU

- Hardware Type: Intel GPU Max 1100
- [x] run `make test` to ensure correctness - *no changes to the library source code*
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence - *no changes to the library source code*
