### PR TITLE
Fix Gemma3TextConfig rope parameters in convergence tests

### DIFF
--- a/test/convergence/bf16/test_mini_models.py
+++ b/test/convergence/bf16/test_mini_models.py
@@ -713,8 +713,15 @@ if GEMMA3_AVAILABLE:
             eos_token_id=1,
             tie_word_embeddings=True,
             rope_parameters=dict(
-                rope_theta=10000.0,
-            ),  # 1000000
+                full_attention=dict(
+                    rope_theta=10000.0,
+                    rope_type="default",
+                ),
+                sliding_attention=dict(
+                    rope_theta=10000.0,
+                    rope_type="default",
+                ),
+            ),
             attention_bias=False,
             attention_dropout=0.0,
             attn_implementation="eager",

--- a/test/convergence/bf16/test_mini_models_with_logits.py
+++ b/test/convergence/bf16/test_mini_models_with_logits.py
@@ -768,7 +768,16 @@ if GEMMA3_AVAILABLE:
             bos_token_id=2,
             eos_token_id=1,
             tie_word_embeddings=True,
-            rope_theta=10000.0,  # 1000000
+            rope_parameters=dict(
+                full_attention=dict(
+                    rope_theta=10000.0,
+                    rope_type="default",
+                ),
+                sliding_attention=dict(
+                    rope_theta=10000.0,
+                    rope_type="default",
+                ),
+            ),
             attention_bias=False,
             attention_dropout=0.0,
             attn_implementation="eager",

--- a/test/convergence/fp32/test_mini_models.py
+++ b/test/convergence/fp32/test_mini_models.py
@@ -711,7 +711,14 @@ if GEMMA3_AVAILABLE:
             eos_token_id=1,
             tie_word_embeddings=True,
             rope_parameters=dict(
-                rope_theta=10000.0,
+                full_attention=dict(
+                    rope_theta=10000.0,
+                    rope_type="default",
+                ),
+                sliding_attention=dict(
+                    rope_theta=10000.0,
+                    rope_type="default",
+                ),
             ),
             attention_bias=False,
             attention_dropout=0.0,

--- a/test/convergence/fp32/test_mini_models_with_logits.py
+++ b/test/convergence/fp32/test_mini_models_with_logits.py
@@ -676,7 +676,14 @@ if GEMMA3_AVAILABLE:
             eos_token_id=1,
             tie_word_embeddings=True,
             rope_parameters=dict(
-                rope_theta=10000.0,
+                full_attention=dict(
+                    rope_theta=10000.0,
+                    rope_type="default",
+                ),
+                sliding_attention=dict(
+                    rope_theta=10000.0,
+                    rope_type="default",
+                ),
             ),
             attention_bias=False,
             attention_dropout=0.0,


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Follow-up to #1014 

Change all occurences in all convergence tests.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
