### PR TITLE
Remove deprecated argument `position_id` 

### DIFF
--- a/test/transformers/test_rope.py
+++ b/test/transformers/test_rope.py
@@ -83,7 +83,7 @@ def test_correctness(
     cos, sin = rotary_emb(k1, pos_ids)
 
     # validate forward pass
-    hf_q, hf_k = apply_rotary_pos_emb(q1, k1, cos, sin, pos_ids)
+    hf_q, hf_k = apply_rotary_pos_emb(q1, k1, cos, sin)
     tt_q, tt_k = liger_rotary_pos_emb(q2, k2, cos, sin)
     assert torch.allclose(hf_q, tt_q, atol=atol, rtol=rtol)
     assert torch.allclose(hf_k, tt_k, atol=atol, rtol=rtol)


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->
`position_id` has been removed from `apply_rotary_pos_emb` in https://github.com/huggingface/transformers/pull/43255
## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
```
❯ python3 -m pytest test/transformers/test_rope.py -q

test/transformers/test_rope.py::test_correctness[True-dtype0-1e-05-1e-05-1-128-32-32-64] PASSED                              [  2%]
test/transformers/test_rope.py::test_correctness[True-dtype0-1e-05-1e-05-2-128-32-32-64] PASSED                              [  5%]
test/transformers/test_rope.py::test_correctness[True-dtype0-1e-05-1e-05-1-128-32-8-64] PASSED                               [  8%]
test/transformers/test_rope.py::test_correctness[True-dtype0-1e-05-1e-05-2-128-32-8-64] PASSED                               [ 11%]
test/transformers/test_rope.py::test_correctness[True-dtype0-1e-05-1e-05-3-423-73-213-92] PASSED                             [ 13%]
test/transformers/test_rope.py::test_correctness[True-dtype0-1e-05-1e-05-3-423-73-155-92] PASSED                             [ 16%]
test/transformers/test_rope.py::test_correctness[True-dtype1-0.1-1e-05-1-128-32-32-64] PASSED                                [ 19%]
test/transformers/test_rope.py::test_correctness[True-dtype1-0.1-1e-05-2-128-32-32-64] PASSED                                [ 22%]
test/transformers/test_rope.py::test_correctness[True-dtype1-0.1-1e-05-1-128-32-8-64] PASSED                                 [ 25%]
test/transformers/test_rope.py::test_correctness[True-dtype1-0.1-1e-05-2-128-32-8-64] PASSED                                 [ 27%]
test/transformers/test_rope.py::test_correctness[True-dtype1-0.1-1e-05-3-423-73-213-92] PASSED                               [ 30%]
test/transformers/test_rope.py::test_correctness[True-dtype1-0.1-1e-05-3-423-73-155-92] PASSED                               [ 33%]
test/transformers/test_rope.py::test_correctness[False-dtype0-1e-05-1e-05-1-128-32-32-64] PASSED                             [ 36%]
test/transformers/test_rope.py::test_correctness[False-dtype0-1e-05-1e-05-2-128-32-32-64] PASSED                             [ 38%]
test/transformers/test_rope.py::test_correctness[False-dtype0-1e-05-1e-05-1-128-32-8-64] PASSED                              [ 41%]
test/transformers/test_rope.py::test_correctness[False-dtype0-1e-05-1e-05-2-128-32-8-64] PASSED                              [ 44%]
test/transformers/test_rope.py::test_correctness[False-dtype0-1e-05-1e-05-3-423-73-213-92] PASSED                            [ 47%]
test/transformers/test_rope.py::test_correctness[False-dtype0-1e-05-1e-05-3-423-73-155-92] PASSED                            [ 50%]
test/transformers/test_rope.py::test_correctness[False-dtype1-0.1-1e-05-1-128-32-32-64] PASSED                               [ 52%]
test/transformers/test_rope.py::test_correctness[False-dtype1-0.1-1e-05-2-128-32-32-64] PASSED                               [ 55%]
test/transformers/test_rope.py::test_correctness[False-dtype1-0.1-1e-05-1-128-32-8-64] PASSED                                [ 58%]
test/transformers/test_rope.py::test_correctness[False-dtype1-0.1-1e-05-2-128-32-8-64] PASSED                                [ 61%]
test/transformers/test_rope.py::test_correctness[False-dtype1-0.1-1e-05-3-423-73-213-92] PASSED                              [ 63%]
test/transformers/test_rope.py::test_correctness[False-dtype1-0.1-1e-05-3-423-73-155-92] PASSED                              [ 66%]
test/transformers/test_rope.py::test_functional_correctness[True-dtype0-1e-05-1e-05-1-2-2-2-8] PASSED                        [ 69%]
test/transformers/test_rope.py::test_functional_correctness[True-dtype0-1e-05-1e-05-1-2-1-2-8] PASSED                        [ 72%]
test/transformers/test_rope.py::test_functional_correctness[True-dtype0-1e-05-1e-05-9-7-41-41-41] PASSED                     [ 75%]
test/transformers/test_rope.py::test_functional_correctness[True-dtype1-0.1-1e-05-1-2-2-2-8] PASSED                          [ 77%]
test/transformers/test_rope.py::test_functional_correctness[True-dtype1-0.1-1e-05-1-2-1-2-8] PASSED                          [ 80%]
test/transformers/test_rope.py::test_functional_correctness[True-dtype1-0.1-1e-05-9-7-41-41-41] PASSED                       [ 83%]
test/transformers/test_rope.py::test_functional_correctness[False-dtype0-1e-05-1e-05-1-2-2-2-8] PASSED                       [ 86%]
test/transformers/test_rope.py::test_functional_correctness[False-dtype0-1e-05-1e-05-1-2-1-2-8] PASSED                       [ 88%]
test/transformers/test_rope.py::test_functional_correctness[False-dtype0-1e-05-1e-05-9-7-41-41-41] PASSED                    [ 91%]
test/transformers/test_rope.py::test_functional_correctness[False-dtype1-0.1-1e-05-1-2-2-2-8] PASSED                         [ 94%]
test/transformers/test_rope.py::test_functional_correctness[False-dtype1-0.1-1e-05-1-2-1-2-8] PASSED                         [ 97%]
test/transformers/test_rope.py::test_functional_correctness[False-dtype1-0.1-1e-05-9-7-41-41-41] PASSED                      [100%]
```
<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
