### PR TITLE
Fix/transformers v5 gemma tokenizer

### DIFF
--- a/test/convergence/bf16/test_mini_models_multimodal.py
+++ b/test/convergence/bf16/test_mini_models_multimodal.py
@@ -8,7 +8,7 @@ import torch
 from datasets import load_dataset
 from torch.utils.data import DataLoader
 from transformers import PreTrainedTokenizerFast
-from transformers.models.gemma.tokenization_gemma_fast import GemmaTokenizerFast
+from transformers.models.gemma.tokenization_gemma import GemmaTokenizer
 from transformers.models.siglip.configuration_siglip import SiglipVisionConfig
 
 from liger_kernel.transformers import apply_liger_kernel_to_gemma3
@@ -138,7 +138,7 @@ try:
 
     from packaging import version
     from transformers.models.gemma.configuration_gemma import GemmaConfig
-    from transformers.models.gemma.tokenization_gemma_fast import GemmaTokenizerFast
+    from transformers.models.gemma.tokenization_gemma import GemmaTokenizer
     from transformers.models.gemma2.configuration_gemma2 import Gemma2Config
     from transformers.models.paligemma.configuration_paligemma import PaliGemmaConfig
     from transformers.models.paligemma.modeling_paligemma import PaliGemmaForConditionalGeneration
@@ -1020,7 +1020,7 @@ def create_processor(model_name: str):
             ]
         )
 
-        fast_tokenizer = GemmaTokenizerFast(tokenizer_object=tokenizer_base, **tokenizer_config)
+        fast_tokenizer = GemmaTokenizer(tokenizer_object=tokenizer_base, **tokenizer_config)
         image_processor = SiglipImageProcessor(size={"height": 224, "width": 224}, image_seq_length=256)
         return PaliGemmaProcessor(image_processor=image_processor, tokenizer=fast_tokenizer)
 
@@ -1040,7 +1040,7 @@ def create_processor(model_name: str):
                 )
             ]
         )
-        fast_tokenizer = GemmaTokenizerFast(tokenizer_object=tokenizer_base, **tokenizer_config)
+        fast_tokenizer = GemmaTokenizer(tokenizer_object=tokenizer_base, **tokenizer_config)
         image_processor = Gemma3ImageProcessor()
         return Gemma3Processor(image_processor=image_processor, tokenizer=fast_tokenizer)
 

--- a/test/convergence/fp32/test_mini_models_multimodal.py
+++ b/test/convergence/fp32/test_mini_models_multimodal.py
@@ -9,7 +9,7 @@ import torch
 from datasets import load_dataset
 from torch.utils.data import DataLoader
 from transformers import PreTrainedTokenizerFast
-from transformers.models.gemma.tokenization_gemma_fast import GemmaTokenizerFast
+from transformers.models.gemma.tokenization_gemma import GemmaTokenizer
 from transformers.models.siglip.configuration_siglip import SiglipVisionConfig
 
 from liger_kernel.transformers import apply_liger_kernel_to_gemma3
@@ -1157,7 +1157,7 @@ def create_processor(model_name: str):
                 )
             ]
         )
-        fast_tokenizer = GemmaTokenizerFast(tokenizer_object=tokenizer_base, **tokenizer_config)
+        fast_tokenizer = GemmaTokenizer(tokenizer_object=tokenizer_base, **tokenizer_config)
         image_processor = SiglipImageProcessor(size={"height": 224, "width": 224}, image_seq_length=256)
         return PaliGemmaProcessor(image_processor=image_processor, tokenizer=fast_tokenizer)
 
@@ -1177,7 +1177,7 @@ def create_processor(model_name: str):
                 )
             ]
         )
-        fast_tokenizer = GemmaTokenizerFast(tokenizer_object=tokenizer_base, **tokenizer_config)
+        fast_tokenizer = GemmaTokenizer(tokenizer_object=tokenizer_base, **tokenizer_config)
         image_processor = Gemma3ImageProcessor()
         return Gemma3Processor(image_processor=image_processor, tokenizer=fast_tokenizer)
 


### PR DESCRIPTION
## Summary
Update Gemma tokenizer usage in convergence tests for Transformers v5 by removing deprecated `GemmaTokenizerFast` imports and renaming usages to the supported non-fast tokenizer class. This fixes the `No module named transformers.models.gemma.tokenization_gemma_fast` error when running convergence tests under Transformers v5.

## Details
Transformers v5 moves away from parallel “fast” and “slow” tokenizer implementations and adopts a single tokenizer implementation (see [huggingface/transformers#40936](https://github.com/huggingface/transformers/pull/40936#issue-3425973764)).
- Convergence tests were importing and instantiating the fast tokenizer class, causing import errors. 
- This change updates both: 1) the import path, and 2) the tokenizer class name used in code (`GemmaTokenizerFast` → `GemmaTokenizer`), following the new Transformers v5 API. 

## Testing Done
- Hardware Type: A100-40G-PCIe
- [ ] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
