### PR TITLE
[NPU] FIX CE ub overflow on NPU

### DIFF
--- a/test/transformers/test_cross_entropy.py
+++ b/test/transformers/test_cross_entropy.py
@@ -1013,7 +1013,7 @@ def test_float32_internal():
     label_smoothing = 0.0
     lse_square_scale = 0.0
     softcap = 0.0
-    BLOCK_SIZE = 32768
+    BLOCK_SIZE = 4096 if device == "npu" else 32768
     reduction = "mean"
 
     # Initialize input tensors


### PR DESCRIPTION
Fix the UB overflow error to prevent CE test failure on NPU


Testing Done with `python -m pytest ./test/transformers/test_cross_enthopy.py -v`

Hardware Type: Atlas 800I A2(32G)

- [ ] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
