### PR TITLE
Fix pad token id issue for transformers v5 support

### DIFF
--- a/test/transformers/test_monkey_patch.py
+++ b/test/transformers/test_monkey_patch.py
@@ -779,6 +779,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_vl_moe_for_conditional_generat
                 num_experts_per_tok=2,
                 num_experts=4,
                 mlp_only_layers=[],
+                pad_token_id=None,
             ).to_dict(),
         )
         dummy_model_instance = Qwen3VLMoeForConditionalGeneration._from_config(config)
@@ -884,6 +885,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_vl_moe():
                 num_experts_per_tok=2,
                 num_experts=4,
                 mlp_only_layers=[],
+                pad_token_id=None,
             ).to_dict(),
         )
         dummy_model_instance = Qwen3VLMoeModel._from_config(config)
@@ -965,6 +967,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_vl_moe_text():
             num_experts_per_tok=2,
             num_experts=4,
             mlp_only_layers=[],
+            pad_token_id=None,
         )
         dummy_model_instance = Qwen3VLMoeTextModel._from_config(config)
 
@@ -1321,6 +1324,7 @@ def test_apply_liger_kernel_to_instance_for_llama4_for_conditional_generation():
                 num_hidden_layers=2,
                 vision_output_dim=64,
             ),
+            pad_token_id=None,
         )
         dummy_model_instance = Llama4ForConditionalGeneration._from_config(config)
 
@@ -2599,6 +2603,7 @@ def test_apply_liger_kernel_to_instance_for_glm4v():
                 "hidden_size": 32,
                 "intermediate_size": 64,
                 "hidden_act": "silu",
+                "pad_token_id": None,
             },
             vision_config={
                 "num_hidden_layers": 2,


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Fix multiple failing monkey_patch tests for transformers v5. The tests failed because of https://github.com/huggingface/transformers/pull/41541.

These changes are backward compatible.

This change fixes the following failing tests:
```
FAILED test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_vl_moe_for_conditional_generation - AttributeError: 'Qwen3VLMoeTextConfig' object has no attribute 'pad_token_id'
FAILED test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_vl_moe - AttributeError: 'Qwen3VLMoeTextConfig' object has no attribute 'pad_token_id'
FAILED test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_vl_moe_text - AttributeError: 'Qwen3VLMoeTextConfig' object has no attribute 'pad_token_id'
FAILED test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_llama4_for_conditional_generation - AttributeError: 'Llama4Config' object has no attribute 'pad_token_id'
FAILED test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_glm4v - AttributeError: 'Glm4vTextConfig' object has no attribute 'pad_token_id'
```


Fixes https://github.com/linkedin/Liger-Kernel/issues/1059.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
