### PR TITLE
Fix CLIPVisionModel hidden_states issue in Llava convergence test for transformers v5

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -620,11 +620,12 @@ def revert_liger_kernel_to_llava(model_config: MiniModelConfig):
     Revert all Liger kernel patches applied to llava.
     """
 
-    from transformers.models.clip import modeling_clip
     from transformers.models.llama import modeling_llama
     from transformers.models.llava import modeling_llava
 
-    importlib.reload(modeling_clip)
+    # Note: Do NOT reload modeling_clip as it breaks CLIPVisionModel's
+    # output_hidden_states functionality in transformers v5.
+    # Liger kernel does not patch modeling_clip when model=None.
     importlib.reload(modeling_llava)
     importlib.reload(modeling_llama)
 


### PR DESCRIPTION
Fixes https://github.com/linkedin/Liger-Kernel/issues/1011

## Summary
- Fix `TypeError: 'NoneType' object is not subscriptable` error in Llava convergence test caused by `image_outputs.hidden_states` returning `None`
- Remove unnecessary `importlib.reload(modeling_clip)` from `revert_liger_kernel_to_llava()` function

## Problem
In transformers v5, calling `importlib.reload(modeling_clip)` breaks `CLIPVisionModel`'s `output_hidden_states` functionality. When the Llava convergence test runs:

1. First run (without Liger): creates model, runs test, then calls `revert_liger_kernel_to_llava()` which reloads `modeling_clip`
2. Second run (with Liger): creates new model, but `CLIPVisionModel.forward()` now returns `hidden_states=None` even when `output_hidden_states=True` is passed

This causes the error at:
```python
selected_image_feature = image_outputs.hidden_states[vision_feature_layer]
# TypeError: 'NoneType' object is not subscriptable
```

## Solution
Remove `importlib.reload(modeling_clip)` from `revert_liger_kernel_to_llava()`. This is safe because:
- Liger kernel does not patch `modeling_clip` when `model=None` (which is the case in convergence tests)
- Only `modeling_llava` and `modeling_llama` need to be reloaded to revert Liger patches

## Test plan
- [x] `python -m pytest test/convergence/bf16/test_mini_models_multimodal.py -k llava` passes
- [x] Verified `hidden_states` is no longer `None` after the fix