### PR TITLE
Update checkstyle and fix the format issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ coverage:
 
 # Command to run ruff for linting and formatting code
 checkstyle:
-	ruff check .; ruff_check_status=$$?; \
-	ruff format --check .; ruff_format_status=$$?; \
+	ruff check --output-format=concise .; ruff_check_status=$$?; \
+	ruff format --check --diff .; ruff_format_status=$$?; \
 	ruff check . --fix; \
 	ruff format .; \
 	if [ $$ruff_check_status -ne 0 ] || [ $$ruff_format_status -ne 0 ]; then \
@@ -71,4 +71,3 @@ build:
 # Clean the output directory
 clean:
 	rm -rf $(SITE_DIR)/
-

--- a/benchmark/scripts/benchmark_fused_add_rms_norm.py
+++ b/benchmark/scripts/benchmark_fused_add_rms_norm.py
@@ -103,7 +103,7 @@ def bench_speed_fused_residual_rms_norm(input: SingleBenchmarkRunInput) -> Singl
     elif mode == "backward":
         y, s = y_fwd()
         ms_50, ms_20, ms_80 = triton.testing.do_bench(
-            lambda: (torch.autograd.backward((y, s), (dy, ds), retain_graph=True)),
+            lambda: torch.autograd.backward((y, s), (dy, ds), retain_graph=True),
             grad_to_none=[x, r],
             rep=500,
             quantiles=QUANTILES,


### PR DESCRIPTION
Summary
----------

1. I found that the benchmark_fused_add_rms_norm.py format issue led to the collective failure of CI.  fix it first.
2. The checkstyle script has been updated to enable it to display the modified logs.

Test

```
>> make checkstyle
ruff check --output-format=concise .; ruff_check_status=$?; \
        ruff format --check --diff .; ruff_format_status=$?; \
        ruff check . --fix; \
        ruff format .; \
        if [ $ruff_check_status -ne 0 ] || [ $ruff_format_status -ne 0 ]; then \
                exit 1; \
        fi
All checks passed!
--- benchmark/scripts/benchmark_fused_add_rms_norm.py
+++ benchmark/scripts/benchmark_fused_add_rms_norm.py
@@ -103,7 +103,7 @@
     elif mode == "backward":
         y, s = y_fwd()
         ms_50, ms_20, ms_80 = triton.testing.do_bench(
-            lambda: (torch.autograd.backward((y, s), (dy, ds), retain_graph=True)),
+            lambda: torch.autograd.backward((y, s), (dy, ds), retain_graph=True),
             grad_to_none=[x, r],
             rep=500,
             quantiles=QUANTILES,

1 file would be reformatted, 226 files already formatted
All checks passed!
1 file reformatted, 226 files left unchanged
make: *** [checkstyle] Error 1
```