### PR TITLE
Fix Backward Compatibility for Convergence Test

### DIFF
--- a/test/convergence/bf16/test_mini_models.py
+++ b/test/convergence/bf16/test_mini_models.py
@@ -4,8 +4,10 @@ os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # Ensure deterministic behavi
 
 import pytest
 import torch
+import transformers
 
 from datasets import load_from_disk
+from packaging import version
 from torch.utils.data import DataLoader
 from transformers.models.gemma import GemmaConfig
 from transformers.models.gemma import GemmaForCausalLM
@@ -53,6 +55,7 @@ from liger_kernel.transformers import apply_liger_kernel_to_qwen3_next
 from liger_kernel.transformers import apply_liger_kernel_to_qwen3_vl
 from liger_kernel.transformers import apply_liger_kernel_to_qwen3_vl_moe
 from liger_kernel.transformers import apply_liger_kernel_to_smollm3
+from liger_kernel.utils import infer_device
 from test.utils import DEFAULT_DATASET_PATH
 from test.utils import MiniModelConfig
 from test.utils import assert_verbose_allclose
@@ -93,9 +96,6 @@ from test.utils import revert_liger_kernel_to_smollm3
 from test.utils import set_seed
 from test.utils import simple_collate_fn
 from test.utils import supports_bfloat16
-
-import transformers
-from packaging import version
 
 IS_TRANSFORMERS_V5_OR_LATER = version.parse(transformers.__version__) >= version.parse("5.0.0")
 
@@ -312,7 +312,6 @@ try:
 except ImportError:
     EXAONE4_AVAILABLE = False
 
-from liger_kernel.utils import infer_device
 
 device = infer_device()
 
@@ -714,7 +713,9 @@ if MLLAMA_AVAILABLE:
                 original_max_position_embeddings=8192,
                 rope_type="llama3",
                 rope_theta=500_000,
-            ) if not IS_TRANSFORMERS_V5_OR_LATER else None,
+            )
+            if not IS_TRANSFORMERS_V5_OR_LATER
+            else None,
         ),
     )
 
@@ -741,9 +742,11 @@ if QWEN2_VL_AVAILABLE:
                 "num_hidden_layers": 4,  # 80
                 "num_key_value_heads": 2,  # 8
                 "rms_norm_eps": 1e-6,  # 1e-5
-                "rope_parameters": {
-                    "mrope_section": [16, 24, 24],  # (temporal, height, width)
-                },
+                **(
+                    {"rope_parameters": {"mrope_section": [16, 24, 24]}}  # (temporal, height, width)
+                    if IS_TRANSFORMERS_V5_OR_LATER
+                    else {"rope_scaling": {"type": "mrope", "mrope_section": [16, 24, 24]}}
+                ),
                 "sliding_window": 4096,
                 "tie_word_embeddings": False,
                 "use_cache": True,
@@ -792,9 +795,11 @@ if QWEN2_5_VL_AVAILABLE:
                 "num_hidden_layers": 4,  # 80
                 "num_key_value_heads": 2,  # 8
                 "rms_norm_eps": 1e-6,  # 1e-5
-                "rope_parameters": {
-                    "mrope_section": [16, 24, 24],  # (temporal, height, width)
-                },
+                **(
+                    {"rope_parameters": {"mrope_section": [16, 24, 24]}}  # (temporal, height, width)
+                    if IS_TRANSFORMERS_V5_OR_LATER
+                    else {"rope_scaling": {"type": "mrope", "mrope_section": [16, 24, 24]}}
+                ),
                 "sliding_window": 4096,
                 "tie_word_embeddings": False,
                 "use_cache": True,
@@ -852,6 +857,12 @@ if QWEN3_VL_AVAILABLE:
                 rms_norm_eps=1e-6,
                 use_cache=True,
                 vocab_size=32768,
+                rope_scaling=dict(
+                    type="mrope",
+                    mrope_section=[16, 24, 24],  # (temporal, height, width)
+                )
+                if not IS_TRANSFORMERS_V5_OR_LATER
+                else None,
             ),
             vision_config=dict(
                 depth=4,
@@ -906,6 +917,12 @@ if QWEN3_VL_MOE_AVAILABLE:
                 num_experts=4,
                 tie_word_embeddings=False,
                 mlp_only_layers=[],
+                rope_scaling=dict(
+                    type="mrope",
+                    mrope_section=[16, 24, 24],  # (temporal, height, width)
+                )
+                if not IS_TRANSFORMERS_V5_OR_LATER
+                else None,
             ).to_dict(),
             vision_config=Qwen3VLMoeVisionConfig(
                 depth=4,
@@ -1142,6 +1159,11 @@ if GLM4V_AVAILABLE:
                 "rms_norm_eps": 1e-5,
                 "vocab_size": 32000,
                 "attention_bias": True,
+                **(
+                    {"rope_scaling": {"type": "default", "mrope_section": [8, 12, 12]}}
+                    if not IS_TRANSFORMERS_V5_OR_LATER
+                    else {}
+                ),
             },
             vision_config={
                 "depth": 4,  # 32
@@ -1212,6 +1234,11 @@ if GLM4V_MOE_AVAILABLE:
                 "topk_group": 1,
                 "first_k_dense_replace": 1,
                 "norm_topk_prob": True,
+                **(
+                    {"rope_scaling": {"type": "default", "mrope_section": [8, 12, 12]}}
+                    if not IS_TRANSFORMERS_V5_OR_LATER
+                    else {}
+                ),
             },
             vision_config={
                 "depth": 4,  # 32

--- a/test/convergence/bf16/test_mini_models_multimodal.py
+++ b/test/convergence/bf16/test_mini_models_multimodal.py
@@ -4,8 +4,10 @@ import os
 os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # Ensure deterministic behavior with CuBLAS
 import pytest
 import torch
+import transformers
 
 from datasets import load_dataset
+from packaging import version
 from torch.utils.data import DataLoader
 from transformers import PreTrainedTokenizerFast
 from transformers.models.siglip.configuration_siglip import SiglipVisionConfig
@@ -21,6 +23,7 @@ from liger_kernel.transformers import apply_liger_kernel_to_qwen2_vl
 from liger_kernel.transformers import apply_liger_kernel_to_qwen3_vl
 from liger_kernel.transformers import apply_liger_kernel_to_qwen3_vl_moe
 from liger_kernel.transformers import apply_liger_kernel_to_smolvlm
+from liger_kernel.utils import infer_device
 from test.utils import FAKE_CONFIGS_PATH
 from test.utils import UNTOKENIZED_DATASET_PATH
 from test.utils import MiniModelConfig
@@ -48,20 +51,23 @@ from test.utils import set_seed
 from test.utils import supports_bfloat16
 from test.utils import train_bpe_tokenizer
 
-import transformers
-from packaging import version
+IS_TRANSFORMERS_V5_OR_LATER = version.parse(transformers.__version__) >= version.parse("5.0.0")
 
-if version.parse(transformers.__version__) < version.parse("5.0.0"):
-    from transformers.models.gemma.tokenization_gemma_fast import GemmaTokenizerFast as GemmaTokenizer
-else:
+if IS_TRANSFORMERS_V5_OR_LATER:
     from transformers.models.gemma.tokenization_gemma import GemmaTokenizer
+else:
+    from transformers.models.gemma.tokenization_gemma_fast import GemmaTokenizerFast as GemmaTokenizer
 
 try:
     # Qwen2-VL is only available in transformers>=4.52.4
     import transformers
 
     from packaging import version
-    from transformers.models.qwen2.tokenization_qwen2 import Qwen2Tokenizer
+
+    if IS_TRANSFORMERS_V5_OR_LATER:
+        from transformers.models.qwen2.tokenization_qwen2 import Qwen2Tokenizer
+    else:
+        from transformers.models.qwen2.tokenization_qwen2_fast import Qwen2TokenizerFast as Qwen2Tokenizer
     from transformers.models.qwen2_vl.configuration_qwen2_vl import Qwen2VLConfig
     from transformers.models.qwen2_vl.image_processing_qwen2_vl import Qwen2VLImageProcessor
     from transformers.models.qwen2_vl.modeling_qwen2_vl import Qwen2VLForConditionalGeneration
@@ -77,7 +83,11 @@ try:
     import transformers
 
     from packaging import version
-    from transformers.models.qwen2.tokenization_qwen2 import Qwen2Tokenizer
+
+    if IS_TRANSFORMERS_V5_OR_LATER:
+        from transformers.models.qwen2.tokenization_qwen2 import Qwen2Tokenizer
+    else:
+        from transformers.models.qwen2.tokenization_qwen2_fast import Qwen2TokenizerFast as Qwen2Tokenizer
     from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import Qwen2_5_VLConfig
     from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import Qwen2_5_VLForConditionalGeneration
     from transformers.models.qwen2_5_vl.processing_qwen2_5_vl import Qwen2_5_VLProcessor
@@ -89,7 +99,10 @@ except ImportError:
     QWEN2_5_VL_AVAILABLE = False
 
 try:
-    from transformers.models.qwen2.tokenization_qwen2 import Qwen2Tokenizer
+    if IS_TRANSFORMERS_V5_OR_LATER:
+        from transformers.models.qwen2.tokenization_qwen2 import Qwen2Tokenizer
+    else:
+        from transformers.models.qwen2.tokenization_qwen2_fast import Qwen2TokenizerFast as Qwen2Tokenizer
     from transformers.models.qwen2_vl.image_processing_qwen2_vl import Qwen2VLImageProcessor
     from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLConfig
     from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLTextConfig
@@ -215,7 +228,6 @@ try:
 except ImportError:
     NUM2WORDS_AVAILABLE = False
 
-from liger_kernel.utils import infer_device
 
 device = infer_device()
 
@@ -320,6 +332,15 @@ if MLLAMA_AVAILABLE:
                 num_hidden_layers=4,  # 40
                 num_key_value_heads=2,  # 8
                 rms_norm_eps=1e-5,
+                rope_scaling=dict(
+                    factor=8.0,
+                    high_freq_factor=4.0,
+                    low_freq_factor=1.0,
+                    original_max_position_embeddings=8192,
+                    rope_type="llama3",
+                )
+                if not IS_TRANSFORMERS_V5_OR_LATER
+                else None,
                 tie_word_embeddings=False,
                 use_cache=True,
                 vocab_size=32000,  # 128256,
@@ -497,8 +518,10 @@ if QWEN2_VL_AVAILABLE:
             num_hidden_layers=4,  # 80
             num_key_value_heads=2,  # 8
             rms_norm_eps=1e-6,  # 1e-5
-            rope_parameters=dict(
-                mrope_section=[16, 24, 24],  # (temporal, height, width)
+            **(
+                dict(rope_parameters=dict(mrope_section=[16, 24, 24]))  # (temporal, height, width)
+                if IS_TRANSFORMERS_V5_OR_LATER
+                else dict(rope_scaling=dict(type="mrope", mrope_section=[16, 24, 24]))
             ),
             sliding_window=4096,
             tie_word_embeddings=True,
@@ -669,8 +692,10 @@ if QWEN2_5_VL_AVAILABLE:
             num_hidden_layers=4,  # 80
             num_key_value_heads=2,  # 8
             rms_norm_eps=1e-6,  # 1e-5
-            rope_parameters=dict(
-                mrope_section=[16, 24, 24],  # (temporal, height, width)
+            **(
+                dict(rope_parameters=dict(mrope_section=[16, 24, 24]))  # (temporal, height, width)
+                if IS_TRANSFORMERS_V5_OR_LATER
+                else dict(rope_scaling=dict(type="mrope", mrope_section=[16, 24, 24]))
             ),
             sliding_window=4096,
             tie_word_embeddings=True,
@@ -729,6 +754,12 @@ if QWEN3_VL_AVAILABLE:
                 rms_norm_eps=1e-6,
                 use_cache=False,
                 tie_word_embeddings=True,
+                rope_scaling=dict(
+                    type="mrope",
+                    mrope_section=[16, 24, 24],  # (temporal, height, width)
+                )
+                if not IS_TRANSFORMERS_V5_OR_LATER
+                else None,
                 attention_dropout=0.0,
                 attention_bias=False,
             ).to_dict(),
@@ -776,6 +807,12 @@ if QWEN3_VL_MOE_AVAILABLE:
                 rms_norm_eps=1e-6,
                 use_cache=False,
                 tie_word_embeddings=True,
+                rope_scaling=dict(
+                    type="mrope",
+                    mrope_section=[16, 24, 24],  # (temporal, height, width)
+                )
+                if not IS_TRANSFORMERS_V5_OR_LATER
+                else None,
                 attention_dropout=0.0,
                 attention_bias=False,
                 decoder_sparse_step=1,

--- a/test/convergence/bf16/test_mini_models_with_logits.py
+++ b/test/convergence/bf16/test_mini_models_with_logits.py
@@ -4,8 +4,10 @@ os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # Ensure deterministic behavi
 
 import pytest
 import torch
+import transformers
 
 from datasets import load_from_disk
+from packaging import version
 from torch.utils.data import DataLoader
 from transformers.models.gemma import GemmaConfig
 from transformers.models.gemma import GemmaForCausalLM
@@ -52,6 +54,7 @@ from liger_kernel.transformers import apply_liger_kernel_to_qwen3_next
 from liger_kernel.transformers import apply_liger_kernel_to_qwen3_vl
 from liger_kernel.transformers import apply_liger_kernel_to_qwen3_vl_moe
 from liger_kernel.transformers import apply_liger_kernel_to_smollm3
+from liger_kernel.utils import infer_device
 from test.utils import DEFAULT_DATASET_PATH
 from test.utils import MiniModelConfig
 from test.utils import assert_verbose_allclose
@@ -91,9 +94,6 @@ from test.utils import revert_liger_kernel_to_smollm3
 from test.utils import set_seed
 from test.utils import simple_collate_fn
 from test.utils import supports_bfloat16
-
-import transformers
-from packaging import version
 
 IS_TRANSFORMERS_V5_OR_LATER = version.parse(transformers.__version__) >= version.parse("5.0.0")
 
@@ -293,8 +293,6 @@ try:
 except ImportError:
     EXAONE4_AVAILABLE = False
 
-
-from liger_kernel.utils import infer_device
 
 device = infer_device()
 
@@ -637,6 +635,12 @@ if QWEN3_VL_AVAILABLE:
                 tie_word_embeddings=False,
                 use_cache=True,
                 vocab_size=32000,
+                rope_scaling=dict(
+                    type="mrope",
+                    mrope_section=[16, 24, 24],  # (temporal, height, width)
+                )
+                if not IS_TRANSFORMERS_V5_OR_LATER
+                else None,
             ),
             vision_config=dict(
                 depth=4,
@@ -769,7 +773,9 @@ if MLLAMA_AVAILABLE:
                 original_max_position_embeddings=8192,
                 rope_type="llama3",
                 rope_theta=500_000,
-            ) if not IS_TRANSFORMERS_V5_OR_LATER else None,
+            )
+            if not IS_TRANSFORMERS_V5_OR_LATER
+            else None,
         ),
     )
 
@@ -799,8 +805,10 @@ if QWEN2_VL_AVAILABLE:
             num_hidden_layers=4,  # 80
             num_key_value_heads=2,  # 8
             rms_norm_eps=1e-6,  # 1e-5
-            rope_parameters=dict(
-                mrope_section=[16, 24, 24],  # (temporal, height, width)
+            **(
+                dict(rope_parameters=dict(mrope_section=[16, 24, 24]))  # (temporal, height, width)
+                if IS_TRANSFORMERS_V5_OR_LATER
+                else dict(rope_scaling=dict(type="mrope", mrope_section=[16, 24, 24]))
             ),
             sliding_window=4096,
             tie_word_embeddings=False,
@@ -849,8 +857,10 @@ if QWEN2_5_VL_AVAILABLE:
             num_hidden_layers=4,  # 80
             num_key_value_heads=2,  # 8
             rms_norm_eps=1e-6,  # 1e-5
-            rope_parameters=dict(
-                mrope_section=[16, 24, 24],  # (temporal, height, width)
+            **(
+                dict(rope_parameters=dict(mrope_section=[16, 24, 24]))  # (temporal, height, width)
+                if IS_TRANSFORMERS_V5_OR_LATER
+                else dict(rope_scaling=dict(type="mrope", mrope_section=[16, 24, 24]))
             ),
             sliding_window=4096,
             tie_word_embeddings=False,
@@ -1094,6 +1104,11 @@ if GLM4V_AVAILABLE:
                 "rms_norm_eps": 1e-5,
                 "vocab_size": 32000,
                 "attention_bias": True,
+                **(
+                    {"rope_scaling": {"type": "default", "mrope_section": [8, 12, 12]}}
+                    if not IS_TRANSFORMERS_V5_OR_LATER
+                    else {}
+                ),
             },
             vision_config={
                 "depth": 4,  # 32
@@ -1164,6 +1179,11 @@ if GLM4V_MOE_AVAILABLE:
                 "topk_group": 1,
                 "first_k_dense_replace": 1,
                 "norm_topk_prob": True,
+                **(
+                    {"rope_scaling": {"type": "default", "mrope_section": [8, 12, 12]}}
+                    if not IS_TRANSFORMERS_V5_OR_LATER
+                    else {}
+                ),
             },
             vision_config={
                 "depth": 4,  # 32

--- a/test/convergence/fp32/test_mini_models_multimodal.py
+++ b/test/convergence/fp32/test_mini_models_multimodal.py
@@ -5,8 +5,10 @@ os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # Ensure deterministic behavi
 
 import pytest
 import torch
+import transformers
 
 from datasets import load_dataset
+from packaging import version
 from torch.utils.data import DataLoader
 from transformers import PreTrainedTokenizerFast
 from transformers.models.siglip.configuration_siglip import SiglipVisionConfig
@@ -22,6 +24,7 @@ from liger_kernel.transformers import apply_liger_kernel_to_qwen2_vl
 from liger_kernel.transformers import apply_liger_kernel_to_qwen3_vl
 from liger_kernel.transformers import apply_liger_kernel_to_qwen3_vl_moe
 from liger_kernel.transformers import apply_liger_kernel_to_smolvlm
+from liger_kernel.utils import infer_device
 from test.utils import FAKE_CONFIGS_PATH
 from test.utils import UNTOKENIZED_DATASET_PATH
 from test.utils import MiniModelConfig
@@ -48,20 +51,23 @@ from test.utils import revert_liger_kernel_to_smolvlm2
 from test.utils import set_seed
 from test.utils import train_bpe_tokenizer
 
-import transformers
-from packaging import version
+IS_TRANSFORMERS_V5_OR_LATER = version.parse(transformers.__version__) >= version.parse("5.0.0")
 
-if version.parse(transformers.__version__) < version.parse("5.0.0"):
-    from transformers.models.gemma.tokenization_gemma_fast import GemmaTokenizerFast as GemmaTokenizer
-else:
+if IS_TRANSFORMERS_V5_OR_LATER:
     from transformers.models.gemma.tokenization_gemma import GemmaTokenizer
+else:
+    from transformers.models.gemma.tokenization_gemma_fast import GemmaTokenizerFast as GemmaTokenizer
 
 try:
     # Qwen2-VL is only available in transformers>=4.52.4
     import transformers
 
     from packaging import version
-    from transformers.models.qwen2.tokenization_qwen2 import Qwen2Tokenizer
+
+    if IS_TRANSFORMERS_V5_OR_LATER:
+        from transformers.models.qwen2.tokenization_qwen2 import Qwen2Tokenizer
+    else:
+        from transformers.models.qwen2.tokenization_qwen2_fast import Qwen2TokenizerFast as Qwen2Tokenizer
     from transformers.models.qwen2_vl.configuration_qwen2_vl import Qwen2VLConfig
     from transformers.models.qwen2_vl.image_processing_qwen2_vl import Qwen2VLImageProcessor
     from transformers.models.qwen2_vl.modeling_qwen2_vl import Qwen2VLForConditionalGeneration
@@ -77,7 +83,11 @@ try:
     import transformers
 
     from packaging import version
-    from transformers.models.qwen2.tokenization_qwen2 import Qwen2Tokenizer
+
+    if IS_TRANSFORMERS_V5_OR_LATER:
+        from transformers.models.qwen2.tokenization_qwen2 import Qwen2Tokenizer
+    else:
+        from transformers.models.qwen2.tokenization_qwen2_fast import Qwen2TokenizerFast as Qwen2Tokenizer
     from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import Qwen2_5_VLConfig
     from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import Qwen2_5_VLForConditionalGeneration
     from transformers.models.qwen2_5_vl.processing_qwen2_5_vl import Qwen2_5_VLProcessor
@@ -90,7 +100,10 @@ except ImportError:
 
 
 try:
-    from transformers.models.qwen2.tokenization_qwen2 import Qwen2Tokenizer
+    if IS_TRANSFORMERS_V5_OR_LATER:
+        from transformers.models.qwen2.tokenization_qwen2 import Qwen2Tokenizer
+    else:
+        from transformers.models.qwen2.tokenization_qwen2_fast import Qwen2TokenizerFast as Qwen2Tokenizer
     from transformers.models.qwen2_vl.image_processing_qwen2_vl import Qwen2VLImageProcessor
     from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLConfig
     from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLTextConfig
@@ -115,7 +128,10 @@ except ImportError:
     QWEN3_VL_MOE_AVAILABLE = False
 
 try:
-    from transformers.models.qwen2.tokenization_qwen2 import Qwen2Tokenizer
+    if IS_TRANSFORMERS_V5_OR_LATER:
+        from transformers.models.qwen2.tokenization_qwen2 import Qwen2Tokenizer
+    else:
+        from transformers.models.qwen2.tokenization_qwen2_fast import Qwen2TokenizerFast as Qwen2Tokenizer
     from transformers.models.qwen2_vl.image_processing_qwen2_vl import Qwen2VLImageProcessor
     from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLConfig
     from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLTextConfig
@@ -239,7 +255,6 @@ try:
 except ImportError:
     NUM2WORDS_AVAILABLE = False
 
-from liger_kernel.utils import infer_device
 
 device = infer_device()
 
@@ -345,6 +360,15 @@ if MLLAMA_AVAILABLE:
                 num_hidden_layers=4,  # 40
                 num_key_value_heads=2,  # 8
                 rms_norm_eps=1e-5,
+                rope_scaling=dict(
+                    factor=8.0,
+                    high_freq_factor=4.0,
+                    low_freq_factor=1.0,
+                    original_max_position_embeddings=8192,
+                    rope_type="llama3",
+                )
+                if not IS_TRANSFORMERS_V5_OR_LATER
+                else None,
                 tie_word_embeddings=False,
                 use_cache=True,
                 vocab_size=32000,  # 128256,
@@ -523,8 +547,10 @@ if QWEN2_VL_AVAILABLE:
             num_hidden_layers=4,  # 80
             num_key_value_heads=2,  # 8
             rms_norm_eps=1e-6,  # 1e-5
-            rope_parameters=dict(
-                mrope_section=[16, 24, 24],  # (temporal, height, width)
+            **(
+                dict(rope_parameters=dict(mrope_section=[16, 24, 24]))  # (temporal, height, width)
+                if IS_TRANSFORMERS_V5_OR_LATER
+                else dict(rope_scaling=dict(type="mrope", mrope_section=[16, 24, 24]))
             ),
             sliding_window=4096,
             tie_word_embeddings=True,
@@ -695,8 +721,10 @@ if QWEN2_5_VL_AVAILABLE:
             num_hidden_layers=4,  # 80
             num_key_value_heads=2,  # 8
             rms_norm_eps=1e-6,  # 1e-5
-            rope_parameters=dict(
-                mrope_section=[16, 24, 24],  # (temporal, height, width)
+            **(
+                dict(rope_parameters=dict(mrope_section=[16, 24, 24]))  # (temporal, height, width)
+                if IS_TRANSFORMERS_V5_OR_LATER
+                else dict(rope_scaling=dict(type="mrope", mrope_section=[16, 24, 24]))
             ),
             sliding_window=4096,
             tie_word_embeddings=True,

--- a/test/convergence/fp32/test_mini_models_with_logits.py
+++ b/test/convergence/fp32/test_mini_models_with_logits.py
@@ -4,8 +4,10 @@ os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"  # Ensure deterministic behavi
 
 import pytest
 import torch
+import transformers
 
 from datasets import load_from_disk
+from packaging import version
 from torch.utils.data import DataLoader
 from transformers.models.gemma import GemmaConfig
 from transformers.models.gemma import GemmaForCausalLM
@@ -52,6 +54,7 @@ from liger_kernel.transformers import apply_liger_kernel_to_qwen3_next
 from liger_kernel.transformers import apply_liger_kernel_to_qwen3_vl
 from liger_kernel.transformers import apply_liger_kernel_to_qwen3_vl_moe
 from liger_kernel.transformers import apply_liger_kernel_to_smollm3
+from liger_kernel.utils import infer_device
 from test.utils import DEFAULT_DATASET_PATH
 from test.utils import MiniModelConfig
 from test.utils import assert_verbose_allclose
@@ -90,9 +93,6 @@ from test.utils import revert_liger_kernel_to_qwen3_vl_moe
 from test.utils import revert_liger_kernel_to_smollm3
 from test.utils import set_seed
 from test.utils import simple_collate_fn
-
-import transformers
-from packaging import version
 
 IS_TRANSFORMERS_V5_OR_LATER = version.parse(transformers.__version__) >= version.parse("5.0.0")
 
@@ -313,8 +313,6 @@ try:
 except ImportError:
     EXAONE4_AVAILABLE = False
 
-
-from liger_kernel.utils import infer_device
 
 device = infer_device()
 
@@ -684,7 +682,9 @@ if MLLAMA_AVAILABLE:
                 original_max_position_embeddings=8192,
                 rope_type="llama3",
                 rope_theta=500_000,
-            ) if not IS_TRANSFORMERS_V5_OR_LATER else None,
+            )
+            if not IS_TRANSFORMERS_V5_OR_LATER
+            else None,
         ),
     )
 
@@ -714,8 +714,10 @@ if QWEN2_VL_AVAILABLE:
             num_hidden_layers=4,  # 80
             num_key_value_heads=2,  # 8
             rms_norm_eps=1e-6,  # 1e-5
-            rope_parameters=dict(
-                mrope_section=[16, 24, 24],  # (temporal, height, width)
+            **(
+                dict(rope_parameters=dict(mrope_section=[16, 24, 24]))  # (temporal, height, width)
+                if IS_TRANSFORMERS_V5_OR_LATER
+                else dict(rope_scaling=dict(type="mrope", mrope_section=[16, 24, 24]))
             ),
             sliding_window=4096,
             tie_word_embeddings=False,
@@ -764,8 +766,10 @@ if QWEN2_5_VL_AVAILABLE:
             num_hidden_layers=4,  # 80
             num_key_value_heads=2,  # 8
             rms_norm_eps=1e-6,  # 1e-5
-            rope_parameters=dict(
-                mrope_section=[16, 24, 24],  # (temporal, height, width)
+            **(
+                dict(rope_parameters=dict(mrope_section=[16, 24, 24]))  # (temporal, height, width)
+                if IS_TRANSFORMERS_V5_OR_LATER
+                else dict(rope_scaling=dict(type="mrope", mrope_section=[16, 24, 24]))
             ),
             sliding_window=4096,
             tie_word_embeddings=False,
@@ -823,6 +827,12 @@ if QWEN3_VL_AVAILABLE:
                 tie_word_embeddings=False,
                 use_cache=True,
                 vocab_size=32000,
+                rope_scaling=dict(
+                    type="mrope",
+                    mrope_section=[16, 24, 24],  # (temporal, height, width)
+                )
+                if not IS_TRANSFORMERS_V5_OR_LATER
+                else None,
             ),
             vision_config=dict(
                 depth=4,
@@ -1114,6 +1124,11 @@ if GLM4V_AVAILABLE:
                 "rms_norm_eps": 1e-5,
                 "vocab_size": 32000,
                 "attention_bias": True,
+                **(
+                    {"rope_scaling": {"type": "default", "mrope_section": [8, 12, 12]}}
+                    if not IS_TRANSFORMERS_V5_OR_LATER
+                    else {}
+                ),
             },
             vision_config={
                 "depth": 4,  # 32
@@ -1183,6 +1198,11 @@ if GLM4V_MOE_AVAILABLE:
                 "topk_group": 1,
                 "first_k_dense_replace": 1,
                 "norm_topk_prob": True,
+                **(
+                    {"rope_scaling": {"type": "default", "mrope_section": [8, 12, 12]}}
+                    if not IS_TRANSFORMERS_V5_OR_LATER
+                    else {}
+                ),
             },
             vision_config={
                 "depth": 4,  # 32


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
This PR restores backward compatibility for convergence tests with transformers v4 (v4.49.0 ~ v4.57.6). During the initial development phase for transformers v5 support, backward compatibility was intentionally deprioritized, leading to significant test regressions. This PR fixes those regressions while maintaining a stable foundation for the ongoing v5 integration.

## Related Issues & PRs
- #978 
- #994 

## Details

The current codebase assumes transformers v5 conventions, which broke compatibility with the v4.x series in two major areas:

1. RoPE Parameters: Some model miss some rope parameters (`rope_scaling`) since they are unified to `rope_parameters` in transformer v5.
2. Tokenizer Consistency: v5 and v4 handle the Tokenizer interfaces differently. V5's Tokenizer will select the appropriate backend, while v4's Tokenizer is the python-based implementation using SentencePiece as backend. 

Key Fixes:

- Added conditional logic to provide different rope parameters for different transformers versions.
- Enforced TokenizerFast usage for transformers < v5 to resolve interface mismatches.

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
I ran `python -m pytest test/convergence/*` on different versions of transformers on the original branch and after making changes. The result is shown below:

| Branches| v4.49.0 | v4.57.6 | v5.0.0 |
|---|---|---|---|
| transformer-5.0.0rc1 | 8 failed, 37 passed, 98 skipped, 1 warning | 42 failed, 92 passed, 9 skipped, 3 warnings| 19 failed, 115 passed, 9 skipped, 29 warnings |
| This PR | 0 failed, 45 passed, 98 skipped, 1 warning | 0 failed, 134 passed, 9 skipped, 19 warnings | 19 failed, 115 passed, 9 skipped, 29 warnings |

All of the failed tests in v5 are inspected carefully that all of them are identical to the previously thrown error.


</div></b>

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: H100
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence