### PR TITLE
fix: correct typo 'occured' to 'occurred' in test file

### DIFF
--- a/test/transformers/test_monkey_patch.py
+++ b/test/transformers/test_monkey_patch.py
@@ -449,7 +449,7 @@ def test_apply_liger_kernel_to_instance_for_llama():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_qwen3_vl_available(), reason="qwen3_vl module not available")
@@ -550,7 +550,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_vl_for_conditional_generation(
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_qwen3_vl_available(), reason="qwen3_vl module not available")
@@ -651,7 +651,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_vl():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_qwen3_vl_available(), reason="qwen3_vl module not available")
@@ -723,7 +723,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_vl_text():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_qwen3_vl_moe_available(), reason="qwen3_vl_moe module not available")
@@ -829,7 +829,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_vl_moe_for_conditional_generat
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_qwen3_vl_moe_available(), reason="qwen3_vl_moe module not available")
@@ -935,7 +935,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_vl_moe():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_qwen3_vl_moe_available(), reason="qwen3_vl_moe module not available")
@@ -1012,7 +1012,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_vl_moe_text():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_qwen3_vl_available(), reason="qwen3_vl module not available")
@@ -1087,7 +1087,7 @@ def test_apply_liger_kernel_to_falcon_h1_for_causal_lm():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.xfail(reason="'MllamaForConditionalGeneration' object has no attribute 'model'")
@@ -1189,7 +1189,7 @@ def test_apply_liger_kernel_to_instance_for_mllama_for_conditional_generation():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_mllama_available(), reason="mllama module not available")
@@ -1240,7 +1240,7 @@ def test_apply_liger_kernel_to_instance_for_mllama_for_causal_lm():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_llama4_available(), reason="llama4 module not available")
@@ -1291,7 +1291,7 @@ def test_apply_liger_kernel_to_instance_for_llama4_for_causal_lm():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_llama4_available(), reason="llama4 module not available")
@@ -1384,7 +1384,7 @@ def test_apply_liger_kernel_to_instance_for_llama4_for_conditional_generation():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(
@@ -1427,7 +1427,7 @@ def test_apply_liger_kernel_to_instance_for_mistral():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 def test_apply_liger_kernel_to_instance_for_mixtral():
@@ -1470,7 +1470,7 @@ def test_apply_liger_kernel_to_instance_for_mixtral():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 def test_apply_liger_kernel_to_instance_for_gemma():
@@ -1509,7 +1509,7 @@ def test_apply_liger_kernel_to_instance_for_gemma():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 def test_apply_liger_kernel_to_instance_for_gemma2():
@@ -1556,7 +1556,7 @@ def test_apply_liger_kernel_to_instance_for_gemma2():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.xfail(reason="'PaliGemmaForConditionalGeneration' object has no attribute 'model'")
@@ -1613,7 +1613,7 @@ def test_apply_liger_kernel_to_instance_for_paligemma():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_gemma3_available(), reason="gemma3 module not available")
@@ -1666,7 +1666,7 @@ def test_apply_liger_kernel_to_instance_for_gemma3_text():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_gemma3_available(), reason="gemma3 module not available")
@@ -1759,7 +1759,7 @@ def test_apply_liger_kernel_to_instance_for_gemma3_conditional_generation():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 def test_apply_liger_kernel_to_instance_for_qwen2():
@@ -1798,7 +1798,7 @@ def test_apply_liger_kernel_to_instance_for_qwen2():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_qwen3_available(), reason="qwen3 module not available")
@@ -1840,7 +1840,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_qwen3_available(), reason="qwen3 module not available")
@@ -1883,7 +1883,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_moe():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(
@@ -1952,7 +1952,7 @@ def test_apply_liger_kernel_to_instance_for_qwen2_vl_for_conditional_generation(
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(
@@ -2021,7 +2021,7 @@ def test_apply_liger_kernel_to_instance_for_qwen2_vl():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(
@@ -2072,7 +2072,7 @@ def test_apply_liger_kernel_to_instance_for_qwen2_vl_text():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(
@@ -2141,7 +2141,7 @@ def test_apply_liger_kernel_to_instance_for_qwen2_5_vl():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(
@@ -2210,7 +2210,7 @@ def test_apply_liger_kernel_to_instance_for_qwen2_5_vl_for_conditional_generatio
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(
@@ -2261,7 +2261,7 @@ def test_apply_liger_kernel_to_instance_for_qwen2_5_vl_text():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_internvl_available(), reason="internvl module not available")
@@ -2325,7 +2325,7 @@ def test_apply_liger_kernel_to_instance_for_internvl():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_smolvlm_available(), reason="smolvlm module not available")
@@ -2401,7 +2401,7 @@ def test_apply_liger_kernel_to_instance_for_smolvlm2():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 def test_apply_liger_kernel_to_instance_for_phi3():
@@ -2440,7 +2440,7 @@ def test_apply_liger_kernel_to_instance_for_phi3():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_olmo2_available(), reason="olmo2 module not available")
@@ -2486,7 +2486,7 @@ def test_apply_liger_kernel_to_instance_for_olmo2():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_olmo3_available(), reason="olmo3 module not available")
@@ -2532,7 +2532,7 @@ def test_apply_liger_kernel_to_instance_for_olmo3():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_glm4_available(), reason="glm4 module not available")
@@ -2578,7 +2578,7 @@ def test_apply_liger_kernel_to_instance_for_glm4():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_glm4v_available(), reason="glm4v module not available")
@@ -2647,7 +2647,7 @@ def test_apply_liger_kernel_to_instance_for_glm4v():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_glm4v_moe_available(), reason="glm4v_moe module not available")
@@ -2755,7 +2755,7 @@ def test_apply_liger_kernel_to_instance_for_glm4v_moe():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_smollm3_available(), reason="smollm3 module not available")
@@ -2796,7 +2796,7 @@ def test_apply_liger_kernel_to_instance_for_smollm3():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_qwen3_next_available(), reason="qwen3_next module not available")
@@ -2855,7 +2855,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_next():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_hunyuan_v1_available(), reason="hunyuan_v1 module not available")
@@ -2899,7 +2899,7 @@ def test_apply_liger_kernel_to_instance_for_hunyuan_v1_moe():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")
 
 
 @pytest.mark.skipif(not is_hunyuan_v1_available(), reason="hunyuan_v1_dense module not available")
@@ -2942,4 +2942,4 @@ def test_apply_liger_kernel_to_instance_for_hunyuan_v1_dense():
         try:
             print(dummy_model_instance)
         except Exception as e:
-            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+            pytest.fail(f"An exception occurred in extra_expr: {type(e).__name__} - {e}")


### PR DESCRIPTION
Fixes 40 instances of the typo 'occured' → 'occurred' in test_monkey_patch.py.