### PR TITLE
Relaxing logp relative tolerances for mini-llama4 to fix flaky test.

### DIFF
--- a/test/convergence/fp32/test_mini_models.py
+++ b/test/convergence/fp32/test_mini_models.py
@@ -1597,7 +1597,7 @@ def run_mini_model(
             1e-8,
             1e-5,
             5e-3,
-            1e-5,
+            1e-3,
             5e-3,
             1e-5,
             marks=pytest.mark.skipif(


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Relaxing logp relative tolerances for mini-llama4 to fix flaky test.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
Unit testing.

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
