### PR TITLE
[NPU]Fix  OOM in benchmark_tvd on NPU

### DIFF
--- a/benchmark/scripts/benchmark_tvd.py
+++ b/benchmark/scripts/benchmark_tvd.py
@@ -114,8 +114,10 @@ if __name__ == "__main__":
     # We know that the full test will require 66GBs for vocab size 2^17
     if gpu_memory_gbs >= 66:
         x_max = 17
-    else:
+    elif gpu_memory_gbs >= 32:
         x_max = 16
+    else:
+        x_max = 15
     common_args = {
         "kernel_name": "tvd",
         "x_name": "V",


### PR DESCRIPTION
## Summary
`benchmark_tvd.py` can fail with an OOM error on Atlas 800I A2 (32GB) because of exceeding the available NPU global memory.This change addresses the issue and prevents the benchmark from exceeding device memory capacity.

## Testing Done
Atlas 800I A2(32GB)

- [ ] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
