### PR TITLE
[NPU]:rms_norm kernel employs two-dimensional tensors

### DIFF
--- a/src/liger_kernel/ops/backends/_ascend/ops/rms_norm.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/rms_norm.py
@@ -23,7 +23,7 @@ def torch_dtype_to_triton(dtype):
 
 
 # -----------------------------------------------------------------------------
-# Forward Kernel - No Tiling (for n_cols < 2048)
+# Forward Kernel - No Tiling (for n_cols <= 2048)
 # -----------------------------------------------------------------------------
 
 
@@ -36,22 +36,24 @@ def _rms_norm_forward_kernel_no_tiling(
     W_ptr,
     RSTD_ptr,
     RSTD_row_stride,
-    n_rows,
-    n_cols,
+    n_rows: tl.constexpr,
+    n_cols: tl.constexpr,
     eps,
     offset,
     casting_mode: tl.constexpr,
     elementwise_affine: tl.constexpr,
     X_DTYPE: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
 ):
     """
     NPU-optimized rms_norm forward kernel for small n_cols (< 2048).
 
-    This kernel loads entire rows without column tiling:
-    1. Each program handles multiple rows using grid-stride loop
-    2. For each row, load the entire row at once (no column chunking)
-    3. Grid size is limited to NPU core count to avoid resource overflow
+    Performance optimizations:
+    1. Use 2D vector loading to maximize UB utilization (e.g., (1,2048), (2,1024), (4,512))
+    2. Process multiple rows at once using 2D indexing
+    3. Keep data in registers, minimize conversions
+    4. Use optimal cache policies
 
     Used when n_cols < 2048 to avoid the overhead of column blocking.
     """
@@ -62,69 +64,78 @@ def _rms_norm_forward_kernel_no_tiling(
         eps = eps.to(X_DTYPE)
         offset = offset.to(X_DTYPE)
 
-    # Load entire row at once
-    col_offsets = tl.arange(0, BLOCK_SIZE)
-    mask = col_offsets < n_cols
+    # Grid-stride loop setup for 2D blocks
+    grid_stride = num_progs * BLOCK_SIZE_M
+    num_iterations = tl.cdiv(n_rows, grid_stride)
 
-    # Grid-stride loop over rows
-    for row_idx in tl.range(pid, n_rows, num_progs):
-        Y_row_ptr = Y_ptr + row_idx * Y_row_stride
-        X_row_ptr = X_ptr + row_idx * X_row_stride
-        RSTD_row_ptr = RSTD_ptr + row_idx * RSTD_row_stride
+    col_offsets = tl.arange(0, BLOCK_SIZE_N)
+    col_mask = col_offsets < n_cols
+    row_offsets = tl.arange(0, BLOCK_SIZE_M)
 
-        # Load entire row
-        X_row = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0, eviction_policy="evict_first")
+    if elementwise_affine:
+        W_row = tl.load(W_ptr + col_offsets, mask=col_mask, other=0.0)
 
+    # Grid-stride loop over row blocks
+    for i in range(num_iterations):
+        row_idx = i * grid_stride + pid * BLOCK_SIZE_M + row_offsets
+        row_mask = row_idx < n_rows
+        block_mask = row_mask[:, None] & col_mask[None, :]
+
+        # Load multiple rows at once using 2D indexing
+        X_rows = tl.load(
+            X_ptr + row_idx[:, None] * X_row_stride + col_offsets[None, :],
+            mask=block_mask,
+            other=0.0,
+            eviction_policy="evict_first",
+        )
+
+        # Compute sum_square for all rows
         if casting_mode == _CASTING_MODE_LLAMA or casting_mode == _CASTING_MODE_GEMMA:
-            X_row = X_row.to(tl.float32)
+            X_rows = X_rows.to(tl.float32)
 
-        # Compute sum of squares for the entire row
-        sum_square = tl.sum(tl.where(mask, X_row * X_row, 0.0))
+        sum_squares = tl.sum(tl.where(block_mask, X_rows * X_rows, 0.0), axis=1)
 
-        # Compute rstd for this row
-        mean_square = sum_square / n_cols
-        rstd = rsqrt(mean_square + eps)
+        # Compute rstd for all rows
+        mean_squares = sum_squares / n_cols
+        rstd_rows = rsqrt(mean_squares + eps)
 
-        # Store rstd
-        tl.store(RSTD_row_ptr, rstd)
-
-        # Load row again for normalization
-        X_row = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0, cache_modifier=".ca")
-
-        if elementwise_affine:
-            W_row = tl.load(W_ptr + col_offsets, mask=mask, other=0.0)
+        # Store rstd_rows
+        tl.store(RSTD_ptr + row_idx * RSTD_row_stride, rstd_rows, mask=row_mask)
 
         # Apply casting based on mode
         if casting_mode == _CASTING_MODE_GEMMA:
-            X_row = X_row.to(tl.float32)
+            X_rows = X_rows.to(tl.float32)
             if elementwise_affine:
-                W_row = W_row.to(tl.float32)
+                W_row_fp32 = W_row.to(tl.float32)
         elif casting_mode == _CASTING_MODE_LLAMA:
-            X_row = X_row.to(tl.float32)
+            X_rows = X_rows.to(tl.float32)
 
         # Normalize
-        X_row = X_row * rstd
+        X_rows = X_rows * rstd_rows[:, None]
 
         # Cast back for Llama mode before weight multiplication
         if casting_mode == _CASTING_MODE_LLAMA:
-            X_row = X_row.to(X_DTYPE)
+            X_rows = X_rows.to(X_DTYPE)
 
         # Apply weight
         if elementwise_affine:
-            Y_row = X_row * (offset + W_row)
+            if casting_mode == _CASTING_MODE_GEMMA:
+                Y_rows = X_rows * (offset + W_row_fp32[None, :])
+            else:
+                Y_rows = X_rows * (offset + W_row[None, :])
         else:
-            Y_row = X_row
+            Y_rows = X_rows
 
         # Cast back for Gemma mode
         if casting_mode == _CASTING_MODE_GEMMA:
-            Y_row = Y_row.to(X_DTYPE)
+            Y_rows = Y_rows.to(X_DTYPE)
 
-        # Store result
-        tl.store(Y_row_ptr + col_offsets, Y_row, mask=mask)
+        # Store results
+        tl.store(Y_ptr + row_idx[:, None] * Y_row_stride + col_offsets[None, :], Y_rows, mask=block_mask)
 
 
 # -----------------------------------------------------------------------------
-# Forward Kernel - With Tiling (for n_cols >= 2048)
+# Forward Kernel - With Tiling (for n_cols > 2048)
 # -----------------------------------------------------------------------------
 
 
@@ -137,8 +148,8 @@ def _rms_norm_forward_kernel_tiled(
     W_ptr,
     RSTD_ptr,
     RSTD_row_stride,
-    n_rows,
-    n_cols,
+    n_rows: tl.constexpr,
+    n_cols: tl.constexpr,
     eps,
     offset,
     casting_mode: tl.constexpr,
@@ -240,7 +251,7 @@ def _rms_norm_forward_kernel_tiled(
 
 
 # -----------------------------------------------------------------------------
-# Backward Kernel - No Tiling (for n_cols < 2048)
+# Backward Kernel - No Tiling (for n_cols <= 2048)
 # -----------------------------------------------------------------------------
 
 
@@ -258,95 +269,109 @@ def _rms_norm_backward_kernel_no_tiling(
     RSTD_row_stride,
     dW_ptr,
     dW_row_stride,
-    n_rows,
-    n_cols,
+    n_rows: tl.constexpr,
+    n_cols: tl.constexpr,
     offset,
     casting_mode: tl.constexpr,
     elementwise_affine: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
 ):
     """
     NPU-optimized rms_norm backward kernel for small n_cols (< 2048).
 
-    Each program processes multiple rows using grid-stride loop.
-    For each row, load the entire row at once without column tiling.
+    Performance optimizations:
+    1. Keep all data in registers, minimize conversions
+    2. Reuse X_normalized (X * rstd) for both dX and dW
+    3. Optimize computation order to reduce register pressure
+    4. Combine operations where possible
+    5. Use 2D vector loading to maximize UB utilization (e.g., (1,2048), (2,1024), (4,512))
     """
     pid = tl.program_id(0)
     num_progs = tl.num_programs(0)
 
-    # Load entire row at once
-    col_offsets = tl.arange(0, BLOCK_SIZE)
-    mask = col_offsets < n_cols
+    # Grid-stride loop setup for 2D blocks
+    grid_stride = num_progs * BLOCK_SIZE_M
+    num_iterations = tl.cdiv(n_rows, grid_stride)
 
-    # Grid-stride loop over rows
-    for row_idx in tl.range(pid, n_rows, num_progs):
-        # Base pointers for this row
-        dY_row_ptr = dY_ptr + row_idx * dY_row_stride
-        dX_row_ptr = dX_ptr + row_idx * dX_row_stride
-        X_row_ptr = X_ptr + row_idx * X_row_stride
-        RSTD_row_ptr = RSTD_ptr + row_idx * RSTD_row_stride
+    col_offsets = tl.arange(0, BLOCK_SIZE_N)
+    col_mask = col_offsets < n_cols
+    row_offsets = tl.arange(0, BLOCK_SIZE_M)
 
-        # Load rstd for this row
-        rstd = tl.load(RSTD_row_ptr)
+    # Load W once for all iterations
+    if elementwise_affine:
+        W_row = tl.load(W_ptr + col_offsets, mask=col_mask, other=0.0)
+        W_offset = W_row + offset
 
-        # Load entire row
-        dY_row = tl.load(dY_row_ptr + col_offsets, mask=mask, other=0.0, eviction_policy="evict_first")
-        X_row = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0, eviction_policy="evict_first")
+    # Grid-stride loop over row blocks
+    for i in range(num_iterations):
+        row_idx = i * grid_stride + pid * BLOCK_SIZE_M + row_offsets
+        row_mask = row_idx < n_rows
+        block_mask = row_mask[:, None] & col_mask[None, :]
 
-        # Convert to fp32 for computation
-        X_row = X_row.to(tl.float32)
+        dY_rows = tl.load(
+            dY_ptr + row_idx[:, None] * dY_row_stride + col_offsets[None, :],
+            mask=block_mask,
+            other=0.0,
+            eviction_policy="evict_first",
+        )
+        X_rows = tl.load(
+            X_ptr + row_idx[:, None] * X_row_stride + col_offsets[None, :],
+            mask=block_mask,
+            other=0.0,
+            eviction_policy="evict_first",
+        )
 
+        # Load rstd for all rows in the block
+        rstd_rows = tl.load(RSTD_ptr + row_idx * RSTD_row_stride, mask=row_mask, other=0.0)
+
+        # Convert X to fp32 once
+        X_rows = X_rows.to(tl.float32)
+
+        # Compute X_normalized (reused in dX and dW)
+        X_normalized = X_rows * rstd_rows[:, None]
+
+        # Compute m based on casting mode and elementwise_affine
         if elementwise_affine:
-            W_row = tl.load(W_ptr + col_offsets, mask=mask, other=0.0, eviction_policy="evict_first")
-            W_offset = W_row + offset
-
-            # Compute m based on casting mode
             if casting_mode == _CASTING_MODE_LLAMA:
-                m = (dY_row * W_offset).to(tl.float32)
+                m_rows = (dY_rows * W_offset[None, :]).to(tl.float32)
+                # For dW in Llama mode, we need X_normalized in original dtype
+                X_normalized = X_normalized.to(X_dtype)
             elif casting_mode == _CASTING_MODE_GEMMA:
-                dY_row_fp32 = dY_row.to(tl.float32)
-                m = dY_row_fp32 * W_offset
+                m_rows = dY_rows.to(tl.float32) * W_offset[None, :]
             else:
-                m = dY_row * W_offset
+                m_rows = dY_rows * W_offset[None, :]
         else:
-            # Compute m based on casting mode
-            if casting_mode == _CASTING_MODE_LLAMA:
-                m = dY_row.to(tl.float32)
-            elif casting_mode == _CASTING_MODE_GEMMA:
-                m = dY_row.to(tl.float32)
+            if casting_mode == _CASTING_MODE_LLAMA or casting_mode == _CASTING_MODE_GEMMA:
+                m_rows = dY_rows.to(tl.float32)
             else:
-                m = dY_row
+                m_rows = dY_rows
 
-        # Compute sum(m * X) for the correction term
-        sum_m_X = tl.sum(tl.where(mask, m * X_row, 0.0))
+        # Compute sum(m * X) for correction factor
+        sum_m_X = tl.sum(tl.where(block_mask, m_rows * X_rows, 0.0), axis=1)
 
-        # Compute the correction factor
-        correction_factor = -(1.0 / n_cols) * rstd * rstd * sum_m_X
+        # Compute correction factor
+        correction_factors = -(1.0 / n_cols) * rstd_rows * rstd_rows * sum_m_X
 
-        # Compute dX
-        dX_row = rstd * m + rstd * correction_factor * X_row
+        # Compute dX = rstd * m + rstd * correction_factor * X
+        dX_rows = rstd_rows[:, None] * m_rows + rstd_rows[:, None] * correction_factors[:, None] * X_rows
 
         # Store dX
-        tl.store(dX_row_ptr + col_offsets, dX_row.to(X_dtype), mask=mask)
+        tl.store(dX_ptr + row_idx[:, None] * dX_row_stride + col_offsets[None, :], dX_rows.to(X_dtype), mask=block_mask)
 
         if elementwise_affine:
-            # Compute dW contribution (accumulate per program)
-            if casting_mode == _CASTING_MODE_LLAMA:
-                dW_row = dY_row * (X_row * rstd).to(X_dtype)
-            else:
-                dW_row = dY_row * (X_row * rstd)
+            # Compute dW contribution: dY * X_normalized
+            dW_rows = (dY_rows * X_normalized).to(tl.float32)
 
-            # Atomic add to dW_ptr (each program writes to its own row)
+            # Accumulate to per-program dW buffer
             dW_row_ptr = dW_ptr + pid * dW_row_stride
-
-            # Load existing dW, add contribution, store back
-            existing_dW = tl.load(dW_row_ptr + col_offsets, mask=mask, other=0.0)
-            new_dW = existing_dW + dW_row.to(tl.float32)
-            tl.store(dW_row_ptr + col_offsets, new_dW, mask=mask)
+            existing_dW = tl.load(dW_row_ptr + col_offsets, mask=col_mask, other=0.0)
+            new_dW = existing_dW + tl.sum(tl.where(block_mask, dW_rows, 0.0), axis=0)
+            tl.store(dW_row_ptr + col_offsets, new_dW, mask=col_mask)
 
 
 # -----------------------------------------------------------------------------
-# Backward Kernel - With Tiling (for n_cols >= 2048)
+# Backward Kernel - With Tiling (for n_cols > 2048)
 # -----------------------------------------------------------------------------
 
 
@@ -364,8 +389,8 @@ def _rms_norm_backward_kernel_tiled(
     RSTD_row_stride,
     dW_ptr,
     dW_row_stride,
-    n_rows,
-    n_cols,
+    n_rows: tl.constexpr,
+    n_cols: tl.constexpr,
     offset,
     casting_mode: tl.constexpr,
     elementwise_affine: tl.constexpr,
@@ -563,6 +588,7 @@ def rms_norm_forward(X, W, eps, offset, casting_mode):
 
     # Get optimal block size for column processing
     BLOCK_SIZE = get_optimal_block_size(n_cols, True)
+    BLOCK_SIZE_M = 2048 // BLOCK_SIZE
 
     Y = torch.empty((n_rows, n_cols), dtype=X.dtype, device=X.device)
 
@@ -599,7 +625,8 @@ def rms_norm_forward(X, W, eps, offset, casting_mode):
             casting_mode,
             elementwise_affine,
             X_DTYPE,
-            BLOCK_SIZE=BLOCK_SIZE,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE,
         )
     else:
         # Use tiled kernel for large n_cols
@@ -636,6 +663,7 @@ def rms_norm_backward(dY, X, W, RSTD, offset, casting_mode, in_place):
 
     # Get optimal block size for backward pass
     BLOCK_SIZE = get_optimal_block_size(n_cols, False)
+    BLOCK_SIZE_M = 2048 // BLOCK_SIZE
 
     if W is not None:
         # fp32 for numerical stability
@@ -671,7 +699,8 @@ def rms_norm_backward(dY, X, W, RSTD, offset, casting_mode, in_place):
             offset,
             casting_mode,
             elementwise_affine,
-            BLOCK_SIZE=BLOCK_SIZE,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE,
         )
     else:
         # Use tiled kernel for large n_cols


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Since the tile size is smaller, we can process mulitple rows at once for each programs. Use 2D vector loading to maximize UB utilization (e.g., (1,2048), (2,1024), (4,512)). Processing multiple rows at once --> less iterations --> shorter runtime
<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
<img width="1112" height="388" alt="image" src="https://github.com/user-attachments/assets/79d47b7d-21c1-4e6d-8bcf-e86021538b8e" />

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: Atlas 800I A2
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
