### PR TITLE
Prevent FLCE backward when `reduction="none"`

### DIFF
--- a/src/liger_kernel/ops/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_cross_entropy.py
@@ -219,11 +219,6 @@ def fused_linear_cross_entropy_forward(
                 alpha=1.0,
             )
 
-    # Need extra calculations for backward if reduction=='none'. Not supporting reduction='none' now.
-    # if reduction == "none":
-    #     loss = loss_1d
-    #     z_loss = z_loss_1d if return_z_loss else None
-
     if reduction == "none":
         # Return per-token losses
         loss = loss_1d
@@ -245,6 +240,8 @@ def fused_linear_cross_entropy_forward(
 
 
 def fused_linear_cross_entropy_backward(grad_output, grad_input, grad_weight, grad_bias):
+    # Need extra calculations for backward if reduction=='none'. Not supporting reduction='none' now.
+    assert grad_output.ndim == 0, 'Backward unsupported for reduction="none"'
     # If cross entropy is the last layer, grad_output is 1.0. Skip the mul to save time
     if not torch.equal(grad_output, torch.tensor(1.0, device=grad_output.device)):
         # We use a Triton kernel instead of a PyTorch operation because modifying inputs in-place


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->

This PR adds an assertion to prevent the backward pass of FLCE (fused linear cross-entropy loss) from being invoked when `reduction="none"`. This unsupported functionality was previously discussed in https://github.com/linkedin/Liger-Kernel/issues/968. This PR also trims some out-of-date text from an existing comment about this functionality gap, and relocates the rest of the comment from the forward pass to the site of the assertion.

## Testing Done

I was unable to test this PR according to the contributor guidelines. I saw numerous failures with `make test` and `make test-convergence`, and didn't try to debug them. Thus I am leaving this as a **Draft PR**.

- Hardware Type: H100-80GB-HBM3
- [ ] run `make test` to ensure correctness
- [X] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence