### PR TITLE
Add FSDP support to TiledMLP

### DIFF
--- a/src/liger_kernel/ops/tiled_mlp.py
+++ b/src/liger_kernel/ops/tiled_mlp.py
@@ -78,19 +78,27 @@ class LigerTiledMLPFunction(torch.autograd.Function):
 
         x_shards = list(torch.chunk(x, chunks=shards, dim=0))
 
+        # Recompute every shard first, then run a single backward over all of them.
+        # Per-shard backward is incompatible with FSDP: the first shard's backward
+        # triggers resharding, so later shards recompute against flat local shards.
+        all_outputs = []
+        all_incoming_grads = []
+        shard_offset = 0
         for i, x_shard in enumerate(x_shards):
             x_shard.requires_grad_(x_requires_grad)
 
-            # if seqlen is not exactly divisible by shards the last step will be shorter than shard_step
             shard_step = x_shards[i].shape[0]
-            shard_offset = i * x_shards[0].shape[0]
-
-            x_shard.grad = x_grad.narrow(0, shard_offset, shard_step).view_as(x_shard)
             incoming_grad_shard = incoming_grad.narrow(0, shard_offset, shard_step).view_as(x_shard)
 
+            x_shard.grad = x_grad.narrow(0, shard_offset, shard_step).view_as(x_shard)
+
             with torch.enable_grad():
-                output = fn(mlp_module, x_shard)
-            torch.autograd.backward(output, incoming_grad_shard)
+                all_outputs.append(fn(mlp_module, x_shard))
+            all_incoming_grads.append(incoming_grad_shard)
+
+            shard_offset += shard_step
+
+        torch.autograd.backward(all_outputs, all_incoming_grads)
 
         # unflatten
         x_grad = x_grad.view(x_shape_orig)

--- a/src/liger_kernel/ops/tiled_mlp.py
+++ b/src/liger_kernel/ops/tiled_mlp.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import torch
 
+from liger_kernel.ops.utils import GradientAccumulator
 from liger_kernel.ops.utils import ensure_contiguous
 
 
@@ -44,6 +45,7 @@ class LigerTiledMLPFunction(torch.autograd.Function):
         ctx.fn = fn
         ctx.mlp_module = mlp_module
         ctx.shards = shards
+        ctx.compute_params = compute_params
         ctx.save_for_backward(x)
 
         # x.shape could be [bs, seqlen, hidden_size] or [seqlen, hidden_size] (moe experts)
@@ -61,6 +63,9 @@ class LigerTiledMLPFunction(torch.autograd.Function):
         (x,) = ctx.saved_tensors
         mlp_module = ctx.mlp_module
         shards = ctx.shards
+        compute_params = ctx.compute_params
+        if compute_params is None:
+            compute_params = list(mlp_module.parameters())
 
         x_requires_grad = x.requires_grad
         x = x.detach()
@@ -74,26 +79,42 @@ class LigerTiledMLPFunction(torch.autograd.Function):
         # flatten bs+seqlen to avoid having stride issues when narrowing into seqlen w/ bs>1
         x = x.view(-1, hidden_size)
         incoming_grad = grads[0].view(-1, hidden_size)
-        x_grad = torch.zeros_like(x)
+        x_grad = torch.zeros_like(x) if x_requires_grad else None
+
+        for param in compute_params:
+            if param.grad is not None:
+                param.grad = None
+
+        grad_accumulator = GradientAccumulator(compute_params)
+        grad_accumulator.install_hooks()
 
         x_shards = list(torch.chunk(x, chunks=shards, dim=0))
-
+        all_outputs = []
+        all_incoming_grads = []
+        shard_offset = 0
         for i, x_shard in enumerate(x_shards):
             x_shard.requires_grad_(x_requires_grad)
 
             # if seqlen is not exactly divisible by shards the last step will be shorter than shard_step
             shard_step = x_shards[i].shape[0]
-            shard_offset = i * x_shards[0].shape[0]
-
-            x_shard.grad = x_grad.narrow(0, shard_offset, shard_step).view_as(x_shard)
             incoming_grad_shard = incoming_grad.narrow(0, shard_offset, shard_step).view_as(x_shard)
 
-            with torch.enable_grad():
-                output = fn(mlp_module, x_shard)
-            torch.autograd.backward(output, incoming_grad_shard)
+            if x_grad is not None:
+                x_shard.grad = x_grad.narrow(0, shard_offset, shard_step).view_as(x_shard)
 
-        # unflatten
-        x_grad = x_grad.view(x_shape_orig)
+            with torch.enable_grad():
+                all_outputs.append(fn(mlp_module, x_shard))
+            all_incoming_grads.append(incoming_grad_shard)
+
+            shard_offset += shard_step
+
+        torch.autograd.backward(all_outputs, all_incoming_grads)
+
+        grad_accumulator.finalize_gradients()
+        grad_accumulator.cleanup()
+
+        if x_grad is not None:
+            x_grad = x_grad.view(x_shape_orig)
 
         return (None, None, x_grad, None, None)
 

--- a/src/liger_kernel/ops/utils.py
+++ b/src/liger_kernel/ops/utils.py
@@ -13,9 +13,12 @@ Modifications made by Yanning Chen, 2024.
 import functools
 import importlib
 import operator
+import threading
 
 from contextlib import contextmanager
 from typing import Callable
+from typing import List
+from typing import Optional
 
 import torch
 import triton
@@ -151,6 +154,57 @@ def get_npu_core_count(default: int = 20) -> int:
         return int(props.get("num_vectorcore", default))
     except Exception:
         return default
+
+
+class GradientAccumulator:
+    """
+    Hook-based gradient accumulator for TiledMLP (Axolotl pattern).
+
+    Reference:
+    https://github.com/axolotl-ai-cloud/axolotl/blob/main/src/axolotl/monkeypatch/tiled_mlp/base.py
+    """
+
+    def __init__(
+        self,
+        params: List[torch.nn.Parameter],
+        dtype: Optional[torch.dtype] = None,
+    ):
+        self.params = [p for p in params if p.requires_grad]
+        self.grad_accumulation_dtype = dtype or torch.float32
+        self.accumulated_grads = {}
+        self.hooks = []
+        self.lock = threading.Lock()
+
+        for param in self.params:
+            if param.grad is not None:
+                self.accumulated_grads[param] = param.grad.to(self.grad_accumulation_dtype)
+                param.grad = None
+            else:
+                self.accumulated_grads[param] = torch.zeros_like(
+                    param, dtype=self.grad_accumulation_dtype
+                )
+
+    def install_hooks(self):
+        def create_hook(param):
+            def hook(grad):
+                with self.lock:
+                    self.accumulated_grads[param] += grad.to(self.grad_accumulation_dtype)
+                    return None
+
+            return hook
+
+        for param in self.params:
+            self.hooks.append(param.register_hook(create_hook(param)))
+
+    def finalize_gradients(self):
+        for param in self.params:
+            param.grad = self.accumulated_grads[param].to(param.dtype)
+
+    def cleanup(self):
+        for hook in self.hooks:
+            hook.remove()
+        self.hooks.clear()
+        del self.accumulated_grads
 
 
 def set_large_grf_mode(kernel_args: dict):

--- a/test/transformers/test_tiled_mlp.py
+++ b/test/transformers/test_tiled_mlp.py
@@ -1,5 +1,9 @@
+import tempfile
+
 import pytest
 import torch
+import torch.multiprocessing as mp
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
 from test.utils import supports_bfloat16
 from transformers.models.llama.configuration_llama import LlamaConfig
@@ -195,3 +199,147 @@ def test_tiled_swiglu_correctness(
         )
 
     torch.testing.assert_close(x1.grad, x2.grad, atol=atol, rtol=rtol, msg="Input gradients don't match")
+
+
+class _TorchSwiGLUMLP(torch.nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.gate_proj = torch.nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
+        self.up_proj = torch.nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
+        self.down_proj = torch.nn.Linear(config.intermediate_size, config.hidden_size, bias=False)
+
+    def forward(self, x):
+        return self.down_proj(torch.nn.functional.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class _TorchGEGLUMLP(torch.nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.gate_proj = torch.nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
+        self.up_proj = torch.nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
+        self.down_proj = torch.nn.Linear(config.intermediate_size, config.hidden_size, bias=False)
+
+    def forward(self, x):
+        return self.down_proj(
+            torch.nn.functional.gelu(self.gate_proj(x), approximate="tanh") * self.up_proj(x)
+        )
+
+
+def _test_fsdp_tiled_vs_torch(
+    rank,
+    world_size,
+    bsz,
+    seq_len,
+    hidden_size,
+    intermediate_size,
+    num_shards,
+    activation,
+    dtype,
+    atol,
+    rtol,
+    file_name,
+):
+    torch.distributed.init_process_group(
+        backend="nccl",
+        init_method=f"file://{file_name}",
+        rank=rank,
+        world_size=world_size,
+    )
+    torch.cuda.set_device(rank)
+    device = f"cuda:{rank}"
+
+    if activation == "swiglu":
+        config = LlamaConfig(hidden_size=hidden_size, intermediate_size=intermediate_size, hidden_act="silu")
+        tiled_cls = LigerTiledSwiGLUMLP
+        torch_cls = _TorchSwiGLUMLP
+    else:
+        config = LlamaConfig(
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            hidden_act="gelu_pytorch_tanh",
+        )
+        tiled_cls = LigerTiledGEGLUMLP
+        torch_cls = _TorchGEGLUMLP
+
+    torch.manual_seed(42)
+    G = torch.randn(intermediate_size, hidden_size, device=device, dtype=dtype)
+    U = torch.randn(intermediate_size, hidden_size, device=device, dtype=dtype)
+    D = torch.randn(hidden_size, intermediate_size, device=device, dtype=dtype)
+    for t in (G, U, D):
+        torch.distributed.broadcast(t, src=0)
+
+    tiled_model = tiled_cls(config=config, num_shards=num_shards).to(device).to(dtype)
+    tiled_model.gate_proj.weight.data = G.clone()
+    tiled_model.up_proj.weight.data = U.clone()
+    tiled_model.down_proj.weight.data = D.clone()
+    tiled_model = FSDP(tiled_model, use_orig_params=True)
+
+    torch_model = torch_cls(config=config).to(device).to(dtype)
+    torch_model.gate_proj.weight.data = G.clone()
+    torch_model.up_proj.weight.data = U.clone()
+    torch_model.down_proj.weight.data = D.clone()
+    torch_model = FSDP(torch_model, use_orig_params=True)
+
+    torch.manual_seed(123)
+    x = torch.randn(bsz, seq_len, hidden_size, device=device, dtype=dtype) * 0.1
+    x_tiled = x.clone().requires_grad_(True)
+    x_ref = x.clone().requires_grad_(True)
+
+    out_tiled = tiled_model(x_tiled)
+    out_ref = torch_model(x_ref)
+    torch.testing.assert_close(
+        out_tiled, out_ref, atol=atol, rtol=rtol, msg=f"Rank {rank}: forward outputs don't match"
+    )
+
+    out_tiled.sum().backward()
+    out_ref.sum().backward()
+    torch.testing.assert_close(
+        x_tiled.grad, x_ref.grad, atol=atol, rtol=rtol, msg=f"Rank {rank}: input gradients don't match"
+    )
+
+    with FSDP.summon_full_params(tiled_model, with_grads=True), FSDP.summon_full_params(
+        torch_model, with_grads=True
+    ):
+        for i, (p_tiled, p_ref) in enumerate(zip(tiled_model.parameters(), torch_model.parameters())):
+            if p_tiled.grad is not None and p_ref.grad is not None:
+                torch.testing.assert_close(
+                    p_tiled.grad,
+                    p_ref.grad,
+                    atol=atol,
+                    rtol=rtol,
+                    msg=f"Rank {rank}: parameter {i} gradients don't match",
+                )
+
+    torch.distributed.destroy_process_group()
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires at least 2 GPUs")
+@pytest.mark.parametrize("world_size", [ws for ws in [2, 4, 8] if ws <= torch.cuda.device_count()])
+@pytest.mark.parametrize("num_shards", [2, 4])
+@pytest.mark.parametrize("activation", ["swiglu", "geglu"])
+@pytest.mark.parametrize(
+    "bsz, seq_len, hidden_size, intermediate_size",
+    [(2, 512, 128, 256)],
+)
+def test_fsdp_tiled_mlp_matches_torch(world_size, num_shards, activation, bsz, seq_len, hidden_size, intermediate_size):
+    """TiledMLP + FSDP should match a torch MLP baseline on forward and all gradients."""
+    atol, rtol = 1e-3, 1e-3
+    with tempfile.NamedTemporaryFile() as f:
+        mp.spawn(
+            _test_fsdp_tiled_vs_torch,
+            args=(
+                world_size,
+                bsz,
+                seq_len,
+                hidden_size,
+                intermediate_size,
+                num_shards,
+                activation,
+                torch.float32,
+                atol,
+                rtol,
+                f.name,
+            ),
+            nprocs=world_size,
+            join=True,
+        )

--- a/test/transformers/test_tiled_mlp.py
+++ b/test/transformers/test_tiled_mlp.py
@@ -1,16 +1,36 @@
+import tempfile
+
 import pytest
 import torch
+import torch.multiprocessing as mp
 
 from test.utils import supports_bfloat16
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from transformers.models.llama.configuration_llama import LlamaConfig
+from transformers.models.llama.modeling_llama import LlamaMLP
 
 from liger_kernel.transformers.geglu import LigerGEGLUMLP
 from liger_kernel.transformers.swiglu import LigerSwiGLUMLP
 from liger_kernel.transformers.tiled_mlp import LigerTiledGEGLUMLP
 from liger_kernel.transformers.tiled_mlp import LigerTiledSwiGLUMLP
+from liger_kernel.utils import infer_comm_backend
 from liger_kernel.utils import infer_device
 
 device = infer_device()
+
+_NDEV = torch.cuda.device_count() if torch.cuda.is_available() else 0
+
+
+def _need_gpus(n):
+    return pytest.mark.skipif(_NDEV < n, reason=f"requires {n} GPUs")
+
+
+# HuggingFace LlamaMLP is the torch reference used by test_swiglu / test_geglu.
+# silu → SwiGLU, gelu_pytorch_tanh → GEGLU.
+_FSDP_MLP_KINDS = {
+    "swiglu": {"hidden_act": "silu", "tiled_cls": LigerTiledSwiGLUMLP},
+    "geglu": {"hidden_act": "gelu_pytorch_tanh", "tiled_cls": LigerTiledGEGLUMLP},
+}
 
 
 @pytest.mark.parametrize(
@@ -195,3 +215,99 @@ def test_tiled_swiglu_correctness(
         )
 
     torch.testing.assert_close(x1.grad, x2.grad, atol=atol, rtol=rtol, msg="Input gradients don't match")
+
+
+def _test_fsdp_tiled_mlp(
+    rank, world_size, mlp_kind, num_shards, bsz, seq_len, hidden_size, intermediate_size, file_name
+):
+    """FSDP-wrapped TiledMLP vs FSDP-wrapped HuggingFace LlamaMLP (torch).
+
+    Issue #893: tiled backward must not reshard FSDP params between sequence
+    tiles. Matching *parameter* grads (via summon_full_params) is the actual
+    regression; input grads can still agree when shard grads are wrong.
+    """
+    torch.distributed.init_process_group(
+        backend=infer_comm_backend(),
+        init_method=f"file://{file_name}",
+        rank=rank,
+        world_size=world_size,
+    )
+    torch.cuda.set_device(rank)
+    device = f"cuda:{rank}"
+
+    spec = _FSDP_MLP_KINDS[mlp_kind]
+    config = LlamaConfig(hidden_size=hidden_size, intermediate_size=intermediate_size, hidden_act=spec["hidden_act"])
+    dtype = torch.float32
+    atol, rtol = 1e-3, 1e-3
+
+    torch.manual_seed(42)
+    G = torch.randn(intermediate_size, hidden_size, device=device, dtype=dtype)
+    U = torch.randn(intermediate_size, hidden_size, device=device, dtype=dtype)
+    D = torch.randn(hidden_size, intermediate_size, device=device, dtype=dtype)
+    for t in (G, U, D):
+        torch.distributed.broadcast(t, src=0)
+
+    tiled_model = spec["tiled_cls"](config=config, num_shards=num_shards).to(device).to(dtype)
+    ref_model = LlamaMLP(config=config).to(device).to(dtype)
+    for model in (tiled_model, ref_model):
+        model.gate_proj.weight.data = G.clone()
+        model.up_proj.weight.data = U.clone()
+        model.down_proj.weight.data = D.clone()
+    tiled_model = FSDP(tiled_model, use_orig_params=True, device_id=rank)
+    ref_model = FSDP(ref_model, use_orig_params=True, device_id=rank)
+
+    torch.manual_seed(123)
+    x = torch.randn(bsz, seq_len, hidden_size, device=device, dtype=dtype) * 0.1
+    torch.distributed.broadcast(x, src=0)
+    x_tiled = x.clone().requires_grad_(True)
+    x_ref = x.clone().requires_grad_(True)
+
+    out_tiled = tiled_model(x_tiled)
+    out_ref = ref_model(x_ref)
+    torch.testing.assert_close(
+        out_tiled, out_ref, atol=atol, rtol=rtol, msg=f"Rank {rank}: forward outputs don't match"
+    )
+
+    out_tiled.sum().backward()
+    out_ref.sum().backward()
+    torch.testing.assert_close(
+        x_tiled.grad, x_ref.grad, atol=atol, rtol=rtol, msg=f"Rank {rank}: input gradients don't match"
+    )
+
+    with FSDP.summon_full_params(tiled_model, with_grads=True), FSDP.summon_full_params(ref_model, with_grads=True):
+        for i, (p_tiled, p_ref) in enumerate(zip(tiled_model.parameters(), ref_model.parameters())):
+            assert p_tiled.grad is not None, f"Rank {rank}: tiled param {i} has no grad"
+            assert p_ref.grad is not None, f"Rank {rank}: ref param {i} has no grad"
+            torch.testing.assert_close(
+                p_tiled.grad,
+                p_ref.grad,
+                atol=atol,
+                rtol=rtol,
+                msg=f"Rank {rank}: parameter {i} gradients don't match",
+            )
+
+    torch.distributed.destroy_process_group()
+
+
+@pytest.mark.skipif(_NDEV < 2, reason="requires at least 2 GPUs")
+@pytest.mark.parametrize("mlp_kind", ["swiglu", "geglu"])
+@pytest.mark.parametrize(
+    "world_size, num_shards, bsz, seq_len, hidden_size, intermediate_size",
+    [
+        pytest.param(2, 2, 2, 512, 128, 256, id="2gpu-2shards-even"),
+        pytest.param(2, 4, 2, 127, 128, 256, id="2gpu-4shards-ragged"),
+        pytest.param(4, 2, 2, 512, 128, 256, id="4gpu-2shards-even", marks=_need_gpus(4)),
+        pytest.param(4, 4, 2, 255, 256, 512, id="4gpu-4shards-ragged", marks=_need_gpus(4)),
+        pytest.param(8, 2, 2, 512, 128, 256, id="8gpu-2shards-even", marks=_need_gpus(8)),
+        pytest.param(8, 4, 2, 511, 256, 512, id="8gpu-4shards-ragged", marks=_need_gpus(8)),
+    ],
+)
+def test_fsdp_tiled_mlp(mlp_kind, world_size, num_shards, bsz, seq_len, hidden_size, intermediate_size):
+    """TiledMLP + FSDP must match HuggingFace LlamaMLP (torch) on forward, input grads, and param grads."""
+    with tempfile.NamedTemporaryFile() as f:
+        mp.spawn(
+            _test_fsdp_tiled_mlp,
+            args=(world_size, mlp_kind, num_shards, bsz, seq_len, hidden_size, intermediate_size, f.name),
+            nprocs=world_size,
+            join=True,
+        )


### PR DESCRIPTION
## Summary
- Fix TiledMLP backward under FSDP (#893, #935): per-tile `backward()` reshards parameters mid-loop.
- Accumulate shard grads with `GradientAccumulator`, then run one `autograd.backward` after all tiles.
- Regression vs HuggingFace `LlamaMLP` at 2/4/8 GPUs, including parameter grads.

## Commits
- `feat(ops): add GradientAccumulator for tiled MLP shard grads` — Axolotl-style hook accumulator for per-shard param grads.
- `fix(tiled_mlp): FSDP-safe tiled backward via GradientAccumulator` — single batched backward so FSDP does not reshard between tiles.
- `test(tiled_mlp): FSDP regression vs HuggingFace LlamaMLP` — SwiGLU/GEGLU vs LlamaMLP under FSDP; skip 4/8 GPU if missing.

## Diff
3 files, **+200 / −9**.

## Test plan
- [x] `pytest test/transformers/test_tiled_mlp.py` (single GPU: FSDP cases skip)
- [x] 2× RTX 3060: 4 FSDP cases passed; 4- and 8-GPU skipped
- [x] `make checkstyle`