### PR TITLE
[NPU] Add Ascend NPU CI status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,11 @@ loss.backward()
                     <img src="https://github.com/linkedin/Liger-Kernel/actions/workflows/intel-ci.yml/badge.svg?branch=main&event=push" alt="Build">
                 </a>
             </div>
+            <div style="display: block;">
+                <a href="https://github.com/xuedinge233/Liger-Kernel/actions/workflows/ascend_npu_ci.yml">
+                    <img src="https://github.com/xuedinge233/Liger-Kernel/actions/workflows/ascend_npu_ci.yml/badge.svg?branch=main" alt="Build">
+                </a>
+            </div>
         </td>
     </tr>
 </table>


### PR DESCRIPTION
Summary
-----------
Due to the self-hosted runner permission issue, the test workflow of Ascend NPU cannot be pushed upstream for the time being (https://github.com/linkedin/Liger-Kernel/issues/1022). Now it is placed in the fork repository for running, and echo the test results to the upstream README.

Source workflow file
----------
https://github.com/xuedinge233/Liger-Kernel/blob/main/.github/workflows/ascend_npu_ci.yml