### PR TITLE
[Test]: Fix test imports to use package-level ops imports

### DIFF
--- a/test/transformers/test_cross_entropy.py
+++ b/test/transformers/test_cross_entropy.py
@@ -7,7 +7,7 @@ from test.utils import set_seed
 from test.utils import supports_bfloat16
 from torch.nn import CrossEntropyLoss
 
-from liger_kernel.ops.cross_entropy import LigerCrossEntropyFunction
+from liger_kernel.ops import LigerCrossEntropyFunction
 from liger_kernel.ops.cross_entropy import liger_cross_entropy_kernel
 from liger_kernel.ops.utils import is_hip
 from liger_kernel.transformers.cross_entropy import LigerCrossEntropyLoss

--- a/test/transformers/test_dyt.py
+++ b/test/transformers/test_dyt.py
@@ -6,7 +6,7 @@ from test.utils import infer_device
 from test.utils import set_seed
 from test.utils import supports_bfloat16
 
-from liger_kernel.ops.dyt import LigerDyTFunction
+from liger_kernel.ops import LigerDyTFunction
 from liger_kernel.transformers.dyt import LigerDyT
 from liger_kernel.transformers.functional import liger_dyt
 

--- a/test/transformers/test_fused_add_rms_norm.py
+++ b/test/transformers/test_fused_add_rms_norm.py
@@ -8,7 +8,7 @@ from test.utils import assert_verbose_allclose
 from test.utils import set_seed
 from test.utils import supports_bfloat16
 
-from liger_kernel.ops.fused_add_rms_norm import LigerFusedAddRMSNormFunction
+from liger_kernel.ops import LigerFusedAddRMSNormFunction
 from liger_kernel.transformers.functional import liger_fused_add_rms_norm
 from liger_kernel.transformers.fused_add_rms_norm import LigerFusedAddRMSNorm
 from liger_kernel.utils import infer_device

--- a/test/transformers/test_fused_linear_cross_entropy.py
+++ b/test/transformers/test_fused_linear_cross_entropy.py
@@ -7,7 +7,7 @@ from test.transformers.test_cross_entropy import CrossEntropyWithZLoss
 from test.utils import assert_verbose_allclose
 from test.utils import set_seed
 
-from liger_kernel.ops.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyFunction
+from liger_kernel.ops import LigerFusedLinearCrossEntropyFunction
 from liger_kernel.transformers.functional import CrossEntropyOutput
 from liger_kernel.transformers.functional import liger_fused_linear_cross_entropy
 from liger_kernel.transformers.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyLoss

--- a/test/transformers/test_fused_linear_jsd.py
+++ b/test/transformers/test_fused_linear_jsd.py
@@ -5,7 +5,7 @@ from test.transformers.test_jsd import JSD as TorchJSD
 from test.utils import assert_verbose_allclose
 from test.utils import set_seed
 
-from liger_kernel.ops.fused_linear_jsd import LigerFusedLinearJSDFunction
+from liger_kernel.ops import LigerFusedLinearJSDFunction
 from liger_kernel.transformers.functional import liger_fused_linear_jsd
 from liger_kernel.transformers.fused_linear_jsd import LigerFusedLinearJSD
 from liger_kernel.utils import infer_device

--- a/test/transformers/test_geglu.py
+++ b/test/transformers/test_geglu.py
@@ -7,7 +7,7 @@ from test.utils import supports_bfloat16
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaMLP
 
-from liger_kernel.ops.geglu import LigerGELUMulFunction
+from liger_kernel.ops import LigerGELUMulFunction
 from liger_kernel.transformers.functional import liger_geglu
 from liger_kernel.transformers.geglu import LigerGEGLUMLP
 from liger_kernel.utils import infer_device

--- a/test/transformers/test_layer_norm.py
+++ b/test/transformers/test_layer_norm.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from liger_kernel.ops.layer_norm import LigerLayerNormFunction
+from liger_kernel.ops import LigerLayerNormFunction
 from liger_kernel.transformers.functional import liger_layer_norm
 from liger_kernel.transformers.layer_norm import LigerLayerNorm
 from liger_kernel.utils import infer_device

--- a/test/transformers/test_poly_norm.py
+++ b/test/transformers/test_poly_norm.py
@@ -8,7 +8,7 @@ from test.utils import assert_verbose_allclose
 from test.utils import set_seed
 from test.utils import supports_bfloat16
 
-from liger_kernel.ops.poly_norm import LigerPolyNormFunction
+from liger_kernel.ops import LigerPolyNormFunction
 from liger_kernel.transformers.functional import liger_poly_norm
 from liger_kernel.transformers.poly_norm import LigerPolyNorm
 from liger_kernel.utils import infer_device

--- a/test/transformers/test_qwen2vl_mrope.py
+++ b/test/transformers/test_qwen2vl_mrope.py
@@ -12,7 +12,7 @@ try:
 except Exception:
     IS_QWEN_AVAILABLE = False
 
-from liger_kernel.ops.qwen2vl_mrope import LigerQwen2VLMRopeFunction
+from liger_kernel.ops import LigerQwen2VLMRopeFunction
 from liger_kernel.transformers.functional import liger_qwen2vl_mrope
 from liger_kernel.transformers.qwen2vl_mrope import liger_multimodal_rotary_pos_emb
 from liger_kernel.utils import infer_device

--- a/test/transformers/test_rms_norm.py
+++ b/test/transformers/test_rms_norm.py
@@ -10,7 +10,7 @@ from test.utils import assert_verbose_allclose
 from test.utils import set_seed
 from test.utils import supports_bfloat16
 
-from liger_kernel.ops.rms_norm import LigerRMSNormFunction
+from liger_kernel.ops import LigerRMSNormFunction
 from liger_kernel.transformers.functional import liger_rms_norm
 from liger_kernel.transformers.rms_norm import LigerRMSNorm
 from liger_kernel.utils import infer_comm_backend

--- a/test/transformers/test_rope.py
+++ b/test/transformers/test_rope.py
@@ -6,7 +6,7 @@ from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding
 from transformers.models.llama.modeling_llama import apply_rotary_pos_emb
 
-from liger_kernel.ops.rope import LigerRopeFunction
+from liger_kernel.ops import LigerRopeFunction
 from liger_kernel.transformers.functional import liger_rope
 from liger_kernel.transformers.rope import liger_rotary_pos_emb
 from liger_kernel.utils import infer_device

--- a/test/transformers/test_swiglu.py
+++ b/test/transformers/test_swiglu.py
@@ -13,7 +13,7 @@ from transformers.models.mixtral.configuration_mixtral import MixtralConfig
 from transformers.models.phi3.configuration_phi3 import Phi3Config
 from transformers.models.phi3.modeling_phi3 import Phi3MLP
 
-from liger_kernel.ops.swiglu import LigerSiLUMulFunction
+from liger_kernel.ops import LigerSiLUMulFunction
 from liger_kernel.transformers.functional import liger_swiglu
 from liger_kernel.transformers.swiglu import LigerBlockSparseTop2MLP
 from liger_kernel.transformers.swiglu import LigerExperts


### PR DESCRIPTION
Import Function classes from `liger_kernel.ops` instead of submodules (e.g., `liger_kernel.ops.geglu`) so that vendor-specific replacements (Ascend NPU, etc.) are applied correctly via the dispatch mechanism in ops/__init__.py.

Hardware Type: Atlas 800I A2
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
