### PR TITLE
[NPU]:Fix the reference issue of the dyt operator.

### DIFF
--- a/src/liger_kernel/ops/backends/_ascend/ops/__init__.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/__init__.py
@@ -14,12 +14,12 @@ To add a new operator:
 If __all__ is not defined, all public symbols will be auto-discovered.
 """
 
-from liger_kernel.ops.backends._ascend.ops.embedding import LigerDyTFunction
+from liger_kernel.ops.backends._ascend.ops.dyt import LigerDyTFunction
+from liger_kernel.ops.backends._ascend.ops.dyt import liger_dyt_bwd
+from liger_kernel.ops.backends._ascend.ops.dyt import liger_dyt_fwd
 from liger_kernel.ops.backends._ascend.ops.embedding import LigerEmbeddingFunction
 from liger_kernel.ops.backends._ascend.ops.embedding import embedding_backward
 from liger_kernel.ops.backends._ascend.ops.embedding import embedding_forward
-from liger_kernel.ops.backends._ascend.ops.embedding import liger_dyt_bwd
-from liger_kernel.ops.backends._ascend.ops.embedding import liger_dyt_fwd
 from liger_kernel.ops.backends._ascend.ops.fused_add_rms_norm import LigerFusedAddRMSNormFunction
 from liger_kernel.ops.backends._ascend.ops.fused_add_rms_norm import fused_add_rms_norm_backward
 from liger_kernel.ops.backends._ascend.ops.fused_add_rms_norm import fused_add_rms_norm_forward


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Fixed the reference issue of the dyt operator, which could lead to incorrect invocation of the original GPU operator implementation on the NPU device.
<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
<img width="908" height="516" alt="image" src="https://github.com/user-attachments/assets/e3ab45a9-d62e-4bdf-8311-861b0625ecba" />

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: Atlas 800I A2
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
