### PR TITLE
[NPU]:Adding the single_block strategy to the softmax operator

### DIFF
--- a/src/liger_kernel/ops/backends/_ascend/ops/softmax.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/softmax.py
@@ -7,13 +7,69 @@ from liger_kernel.ops.utils import get_npu_core_count
 
 
 @triton.jit
+def _softmax_single_block_forward_kernel(
+    Y_ptr,
+    Y_row_stride,
+    X_ptr,
+    X_row_stride,
+    n_rows: tl.constexpr,
+    n_cols: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    ROWS_PER_BLOCK: tl.constexpr,
+):
+    """
+    Single-block softmax forward kernel for small column sizes.
+
+    Processes entire row in one block when n_cols <= BLOCK_SIZE.
+    Uses 2D tensor to process multiple rows simultaneously for better UB utilization.
+
+    Args:
+        Y_ptr: Output tensor pointer
+        Y_row_stride: Stride for output rows
+        X_ptr: Input tensor pointer
+        X_row_stride: Stride for input rows
+        n_rows: Number of rows to process
+        n_cols: Number of columns per row
+        BLOCK_SIZE: Block size for column processing
+        ROWS_PER_BLOCK: Number of rows to process simultaneously
+    """
+    row_block_start = tl.program_id(0) * ROWS_PER_BLOCK
+    row_block_step = tl.num_programs(0) * ROWS_PER_BLOCK
+
+    row_offsets = tl.arange(0, ROWS_PER_BLOCK)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+
+    for row_block_idx in tl.range(row_block_start, n_rows, row_block_step):
+        row_idx = row_block_idx + row_offsets
+        row_mask = row_idx < n_rows
+        col_mask = col_offsets < n_cols
+
+        # 2D mask: [ROWS_PER_BLOCK, BLOCK_SIZE]
+        mask = row_mask[:, None] & col_mask[None, :]
+
+        # Load 2D block: [ROWS_PER_BLOCK, BLOCK_SIZE]
+        offsets = row_idx[:, None] * X_row_stride + col_offsets[None, :]
+        x = tl.load(X_ptr + offsets, mask=mask, other=float("-inf"))
+
+        # Compute softmax per row (axis=1)
+        m = tl.max(x, axis=1)
+        e = tl.exp(x - m[:, None])
+        d = tl.sum(e, axis=1)
+        y = e / d[:, None]
+
+        # Store 2D block
+        offsets = row_idx[:, None] * Y_row_stride + col_offsets[None, :]
+        tl.store(Y_ptr + offsets, y, mask=mask)
+
+
+@triton.jit
 def _softmax_multi_block_forward_kernel(
     Y_ptr,
     Y_row_stride,
     X_ptr,
     X_row_stride,
-    n_rows,
-    n_cols,
+    n_rows: tl.constexpr,
+    n_cols: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
     """
@@ -33,12 +89,12 @@ def _softmax_multi_block_forward_kernel(
     """
     row_start = tl.program_id(0)
     row_step = tl.num_programs(0)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
 
     for row_idx in tl.range(row_start, n_rows, row_step):
         row_start_ptr = X_ptr + row_idx * X_row_stride
-        col_offsets = tl.arange(0, BLOCK_SIZE)
-        m = float("-inf")
-        d = 0.0
+        m = tl.float32(float("-inf"))
+        d = tl.float32(0.0)
 
         for start in tl.range(0, n_cols, BLOCK_SIZE):
             idx = start + col_offsets
@@ -62,6 +118,67 @@ def _softmax_multi_block_forward_kernel(
 
 
 @triton.jit
+def _softmax_single_block_backward_kernel(
+    dy_ptr,
+    dy_stride,
+    y_ptr,
+    y_stride,
+    dx_ptr,
+    dx_stride,
+    n_rows: tl.constexpr,
+    n_cols: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    ROWS_PER_BLOCK: tl.constexpr,
+):
+    """
+    Single-block softmax backward kernel for small column sizes.
+
+    Computes gradient: dx = y * (dy - sum(dy * y))
+    Uses 2D tensor to process multiple rows simultaneously for better UB utilization.
+
+    Args:
+        dy_ptr: Gradient output pointer
+        dy_stride: Stride for gradient output rows
+        y_ptr: Forward output pointer
+        y_stride: Stride for forward output rows
+        dx_ptr: Gradient input pointer
+        dx_stride: Stride for gradient input rows
+        n_rows: Number of rows to process
+        n_cols: Number of columns per row
+        BLOCK_SIZE: Block size for column processing
+        ROWS_PER_BLOCK: Number of rows to process simultaneously
+    """
+    row_block_start = tl.program_id(0) * ROWS_PER_BLOCK
+    row_block_step = tl.num_programs(0) * ROWS_PER_BLOCK
+
+    row_offsets = tl.arange(0, ROWS_PER_BLOCK)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+
+    for row_block_idx in tl.range(row_block_start, n_rows, row_block_step):
+        row_idx = row_block_idx + row_offsets
+        row_mask = row_idx < n_rows
+        col_mask = col_offsets < n_cols
+
+        # 2D mask: [ROWS_PER_BLOCK, BLOCK_SIZE]
+        mask = row_mask[:, None] & col_mask[None, :]
+
+        # Load 2D blocks: [ROWS_PER_BLOCK, BLOCK_SIZE]
+        dy_offsets = row_idx[:, None] * dy_stride + col_offsets[None, :]
+        y_offsets = row_idx[:, None] * y_stride + col_offsets[None, :]
+
+        dy = tl.load(dy_ptr + dy_offsets, mask=mask, other=0.0)
+        y = tl.load(y_ptr + y_offsets, mask=mask, other=0.0)
+
+        # Compute dot product per row (axis=1)
+        dot = tl.sum(dy * y, axis=1)
+        dx = y * (dy - dot[:, None])
+
+        # Store 2D block
+        dx_offsets = row_idx[:, None] * dx_stride + col_offsets[None, :]
+        tl.store(dx_ptr + dx_offsets, dx, mask=mask)
+
+
+@triton.jit
 def _softmax_multi_block_backward_kernel(
     dy_ptr,
     dy_stride,
@@ -69,8 +186,8 @@ def _softmax_multi_block_backward_kernel(
     y_stride,
     dx_ptr,
     dx_stride,
-    n_rows,
-    n_cols,
+    n_rows: tl.constexpr,
+    n_cols: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
     """
@@ -127,19 +244,39 @@ def softmax_forward(x):
 
     y2d = torch.empty_like(x2d)
     num_cores = get_npu_core_count()
-    num_programs = min(num_cores, n_rows)
 
-    _softmax_multi_block_forward_kernel[(num_programs,)](
-        y2d, y2d.stride(0), x2d, x2d.stride(0), n_rows, n_cols, BLOCK_SIZE=BLOCK_SIZE
-    )
+    if n_cols <= BLOCK_SIZE:
+        # Calculate optimal ROWS_PER_BLOCK to utilize UB efficiently
+        # Target: ROWS_PER_BLOCK * BLOCK_SIZE <= MAX_FUSED_BLOCK_SIZE
+        ROWS_PER_BLOCK = min(MAX_FUSED_BLOCK_SIZE // BLOCK_SIZE, 32)
+        ROWS_PER_BLOCK = triton.next_power_of_2(ROWS_PER_BLOCK)
 
-    return y2d.view(*batch, n_cols), BLOCK_SIZE
+        # Calculate number of programs needed
+        num_row_blocks = (n_rows + ROWS_PER_BLOCK - 1) // ROWS_PER_BLOCK
+        num_programs = min(num_cores, num_row_blocks)
+
+        _softmax_single_block_forward_kernel[(num_programs,)](
+            y2d, y2d.stride(0), x2d, x2d.stride(0), n_rows, n_cols, BLOCK_SIZE=BLOCK_SIZE, ROWS_PER_BLOCK=ROWS_PER_BLOCK
+        )
+        multi_block_launch = False
+    else:
+        num_programs = min(num_cores, n_rows)
+        ROWS_PER_BLOCK = 1  # Not used in multi-block
+
+        _softmax_multi_block_forward_kernel[(num_programs,)](
+            y2d, y2d.stride(0), x2d, x2d.stride(0), n_rows, n_cols, BLOCK_SIZE=BLOCK_SIZE
+        )
+        multi_block_launch = True
+
+    return y2d.view(*batch, n_cols), BLOCK_SIZE, ROWS_PER_BLOCK, multi_block_launch
 
 
 def softmax_backward(
     dy: torch.Tensor,
     y: torch.Tensor,
     BLOCK_SIZE: int,
+    ROWS_PER_BLOCK: int,
+    multi_block_launch: bool,
 ) -> torch.Tensor:
     *batch, n_cols = dy.shape
     dy2d = dy.contiguous().view(-1, n_cols)
@@ -148,19 +285,36 @@ def softmax_backward(
     dx2d = torch.empty_like(dy2d)
 
     num_cores = get_npu_core_count()
-    num_programs = min(num_cores, n_rows)
 
-    _softmax_multi_block_backward_kernel[(num_programs,)](
-        dy2d,
-        dy2d.stride(0),
-        y2d,
-        y2d.stride(0),
-        dx2d,
-        dx2d.stride(0),
-        n_rows,
-        n_cols,
-        BLOCK_SIZE=BLOCK_SIZE,
-    )
+    if not multi_block_launch and n_cols <= BLOCK_SIZE:
+        num_row_blocks = (n_rows + ROWS_PER_BLOCK - 1) // ROWS_PER_BLOCK
+        num_programs = min(num_cores, num_row_blocks)
+        _softmax_single_block_backward_kernel[(num_programs,)](
+            dy2d,
+            dy2d.stride(0),
+            y2d,
+            y2d.stride(0),
+            dx2d,
+            dx2d.stride(0),
+            n_rows,
+            n_cols,
+            BLOCK_SIZE=BLOCK_SIZE,
+            ROWS_PER_BLOCK=ROWS_PER_BLOCK,
+        )
+    else:
+        num_programs = min(num_cores, n_rows)
+
+        _softmax_multi_block_backward_kernel[(num_programs,)](
+            dy2d,
+            dy2d.stride(0),
+            y2d,
+            y2d.stride(0),
+            dx2d,
+            dx2d.stride(0),
+            n_rows,
+            n_cols,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
 
     return dx2d.view(*batch, n_cols)
 
@@ -169,9 +323,11 @@ class LigerSoftmaxFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
     def forward(ctx, input_: torch.Tensor):
-        y, BLOCK_SIZE = softmax_forward(input_)
+        y, BLOCK_SIZE, ROWS_PER_BLOCK, multi_block_launch = softmax_forward(input_)
         ctx.save_for_backward(y)
         ctx.BLOCK_SIZE = BLOCK_SIZE
+        ctx.ROWS_PER_BLOCK = ROWS_PER_BLOCK
+        ctx.multi_block_launch = multi_block_launch
         return y
 
     @staticmethod
@@ -182,5 +338,7 @@ class LigerSoftmaxFunction(torch.autograd.Function):
             grad_output,
             y,
             ctx.BLOCK_SIZE,
+            ctx.ROWS_PER_BLOCK,
+            ctx.multi_block_launch,
         )
         return dx


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Add single-block softmax kernel for small column sizes: 
    Processes entire row in one block when n_cols <= BLOCK_SIZE.
    Uses 2D tensor to process multiple rows simultaneously for better UB utilization.
The modified version has a performance improvement of about 50% compared to the original. However, it still has a gap compared to HuggingFace. We will continue to conduct research in the future.
<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
<img width="870" height="612" alt="image" src="https://github.com/user-attachments/assets/c8354b15-1d8c-4572-9461-3006250acc76" />

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: Atlas 800I A2
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
