### PR TITLE
Add mm_token_type_ids to qwen3_5_moe lce_forward

### DIFF
--- a/src/liger_kernel/transformers/model/qwen3_5_moe.py
+++ b/src/liger_kernel/transformers/model/qwen3_5_moe.py
@@ -27,6 +27,7 @@ def lce_forward(
     output_attentions: Optional[bool] = None,
     output_hidden_states: Optional[bool] = None,
     output_router_logits: Optional[bool] = None,
+    mm_token_type_ids: Optional[torch.IntTensor] = None,
     cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
     skip_logits: Optional[bool] = None,
@@ -84,6 +85,7 @@ def lce_forward(
         output_attentions=output_attentions,
         output_hidden_states=output_hidden_states,
         output_router_logits=output_router_logits,
+        mm_token_type_ids=mm_token_type_ids,
         cache_position=cache_position,
         **kwargs,
     )


### PR DESCRIPTION
## Summary

This PR fixes the `lce_forward` function for qwen3_5_moe model, adding support for `mm_token_type_ids` optional parameter related to multimodal processing.

Follow-up to:
- #1120
- #1109

This fixes a ValueError in `model.generate()` with transformers > 5.2.0, after they merged:
- https://github.com/huggingface/transformers/pull/43972

See related issue downstream in TRL:
- https://github.com/huggingface/trl/issues/5216
- https://github.com/huggingface/trl/issues/5201

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
