### PR TITLE
[NPU]:Resolve the ub overflow issue of the kl_div operator

### DIFF
--- a/src/liger_kernel/ops/backends/_ascend/ops/kl_div.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/kl_div.py
@@ -147,6 +147,7 @@ def get_optimal_block_size(
     n_rows,
     dtype_size,
     BLOCK_SIZE_N: tl.constexpr,
+    log_target: bool = False,
     is_backward: bool = False,
     is_scalar_grad_output: bool = True,
 ):
@@ -160,7 +161,7 @@ def get_optimal_block_size(
     if is_backward:
         multiplier = 2.5 if is_scalar_grad_output else 3.0
     else:
-        multiplier = 3.0
+        multiplier = 3.0 if log_target else 6.0
 
     # For bf16/fp16 (dtype_size < 4), compile-time UB overflow was observed on some shapes.
     # Clamp to fp32 size for a conservative tiling estimate; this can be refined later.
@@ -191,7 +192,7 @@ def kldiv_forward_triton(y_pred, y_true, log_target, reduction, eps):  # [BT, V]
     output_tensor = torch.zeros(out_size, device=y_pred.device, dtype=torch.float32)
 
     BLOCK_SIZE_N = triton.next_power_of_2(min(128, V))
-    BLOCK_SIZE_M = get_optimal_block_size(BT, y_pred.element_size(), BLOCK_SIZE_N)
+    BLOCK_SIZE_M = get_optimal_block_size(BT, y_pred.element_size(), BLOCK_SIZE_N, log_target=log_target)
     num_cores = get_npu_core_count()
     total_blocks = triton.cdiv(BT, BLOCK_SIZE_M) * triton.cdiv(V, BLOCK_SIZE_N)
     grid = min(num_cores, total_blocks)
@@ -235,6 +236,7 @@ def kldiv_backward_triton(target, grad_output, new_grads, log_target, reduction)
         BT,
         target.element_size(),
         BLOCK_SIZE_N,
+        log_target=log_target,
         is_backward=True,
         is_scalar_grad_output=is_scalar_grad_output,
     )


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
In the original code, the calculation logic is different when log_target is true or false, and the occupied ub is also different. Therefore, using a single logic to calculate the block size is inaccurate and will lead to ub overflow when log_target is false, because at this time, the ub occupies more space. So, we take log_target as a judgment condition when calculating ub.
<img width="865" height="166" alt="image" src="https://github.com/user-attachments/assets/c4818019-7491-4078-bf75-981f101fc5f1" />
<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
<img width="1046" height="440" alt="image" src="https://github.com/user-attachments/assets/1fc89136-881e-41e8-ad2e-bfba32983ee2" />

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: Atlas 800I A2
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
