### PR TITLE
Set `warn_only` for unsupported deterministic algorithms

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -126,7 +126,7 @@ def require_deterministic(test_case):
     def wrapper(*args, **kwargs):
         original_state = torch.are_deterministic_algorithms_enabled()
         try:
-            torch.use_deterministic_algorithms(True)
+            torch.use_deterministic_algorithms(True, warn_only=True)
             return test_case(*args, **kwargs)
         finally:
             torch.use_deterministic_algorithms(original_state)


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->

Before the fix (current main branch):
```
❯ python3 -m pytest test/convergence/bf16/test_mini_models.py -k qwen3_5_moe
========================================================= test session starts =========================================================
platform linux -- Python 3.13.1, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/tcc/Liger-Kernel
configfile: pyproject.toml
plugins: anyio-4.12.1, rerunfailures-16.1, cov-7.0.0, asyncio-1.3.0, xdist-3.8.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 32 items / 31 deselected / 1 selected

test/convergence/bf16/test_mini_models.py::test_mini_model[mini_qwen3_5_moe-32-1e-05-dtype27-0.05-0.2-0.1-0.1-0.01-0.01] FAILED [100%]
```
```
E       RuntimeError: _histc_cuda does not have a deterministic implementation, but you set 'torch.use_deterministic_algorithms(True)'. You can turn off determinism just for this operation, or you can use the 'warn_only=True' option, if that's acceptable for your application. You can also file an issue at https://github.com/pytorch/pytorch/issues to help us prioritize adding deterministic support for this operation.

.venv/lib/python3.13/site-packages/transformers/integrations/moe.py:369: RuntimeError
```
After the fix (this PR):
```
❯ python3 -m pytest test/convergence/bf16/test_mini_models.py -k qwen3_5_moe
========================================================= test session starts =========================================================
platform linux -- Python 3.13.1, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/tcc/Liger-Kernel
configfile: pyproject.toml
plugins: anyio-4.12.1, rerunfailures-16.1, cov-7.0.0, asyncio-1.3.0, xdist-3.8.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 32 items / 31 deselected / 1 selected

test/convergence/bf16/test_mini_models.py::test_mini_model[mini_qwen3_5_moe-32-1e-05-dtype27-0.05-0.2-0.1-0.1-0.01-0.01] PASSED [100%]
```

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

Root cause:
`torch.histc` doesn't support deterministic algorithm
https://github.com/huggingface/transformers/blob/adc2f16bf1824f7b57c790b4cf3bc48f95ecec69/src/transformers/integrations/moe.py#L373

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
