### PR TITLE
[NPU] FIX Softmax for loop 

### DIFF
--- a/src/liger_kernel/ops/backends/_ascend/ops/softmax.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/softmax.py
@@ -89,10 +89,9 @@ def _softmax_multi_block_forward_kernel(
     """
     row_start = tl.program_id(0)
     num_prog = tl.num_programs(0)
-    row_step = tl.cdiv(n_rows, num_prog)
     col_offsets = tl.arange(0, BLOCK_SIZE)
 
-    for row_idx in tl.range(row_start, n_rows, row_step):
+    for row_idx in tl.range(row_start, n_rows, num_prog):
         row_start_ptr = X_ptr + row_idx * X_row_stride
         m = tl.float32(float("-inf"))
         d = tl.float32(0.0)
@@ -209,11 +208,9 @@ def _softmax_multi_block_backward_kernel(
     """
     row_start = tl.program_id(0)
     num_prog = tl.num_programs(0)
-    row_step = tl.cdiv(n_rows, num_prog)
-
     col_offsets = tl.arange(0, BLOCK_SIZE)
 
-    for row_idx in tl.range(row_start, n_rows, row_step):
+    for row_idx in tl.range(row_start, n_rows, num_prog):
         dy_start_ptr = dy_ptr + row_idx * dy_stride
         y_start_ptr = y_ptr + row_idx * y_stride
         acc = 0.0


### PR DESCRIPTION
## Summary
The previous fix used an incorrect loop step. This change updates it to `num_prog`, since each grid processes one row out of every `num_prog` rows.


## Testing Done
`python -m pytest ./test/transformers/test_softmax.py`
Device type: Atlas 800I A2


- Hardware Type: <BLANK>
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
