### PR TITLE
Enable SwiGLU patching for Qwen3-VL

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ loss.backward()
 | Qwen2, Qwen2.5, & QwQ      | `liger_kernel.transformers.apply_liger_kernel_to_qwen2`    | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy        |
 | Qwen2-VL, & QVQ       | `liger_kernel.transformers.apply_liger_kernel_to_qwen2_vl`    | RMSNorm, LayerNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy        |
 | Qwen2.5-VL       | `liger_kernel.transformers.apply_liger_kernel_to_qwen2_5_vl`    | RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy        |
+| Qwen3-VL       | `liger_kernel.transformers.apply_liger_kernel_to_qwen3_vl`    | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy        |
 | Qwen3   | `liger_kernel.transformers.apply_liger_kernel_to_qwen3`    |  RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy       |
 | Qwen3 MoE | `liger_kernel.transformers.apply_liger_kernel_to_qwen3_moe` | RoPE, RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy       |
 | Qwen3.5      | `liger_kernel.transformers.apply_liger_kernel_to_qwen3_5`    | RMSNorm, SwiGLU, CrossEntropyLoss, FusedLinearCrossEntropy        |

--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -1789,7 +1789,7 @@ def apply_liger_kernel_to_qwen3_vl(
     cross_entropy: bool = False,
     fused_linear_cross_entropy: bool = True,
     rms_norm: bool = True,
-    swiglu: bool = False,
+    swiglu: bool = True,
     model: PreTrainedModel = None,
 ) -> None:
     """
@@ -1802,7 +1802,7 @@ def apply_liger_kernel_to_qwen3_vl(
             `cross_entropy` and `fused_linear_cross_entropy` cannot both be True.
             If `fused_linear_cross_entropy` is True, the logits will not be materialized but more memory efficient.
         rms_norm (bool): Whether to apply Liger's RMSNorm. Default is True.
-        swiglu (bool): Whether to apply Liger's SwiGLU MLP. Default is False.
+        swiglu (bool): Whether to apply Liger's SwiGLU MLP. Default is True.
         model (PreTrainedModel): The model instance to apply Liger kernels to, if the model has already been
         loaded. Default is None.
     """
@@ -1836,7 +1836,10 @@ def apply_liger_kernel_to_qwen3_vl(
         else:
             modeling_qwen3_vl.Qwen3VLForConditionalGeneration.forward = qwen3_vl_lce_forward
 
-    if model is not None and rms_norm:
+    if swiglu:
+        modeling_qwen3_vl.Qwen3VLTextMLP = LigerSwiGLUMLP
+
+    if model is not None:
         if isinstance(model, Qwen3VLForConditionalGeneration):
             text_model: Qwen3VLTextModel = model.model.language_model
         elif isinstance(model, Qwen3VLModel):
@@ -1851,16 +1854,20 @@ def apply_liger_kernel_to_qwen3_vl(
         _patch_qwen3_vl_rms_norm = partial(_patch_rms_norm_module, offset=0.0, casting_mode="llama")
 
         if text_model is not None:
-            _patch_qwen3_vl_rms_norm(text_model.norm)
+            if rms_norm:
+                _patch_qwen3_vl_rms_norm(text_model.norm)
             for decoder_layer in text_model.layers:
-                _patch_qwen3_vl_rms_norm(decoder_layer.input_layernorm)
-                _patch_qwen3_vl_rms_norm(decoder_layer.post_attention_layernorm)
-                self_attn = getattr(decoder_layer, "self_attn", None)
-                if self_attn is not None:
-                    if hasattr(self_attn, "q_norm") and self_attn.q_norm is not None:
-                        _patch_qwen3_vl_rms_norm(self_attn.q_norm)
-                    if hasattr(self_attn, "k_norm") and self_attn.k_norm is not None:
-                        _patch_qwen3_vl_rms_norm(self_attn.k_norm)
+                if swiglu:
+                    _patch_swiglu_module(decoder_layer.mlp, LigerSwiGLUMLP)
+                if rms_norm:
+                    _patch_qwen3_vl_rms_norm(decoder_layer.input_layernorm)
+                    _patch_qwen3_vl_rms_norm(decoder_layer.post_attention_layernorm)
+                    self_attn = getattr(decoder_layer, "self_attn", None)
+                    if self_attn is not None:
+                        if hasattr(self_attn, "q_norm") and self_attn.q_norm is not None:
+                            _patch_qwen3_vl_rms_norm(self_attn.q_norm)
+                        if hasattr(self_attn, "k_norm") and self_attn.k_norm is not None:
+                            _patch_qwen3_vl_rms_norm(self_attn.k_norm)
 
 
 def apply_liger_kernel_to_qwen3_vl_moe(

--- a/test/transformers/test_monkey_patch.py
+++ b/test/transformers/test_monkey_patch.py
@@ -554,6 +554,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_vl_for_conditional_generation(
             LigerRMSNorm.forward
         )
         for decoder_layer in dummy_model_instance.model.language_model.layers:
+            assert inspect.getsource(decoder_layer.mlp.forward) != inspect.getsource(LigerSwiGLUMLP.forward)
             assert inspect.getsource(decoder_layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(decoder_layer.post_attention_layernorm.forward) != inspect.getsource(
                 LigerRMSNorm.forward
@@ -574,6 +575,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_vl_for_conditional_generation(
             LigerRMSNorm.forward
         )
         for decoder_layer in dummy_model_instance.model.language_model.layers:
+            assert inspect.getsource(decoder_layer.mlp.forward) == inspect.getsource(LigerSwiGLUMLP.forward)
             assert inspect.getsource(decoder_layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(decoder_layer.post_attention_layernorm.forward) == inspect.getsource(
                 LigerRMSNorm.forward
@@ -651,6 +653,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_vl():
             LigerRMSNorm.forward
         )
         for decoder_layer in dummy_model_instance.language_model.layers:
+            assert inspect.getsource(decoder_layer.mlp.forward) != inspect.getsource(LigerSwiGLUMLP.forward)
             assert inspect.getsource(decoder_layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(decoder_layer.post_attention_layernorm.forward) != inspect.getsource(
                 LigerRMSNorm.forward
@@ -671,6 +674,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_vl():
             LigerRMSNorm.forward
         )
         for decoder_layer in dummy_model_instance.language_model.layers:
+            assert inspect.getsource(decoder_layer.mlp.forward) == inspect.getsource(LigerSwiGLUMLP.forward)
             assert inspect.getsource(decoder_layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(decoder_layer.post_attention_layernorm.forward) == inspect.getsource(
                 LigerRMSNorm.forward
@@ -721,6 +725,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_vl_text():
         # Note: Text models don't have forward method patching, so skip this check
         assert inspect.getsource(dummy_model_instance.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
         for decoder_layer in dummy_model_instance.layers:
+            assert inspect.getsource(decoder_layer.mlp.forward) != inspect.getsource(LigerSwiGLUMLP.forward)
             assert inspect.getsource(decoder_layer.input_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(decoder_layer.post_attention_layernorm.forward) != inspect.getsource(
                 LigerRMSNorm.forward
@@ -739,6 +744,7 @@ def test_apply_liger_kernel_to_instance_for_qwen3_vl_text():
         # Note: Text models don't have forward method patching, so skip this check
         assert inspect.getsource(dummy_model_instance.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
         for decoder_layer in dummy_model_instance.layers:
+            assert inspect.getsource(decoder_layer.mlp.forward) == inspect.getsource(LigerSwiGLUMLP.forward)
             assert inspect.getsource(decoder_layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(decoder_layer.post_attention_layernorm.forward) == inspect.getsource(
                 LigerRMSNorm.forward
@@ -754,6 +760,47 @@ def test_apply_liger_kernel_to_instance_for_qwen3_vl_text():
             print(dummy_model_instance)
         except Exception as e:
             pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+
+
+@pytest.mark.skipif(not is_qwen3_vl_available(), reason="qwen3_vl module not available")
+def test_apply_liger_kernel_to_qwen3_vl_swiglu_flag_patches_mlp():
+    with patch("transformers.models.qwen3_vl.modeling_qwen3_vl"):
+        from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLTextModel
+
+        config = transformers.models.qwen3_vl.configuration_qwen3_vl.Qwen3VLTextConfig(
+            vocab_size=32000,
+            hidden_size=512,
+            intermediate_size=2048,
+            num_hidden_layers=2,
+            num_attention_heads=8,
+            num_key_value_heads=2,
+            head_dim=64,
+            hidden_act="silu",
+            max_position_embeddings=32768,
+            initializer_range=0.02,
+            rms_norm_eps=1e-6,
+            use_cache=False,
+            tie_word_embeddings=True,
+            attention_dropout=0.0,
+            attention_bias=False,
+            **get_qwen3_vl_rope_config(),
+        )
+        dummy_model_instance = Qwen3VLTextModel._from_config(config)
+
+        for decoder_layer in dummy_model_instance.layers:
+            assert inspect.getsource(decoder_layer.mlp.forward) != inspect.getsource(LigerSwiGLUMLP.forward)
+
+        monkey_patch.apply_liger_kernel_to_qwen3_vl(
+            model=dummy_model_instance,
+            rope=False,
+            cross_entropy=False,
+            fused_linear_cross_entropy=False,
+            rms_norm=False,
+            swiglu=True,
+        )
+
+        for decoder_layer in dummy_model_instance.layers:
+            assert inspect.getsource(decoder_layer.mlp.forward) == inspect.getsource(LigerSwiGLUMLP.forward)
 
 
 @pytest.mark.skipif(not is_qwen3_vl_moe_available(), reason="qwen3_vl_moe module not available")


### PR DESCRIPTION
## Summary

Fix `apply_liger_kernel_to_qwen3_vl(..., swiglu=True)` so it is no longer a no-op.

## Changes

- patch `transformers.models.qwen3_vl.modeling_qwen3_vl.Qwen3VLTextMLP` to `LigerSwiGLUMLP`
- patch instantiated `decoder_layer.mlp` modules for existing Qwen3-VL model instances
- enable `swiglu=True` by default for `apply_liger_kernel_to_qwen3_vl`
- add monkey-patch tests covering both default instance patching and explicit `swiglu=True`
- document Qwen3-VL support in the README table

## Validation

```bash
python -m pytest -q test/transformers/test_monkey_patch.py -k 'qwen3_vl and not moe'
python -m pytest -q test/convergence/bf16/test_mini_models.py -k 'mini_qwen3_vl and test_mini_model'
python -m ruff check src/liger_kernel/transformers/monkey_patch.py test/transformers/test_monkey_patch.py README.md
```
