### PR TITLE
Functorch support

### DIFF
--- a/benchmark/scripts/benchmark_attn_res.py
+++ b/benchmark/scripts/benchmark_attn_res.py
@@ -48,7 +48,7 @@ def _setup_attn_res(input: SingleBenchmarkRunInput):
     eps = cfg.get("eps", 1e-6)
 
     if input.kernel_provider == "liger":
-        fn = lambda: LigerAttnResFunction.apply(V, w_query, w_norm, eps)
+        fn = lambda: LigerAttnResFunction.apply(V, w_query, w_norm, eps)[0]
     elif input.kernel_provider == "pytorch":
         from test.transformers.test_attn_res import pytorch_attn_res
 

--- a/src/liger_kernel/chunked_loss/cosine_similarity_loss.py
+++ b/src/liger_kernel/chunked_loss/cosine_similarity_loss.py
@@ -35,7 +35,6 @@ class LigerFusedLinearCosineSimilarityFunction(LigerFusedLinearDistillationBase)
     @classmethod
     def forward(
         cls,
-        ctx,
         student_input: torch.Tensor,
         student_weight: torch.Tensor,
         teacher_input: torch.Tensor,
@@ -54,7 +53,6 @@ class LigerFusedLinearCosineSimilarityFunction(LigerFusedLinearDistillationBase)
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
         return super().forward(
             cls=cls,
-            ctx=ctx,
             student_input=student_input,
             student_weight=student_weight,
             teacher_input=teacher_input,
@@ -123,7 +121,7 @@ class LigerFusedLinearCosineSimilarityLoss(torch.nn.Module):
         student_bias: torch.Tensor = None,
         teacher_bias: torch.Tensor = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
-        return LigerFusedLinearCosineSimilarityFunction.apply(
+        result = LigerFusedLinearCosineSimilarityFunction.apply(
             student_input,
             student_weight,
             teacher_input,
@@ -140,3 +138,7 @@ class LigerFusedLinearCosineSimilarityLoss(torch.nn.Module):
             self.chunk_size,
             self.return_soft_hard_loss,
         )
+        # Return only loss (and optionally soft/hard losses), not the grad tensors
+        if self.return_soft_hard_loss:
+            return result[0], result[1], result[2]
+        return result[0]

--- a/src/liger_kernel/chunked_loss/cpo_loss.py
+++ b/src/liger_kernel/chunked_loss/cpo_loss.py
@@ -42,7 +42,6 @@ class LigerFusedLinearCPOFunction(LigerFusedLinearPreferenceBase):
     @classmethod
     def forward(
         cls,
-        ctx,
         _input,
         weight,
         target,
@@ -76,7 +75,6 @@ class LigerFusedLinearCPOFunction(LigerFusedLinearPreferenceBase):
         """
         return super().forward(
             cls=cls,
-            ctx=ctx,
             _input=_input,
             weight=weight,
             target=target,
@@ -141,7 +139,7 @@ class LigerFusedLinearCPOLoss(torch.nn.Module):
         target,
         bias=None,
     ):
-        return LigerFusedLinearCPOFunction.apply(
+        result = LigerFusedLinearCPOFunction.apply(
             _input,
             lin_weight,
             target,
@@ -155,3 +153,5 @@ class LigerFusedLinearCPOLoss(torch.nn.Module):
             self.average_log_prob,
             self.chunk_size,
         )
+        # Return only loss and aux outputs, not the grad tensors
+        return result[0], result[1]

--- a/src/liger_kernel/chunked_loss/dpo_loss.py
+++ b/src/liger_kernel/chunked_loss/dpo_loss.py
@@ -98,7 +98,6 @@ class LigerFusedLinearDPOFunction(LigerFusedLinearPreferenceBase):
     @classmethod
     def forward(
         cls,
-        ctx,
         _input,
         weight,
         target,
@@ -137,7 +136,6 @@ class LigerFusedLinearDPOFunction(LigerFusedLinearPreferenceBase):
         """
         return super().forward(
             cls=cls,
-            ctx=ctx,
             _input=_input,
             weight=weight,
             target=target,
@@ -210,7 +208,7 @@ class LigerFusedLinearDPOLoss(torch.nn.Module):
         ref_weight=None,
         ref_bias=None,
     ):
-        return LigerFusedLinearDPOFunction.apply(
+        result = LigerFusedLinearDPOFunction.apply(
             _input,
             lin_weight,
             target,
@@ -227,3 +225,5 @@ class LigerFusedLinearDPOLoss(torch.nn.Module):
             self.chunk_size,
             self.loss_type,
         )
+        # Return only loss and aux outputs, not the grad tensors
+        return result[0], result[1]

--- a/src/liger_kernel/chunked_loss/fused_linear_distillation.py
+++ b/src/liger_kernel/chunked_loss/fused_linear_distillation.py
@@ -150,7 +150,6 @@ class LigerFusedLinearDistillationBase(torch.autograd.Function):
     @staticmethod
     def forward(
         cls,
-        ctx,
         student_input,
         student_weight,
         teacher_input,
@@ -279,14 +278,16 @@ class LigerFusedLinearDistillationBase(torch.autograd.Function):
             grad_input = accumulate_chunk(student_input_chunk, teacher_input_chunk, target_chunk)
             grad_inputs.append(grad_input)
 
-        ctx.save_for_backward(
-            torch.cat(grad_inputs, dim=0),
-            grad_weight,
-            grad_bias,
-        )
-        if return_soft_hard_loss:
-            return loss_acc, soft_loss_acc, hard_loss_acc
-        return loss_acc
+        # Return grad tensors as extra outputs for setup_context
+        grad_input_cat = torch.cat(grad_inputs, dim=0)
+        # Always return 6 values for consistent setup_context unpacking
+        # When return_soft_hard_loss=False, soft_loss_acc and hard_loss_acc are None
+        return loss_acc, soft_loss_acc, hard_loss_acc, grad_input_cat, grad_weight, grad_bias
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        _, _, _, grad_input_cat, grad_weight, grad_bias = output
+        ctx.save_for_backward(grad_input_cat, grad_weight, grad_bias)
 
     @staticmethod
     def backward(ctx, grad_output, *args):

--- a/src/liger_kernel/chunked_loss/fused_linear_ppo.py
+++ b/src/liger_kernel/chunked_loss/fused_linear_ppo.py
@@ -17,7 +17,6 @@ class LigerFusedLinearPPOBase(torch.autograd.Function):
     @staticmethod
     def forward(
         cls,
-        ctx,
         _input,
         weight,
         selected_token_ids,
@@ -50,7 +49,6 @@ class LigerFusedLinearPPOBase(torch.autograd.Function):
 
         Args:
             cls: The class
-            ctx: Context for backward
             _input: Input tensor
             weight: Weight tensor
             selected_token_ids: Selected token ids tensor
@@ -271,9 +269,6 @@ class LigerFusedLinearPPOBase(torch.autograd.Function):
         # Combine gradients
         grad_input = torch.cat(grad_inputs, dim=0)
 
-        # Save for backward
-        ctx.save_for_backward(grad_input, grad_weight, grad_bias)
-
         # Finalize metrics
         final_metrics = []
         for metric in aggregated_metrics:
@@ -282,7 +277,13 @@ class LigerFusedLinearPPOBase(torch.autograd.Function):
             else:
                 final_metrics.append(metric)
 
-        return loss_acc, tuple(final_metrics)
+        # Return grad tensors as extra outputs for setup_context
+        return loss_acc, tuple(final_metrics), grad_input, grad_weight, grad_bias
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        loss_acc, final_metrics, grad_input, grad_weight, grad_bias = output
+        ctx.save_for_backward(grad_input, grad_weight, grad_bias)
 
     @staticmethod
     def _compute_dapo_normalizer(attention_mask):

--- a/src/liger_kernel/chunked_loss/fused_linear_preference.py
+++ b/src/liger_kernel/chunked_loss/fused_linear_preference.py
@@ -17,7 +17,6 @@ class LigerFusedLinearPreferenceBase(torch.autograd.Function):
     @staticmethod
     def forward(
         cls,
-        ctx,
         _input,
         weight,
         target,
@@ -249,11 +248,8 @@ class LigerFusedLinearPreferenceBase(torch.autograd.Function):
             if isinstance(aux, list):
                 aggregated_aux_outputs[i] = torch.cat(aux, dim=0)
 
-        ctx.save_for_backward(
-            torch.cat(grad_inputs, dim=0),
-            grad_weight,
-            grad_bias,
-        )
+        # Return grad tensors as extra outputs for setup_context
+        grad_input_cat = torch.cat(grad_inputs, dim=0)
         return_vars = (
             policy_chosen_logps,
             policy_rejected_logps,
@@ -261,7 +257,12 @@ class LigerFusedLinearPreferenceBase(torch.autograd.Function):
             policy_rejected_logits_mean,
             policy_nll_loss,
         )
-        return loss_acc, (*return_vars, *aggregated_aux_outputs)
+        return loss_acc, (*return_vars, *aggregated_aux_outputs), grad_input_cat, grad_weight, grad_bias
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        loss_acc, aux_tuple, grad_input_cat, grad_weight, grad_bias = output
+        ctx.save_for_backward(grad_input_cat, grad_weight, grad_bias)
 
     @staticmethod
     def backward(ctx, *grad_output):

--- a/src/liger_kernel/chunked_loss/fused_linear_unpaired_preference.py
+++ b/src/liger_kernel/chunked_loss/fused_linear_unpaired_preference.py
@@ -17,7 +17,6 @@ class LigerFusedLinearUnpairedPreferenceBase(torch.autograd.Function):
     @staticmethod
     def forward(
         cls,
-        ctx,
         _input,
         weight,
         target,
@@ -193,11 +192,8 @@ class LigerFusedLinearUnpairedPreferenceBase(torch.autograd.Function):
             if isinstance(aux, list):
                 aggregated_aux_outputs[i] = torch.cat(aux, dim=0)
 
-        ctx.save_for_backward(
-            torch.cat(grad_inputs, dim=0),
-            grad_weight,
-            grad_bias,
-        )
+        # Return grad tensors as extra outputs for setup_context
+        grad_input_cat = torch.cat(grad_inputs, dim=0)
 
         return_vars = (
             chosen_logps_sum,
@@ -206,7 +202,12 @@ class LigerFusedLinearUnpairedPreferenceBase(torch.autograd.Function):
             rejected_logits_sum,
         )
 
-        return loss_acc, (*return_vars, *aggregated_aux_outputs)
+        return loss_acc, (*return_vars, *aggregated_aux_outputs), grad_input_cat, grad_weight, grad_bias
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        loss_acc, aux_tuple, grad_input_cat, grad_weight, grad_bias = output
+        ctx.save_for_backward(grad_input_cat, grad_weight, grad_bias)
 
     @staticmethod
     def backward(ctx, *grad_output):

--- a/src/liger_kernel/chunked_loss/grpo_loss.py
+++ b/src/liger_kernel/chunked_loss/grpo_loss.py
@@ -224,7 +224,6 @@ class LigerFusedLinearGRPOFunction(LigerFusedLinearPPOBase):
     @classmethod
     def forward(
         cls,
-        ctx,
         _input,
         weight,
         selected_token_ids,
@@ -290,7 +289,6 @@ class LigerFusedLinearGRPOFunction(LigerFusedLinearPPOBase):
 
         return super().forward(
             cls=cls,
-            ctx=ctx,
             _input=_input,
             weight=weight,
             selected_token_ids=selected_token_ids,
@@ -432,7 +430,7 @@ class LigerFusedLinearGRPOLoss(torch.nn.Module):
         ref_bias=None,
         vllm_is_ratio=None,
     ):
-        return LigerFusedLinearGRPOFunction.apply(
+        result = LigerFusedLinearGRPOFunction.apply(
             _input,
             lin_weight,
             selected_token_ids,
@@ -460,3 +458,5 @@ class LigerFusedLinearGRPOLoss(torch.nn.Module):
             self.delta,
             self.use_bias_correction_kl,
         )
+        # Return only loss and metrics, not the grad tensors
+        return result[0], result[1]

--- a/src/liger_kernel/chunked_loss/jsd_loss.py
+++ b/src/liger_kernel/chunked_loss/jsd_loss.py
@@ -59,7 +59,6 @@ class LigerFusedLinearJSDFunction(LigerFusedLinearDistillationBase):
     @classmethod
     def forward(
         cls,
-        ctx,
         student_input: torch.Tensor,
         student_weight: torch.Tensor,
         teacher_input: torch.Tensor,
@@ -97,7 +96,6 @@ class LigerFusedLinearJSDFunction(LigerFusedLinearDistillationBase):
         """
         return super().forward(
             cls=cls,
-            ctx=ctx,
             student_input=student_input,
             student_weight=student_weight,
             teacher_input=teacher_input,
@@ -196,7 +194,7 @@ class LigerFusedLinearJSDLoss(torch.nn.Module):
                 If return_soft_hard_loss is False: Computed combined loss
                 If return_soft_hard_loss is True: Tuple of (combined_loss, soft_loss, hard_loss)
         """
-        return LigerFusedLinearJSDFunction.apply(
+        result = LigerFusedLinearJSDFunction.apply(
             student_input,
             student_weight,
             teacher_input,
@@ -213,3 +211,7 @@ class LigerFusedLinearJSDLoss(torch.nn.Module):
             self.chunk_size,
             self.return_soft_hard_loss,
         )
+        # Return only loss (and optionally soft/hard losses), not the grad tensors
+        if self.return_soft_hard_loss:
+            return result[0], result[1], result[2]
+        return result[0]

--- a/src/liger_kernel/chunked_loss/kto_loss.py
+++ b/src/liger_kernel/chunked_loss/kto_loss.py
@@ -71,7 +71,6 @@ class LigerFusedLinearKTOFunction(LigerFusedLinearUnpairedPreferenceBase):
     @classmethod
     def forward(
         cls,
-        ctx,
         _input,
         weight,
         target,
@@ -111,7 +110,6 @@ class LigerFusedLinearKTOFunction(LigerFusedLinearUnpairedPreferenceBase):
         """
         return super().forward(
             cls=cls,
-            ctx=ctx,
             _input=_input,
             weight=weight,
             target=target,
@@ -191,7 +189,7 @@ class LigerFusedLinearKTOLoss(torch.nn.Module):
         ref_bias=None,
         kl=None,
     ):
-        return LigerFusedLinearKTOFunction.apply(
+        result = LigerFusedLinearKTOFunction.apply(
             _input,
             lin_weight,
             target,
@@ -208,3 +206,5 @@ class LigerFusedLinearKTOLoss(torch.nn.Module):
             self.average_log_prob,
             self.chunk_size,
         )
+        # Return only loss and aux outputs, not the grad tensors
+        return result[0], result[1]

--- a/src/liger_kernel/chunked_loss/orpo_loss.py
+++ b/src/liger_kernel/chunked_loss/orpo_loss.py
@@ -45,7 +45,6 @@ class LigerFusedLinearORPOFunction(LigerFusedLinearPreferenceBase):
     @classmethod
     def forward(
         cls,
-        ctx,
         _input,
         weight,
         target,
@@ -75,7 +74,6 @@ class LigerFusedLinearORPOFunction(LigerFusedLinearPreferenceBase):
         """
         return super().forward(
             cls=cls,
-            ctx=ctx,
             _input=_input,
             weight=weight,
             target=target,
@@ -130,7 +128,7 @@ class LigerFusedLinearORPOLoss(torch.nn.Module):
         bias=None,
         nll_target=None,
     ):
-        return LigerFusedLinearORPOFunction.apply(
+        result = LigerFusedLinearORPOFunction.apply(
             _input,
             lin_weight,
             target,
@@ -142,3 +140,5 @@ class LigerFusedLinearORPOLoss(torch.nn.Module):
             self.compiled,
             self.chunk_size,
         )
+        # Return only loss and aux outputs, not the grad tensors
+        return result[0], result[1]

--- a/src/liger_kernel/chunked_loss/simpo_loss.py
+++ b/src/liger_kernel/chunked_loss/simpo_loss.py
@@ -50,7 +50,6 @@ class LigerFusedLinearSimPOFunction(LigerFusedLinearPreferenceBase):
     @classmethod
     def forward(
         cls,
-        ctx,
         _input,
         weight,
         target,
@@ -84,7 +83,6 @@ class LigerFusedLinearSimPOFunction(LigerFusedLinearPreferenceBase):
         """
         return super().forward(
             cls=cls,
-            ctx=ctx,
             _input=_input,
             weight=weight,
             target=target,
@@ -149,7 +147,7 @@ class LigerFusedLinearSimPOLoss(torch.nn.Module):
         target,
         bias=None,
     ):
-        return LigerFusedLinearSimPOFunction.apply(
+        result = LigerFusedLinearSimPOFunction.apply(
             _input,
             lin_weight,
             target,
@@ -163,3 +161,5 @@ class LigerFusedLinearSimPOLoss(torch.nn.Module):
             self.gamma,
             self.chunk_size,
         )
+        # Return only loss and aux outputs, not the grad tensors
+        return result[0], result[1]

--- a/src/liger_kernel/ops/attn_res.py
+++ b/src/liger_kernel/ops/attn_res.py
@@ -329,16 +329,21 @@ def attn_res_backward(dh, V_3d, w_query, w_norm, Alpha, RSTD, eps=1e-6):
 class LigerAttnResFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, V_stacked, w_query, w_norm, eps):
-        ctx.orig_shape = V_stacked.shape  # [N, B, T, D] or [N, B*T, D]
+    def forward(V_stacked, w_query, w_norm, eps):
         h, V_3d, Alpha, RSTD = attn_res_forward(V_stacked, w_query, w_norm, eps)
+        return h, V_3d, Alpha, RSTD
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        V_stacked, w_query, w_norm, eps = inputs
+        h, V_3d, Alpha, RSTD = output
         ctx.save_for_backward(V_3d, w_query, w_norm, Alpha, RSTD)
         ctx.eps = eps
-        return h
+        ctx.orig_shape = V_stacked.shape  # [N, B, T, D] or [N, B*T, D]
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, dh):
+    def backward(ctx, dh, _grad_V_3d, _grad_Alpha, _grad_RSTD):
         V_3d, w_query, w_norm, Alpha, RSTD = ctx.saved_tensors
         dV, dW_query, dW_norm = attn_res_backward(dh, V_3d, w_query, w_norm, Alpha, RSTD, ctx.eps)
         # Reshape dV back to original input shape

--- a/src/liger_kernel/ops/backends/_ascend/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/cross_entropy.py
@@ -474,7 +474,6 @@ class LigerCrossEntropyFunction(torch.autograd.Function):
 
     @staticmethod
     def forward(
-        ctx,
         _input: torch.Tensor,
         target: torch.Tensor,
         weight: Optional[torch.FloatTensor],
@@ -491,7 +490,6 @@ class LigerCrossEntropyFunction(torch.autograd.Function):
         The forward pass of the Liger Cross Entropy loss.
 
         Parameters:
-        ctx : The context object.
         _input (tensor): The input tensor of shape (BT, V) where B is batch size, T is sequence length, V is vocab size.
         target (tensor): The target tensor of shape (BT) where each value is in [0, V-1].
         weight(Tensor, optional): a manual rescaling weight given to each class. If given, has to be a Tensor of size V and floating point dtype
@@ -505,7 +503,7 @@ class LigerCrossEntropyFunction(torch.autograd.Function):
         return_predicted_tokens (bool): When `return_predicted_tokens` is `True`, returns per-token predicted class indices (argmax) without materializing logits. Default: `False`
 
         Returns:
-        tuple: A tuple with the computed losses, accuracy, and predicted tokens: (loss, z_loss, token_accuracy, predicted_tokens). z_loss, token_accuracy, and predicted_tokens are None if not requested.
+        tuple: A tuple with the computed losses, accuracy, and predicted tokens: (loss, z_loss, token_accuracy, predicted_tokens, _input). z_loss, token_accuracy, and predicted_tokens are None if not requested.
         """
         input_requires_grad = _input.requires_grad
 
@@ -522,16 +520,23 @@ class LigerCrossEntropyFunction(torch.autograd.Function):
             return_token_accuracy,
             return_predicted_tokens,
         )
-        if input_requires_grad:
+        return loss, z_loss, token_accuracy, predicted_tokens, _input
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        original_input = inputs[0]
+        return_z_loss = inputs[8] if len(inputs) > 8 else False
+        return_token_accuracy = inputs[9] if len(inputs) > 9 else False
+        return_predicted_tokens = inputs[10] if len(inputs) > 10 else False
+        loss, z_loss, token_accuracy, predicted_tokens, _input = output
+        if original_input.requires_grad:
             ctx.save_for_backward(_input.detach())
         ctx.return_z_loss = return_z_loss
         ctx.return_token_accuracy = return_token_accuracy
         ctx.return_predicted_tokens = return_predicted_tokens
 
-        return loss, z_loss, token_accuracy, predicted_tokens
-
     @staticmethod
-    def backward(ctx, grad_output, grad_output2, grad_output3, grad_output4):
+    def backward(ctx, grad_output, grad_output2, grad_output3, grad_output4, _grad_input):
         """
         The backward pass of the Liger Cross Entropy loss.
 

--- a/src/liger_kernel/ops/backends/_ascend/ops/dyt.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/dyt.py
@@ -272,10 +272,14 @@ def liger_dyt_bwd(dy, x, alpha, gamma, beta):
 class LigerDyTFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, x, alpha, gamma, beta):
+    def forward(x, alpha, gamma, beta):
         y = liger_dyt_fwd(x, alpha, gamma, beta)
-        ctx.save_for_backward(x, alpha, gamma, beta)
         return y
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        x, alpha, gamma, beta = inputs
+        ctx.save_for_backward(x, alpha, gamma, beta)
 
     @staticmethod
     @ensure_contiguous

--- a/src/liger_kernel/ops/backends/_ascend/ops/embedding.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/embedding.py
@@ -196,10 +196,14 @@ def embedding_backward(embeddings, indices, grad_output):
 class LigerEmbeddingFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, embeddings: torch.Tensor, indices: torch.Tensor):
+    def forward(embeddings: torch.Tensor, indices: torch.Tensor):
         output = embedding_forward(embeddings, indices)
-        ctx.save_for_backward(indices, embeddings)
         return output
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        embeddings, indices = inputs
+        ctx.save_for_backward(indices, embeddings)
 
     @staticmethod
     @ensure_contiguous

--- a/src/liger_kernel/ops/backends/_ascend/ops/fused_add_rms_norm.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/fused_add_rms_norm.py
@@ -746,22 +746,29 @@ class LigerFusedAddRMSNormFunction(torch.autograd.Function):
 
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, X, R, W, eps, offset=0.0, casting_mode="llama", in_place=False):
+    def forward(X, R, W, eps, offset=0.0, casting_mode="llama", in_place=False):
         """
         X: (B, T, H) or (BxT, H)
         R: (B, T, H) or (BxT, H)
         W: (H,)
         """
         Y, S, RSTD, casting_mode = fused_add_rms_norm_forward(X, R, W, eps, offset, casting_mode)
+        return Y, S, RSTD, casting_mode
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        W = inputs[2]
+        offset = inputs[4] if len(inputs) > 4 else 0.0
+        in_place = inputs[6] if len(inputs) > 6 else False
+        Y, S, RSTD, casting_mode = output
         ctx.offset = offset
         ctx.casting_mode = casting_mode
         ctx.in_place = in_place
         ctx.save_for_backward(S, W, RSTD)
-        return Y, S
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, dY, dS_out):
+    def backward(ctx, dY, dS_out, _grad_RSTD, _grad_casting_mode):
         """
         dY: (B, T, H) or (BxT, H)
         dS_out: (B, T, H) or (BxT, H)

--- a/src/liger_kernel/ops/backends/_ascend/ops/fused_neighborhood_attention.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/fused_neighborhood_attention.py
@@ -749,20 +749,30 @@ def fused_neighborhood_attention_forward(
 class LigerFusedNeighborhoodAttentionFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, query, key, value, kernel_size=7, dilation=1, scale=None):
+    def forward(query, key, value, kernel_size=7, dilation=1, scale=None):
         output, attn_weights, softmax_params = fused_neighborhood_attention_forward(
             query, key, value, kernel_size, dilation, scale
         )
+        return output, attn_weights, softmax_params
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        query = inputs[0]
+        key = inputs[1]
+        value = inputs[2]
+        kernel_size = inputs[3] if len(inputs) > 3 else 7
+        dilation = inputs[4] if len(inputs) > 4 else 1
+        scale = inputs[5] if len(inputs) > 5 else None
+        output_tensor, attn_weights, softmax_params = output
         ctx.save_for_backward(query, key, value, attn_weights)
         ctx.kernel_size = kernel_size
         ctx.dilation = dilation
         ctx.scale = scale
         ctx.softmax_params = softmax_params
-        return output
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, grad_output):
+    def backward(ctx, grad_output, _grad_attn_weights, _grad_softmax_params):
         query, key, value, attn_weights = ctx.saved_tensors
         BLOCK_SIZE_softmax, ROWS_PER_BLOCK, multi_block_launch = ctx.softmax_params
 

--- a/src/liger_kernel/ops/backends/_ascend/ops/geglu.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/geglu.py
@@ -174,10 +174,14 @@ class LigerGELUMulFunction(torch.autograd.Function):
 
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, a, b):
+    def forward(a, b):
         c = geglu_forward(a, b)
-        ctx.save_for_backward(a, b)
         return c
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        a, b = inputs
+        ctx.save_for_backward(a, b)
 
     @staticmethod
     @ensure_contiguous

--- a/src/liger_kernel/ops/backends/_ascend/ops/group_norm.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/group_norm.py
@@ -445,7 +445,6 @@ class LigerGroupNormFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
     def forward(
-        ctx,
         X,
         affine_scaling_weight,
         affine_shifting_bias,
@@ -461,14 +460,22 @@ class LigerGroupNormFunction(torch.autograd.Function):
             affine_shifting_bias,
             eps,
         )
+        return Y, X, Mean, RSTD
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        affine_scaling_weight = inputs[1]
+        affine_shifting_bias = inputs[2]
+        num_channels = inputs[3]
+        num_groups = inputs[4]
+        Y, X, Mean, RSTD = output
         ctx.num_channels = num_channels
         ctx.num_groups = num_groups
         ctx.save_for_backward(X, affine_scaling_weight, affine_shifting_bias, Mean, RSTD)
-        return Y
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, dY):
+    def backward(ctx, dY, _grad_X, _grad_Mean, _grad_RSTD):
         X, W, B, Mean, RSTD = ctx.saved_tensors
         DX, DW, DB = group_norm_backward(dY, X, W, B, Mean, RSTD, ctx.num_channels, ctx.num_groups)
         return DX, DW, DB, None, None, None

--- a/src/liger_kernel/ops/backends/_ascend/ops/grpo_loss.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/grpo_loss.py
@@ -630,7 +630,6 @@ def reduce_loss(per_token_loss, mask, loss_type, max_completion_length, batch_si
 
 
 def grpo_loss_forward_triton(
-    ctx,
     logits,
     old_logp,
     ref_logp,
@@ -760,7 +759,7 @@ def grpo_loss_forward_triton(
             BLOCK_N=block_n,
         )
 
-        ctx.save_for_backward(
+        saved_tensors = (
             logits,
             old_logp,
             ref_logp,
@@ -800,11 +799,11 @@ def grpo_loss_forward_triton(
             N,
             BLOCK_N=block_n,
         )
-        ctx.save_for_backward(
+        saved_tensors = (
             logits, old_logp, ref_logp, completion_ids, advantages, completion_mask, lse, mask, vllm_is_ratio_ptr
         )
 
-    ctx.infos = (
+    infos = (
         temperature,
         beta,
         eps_low,
@@ -832,10 +831,10 @@ def grpo_loss_forward_triton(
         loss_out = loss * mask
         kl_out = kl * mask if kl is not None else None
         is_clipped_out = is_clipped * mask
-        return loss_out, kl_out, is_clipped_out
+        return loss_out, kl_out, is_clipped_out, saved_tensors, infos
 
     reduced_loss = reduce_loss(loss, mask, loss_type, max_completion_length, B, L)
-    return reduced_loss, kl_mean, clip_ratio
+    return reduced_loss, kl_mean, clip_ratio, saved_tensors, infos
 
 
 def grpo_loss_backward_triton(ctx, *args):
@@ -997,10 +996,19 @@ def grpo_loss_backward_triton(ctx, *args):
 class GrpoLossFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, *args):
-        return grpo_loss_forward_triton(ctx, *args)
+    def forward(*args):
+        result = grpo_loss_forward_triton(*args)
+        return result
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        result1, result2, result3, saved_tensors, infos = output
+        ctx.save_for_backward(*saved_tensors)
+        ctx.infos = infos
 
     @staticmethod
     @ensure_contiguous
     def backward(ctx, *args):
-        return grpo_loss_backward_triton(ctx, *args)
+        # args has 5 grad outputs (3 original + 2 for saved_tensors, infos)
+        # grpo_loss_backward_triton only uses args[0]
+        return grpo_loss_backward_triton(ctx, *args[:3])

--- a/src/liger_kernel/ops/backends/_ascend/ops/jsd.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/jsd.py
@@ -185,7 +185,6 @@ class LigerJSDFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
     def forward(
-        ctx,
         _input: torch.Tensor,
         target: torch.Tensor,
         shift_labels: Optional[torch.Tensor] = None,
@@ -212,12 +211,16 @@ class LigerJSDFunction(torch.autograd.Function):
             has_label = True
 
         loss, dX = jsd_forward(_input, target, shift_labels, beta, ignore_index, has_label)
+        return loss, dX
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        loss, dX = output
         ctx.save_for_backward(dX)
-        return loss
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, grad_output: torch.Tensor) -> torch.Tensor:
+    def backward(ctx, grad_output: torch.Tensor, _grad_dX) -> torch.Tensor:
         (dX,) = ctx.saved_tensors
         dX = jsd_backward(dX, grad_output)
         return (

--- a/src/liger_kernel/ops/backends/_ascend/ops/kl_div.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/kl_div.py
@@ -275,7 +275,6 @@ class LigerKLDivLossFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
     def forward(
-        ctx,
         y_pred: torch.Tensor,
         y_true: torch.Tensor,
         reduction: REDUCTION_LITERAL = "batchmean",
@@ -285,7 +284,6 @@ class LigerKLDivLossFunction(torch.autograd.Function):
         """A forward pass for the KL Divergence Loss.
 
         Args:
-            ctx: Torch autograd context
             y_pred (torch.Tensor): A tensor of shape (BT, V) containing the predicted values, expected to be log-probabilities.
             y_true (torch.Tensor): A tensor of shape (BT, V) containing the target values, expected to be either probabilities or log-probabilities, depending on the value of `log_target`.
             reduction (REDUCTION_LITERAL, optional): Reduction to be used. Defaults to "batchmean".
@@ -295,10 +293,16 @@ class LigerKLDivLossFunction(torch.autograd.Function):
         Returns:
             torch.Tensor: The computed KL Divergence Loss, with shape (BT, V) if `reduction` is "none", else a scalar.
         """
+        return kldiv_forward_triton(y_pred, y_true, log_target=log_target, reduction=reduction, eps=eps)
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        y_true = inputs[1]
+        reduction = inputs[2] if len(inputs) > 2 else "batchmean"
+        log_target = inputs[3] if len(inputs) > 3 else False
         ctx.save_for_backward(y_true)
         ctx.reduction = reduction
         ctx.log_target = log_target
-        return kldiv_forward_triton(y_pred, y_true, log_target=log_target, reduction=reduction, eps=eps)
 
     @staticmethod
     @ensure_contiguous

--- a/src/liger_kernel/ops/backends/_ascend/ops/layer_norm.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/layer_norm.py
@@ -629,14 +629,19 @@ class LigerLayerNormFunction(torch.autograd.Function):
 
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, X, W, B, eps):
+    def forward(X, W, B, eps):
         Y, X, Mean, RSTD = layer_norm_forward(X, W, B, eps)
+        return Y, X, Mean, RSTD
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        _, W, B, _ = inputs
+        Y, X, Mean, RSTD = output
         ctx.save_for_backward(X, W, B, Mean, RSTD)
-        return Y
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, dY):
+    def backward(ctx, dY, _grad_X, _grad_Mean, _grad_RSTD):
         X, W, B, Mean, RSTD = ctx.saved_tensors
         DX, DW, DB = layer_norm_backward(dY, X, W, B, Mean, RSTD)
         return DX, DW, DB, None

--- a/src/liger_kernel/ops/backends/_ascend/ops/llama4_rope.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/llama4_rope.py
@@ -293,11 +293,15 @@ def llama4_rope_backward(dq, dk, freqs_cis):
 
 class LigerLlama4RopeFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, q, k, freqs_cis, BLOCK_SIZE: int = None):
+    def forward(q, k, freqs_cis, BLOCK_SIZE: int = None):
         # BLOCK_SIZE is ignored for Ascend (we auto-tile heads by UB), kept for API compatibility
         q_out, k_out = llama4_rope_forward(q, k, freqs_cis)
-        ctx.save_for_backward(freqs_cis.detach() if isinstance(freqs_cis, torch.Tensor) else freqs_cis)
         return q_out, k_out
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        freqs_cis = inputs[2]
+        ctx.save_for_backward(freqs_cis.detach() if isinstance(freqs_cis, torch.Tensor) else freqs_cis)
 
     @staticmethod
     def backward(ctx, dq, dk):

--- a/src/liger_kernel/ops/backends/_ascend/ops/poly_norm.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/poly_norm.py
@@ -754,7 +754,7 @@ class LigerPolyNormFunction(torch.autograd.Function):
 
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, X, W, B, eps=1e-6, in_place=True):
+    def forward(X, W, B, eps=1e-6, in_place=True):
         """
         Args:
             X: input tensor of shape (B, T, H) or (BxT, H)
@@ -767,13 +767,19 @@ class LigerPolyNormFunction(torch.autograd.Function):
             Y: output tensor of same shape as X
         """
         Y, X, RSTD = poly_norm_forward(X, W, B, eps)
+        return Y, X, RSTD
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        W = inputs[1]
+        in_place = inputs[4] if len(inputs) > 4 else True
+        Y, X, RSTD = output
         ctx.in_place = in_place
         ctx.save_for_backward(X, W, RSTD)
-        return Y
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, grad_output):
+    def backward(ctx, grad_output, _grad_X, _grad_RSTD):
         """
         Args:
             grad_output: gradient of output

--- a/src/liger_kernel/ops/backends/_ascend/ops/qwen2vl_mrope.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/qwen2vl_mrope.py
@@ -246,7 +246,7 @@ def qwen2vl_mrope_backward(dq, dk, cos, sin, mrope_section):
 
 class LigerQwen2VLMRopeFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, q, k, cos, sin, mrope_section, unsqueeze_dim=1):
+    def forward(q, k, cos, sin, mrope_section, unsqueeze_dim=1):
         """
         q size: (bsz, n_q_head, seq_len, head_dim)
         k size: (bsz, n_kv_head, seq_len, head_dim)
@@ -254,12 +254,17 @@ class LigerQwen2VLMRopeFunction(torch.autograd.Function):
         sin size: (3, bsz, seq_len, head_dim)
         """
         q, k, cos, sin = qwen2vl_mrope_forward(q, k, cos, sin, mrope_section)
-        ctx.save_for_backward(cos, sin)
-        ctx.mrope_section = mrope_section
-        return q, k
+        return q, k, cos.view_as(cos), sin.view_as(sin)
 
     @staticmethod
-    def backward(ctx, dq, dk):
+    def setup_context(ctx, inputs, output):
+        mrope_section = inputs[4]
+        q, k, cos, sin = output
+        ctx.save_for_backward(cos, sin)
+        ctx.mrope_section = mrope_section
+
+    @staticmethod
+    def backward(ctx, dq, dk, _grad_cos, _grad_sin):
         """
         dq size: (bsz, n_q_head, seq_len, head_dim)
         dk size: (bsz, n_kv_head, seq_len, head_dim)

--- a/src/liger_kernel/ops/backends/_ascend/ops/rms_norm.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/rms_norm.py
@@ -738,7 +738,7 @@ def rms_norm_backward(dY, X, W, RSTD, offset, casting_mode, in_place):
 class LigerRMSNormFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, X, W, eps, offset=0.0, casting_mode="llama", in_place=True, row_mode=None):
+    def forward(X, W, eps, offset=0.0, casting_mode="llama", in_place=True, row_mode=None):
         """
         X: (B, T, H) or (BxT, H)
         W: (H,)
@@ -751,6 +751,14 @@ class LigerRMSNormFunction(torch.autograd.Function):
             X = X.full_tensor()
 
         Y, X, RSTD, casting_mode = rms_norm_forward(X, W, eps, offset, casting_mode)
+        return Y, X, RSTD, casting_mode
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        W = inputs[1]
+        offset = inputs[3] if len(inputs) > 3 else 0.0
+        in_place = inputs[5] if len(inputs) > 5 else True
+        Y, X, RSTD, casting_mode = output
         ctx.offset = offset
         ctx.casting_mode = casting_mode
         ctx.in_place = in_place
@@ -759,11 +767,10 @@ class LigerRMSNormFunction(torch.autograd.Function):
             ctx.save_for_backward(X, W, RSTD)
         else:
             ctx.save_for_backward(X, RSTD)
-        return Y
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, dY):
+    def backward(ctx, dY, _grad_X, _grad_RSTD, _grad_casting_mode):
         """
         Y: (B, T, H) or (BxT, H)
         """

--- a/src/liger_kernel/ops/backends/_ascend/ops/rope.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/rope.py
@@ -237,7 +237,7 @@ def rope_backward(dq, dk, cos, sin):
 
 class LigerRopeFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+    def forward(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
         """
         q size: (bsz, n_q_head, seq_len, head_dim)
         k size: (bsz, n_kv_head, seq_len, head_dim)
@@ -245,11 +245,15 @@ class LigerRopeFunction(torch.autograd.Function):
         sin size: (1, seq_len, head_dim) or (bsz, seq_len, head_dim)
         """
         q, k, cos, sin = rope_forward(q, k, cos, sin)
-        ctx.save_for_backward(cos, sin)
-        return q, k
+        return q, k, cos.view_as(cos), sin.view_as(sin)
 
     @staticmethod
-    def backward(ctx, dq, dk):
+    def setup_context(ctx, inputs, output):
+        q, k, cos, sin = output
+        ctx.save_for_backward(cos, sin)
+
+    @staticmethod
+    def backward(ctx, dq, dk, _grad_cos, _grad_sin):
         """
         dq size: (bsz, n_q_head, seq_len, head_dim)
         dk size: (bsz, n_kv_head, seq_len, head_dim)

--- a/src/liger_kernel/ops/backends/_ascend/ops/softmax.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/softmax.py
@@ -322,17 +322,21 @@ def _softmax_backward(
 class LigerSoftmaxFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, input_: torch.Tensor):
+    def forward(input_: torch.Tensor):
         y, BLOCK_SIZE, ROWS_PER_BLOCK, multi_block_launch = _softmax_forward(input_)
+        return y, BLOCK_SIZE, ROWS_PER_BLOCK, multi_block_launch
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        y, BLOCK_SIZE, ROWS_PER_BLOCK, multi_block_launch = output
         ctx.save_for_backward(y)
         ctx.BLOCK_SIZE = BLOCK_SIZE
         ctx.ROWS_PER_BLOCK = ROWS_PER_BLOCK
         ctx.multi_block_launch = multi_block_launch
-        return y
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, grad_output):
+    def backward(ctx, grad_output, _grad_bs, _grad_rpb, _grad_mbl):
         (y,) = ctx.saved_tensors
         dx = _softmax_backward(
             grad_output,

--- a/src/liger_kernel/ops/backends/_ascend/ops/sparsemax.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/sparsemax.py
@@ -371,15 +371,20 @@ def sparsemax_backward(
 class LigerSparsemaxFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, x: torch.Tensor, dim: int):
+    def forward(x: torch.Tensor, dim: int):
         y, out_flat = sparsemax_forward(x, dim)
+        return y, out_flat
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        _, dim = inputs
+        y, out_flat = output
         ctx.save_for_backward(out_flat)
         ctx.dim = dim
-        return y
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, grad_out: torch.Tensor):
+    def backward(ctx, grad_out: torch.Tensor, _grad_out_flat):
         (out_flat,) = ctx.saved_tensors
         dx = sparsemax_backward(grad_out, out_flat, ctx.dim)
         return dx, None

--- a/src/liger_kernel/ops/backends/_ascend/ops/swiglu.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/swiglu.py
@@ -124,10 +124,14 @@ def swiglu_backward(a, b, dc):
 
 class LigerSiLUMulFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, a, b):
+    def forward(a, b):
         c = swiglu_forward(a, b)
-        ctx.save_for_backward(a, b)
         return c
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        a, b = inputs
+        ctx.save_for_backward(a, b)
 
     @staticmethod
     def backward(ctx, dc):

--- a/src/liger_kernel/ops/backends/_ascend/ops/tvd.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/tvd.py
@@ -171,7 +171,6 @@ class LigerTVDLossFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
     def forward(
-        ctx,
         p: torch.Tensor,
         q: torch.Tensor,
         shift_labels: Optional[torch.Tensor] = None,
@@ -181,7 +180,6 @@ class LigerTVDLossFunction(torch.autograd.Function):
         """A forward pass for the Total Variation Distance Loss.
 
         Args:
-            ctx: Torch autograd context
             p (torch.Tensor): A tensor of shape (BT, V) containing the first distribution.
             q (torch.Tensor): A tensor of shape (BT, V) containing the second distribution.
             shift_labels (Optional[torch.Tensor]): A tensor of shape (BT,) containing the labels.
@@ -200,12 +198,16 @@ class LigerTVDLossFunction(torch.autograd.Function):
             has_label = True
 
         loss, grads = tv_distance_forward_triton(p, q, shift_labels, reduction, ignore_index, has_label)
+        return loss, grads
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        loss, grads = output
         ctx.save_for_backward(grads)
-        return loss
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, grad_output: torch.Tensor) -> torch.Tensor:
+    def backward(ctx, grad_output: torch.Tensor, _grad_grads) -> torch.Tensor:
         """A backward pass for the Total Variation Distance Loss.
 
         Args:

--- a/src/liger_kernel/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cross_entropy.py
@@ -461,7 +461,6 @@ class LigerCrossEntropyFunction(torch.autograd.Function):
 
     @staticmethod
     def forward(
-        ctx,
         _input: torch.Tensor,
         target: torch.Tensor,
         weight: Optional[torch.FloatTensor],
@@ -478,7 +477,6 @@ class LigerCrossEntropyFunction(torch.autograd.Function):
         The forward pass of the Liger Cross Entropy loss.
 
         Parameters:
-        ctx : The context object.
         _input (tensor): The input tensor of shape (BT, V) where B is batch size, T is sequence length, V is vocab size.
         target (tensor): The target tensor of shape (BT) where each value is in [0, V-1].
         weight(Tensor, optional): a manual rescaling weight given to each class. If given, has to be a Tensor of size V and floating point dtype
@@ -492,10 +490,8 @@ class LigerCrossEntropyFunction(torch.autograd.Function):
         return_predicted_tokens (bool): When `return_predicted_tokens` is `True`, returns per-token predicted class indices (argmax) without materializing logits. Default: `False`
 
         Returns:
-        tuple: A tuple with the computed losses, accuracy, and predicted tokens: (loss, z_loss, token_accuracy, predicted_tokens). z_loss, token_accuracy, and predicted_tokens are None if not requested.
+        tuple: A tuple with the computed losses, accuracy, predicted tokens, and modified input: (loss, z_loss, token_accuracy, predicted_tokens, _input).
         """
-        input_requires_grad = _input.requires_grad
-
         loss, z_loss, token_accuracy, predicted_tokens, _input = cross_entropy_forward(
             _input,
             target,
@@ -509,19 +505,37 @@ class LigerCrossEntropyFunction(torch.autograd.Function):
             return_token_accuracy,
             return_predicted_tokens,
         )
+
+        return loss, z_loss, token_accuracy, predicted_tokens, _input
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        (
+            _input_orig,
+            target,
+            weight,
+            ignore_index,
+            lse_square_scale,
+            label_smoothing,
+            reduction,
+            softcap,
+            return_z_loss,
+            return_token_accuracy,
+            return_predicted_tokens,
+        ) = inputs
+        loss, z_loss, token_accuracy, predicted_tokens, _input_modified = output
+
         # TODO: investigation
         # If we don't detach the _input tensor, the memory will double
         # Not sure why but seems that there will be a time both grad and value exist but in different location
-        if input_requires_grad:
-            ctx.save_for_backward(_input.detach())
+        if _input_orig.requires_grad:
+            ctx.save_for_backward(_input_modified.detach())
         ctx.return_z_loss = return_z_loss
         ctx.return_token_accuracy = return_token_accuracy
         ctx.return_predicted_tokens = return_predicted_tokens
 
-        return loss, z_loss, token_accuracy, predicted_tokens
-
     @staticmethod
-    def backward(ctx, grad_output, grad_output2, grad_output3, grad_output4):
+    def backward(ctx, grad_output, grad_output2, grad_output3, grad_output4, _):
         """
         The backward pass of the Liger Cross Entropy loss.
 
@@ -531,6 +545,7 @@ class LigerCrossEntropyFunction(torch.autograd.Function):
         grad_output2 (tensor): No use. Gradient for z_loss (not used as z_loss is only for logging).
         grad_output3 (tensor): No use. Gradient for token_accuracy (not used as token_accuracy is only for metrics).
         grad_output4 (tensor): No use. Gradient for predicted_tokens (not used as predicted_tokens is only for metrics).
+        _ : No use. Gradient for the extra _input output.
         Returns:
         tuple: A tuple with the gradients with respect to the inputs. The elements are tensors or None.
         """

--- a/src/liger_kernel/ops/dyt.py
+++ b/src/liger_kernel/ops/dyt.py
@@ -147,10 +147,14 @@ def liger_dyt_bwd(dy, x, alpha, gamma, beta):
 class LigerDyTFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, x, alpha, gamma, beta):
+    def forward(x, alpha, gamma, beta):
         y = liger_dyt_fwd(x, alpha, gamma, beta)
-        ctx.save_for_backward(x, alpha, gamma, beta)
         return y
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        x, alpha, gamma, beta = inputs
+        ctx.save_for_backward(x, alpha, gamma, beta)
 
     @staticmethod
     @ensure_contiguous

--- a/src/liger_kernel/ops/experimental/embedding.py
+++ b/src/liger_kernel/ops/experimental/embedding.py
@@ -76,7 +76,7 @@ def embedding_backward_kernel(
 class LigerEmbeddingFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, embeddings: torch.Tensor, indices: torch.Tensor):
+    def forward(embeddings: torch.Tensor, indices: torch.Tensor):
         ori_shape = indices.shape
         indices = indices.view(-1)
         output = torch.empty(
@@ -106,9 +106,12 @@ class LigerEmbeddingFunction(torch.autograd.Function):
             BLOCK_SIZE_N=BLOCK_SIZE_N,
         )
 
-        ctx.save_for_backward(indices, embeddings)
-
         return output.view(*ori_shape, -1)
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        embeddings, indices = inputs
+        ctx.save_for_backward(indices, embeddings)
 
     @staticmethod
     @ensure_contiguous

--- a/src/liger_kernel/ops/fused_add_rms_norm.py
+++ b/src/liger_kernel/ops/fused_add_rms_norm.py
@@ -372,24 +372,29 @@ class LigerFusedAddRMSNormFunction(torch.autograd.Function):
 
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, X, R, W, eps, offset=0.0, casting_mode="llama", in_place=False):
+    def forward(X, R, W, eps, offset=0.0, casting_mode="llama", in_place=False):
         """
         X: (B, T, H) or (BxT, H)
         W: (H,)
         """
         # TODO: add row_mode
         Y, S, RSTD, BLOCK_SIZE, num_warps, casting_mode = fused_add_rms_norm_forward(X, R, W, eps, offset, casting_mode)
+        return Y, S, RSTD, BLOCK_SIZE, num_warps, casting_mode
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        X, R, W, eps, offset, casting_mode, in_place = inputs
+        Y, S, RSTD, BLOCK_SIZE, num_warps, casting_mode_out = output
         ctx.offset = offset
-        ctx.casting_mode = casting_mode
+        ctx.casting_mode = casting_mode_out
         ctx.in_place = in_place
         ctx.BLOCK_SIZE = BLOCK_SIZE
         ctx.num_warps = num_warps
         ctx.save_for_backward(S, W, RSTD)
-        return Y, S
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, dY, dS_out):
+    def backward(ctx, dY, dS_out, _dRSTD, _dBLOCK_SIZE, _dnum_warps, _dcasting_mode):
         """
         Y: (B, T, H) or (BxT, H)
         """
@@ -407,4 +412,4 @@ class LigerFusedAddRMSNormFunction(torch.autograd.Function):
             ctx.in_place,
         )
 
-        return dX, dR, dW, None, None, None, None, None
+        return dX, dR, dW, None, None, None, None

--- a/src/liger_kernel/ops/fused_neighborhood_attention.py
+++ b/src/liger_kernel/ops/fused_neighborhood_attention.py
@@ -862,20 +862,28 @@ def fused_neighborhood_attention_forward(
 class LigerFusedNeighborhoodAttentionFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, query, key, value, kernel_size=7, dilation=1, scale=None):
+    def forward(query, key, value, kernel_size=7, dilation=1, scale=None):
         output, attn_weights, softmax_params = fused_neighborhood_attention_forward(
             query, key, value, kernel_size, dilation, scale
         )
+        return output, attn_weights, softmax_params
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        query, key, value = inputs[:3]
+        kernel_size = inputs[3] if len(inputs) > 3 else 7
+        dilation = inputs[4] if len(inputs) > 4 else 1
+        scale = inputs[5] if len(inputs) > 5 else None
+        output_val, attn_weights, softmax_params = output
         ctx.save_for_backward(query, key, value, attn_weights)
         ctx.kernel_size = kernel_size
         ctx.dilation = dilation
         ctx.scale = scale
         ctx.softmax_params = softmax_params
-        return output
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, grad_output):
+    def backward(ctx, grad_output, _grad_attn_weights, _grad_softmax_params):
         query, key, value, attn_weights = ctx.saved_tensors
         BLOCK_SIZE_softmax, num_warps_softmax, multi_block_launch = ctx.softmax_params
 

--- a/src/liger_kernel/ops/geglu.py
+++ b/src/liger_kernel/ops/geglu.py
@@ -130,14 +130,18 @@ def geglu_backward(a, b, dc):
 class LigerGELUMulFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, a, b):
+    def forward(a, b):
         a, b, c = geglu_forward(a, b)
+        return c, a, b
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        c, a, b = output
         ctx.save_for_backward(a, b)
-        return c
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, dc):
+    def backward(ctx, dc, _da, _db):
         a, b = ctx.saved_tensors
         a, b = geglu_backward(a, b, dc)
         return a, b

--- a/src/liger_kernel/ops/group_norm.py
+++ b/src/liger_kernel/ops/group_norm.py
@@ -282,7 +282,6 @@ class LigerGroupNormFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
     def forward(
-        ctx,
         X,
         affine_scaling_weight,
         affine_shifting_bias,
@@ -298,14 +297,19 @@ class LigerGroupNormFunction(torch.autograd.Function):
             affine_shifting_bias,
             eps,
         )
+        return Y, X, Mean, RSTD
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        _X, affine_scaling_weight, affine_shifting_bias, num_channels, num_groups, eps = inputs
+        Y, X_out, Mean, RSTD = output
         ctx.num_channels = num_channels
         ctx.num_groups = num_groups
-        ctx.save_for_backward(X, affine_scaling_weight, affine_shifting_bias, Mean, RSTD)
-        return Y
+        ctx.save_for_backward(X_out, affine_scaling_weight, affine_shifting_bias, Mean, RSTD)
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, dY):
+    def backward(ctx, dY, _dX_out, _dMean, _dRSTD):
         X, W, B, Mean, RSTD = ctx.saved_tensors
         DX, DW, DB = group_norm_backward(dY, X, W, B, Mean, RSTD, ctx.num_channels, ctx.num_groups)
         return DX, DW, DB, None, None, None

--- a/src/liger_kernel/ops/grpo_loss.py
+++ b/src/liger_kernel/ops/grpo_loss.py
@@ -550,7 +550,6 @@ def _reduce_loss(per_token_loss, mask, loss_type, max_completion_length, B, L):
 class GrpoLossFunction(torch.autograd.Function):
     @staticmethod
     def forward(
-        ctx,
         logits,
         old_logp,
         ref_logp,
@@ -692,20 +691,9 @@ class GrpoLossFunction(torch.autograd.Function):
                 **kwargs,
             )
 
-            # Save extra tensors for backward
-            ctx.save_for_backward(
-                logits,
-                old_logp,
-                ref_logp,
-                completion_ids,
-                advantages,
-                completion_mask,
-                lse,
-                mask,
-                coef_1,
-                seq_lens,
-                vllm_is_ratio_ptr,
-            )
+            # Save coef_1 and seq_lens for sequence-level backward
+            _coef_1 = coef_1
+            _seq_lens = seq_lens
         else:
             # Token-level: use optimized Triton kernel with LOSS_TYPE branching
             kwargs = {"BLOCK_N": 2048, "num_stages": 2, "num_warps": 1}
@@ -735,29 +723,8 @@ class GrpoLossFunction(torch.autograd.Function):
                 N,
                 **kwargs,
             )
-            ctx.save_for_backward(
-                logits, old_logp, ref_logp, completion_ids, advantages, completion_mask, lse, mask, vllm_is_ratio_ptr
-            )
-
-        ctx.infos = (
-            temperature,
-            beta,
-            eps_low,
-            eps_high,
-            inplace,
-            loss_type,
-            loss_type_int,
-            sapo_temperature_pos,
-            sapo_temperature_neg,
-            max_completion_length,
-            B,
-            L,
-            importance_sampling_level,
-            vllm_is_ratio_stride,
-            reduce,
-            delta_val,
-            use_bias_correction_kl,
-        )
+            _coef_1 = None
+            _seq_lens = None
 
         # Compute metrics before reduction
         mask_sum = mask.sum().clamp(min=1.0)
@@ -768,10 +735,48 @@ class GrpoLossFunction(torch.autograd.Function):
             loss_out = loss * mask
             kl_out = kl * mask if kl is not None else None
             is_clipped_out = is_clipped * mask
-            return loss_out, kl_out, is_clipped_out
+            return loss_out, kl_out, is_clipped_out, lse, mask, _coef_1, _seq_lens, vllm_is_ratio_ptr
 
         reduced_loss = _reduce_loss(loss, mask, loss_type, max_completion_length, B, L)
-        return reduced_loss, kl_mean, clip_ratio
+        return reduced_loss, kl_mean, clip_ratio, lse, mask, _coef_1, _seq_lens, vllm_is_ratio_ptr
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        (
+            logits, old_logp, ref_logp, completion_ids, advantages, completion_mask,
+            temperature, beta, eps_low, eps_high, inplace, loss_type,
+            max_completion_length, reduce, importance_sampling_level,
+            sapo_temperature_pos, sapo_temperature_neg, vllm_is_ratio, delta,
+            use_bias_correction_kl,
+        ) = inputs
+        # output has 8 elements: 3 main outputs + 5 intermediates
+        _, _, _, lse, mask, coef_1, seq_lens, vllm_is_ratio_ptr = output
+
+        B, L_ADD_1, N = logits.shape
+        L = L_ADD_1 - 1
+        loss_type_int = _str_to_loss_type[loss_type]
+        delta_val = 0.0 if delta is None else float(delta)
+        vllm_is_ratio_stride = L  # default
+        if vllm_is_ratio is not None:
+            vllm_is_ratio_stride = vllm_is_ratio.shape[1] if vllm_is_ratio.dim() > 1 else 1
+
+        if importance_sampling_level == "sequence":
+            ctx.save_for_backward(
+                logits, old_logp, ref_logp, completion_ids, advantages,
+                completion_mask, lse, mask, coef_1, seq_lens, vllm_is_ratio_ptr,
+            )
+        else:
+            ctx.save_for_backward(
+                logits, old_logp, ref_logp, completion_ids, advantages,
+                completion_mask, lse, mask, vllm_is_ratio_ptr,
+            )
+
+        ctx.infos = (
+            temperature, beta, eps_low, eps_high, inplace, loss_type, loss_type_int,
+            sapo_temperature_pos, sapo_temperature_neg, max_completion_length,
+            B, L, importance_sampling_level, vllm_is_ratio_stride, reduce, delta_val,
+            use_bias_correction_kl,
+        )
 
     @staticmethod
     def backward(ctx, *args):

--- a/src/liger_kernel/ops/jsd.py
+++ b/src/liger_kernel/ops/jsd.py
@@ -157,7 +157,6 @@ class LigerJSDFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
     def forward(
-        ctx,
         _input: torch.Tensor,
         target: torch.Tensor,
         shift_labels: Optional[torch.Tensor] = None,
@@ -173,7 +172,7 @@ class LigerJSDFunction(torch.autograd.Function):
             ignore_index (int): the index to ignore. Default: -100
 
         Returns:
-            loss (torch.Tensor): generalized JSD
+            tuple: (loss, dX) where dX is saved for backward
         """
         has_label = False
         if shift_labels is not None:
@@ -184,12 +183,16 @@ class LigerJSDFunction(torch.autograd.Function):
             has_label = True
 
         loss, dX = jsd_forward(_input, target, shift_labels, beta, ignore_index, has_label)
+        return loss, dX
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        loss, dX = output
         ctx.save_for_backward(dX)
-        return loss
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, grad_output: torch.Tensor) -> torch.Tensor:
+    def backward(ctx, grad_output: torch.Tensor, _) -> torch.Tensor:
         (dX,) = ctx.saved_tensors
         dX = jsd_backward(dX, grad_output)
         return (

--- a/src/liger_kernel/ops/kl_div.py
+++ b/src/liger_kernel/ops/kl_div.py
@@ -200,7 +200,6 @@ class LigerKLDivLossFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
     def forward(
-        ctx,
         y_pred: torch.Tensor,
         y_true: torch.Tensor,
         reduction: REDUCTION_LITERAL = "batchmean",
@@ -210,7 +209,6 @@ class LigerKLDivLossFunction(torch.autograd.Function):
         """A forward pass for the KL Divergence Loss.
 
         Args:
-            ctx: Torch autograd context
             y_pred (torch.Tensor): A tensor of shape (BT, V) containing the predicted values, expected to be log-probabilities.
             y_true (torch.Tensor): A tensor of shape (BT, V) containing the target values, expected to be either probabilities or log-probabilities, depending on the value of `log_target`.
             reduction (REDUCTION_LITERAL, optional): Reduction to be used. Defaults to "batchmean".
@@ -220,10 +218,14 @@ class LigerKLDivLossFunction(torch.autograd.Function):
         Returns:
             torch.Tensor: The computed KL Divergence Loss, with shape (BT, V) if `reduction` is "none", else a scalar.
         """
+        return kldiv_forward_triton(y_pred, y_true, log_target=log_target, reduction=reduction, eps=eps)
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        y_pred, y_true, reduction, log_target, eps = inputs
         ctx.save_for_backward(y_true)
         ctx.reduction = reduction
         ctx.log_target = log_target
-        return kldiv_forward_triton(y_pred, y_true, log_target=log_target, reduction=reduction, eps=eps)
 
     @staticmethod
     @ensure_contiguous

--- a/src/liger_kernel/ops/layer_norm.py
+++ b/src/liger_kernel/ops/layer_norm.py
@@ -307,14 +307,19 @@ def layer_norm_backward(dY, X, W, B, Mean, RSTD):
 class LigerLayerNormFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, X, W, B, eps):
+    def forward(X, W, B, eps):
         Y, X, Mean, RSTD, BLOCK_SIZE, num_warps = layer_norm_forward(X, W, B, eps)
-        ctx.save_for_backward(X, W, B, Mean, RSTD)
-        return Y
+        return Y, X, Mean, RSTD
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        _X, W, B, eps = inputs
+        Y, X_out, Mean, RSTD = output
+        ctx.save_for_backward(X_out, W, B, Mean, RSTD)
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, dY):
+    def backward(ctx, dY, _dX_out, _dMean, _dRSTD):
         X, W, B, Mean, RSTD = ctx.saved_tensors
         DX, DW, DB = layer_norm_backward(dY, X, W, B, Mean, RSTD)
         return DX, DW, DB, None

--- a/src/liger_kernel/ops/llama4_rope.py
+++ b/src/liger_kernel/ops/llama4_rope.py
@@ -165,16 +165,23 @@ def llama4_rope_forward(q, k, freqs_cis, BLOCK_SIZE: int = None, imag_sign: floa
 
 class LigerLlama4RopeFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, q, k, freqs_cis, BLOCK_SIZE: int = None):
+    def forward(q, k, freqs_cis, BLOCK_SIZE: int = None):
         q_out, k_out = llama4_rope_forward(q, k, freqs_cis, BLOCK_SIZE, imag_sign=1.0)
-        ctx.save_for_backward(freqs_cis.detach() if isinstance(freqs_cis, torch.Tensor) else freqs_cis)
-        ctx.BLOCK_SIZE = BLOCK_SIZE
-        return q_out, k_out
+        freqs_cis_saved = freqs_cis.detach() if isinstance(freqs_cis, torch.Tensor) else freqs_cis
+        return q_out, k_out, freqs_cis_saved
 
     @staticmethod
-    def backward(ctx, dq, dk):
+    def setup_context(ctx, inputs, output):
+        _q, _k, _freqs_cis = inputs[:3]
+        BLOCK_SIZE = inputs[3] if len(inputs) > 3 else None
+        _q_out, _k_out, freqs_cis_saved = output
+        ctx.save_for_backward(freqs_cis_saved)
+        ctx.BLOCK_SIZE = BLOCK_SIZE
+
+    @staticmethod
+    def backward(ctx, dq, dk, _grad_freqs):
         (freqs_cis,) = ctx.saved_tensors
         BLOCK_SIZE = getattr(ctx, "BLOCK_SIZE", None)
         # Use imag_sign=-1.0 for conjugate without materializing a new tensor
         dq_out, dk_out = llama4_rope_forward(dq, dk, freqs_cis, BLOCK_SIZE, imag_sign=-1.0)
-        return dq_out, dk_out, None
+        return dq_out, dk_out, None, None

--- a/src/liger_kernel/ops/mhc.py
+++ b/src/liger_kernel/ops/mhc.py
@@ -1392,7 +1392,6 @@ class LigerMHCCoeffsFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
     def forward(  # type: ignore[override]
-        ctx: Any,
         x: torch.Tensor,  # [..., HC, C] bf16/fp16 (or fp32 if allow_fp32)
         phi: torch.Tensor,  # [HC*C, M]
         b: torch.Tensor,  # [M]
@@ -1405,7 +1404,7 @@ class LigerMHCCoeffsFunction(torch.autograd.Function):
         pre_eps: float,
         sinkhorn_eps: float,
         post_mult: float,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         if allow_fp32:
             assert x.dtype in (
                 torch.bfloat16,
@@ -1429,47 +1428,18 @@ class LigerMHCCoeffsFunction(torch.autograd.Function):
         mix, invr = mhc_mm_norm_fwd(x_mat, phi, eps=float(rms_eps))
 
         # (2) split + sigmoid + sinkhorn
-        need_hist = any(ctx.needs_input_grad)
-        if need_hist:
-            h_pre, h_post, h_res, hist = mhc_split_sinkhorn_fwd(
-                mix,
-                b,
-                alpha_pre,
-                alpha_post,
-                alpha_res,
-                tmax=int(tmax),
-                pre_eps=float(pre_eps),
-                sinkhorn_eps=float(sinkhorn_eps),
-                post_mult=float(post_mult),
-                return_hist=True,
-            )
-        else:
-            h_pre, h_post, h_res = mhc_split_sinkhorn_fwd(
-                mix,
-                b,
-                alpha_pre,
-                alpha_post,
-                alpha_res,
-                tmax=int(tmax),
-                pre_eps=float(pre_eps),
-                sinkhorn_eps=float(sinkhorn_eps),
-                post_mult=float(post_mult),
-            )
-            hist = None
-
-        # Save for backward
-        if hist is not None:
-            ctx.save_for_backward(x_mat, phi, b, mix, invr, alpha_pre, alpha_post, alpha_res, hist)
-        else:
-            ctx.save_for_backward(x_mat, phi, b, mix, invr, alpha_pre, alpha_post, alpha_res)
-        ctx.meta = (
-            x_shape,
-            HC,
-            C,
-            int(tmax),
-            float(sinkhorn_eps),
-            float(post_mult),
-            hist is not None,
+        # Always compute history since we cannot check needs_input_grad without ctx
+        h_pre, h_post, h_res, hist = mhc_split_sinkhorn_fwd(
+            mix,
+            b,
+            alpha_pre,
+            alpha_post,
+            alpha_res,
+            tmax=int(tmax),
+            pre_eps=float(pre_eps),
+            sinkhorn_eps=float(sinkhorn_eps),
+            post_mult=float(post_mult),
+            return_hist=True,
         )
 
         # Reshape to original leading dims
@@ -1478,6 +1448,35 @@ class LigerMHCCoeffsFunction(torch.autograd.Function):
             h_pre.view(*outer, HC),
             h_post.view(*outer, HC),
             h_res.view(*outer, HC, HC),
+            x_mat, mix, invr, hist,
+        )
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        x = inputs[0]
+        phi = inputs[1]
+        b = inputs[2]
+        alpha_pre = inputs[3]
+        alpha_post = inputs[4]
+        alpha_res = inputs[5]
+        tmax = inputs[7]
+        sinkhorn_eps = inputs[10]
+        post_mult = inputs[11]
+
+        h_pre, h_post, h_res, x_mat, mix, invr, hist = output
+        x_shape = x.shape
+        x_flat, _ = _flatten_tokens(x)
+        N, HC, C = x_flat.shape
+
+        ctx.save_for_backward(x_mat, phi, b, mix, invr, alpha_pre, alpha_post, alpha_res, hist)
+        ctx.meta = (
+            x_shape,
+            HC,
+            C,
+            int(tmax),
+            float(sinkhorn_eps),
+            float(post_mult),
+            True,
         )
 
     @staticmethod
@@ -1487,6 +1486,10 @@ class LigerMHCCoeffsFunction(torch.autograd.Function):
         grad_h_pre: torch.Tensor | None,
         grad_h_post: torch.Tensor | None,
         grad_h_res: torch.Tensor | None,
+        _grad_x_mat,
+        _grad_mix,
+        _grad_invr,
+        _grad_hist,
     ):
         saved = ctx.saved_tensors
         x_shape, HC, C, tmax, sinkhorn_eps, post_mult, has_hist = ctx.meta
@@ -1615,19 +1618,24 @@ class LigerMHCCoeffsFunction(torch.autograd.Function):
 class LigerMHCPreFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx: Any, x: torch.Tensor, h_pre: torch.Tensor) -> torch.Tensor:
+    def forward(x: torch.Tensor, h_pre: torch.Tensor) -> torch.Tensor:
         x_shape = x.shape
         x_flat, _ = _flatten_tokens(x)
         h_pre_flat = h_pre.view(-1, x_flat.shape[1]).to(torch.float32)
         out = mhc_pre_fwd(x_flat, h_pre_flat)  # [N,C] fp32
-        ctx.save_for_backward(x_flat, h_pre_flat)
-        ctx.x_shape = x_shape
         out = out.to(x_flat.dtype)
-        return out.view(*x_shape[:-2], out.shape[-1])
+        return out.view(*x_shape[:-2], out.shape[-1]), x_flat, h_pre_flat
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        x, h_pre = inputs
+        out_val, x_flat, h_pre_flat = output
+        ctx.save_for_backward(x_flat, h_pre_flat)
+        ctx.x_shape = x.shape
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx: Any, grad_out: torch.Tensor):
+    def backward(ctx: Any, grad_out: torch.Tensor, _grad_x_flat, _grad_h_pre_flat):
         x_flat, h_pre_flat = ctx.saved_tensors
         x_shape = ctx.x_shape
         N, HC, C = x_flat.shape
@@ -1641,7 +1649,7 @@ class LigerMHCPostResFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
     def forward(
-        ctx: Any, x: torch.Tensor, f_out: torch.Tensor, h_post: torch.Tensor, h_res: torch.Tensor
+        x: torch.Tensor, f_out: torch.Tensor, h_post: torch.Tensor, h_res: torch.Tensor
     ) -> torch.Tensor:
         x_shape = x.shape
         x_flat, _ = _flatten_tokens(x)
@@ -1650,14 +1658,19 @@ class LigerMHCPostResFunction(torch.autograd.Function):
         h_post_flat = h_post.view(-1, HC).to(torch.float32)
         h_res_flat = h_res.view(-1, HC, HC).to(torch.float32)
         out = mhc_post_res_fwd(x_flat, f_flat, h_post_flat, h_res_flat)  # [N,HC,C] fp32
-        ctx.save_for_backward(x_flat, f_flat, h_post_flat, h_res_flat)
-        ctx.x_shape = x_shape
         out = out.to(x_flat.dtype)
-        return out.view(*x_shape)
+        return out.view(*x_shape), x_flat, f_flat, h_post_flat, h_res_flat
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        x = inputs[0]
+        out_val, x_flat, f_flat, h_post_flat, h_res_flat = output
+        ctx.save_for_backward(x_flat, f_flat, h_post_flat, h_res_flat)
+        ctx.x_shape = x.shape
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx: Any, grad_out: torch.Tensor):
+    def backward(ctx: Any, grad_out: torch.Tensor, _grad_x_flat, _grad_f_flat, _grad_h_post_flat, _grad_h_res_flat):
         x_flat, f_flat, h_post_flat, h_res_flat = ctx.saved_tensors
         x_shape = ctx.x_shape
         N, HC, C = x_flat.shape

--- a/src/liger_kernel/ops/multi_token_attention.py
+++ b/src/liger_kernel/ops/multi_token_attention.py
@@ -118,26 +118,20 @@ def _mask_zero_backward(grad: torch.Tensor) -> torch.Tensor:
 class LigerMultiTokenAttentionFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, scores, weight, bias=None, stride=1, padding=0, dilation=1, groups=1, sparse=False):
+    def forward(scores, weight, bias=None, stride=1, padding=0, dilation=1, groups=1, sparse=False):
         scores_inf = _mask_inf_forward(scores)
 
         out_flat_sparse = None
         activation_output = None
-
-        ctx.sparse = sparse
 
         if sparse:
             if scores_inf.dtype != torch.float32:
                 raise RuntimeError("Liger sparse multi-token attention currently only supports fp32 input scores")
             probs_sparse, out_flat_sparse = _sparsemax_forward(scores_inf, dim=-1)
             activation_output = probs_sparse
-            ctx.save_for_backward(scores_inf, activation_output, out_flat_sparse, weight, bias)
-            ctx.out_flat_sparse_saved = True
         else:
             probs_softmax, _, _, _ = _softmax_forward(scores_inf)
             activation_output = probs_softmax
-            ctx.save_for_backward(scores_inf, activation_output, weight, bias)
-            ctx.out_flat_sparse_saved = False
 
         out_conv = F.conv2d(
             activation_output,
@@ -151,17 +145,36 @@ class LigerMultiTokenAttentionFunction(torch.autograd.Function):
 
         out = _mask_zero_forward(out_conv)
 
+        return out, scores_inf, activation_output, out_flat_sparse
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        scores, weight, bias = inputs[:3]
+        stride = inputs[3] if len(inputs) > 3 else 1
+        padding = inputs[4] if len(inputs) > 4 else 0
+        dilation = inputs[5] if len(inputs) > 5 else 1
+        groups = inputs[6] if len(inputs) > 6 else 1
+        sparse = inputs[7] if len(inputs) > 7 else False
+
+        out, scores_inf, activation_output, out_flat_sparse = output
+
+        ctx.sparse = sparse
+        if sparse:
+            ctx.save_for_backward(scores_inf, activation_output, out_flat_sparse, weight, bias)
+            ctx.out_flat_sparse_saved = True
+        else:
+            ctx.save_for_backward(scores_inf, activation_output, weight, bias)
+            ctx.out_flat_sparse_saved = False
+
         ctx.stride = _pair(stride)
         ctx.padding = _pair(padding)
         ctx.dilation = _pair(dilation)
         ctx.groups = groups
         ctx.dim = -1
 
-        return out
-
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, grad_out):
+    def backward(ctx, grad_out, _grad_scores_inf, _grad_activation_output, _grad_out_flat_sparse):
         if ctx.out_flat_sparse_saved:
             scores_inf, activation_output, out_flat_sparse, weight, bias = ctx.saved_tensors
         else:

--- a/src/liger_kernel/ops/poly_norm.py
+++ b/src/liger_kernel/ops/poly_norm.py
@@ -350,7 +350,7 @@ class LigerPolyNormFunction(torch.autograd.Function):
 
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, X, W, B, eps=1e-6, in_place=True):
+    def forward(X, W, B, eps=1e-6, in_place=True):
         """
         Args:
             X: input tensor of shape (B, T, H) or (BxT, H)
@@ -361,17 +361,26 @@ class LigerPolyNormFunction(torch.autograd.Function):
 
         Returns:
             Y: output tensor of same shape as X
+            X: input tensor (for setup_context)
+            RSTD: reciprocal standard deviation (for setup_context)
+            BLOCK_SIZE: triton block size (for setup_context)
+            num_warps: triton num warps (for setup_context)
         """
         Y, X, RSTD, BLOCK_SIZE, num_warps = poly_norm_forward(X, W, B, eps)
+        return Y, X, RSTD, BLOCK_SIZE, num_warps
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        _X, W, B, eps, in_place = inputs
+        Y, X_out, RSTD, BLOCK_SIZE, num_warps = output
         ctx.BLOCK_SIZE = BLOCK_SIZE
         ctx.num_warps = num_warps
         ctx.in_place = in_place
-        ctx.save_for_backward(X, W, RSTD)
-        return Y
+        ctx.save_for_backward(X_out, W, RSTD)
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, grad_output):
+    def backward(ctx, grad_output, _dX_out, _dRSTD, _dBLOCK_SIZE, _dnum_warps):
         """
         Args:
             grad_output: gradient of output

--- a/src/liger_kernel/ops/qwen2vl_mrope.py
+++ b/src/liger_kernel/ops/qwen2vl_mrope.py
@@ -197,7 +197,7 @@ class LigerQwen2VLMRopeFunction(torch.autograd.Function):
     """
 
     @staticmethod
-    def forward(ctx, q, k, cos, sin, mrope_section, unsqueeze_dim=1):
+    def forward(q, k, cos, sin, mrope_section, unsqueeze_dim=1):
         """
         q size: (bsz, n_q_head, seq_len, head_dim)
         k size: (bsz, n_kv_head, seq_len, head_dim)
@@ -205,11 +205,17 @@ class LigerQwen2VLMRopeFunction(torch.autograd.Function):
         sin size: (3, bsz, seq_len, head_dim)
         """
         q, k, cos, sin = qwen2vl_mrope_forward(q, k, cos, sin, mrope_section)
+        return q, k, cos.view_as(cos), sin.view_as(sin)
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        _q, _k, _cos, _sin, mrope_section = inputs[:5]
+        q, k, cos, sin = output
         ctx.save_for_backward(cos, sin)
         ctx.mrope_section = mrope_section
-        return q, k
 
-    def backward(ctx, dq, dk):
+    @staticmethod
+    def backward(ctx, dq, dk, _grad_cos, _grad_sin):
         """
         dq size: (bsz, n_q_head, seq_len, head_dim)
         dk size: (bsz, n_kv_head, seq_len, head_dim)

--- a/src/liger_kernel/ops/relu_squared.py
+++ b/src/liger_kernel/ops/relu_squared.py
@@ -107,14 +107,18 @@ def relu_squared_backward(X, dY):
 class LigerReLUSquaredFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, X):
+    def forward(X):
         Y = relu_squared_forward(X)
+        return Y, X.view_as(X)
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        Y, X = output
         ctx.save_for_backward(X)
-        return Y
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, dY):
+    def backward(ctx, dY, _dX):
         (X,) = ctx.saved_tensors
         dX = relu_squared_backward(X, dY)
         return dX

--- a/src/liger_kernel/ops/rms_norm.py
+++ b/src/liger_kernel/ops/rms_norm.py
@@ -604,7 +604,7 @@ class LigerRMSNormFunction(torch.autograd.Function):
 
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, X, W, eps, offset=0.0, casting_mode="llama", in_place=True, row_mode=None):
+    def forward(X, W, eps, offset=0.0, casting_mode="llama", in_place=True, row_mode=None):
         """
         X: (B, T, H) or (BxT, H)
         W: (H,)
@@ -617,22 +617,27 @@ class LigerRMSNormFunction(torch.autograd.Function):
             X = X.full_tensor()
 
         Y, X, RSTD, BLOCK_SIZE, num_warps, casting_mode = rms_norm_forward(X, W, eps, offset, casting_mode, row_mode)
+        return Y, X, RSTD, BLOCK_SIZE, num_warps, casting_mode
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        X, W, eps, offset, casting_mode, in_place, row_mode = inputs
+        Y, X_out, RSTD, BLOCK_SIZE, num_warps, casting_mode_out = output
         ctx.offset = offset
-        ctx.casting_mode = casting_mode
+        ctx.casting_mode = casting_mode_out
         ctx.in_place = in_place
         ctx.row_mode = row_mode
         ctx.BLOCK_SIZE = BLOCK_SIZE
         ctx.num_warps = num_warps
         ctx.elementwise_affine = W is not None
         if W is not None:
-            ctx.save_for_backward(X, W, RSTD)
+            ctx.save_for_backward(X_out, W, RSTD)
         else:
-            ctx.save_for_backward(X, RSTD)
-        return Y
+            ctx.save_for_backward(X_out, RSTD)
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, dY):
+    def backward(ctx, dY, _dX_out, _dRSTD, _dBLOCK_SIZE, _dnum_warps, _dcasting_mode):
         """
         Y: (B, T, H) or (BxT, H)
         """

--- a/src/liger_kernel/ops/rope.py
+++ b/src/liger_kernel/ops/rope.py
@@ -215,7 +215,7 @@ class LigerRopeFunction(torch.autograd.Function):
     """
 
     @staticmethod
-    def forward(ctx, q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+    def forward(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
         """
         q size: (bsz, n_q_head, seq_len, head_dim)
         k size: (bsz, n_kv_head, seq_len, head_dim)
@@ -223,10 +223,15 @@ class LigerRopeFunction(torch.autograd.Function):
         sin size: (1, seq_len, head_dim) or (bsz, seq_len, head_dim)
         """
         q, k, cos, sin = rope_forward(q, k, cos, sin)
-        ctx.save_for_backward(cos, sin)
-        return q, k
+        return q, k, cos.view_as(cos), sin.view_as(sin)
 
-    def backward(ctx, dq, dk):
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        q, k, cos, sin = output
+        ctx.save_for_backward(cos, sin)
+
+    @staticmethod
+    def backward(ctx, dq, dk, _grad_cos, _grad_sin):
         """
         dq size: (bsz, n_q_head, seq_len, head_dim)
         dk size: (bsz, n_kv_head, seq_len, head_dim)

--- a/src/liger_kernel/ops/softmax.py
+++ b/src/liger_kernel/ops/softmax.py
@@ -179,17 +179,21 @@ def _softmax_backward(
 class LigerSoftmaxFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, input_: torch.Tensor):
+    def forward(input_: torch.Tensor):
         y, BLOCK_SIZE, num_warps, multi_block_launch = _softmax_forward(input_)
+        return y, BLOCK_SIZE, num_warps, multi_block_launch
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        y, BLOCK_SIZE, num_warps, multi_block_launch = output
         ctx.save_for_backward(y)
         ctx.BLOCK_SIZE = BLOCK_SIZE
         ctx.num_warps = num_warps
         ctx.multi_block_launch = multi_block_launch
-        return y
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, grad_output):
+    def backward(ctx, grad_output, _grad_block_size, _grad_num_warps, _grad_multi_block_launch):
         (y,) = ctx.saved_tensors
         dx = _softmax_backward(
             grad_output,

--- a/src/liger_kernel/ops/sparsemax.py
+++ b/src/liger_kernel/ops/sparsemax.py
@@ -163,15 +163,20 @@ def _sparsemax_backward(
 class LigerSparsemaxFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, x: torch.Tensor, dim: int):
+    def forward(x: torch.Tensor, dim: int):
         y, out_flat = _sparsemax_forward(x, dim)
+        return y, out_flat
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        x, dim = inputs
+        y, out_flat = output
         ctx.save_for_backward(out_flat)
         ctx.dim = dim
-        return y
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, grad_out: torch.Tensor):
+    def backward(ctx, grad_out: torch.Tensor, _grad_out_flat):
         (out_flat,) = ctx.saved_tensors
         dx = _sparsemax_backward(grad_out, out_flat, ctx.dim)
         return dx, None

--- a/src/liger_kernel/ops/swiglu.py
+++ b/src/liger_kernel/ops/swiglu.py
@@ -103,7 +103,7 @@ def swiglu_backward(a, b, dc):
 class LigerSiLUMulFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
-    def forward(ctx, a, b):
+    def forward(a, b):
         if isinstance(a, torch.distributed.tensor.DTensor) or isinstance(b, torch.distributed.tensor.DTensor):
             device_mesh, placements = (
                 (a.device_mesh, a.placements)
@@ -118,18 +118,23 @@ class LigerSiLUMulFunction(torch.autograd.Function):
             if not isinstance(b, torch.distributed.tensor.DTensor):
                 b = torch.distributed.tensor.distribute_tensor(b, device_mesh=device_mesh, placements=placements)
             a_local, b_local, c_local = swiglu_forward(a.to_local(), b.to_local())
-            ctx.save_for_backward(a_local, b_local)
-            ctx.dtensor_metadata = (device_mesh, placements)
-            return torch.distributed.tensor.DTensor.from_local(c_local, device_mesh, placements)
+            c = torch.distributed.tensor.DTensor.from_local(c_local, device_mesh, placements)
+            dtensor_metadata = (device_mesh, placements)
+            return c, a_local, b_local, dtensor_metadata
         else:
             a, b, c = swiglu_forward(a, b)
-            ctx.save_for_backward(a, b)
-            ctx.dtensor_metadata = None
-            return c
+            dtensor_metadata = None
+            return c, a, b, dtensor_metadata
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        c, a, b, dtensor_metadata = output
+        ctx.save_for_backward(a, b)
+        ctx.dtensor_metadata = dtensor_metadata
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, dc):
+    def backward(ctx, dc, _da, _db, _dmeta):
         a, b = ctx.saved_tensors
         if ctx.dtensor_metadata is not None:
             device_mesh, placements = ctx.dtensor_metadata

--- a/src/liger_kernel/ops/tiled_mlp.py
+++ b/src/liger_kernel/ops/tiled_mlp.py
@@ -34,18 +34,12 @@ class LigerTiledMLPFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
     def forward(
-        ctx,
         fn: Callable,
         mlp_module: torch.nn.Module,
         x: torch.Tensor,
         shards: int,
         compute_params: Optional[List[torch.nn.Parameter]] = None,
     ) -> torch.Tensor:
-        ctx.fn = fn
-        ctx.mlp_module = mlp_module
-        ctx.shards = shards
-        ctx.save_for_backward(x)
-
         # x.shape could be [bs, seqlen, hidden_size] or [seqlen, hidden_size] (moe experts)
         x_shards = list(torch.chunk(x, chunks=shards, dim=-2))
         with torch.no_grad():
@@ -53,6 +47,14 @@ class LigerTiledMLPFunction(torch.autograd.Function):
         output_unsharded = torch.cat(output_shards, dim=-2)
 
         return output_unsharded
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        fn, mlp_module, x, shards = inputs[:4]
+        ctx.fn = fn
+        ctx.mlp_module = mlp_module
+        ctx.shards = shards
+        ctx.save_for_backward(x)
 
     @staticmethod
     @ensure_contiguous

--- a/src/liger_kernel/ops/tvd.py
+++ b/src/liger_kernel/ops/tvd.py
@@ -168,7 +168,6 @@ class LigerTVDLossFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
     def forward(
-        ctx,
         p: torch.Tensor,
         q: torch.Tensor,
         shift_labels: Optional[torch.Tensor] = None,
@@ -178,7 +177,6 @@ class LigerTVDLossFunction(torch.autograd.Function):
         """A forward pass for the Total Variation Distance Loss.
 
         Args:
-            ctx: Torch autograd context
             p (torch.Tensor): A tensor of shape (BT, V) containing the first distribution.
             q (torch.Tensor): A tensor of shape (BT, V) containing the second distribution.
             shift_labels (Optional[torch.Tensor]): A tensor of shape (BT,) containing the labels.
@@ -186,7 +184,7 @@ class LigerTVDLossFunction(torch.autograd.Function):
             ignore_index (int, optional): The index to ignore during loss calculation. Defaults to -100.
 
         Returns:
-            torch.Tensor: The computed Total Variation Distance Loss.
+            tuple: (loss, grads) where grads is saved for backward.
         """
         has_label = False
         if shift_labels is not None:
@@ -197,12 +195,16 @@ class LigerTVDLossFunction(torch.autograd.Function):
             has_label = True
 
         loss, grads = tv_distance_forward_triton(p, q, shift_labels, reduction, ignore_index, has_label)
+        return loss, grads
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        loss, grads = output
         ctx.save_for_backward(grads)
-        return loss
 
     @staticmethod
     @ensure_contiguous
-    def backward(ctx, grad_output: torch.Tensor) -> torch.Tensor:
+    def backward(ctx, grad_output: torch.Tensor, _) -> torch.Tensor:
         """A backward pass for the Total Variation Distance Loss.
 
         Args:

--- a/src/liger_kernel/ops/utils.py
+++ b/src/liger_kernel/ops/utils.py
@@ -31,13 +31,13 @@ def is_hip() -> bool:
 
 def ensure_contiguous(fn):
     @functools.wraps(fn)
-    def wrapper(ctx, *args, **kwargs):
+    def wrapper(*args, **kwargs):
         def maybe_to_contiguous(x):
             return x.contiguous() if isinstance(x, torch.Tensor) else x
 
         args = [maybe_to_contiguous(arg) for arg in args]
         kwargs = {k: maybe_to_contiguous(v) for k, v in kwargs.items()}
-        return fn(ctx, *args, **kwargs)
+        return fn(*args, **kwargs)
 
     return wrapper
 

--- a/src/liger_kernel/transformers/cross_entropy.py
+++ b/src/liger_kernel/transformers/cross_entropy.py
@@ -40,7 +40,7 @@ class LigerCrossEntropyLoss(torch.nn.Module):
         self.return_predicted_tokens = return_predicted_tokens
 
     def forward(self, _input: torch.Tensor, target: torch.Tensor):
-        loss, z_loss, token_accuracy, predicted_tokens = LigerCrossEntropyFunction.apply(
+        loss, z_loss, token_accuracy, predicted_tokens, _ = LigerCrossEntropyFunction.apply(
             _input,
             target,
             self.weight,

--- a/src/liger_kernel/transformers/functional.py
+++ b/src/liger_kernel/transformers/functional.py
@@ -55,7 +55,7 @@ def liger_cross_entropy(
     return_token_accuracy: bool = False,
     return_predicted_tokens: bool = False,
 ):
-    loss, z_loss, token_accuracy, predicted_tokens = LigerCrossEntropyFunction.apply(
+    loss, z_loss, token_accuracy, predicted_tokens, _ = LigerCrossEntropyFunction.apply(
         input,
         target,
         weight,
@@ -143,7 +143,7 @@ def liger_fused_linear_jsd(
 
 
 def liger_geglu(a, b):
-    return LigerGELUMulFunction.apply(a, b)
+    return LigerGELUMulFunction.apply(a, b)[0]
 
 
 def liger_group_norm(
@@ -161,7 +161,7 @@ def liger_group_norm(
         num_channels,
         num_groups,
         eps,
-    )
+    )[0]
 
 
 def liger_jsd(
@@ -171,13 +171,14 @@ def liger_jsd(
     beta: float = 0.5,
     ignore_index: int = -100,
 ):
-    return LigerJSDFunction.apply(
+    loss, _ = LigerJSDFunction.apply(
         input,
         target,
         shift_labels,
         beta,
         ignore_index,
     )
+    return loss
 
 
 # conform to the function signature in https://pytorch.org/docs/stable/generated/torch.nn.functional.kl_div.html#torch.nn.functional.kl_div
@@ -205,7 +206,7 @@ def liger_sparsemax(
     input,
     dim: int = -1,
 ):
-    return LigerSparsemaxFunction.apply(input, dim)
+    return LigerSparsemaxFunction.apply(input, dim)[0]
 
 
 def liger_multi_token_attention(
@@ -233,7 +234,7 @@ def liger_multi_token_attention(
     Returns:
         Output tensor after applying multi-token attention.
     """
-    return LigerMultiTokenAttentionFunction.apply(scores, weight, bias, stride, padding, dilation, groups, sparse)
+    return LigerMultiTokenAttentionFunction.apply(scores, weight, bias, stride, padding, dilation, groups, sparse)[0]
 
 
 def liger_fused_neighborhood_attention(
@@ -260,7 +261,7 @@ def liger_fused_neighborhood_attention(
     Returns:
         Output tensor of shape [batch_size, num_heads, seq_len, head_dim]
     """
-    return LigerFusedNeighborhoodAttentionFunction.apply(query, key, value, kernel_size, dilation, scale)
+    return LigerFusedNeighborhoodAttentionFunction.apply(query, key, value, kernel_size, dilation, scale)[0]
 
 
 def liger_tvd(
@@ -270,49 +271,52 @@ def liger_tvd(
     reduction: str = "mean",
     ignore_index: int = -100,
 ):
-    return LigerTVDLossFunction.apply(
+    loss, _ = LigerTVDLossFunction.apply(
         input,
         target,
         shift_labels,
         reduction,
         ignore_index,
     )
+    return loss
 
 
 def liger_layer_norm(X, W, B, eps):
-    return LigerLayerNormFunction.apply(X, W, B, eps)
+    return LigerLayerNormFunction.apply(X, W, B, eps)[0]
 
 
 def liger_qwen2vl_mrope(q, k, cos, sin, mrope_section, unsqueeze_dim=1):
-    return LigerQwen2VLMRopeFunction.apply(q, k, cos, sin, mrope_section, unsqueeze_dim)
+    q, k, _, _ = LigerQwen2VLMRopeFunction.apply(q, k, cos, sin, mrope_section, unsqueeze_dim)
+    return q, k
 
 
 def liger_relu_squared(x):
-    return LigerReLUSquaredFunction.apply(x)
+    return LigerReLUSquaredFunction.apply(x)[0]
 
 
 def liger_rms_norm(X, W, eps, offset: float = 0.0, casting_mode: str = "llama", in_place: bool = True):
-    return LigerRMSNormFunction.apply(X, W, eps, offset, casting_mode, in_place)
+    return LigerRMSNormFunction.apply(X, W, eps, offset, casting_mode, in_place)[0]
 
 
 def liger_poly_norm(X, W, B, eps=1e-6, in_place=True):
-    return LigerPolyNormFunction.apply(X, W, B, eps, in_place)
+    return LigerPolyNormFunction.apply(X, W, B, eps, in_place)[0]
 
 
 def liger_fused_add_rms_norm(X, R, W, eps, offset: float = 0.0, casting_mode: str = "llama", in_place: bool = True):
-    return LigerFusedAddRMSNormFunction.apply(X, R, W, eps, offset, casting_mode, in_place)
+    return LigerFusedAddRMSNormFunction.apply(X, R, W, eps, offset, casting_mode, in_place)[:2]
 
 
 def liger_rope(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
-    return LigerRopeFunction.apply(q, k, cos, sin, position_ids, unsqueeze_dim)
+    q, k, _, _ = LigerRopeFunction.apply(q, k, cos, sin, position_ids, unsqueeze_dim)
+    return q, k
 
 
 def liger_swiglu(a, b):
-    return LigerSiLUMulFunction.apply(a, b)
+    return LigerSiLUMulFunction.apply(a, b)[0]
 
 
 def liger_softmax(x):
-    return LigerSoftmaxFunction.apply(x)
+    return LigerSoftmaxFunction.apply(x)[0]
 
 
 def liger_dyt(x, alpha, gamma, beta):
@@ -336,7 +340,7 @@ def liger_mhc_coeffs(
 ):
     # Convert config scalars to Python types so they are not included in the
     # autograd computation graph (they are not learnable parameters).
-    return LigerMHCCoeffsFunction.apply(
+    result = LigerMHCCoeffsFunction.apply(
         x,
         phi,
         b,
@@ -350,14 +354,15 @@ def liger_mhc_coeffs(
         float(sinkhorn_eps),
         float(post_mult),
     )
+    return result[0], result[1], result[2]
 
 
 def liger_mhc_pre(x, h_pre):
-    return LigerMHCPreFunction.apply(x, h_pre)
+    return LigerMHCPreFunction.apply(x, h_pre)[0]
 
 
 def liger_mhc_post_res(x, f_out, h_post, h_res):
-    return LigerMHCPostResFunction.apply(x, f_out, h_post, h_res)
+    return LigerMHCPostResFunction.apply(x, f_out, h_post, h_res)[0]
 
 
 def liger_mhc_apply(x, f_out, h_pre, h_post, h_res, *, return_x_in: bool = False):
@@ -425,7 +430,7 @@ def liger_attn_res(V, w_query, w_norm, eps: float = 1e-6):
         #         V = torch.stack(block_outputs)  # [N, B, T, D]
         #         return liger_attn_res(V, self.w_query, self.w_norm)
     """
-    return LigerAttnResFunction.apply(V, w_query, w_norm, eps)
+    return LigerAttnResFunction.apply(V, w_query, w_norm, eps)[0]
 
 
 def liger_mhc_forward(

--- a/src/liger_kernel/transformers/fused_add_rms_norm.py
+++ b/src/liger_kernel/transformers/fused_add_rms_norm.py
@@ -31,7 +31,7 @@ class LigerFusedAddRMSNorm(nn.Module):
             self.offset,
             self.casting_mode,
             self.in_place,
-        )
+        )[:2]
 
     def extra_repr(self):
         return (

--- a/src/liger_kernel/transformers/fused_neighborhood_attention.py
+++ b/src/liger_kernel/transformers/fused_neighborhood_attention.py
@@ -102,7 +102,7 @@ class LigerFusedNeighborhoodAttention(nn.Module):
 
         attn_output = LigerFusedNeighborhoodAttentionFunction.apply(
             query, key, value, self.kernel_size, self.dilation, self.scale
-        )
+        )[0]
 
         attn_output = attn_output.transpose(1, 2).contiguous().view(batch_size, seq_len, hidden_size)
 

--- a/src/liger_kernel/transformers/geglu.py
+++ b/src/liger_kernel/transformers/geglu.py
@@ -19,4 +19,4 @@ class LigerGEGLUMLP(nn.Module):
         # So we can safely assume we use tanh approximation form all the time
 
     def forward(self, x):
-        return self.down_proj(LigerGELUMulFunction.apply(self.gate_proj(x), self.up_proj(x)))
+        return self.down_proj(LigerGELUMulFunction.apply(self.gate_proj(x), self.up_proj(x))[0])

--- a/src/liger_kernel/transformers/group_norm.py
+++ b/src/liger_kernel/transformers/group_norm.py
@@ -44,7 +44,7 @@ class LigerGroupNorm(nn.Module):
             self.num_channels,
             self.num_groups,
             self.variance_epsilon,
-        )
+        )[0]
 
     def extra_repr(self):
         return f"{self.hidden_size}, num_channels={self.num_channels}, num_groups={self.num_groups}, eps={self.eps}"

--- a/src/liger_kernel/transformers/grpo_loss.py
+++ b/src/liger_kernel/transformers/grpo_loss.py
@@ -89,11 +89,12 @@ def triton_grpo_loss(
     )
 
     if not reduce:
-        # Returns (per_token_loss, per_token_kl, is_clipped) - all (B, L) tensors
-        return result
+        # Returns (per_token_loss, per_token_kl, is_clipped, ...) - first 3 are (B, L) tensors
+        per_token_loss, per_token_kl, is_clipped, *_ = result
+        return per_token_loss, per_token_kl, is_clipped
 
-    # reduce=True: Returns (reduced_loss, kl_mean, clip_ratio) - all scalars
-    reduced_loss, kl_mean, clip_ratio = result
+    # reduce=True: Returns (reduced_loss, kl_mean, clip_ratio, ...) - first 3 are scalars
+    reduced_loss, kl_mean, clip_ratio, *_ = result
     metrics = []
     if beta != 0.0 and kl_mean is not None:
         metrics.append(kl_mean)

--- a/src/liger_kernel/transformers/jsd.py
+++ b/src/liger_kernel/transformers/jsd.py
@@ -67,4 +67,5 @@ class LigerJSD(torch.nn.Module):
         log_p: torch.Tensor,
         shift_labels: Optional[torch.LongTensor] = None,
     ):
-        return LigerJSDFunction.apply(log_q, log_p, shift_labels, self.beta, self.ignore_index)
+        loss, _ = LigerJSDFunction.apply(log_q, log_p, shift_labels, self.beta, self.ignore_index)
+        return loss

--- a/src/liger_kernel/transformers/layer_norm.py
+++ b/src/liger_kernel/transformers/layer_norm.py
@@ -18,7 +18,7 @@ class LigerLayerNorm(nn.Module):
         self.variance_epsilon = eps
 
     def forward(self, hidden_states):
-        return LigerLayerNormFunction.apply(hidden_states, self.weight, self.bias, self.variance_epsilon)
+        return LigerLayerNormFunction.apply(hidden_states, self.weight, self.bias, self.variance_epsilon)[0]
 
     def extra_repr(self):
         return f"{self.hidden_size}, eps={self.eps}"

--- a/src/liger_kernel/transformers/llama4_rope.py
+++ b/src/liger_kernel/transformers/llama4_rope.py
@@ -28,7 +28,8 @@ def liger_llama4_text_rotary_pos_emb(
         Tuple[torch.Tensor, torch.Tensor]: Rotated query and key tensors
     """
     # Use fused Triton kernel for complex RoPE
-    return LigerLlama4RopeFunction.apply(xq, xk, freqs_cis)
+    q_out, k_out, _ = LigerLlama4RopeFunction.apply(xq, xk, freqs_cis)
+    return q_out, k_out
 
 
 def liger_llama4_vision_rotary_pos_emb(
@@ -71,7 +72,8 @@ def liger_llama4_vision_rotary_pos_emb(
         raise ValueError(f"Unexpected freqs_ci shape: {freqs_ci.shape}")
 
     # Use the same fused kernel as text RoPE
-    return LigerLlama4RopeFunction.apply(query, key, freqs_ci)
+    q_out, k_out, _ = LigerLlama4RopeFunction.apply(query, key, freqs_ci)
+    return q_out, k_out
 
 
 # Note: We only patch the functions, not the classes

--- a/src/liger_kernel/transformers/multi_token_attention.py
+++ b/src/liger_kernel/transformers/multi_token_attention.py
@@ -61,4 +61,4 @@ class LigerMultiTokenAttention(nn.Module):
             self.dilation,
             self.groups,
             self.sparse,
-        )
+        )[0]

--- a/src/liger_kernel/transformers/poly_norm.py
+++ b/src/liger_kernel/transformers/poly_norm.py
@@ -36,7 +36,7 @@ class LigerPolyNorm(nn.Module):
             self.bias,
             self.variance_epsilon,
             self.in_place,
-        )
+        )[0]
 
     def extra_repr(self):
         return f"weight_shape={tuple(self.weight.shape)}, eps={self.variance_epsilon}, in_place={self.in_place}"

--- a/src/liger_kernel/transformers/qwen2vl_mrope.py
+++ b/src/liger_kernel/transformers/qwen2vl_mrope.py
@@ -17,4 +17,5 @@ def liger_multimodal_rotary_pos_emb(q, k, cos, sin, mrope_section, unsqueeze_dim
         Tuple[torch.Tensor, torch.Tensor]: The query and key tensors after applying the M-RoPE operation.
     """
 
-    return LigerQwen2VLMRopeFunction.apply(q, k, cos, sin, mrope_section, unsqueeze_dim)
+    q, k, _, _ = LigerQwen2VLMRopeFunction.apply(q, k, cos, sin, mrope_section, unsqueeze_dim)
+    return q, k

--- a/src/liger_kernel/transformers/relu_squared.py
+++ b/src/liger_kernel/transformers/relu_squared.py
@@ -8,4 +8,4 @@ class LigerReLUSquared(nn.Module):
         super().__init__()
 
     def forward(self, x):
-        return LigerReLUSquaredFunction.apply(x)
+        return LigerReLUSquaredFunction.apply(x)[0]

--- a/src/liger_kernel/transformers/rms_norm.py
+++ b/src/liger_kernel/transformers/rms_norm.py
@@ -43,7 +43,7 @@ class LigerRMSNorm(nn.Module):
             self.casting_mode,
             self.in_place,
             self.row_mode,
-        )
+        )[0]
 
     def extra_repr(self):
         return f"weight_shape={tuple(self.weight.shape) if self.weight is not None else None}, eps={self.variance_epsilon}, offset={self.offset}, in_place={self.in_place}, row_mode={self.row_mode}"

--- a/src/liger_kernel/transformers/rope.py
+++ b/src/liger_kernel/transformers/rope.py
@@ -21,7 +21,8 @@ def liger_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
         Tuple[torch.Tensor, torch.Tensor]: The query and key tensors after applying the RoPE operation.
     """
 
-    return LigerRopeFunction.apply(q, k, cos, sin, position_ids, unsqueeze_dim)
+    q, k, _, _ = LigerRopeFunction.apply(q, k, cos, sin, position_ids, unsqueeze_dim)
+    return q, k
 
 
 def liger_rotary_pos_emb_vision(

--- a/src/liger_kernel/transformers/softmax.py
+++ b/src/liger_kernel/transformers/softmax.py
@@ -9,4 +9,4 @@ class LigerSoftmax(nn.Module):
         super().__init__()
 
     def forward(self, x: torch.Tensor):
-        return LigerSoftmaxFunction.apply(x)
+        return LigerSoftmaxFunction.apply(x)[0]

--- a/src/liger_kernel/transformers/sparsemax.py
+++ b/src/liger_kernel/transformers/sparsemax.py
@@ -10,7 +10,7 @@ class LigerSparsemax(nn.Module):
         self.dim = dim
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return LigerSparsemaxFunction.apply(x, self.dim)
+        return LigerSparsemaxFunction.apply(x, self.dim)[0]
 
     def extra_repr(self) -> str:
         return f"dim={self.dim}"

--- a/src/liger_kernel/transformers/swiglu.py
+++ b/src/liger_kernel/transformers/swiglu.py
@@ -17,7 +17,7 @@ class LigerSwiGLUMLP(nn.Module):
             raise ValueError(f"Activation function {config.hidden_act} not supported.")
 
     def forward(self, x):
-        return self.down_proj(LigerSiLUMulFunction.apply(self.gate_proj(x), self.up_proj(x)))
+        return self.down_proj(LigerSiLUMulFunction.apply(self.gate_proj(x), self.up_proj(x))[0])
 
 
 class LigerBlockSparseTop2MLP(nn.Module):
@@ -34,7 +34,7 @@ class LigerBlockSparseTop2MLP(nn.Module):
             raise ValueError(f"Activation function {config.hidden_act} not supported.")
 
     def forward(self, x):
-        return self.w2(LigerSiLUMulFunction.apply(self.w1(x), self.w3(x)))
+        return self.w2(LigerSiLUMulFunction.apply(self.w1(x), self.w3(x))[0])
 
 
 class LigerExperts(nn.Module):
@@ -77,7 +77,7 @@ class LigerExperts(nn.Module):
             top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
             current_state = hidden_states[token_idx]
             gate, up = nn.functional.linear(current_state, self.gate_up_proj[expert_idx]).chunk(2, dim=-1)
-            current_hidden_states = LigerSiLUMulFunction.apply(gate, up)
+            current_hidden_states = LigerSiLUMulFunction.apply(gate, up)[0]
             current_hidden_states = nn.functional.linear(current_hidden_states, self.down_proj[expert_idx])
             current_hidden_states = current_hidden_states * top_k_weights[token_idx, top_k_pos, None]
             final_hidden_states.index_add_(0, token_idx, current_hidden_states.to(final_hidden_states.dtype))
@@ -104,7 +104,7 @@ class LigerPhi3SwiGLUMLP(nn.Module):
     def forward(self, x):
         up_states = self.gate_up_proj(x)
         gate, up_states = up_states.chunk(2, dim=-1)
-        return self.down_proj(LigerSiLUMulFunction.apply(gate, up_states))
+        return self.down_proj(LigerSiLUMulFunction.apply(gate, up_states)[0])
 
 
 class LigerQwen3MoeSwiGLUMLP(nn.Module):
@@ -125,7 +125,7 @@ class LigerQwen3MoeSwiGLUMLP(nn.Module):
             raise ValueError(f"Activation function {config.hidden_act} not supported.")
 
     def forward(self, x):
-        return self.down_proj(LigerSiLUMulFunction.apply(self.gate_proj(x), self.up_proj(x)))
+        return self.down_proj(LigerSiLUMulFunction.apply(self.gate_proj(x), self.up_proj(x))[0])
 
 
 class LigerHunyuanV1SwiGLUMLP(nn.Module):
@@ -142,4 +142,4 @@ class LigerHunyuanV1SwiGLUMLP(nn.Module):
             raise ValueError(f"Activation function {config.hidden_act} not supported.")
 
     def forward(self, x):
-        return self.down_proj(LigerSiLUMulFunction.apply(self.gate_proj(x), self.up_proj(x)))
+        return self.down_proj(LigerSiLUMulFunction.apply(self.gate_proj(x), self.up_proj(x))[0])

--- a/src/liger_kernel/transformers/tiled_mlp.py
+++ b/src/liger_kernel/transformers/tiled_mlp.py
@@ -44,7 +44,7 @@ class LigerTiledGEGLUMLP(nn.Module):
         """Internal MLP forward function for tiled computation."""
         gate = module.gate_proj(x)
         up = module.up_proj(x)
-        return module.down_proj(LigerGELUMulFunction.apply(gate, up))
+        return module.down_proj(LigerGELUMulFunction.apply(gate, up)[0])
 
     def forward(self, x):
         """
@@ -101,7 +101,7 @@ class LigerTiledSwiGLUMLP(nn.Module):
         """Internal MLP forward function for tiled computation."""
         gate = module.gate_proj(x)
         up = module.up_proj(x)
-        return module.down_proj(LigerSiLUMulFunction.apply(gate, up))
+        return module.down_proj(LigerSiLUMulFunction.apply(gate, up)[0])
 
     def forward(self, x):
         """

--- a/src/liger_kernel/transformers/tvd.py
+++ b/src/liger_kernel/transformers/tvd.py
@@ -10,4 +10,5 @@ class LigerTVDLoss(nn.Module):
         self.ignore_index = ignore_index
 
     def forward(self, p, q, shift_labels=None):
-        return LigerTVDLossFunction.apply(p, q, shift_labels, self.reduction, self.ignore_index)
+        loss, _ = LigerTVDLossFunction.apply(p, q, shift_labels, self.reduction, self.ignore_index)
+        return loss

--- a/test/chunked_loss/test_cosine_loss.py
+++ b/test/chunked_loss/test_cosine_loss.py
@@ -277,7 +277,7 @@ def test_correctness_functional(
     target = torch.randint(0, V, (B * T,), device=device, dtype=torch.long)
 
     # Functional call using the fused cosine similarity function
-    output1 = liger_fused_linear_cosine(
+    output1, *_ = liger_fused_linear_cosine(
         student_input1,
         student_weight1,
         teacher_input,
@@ -293,7 +293,7 @@ def test_correctness_functional(
         True,
         1024,
     )
-    output2 = LigerFusedLinearCosineSimilarityFunction.apply(
+    output2, *_ = LigerFusedLinearCosineSimilarityFunction.apply(
         student_input2,
         student_weight2,
         teacher_input,

--- a/test/chunked_loss/test_cpo_loss.py
+++ b/test/chunked_loss/test_cpo_loss.py
@@ -288,8 +288,8 @@ def test_correctness_functional(B, T, H, V, scalar, dtype, atol, rtol, bias):
     bias1 = _bias.detach().clone().requires_grad_(True) if bias else None
     bias2 = _bias.detach().clone().requires_grad_(True) if bias else None
 
-    loss1, aggregated_aux_outputs1 = LigerFusedLinearCPOFunction.apply(input1, weight1, target, bias1)
-    loss2, aggregated_aux_outputs2 = liger_fused_linear_cpo(input2, weight2, target, bias2)
+    loss1, aggregated_aux_outputs1, _, _, _ = LigerFusedLinearCPOFunction.apply(input1, weight1, target, bias1)
+    loss2, aggregated_aux_outputs2, _, _, _ = liger_fused_linear_cpo(input2, weight2, target, bias2)
 
     assert_verbose_allclose(loss1, loss2, atol=atol, rtol=rtol)
 

--- a/test/chunked_loss/test_dpo_loss.py
+++ b/test/chunked_loss/test_dpo_loss.py
@@ -635,7 +635,7 @@ def test_correctness_functional(B, T, H, V, scalar, dtype, atol, rtol, bias, ref
     ref_bias1 = _ref_bias.detach().clone().requires_grad_(True) if ref_bias else None
     ref_bias2 = _ref_bias.detach().clone().requires_grad_(True) if ref_bias else None
 
-    loss1, aggregated_aux_outputs1 = LigerFusedLinearDPOFunction.apply(
+    loss1, aggregated_aux_outputs1, _, _, _ = LigerFusedLinearDPOFunction.apply(
         input1,
         weight1,
         target,
@@ -647,7 +647,7 @@ def test_correctness_functional(B, T, H, V, scalar, dtype, atol, rtol, bias, ref
         0.1,
         compute_nll_loss,
     )
-    loss2, aggregated_aux_outputs2 = liger_fused_linear_dpo(
+    loss2, aggregated_aux_outputs2, _, _, _ = liger_fused_linear_dpo(
         input2,
         weight2,
         target,
@@ -878,7 +878,7 @@ def test_correctness_functional_apo_loss_types(
     ref_bias2 = _ref_bias.detach().clone().requires_grad_(True) if ref_bias else None
 
     # Call with loss_type parameter for LigerFusedLinearDPOFunction
-    loss1, aggregated_aux_outputs1 = LigerFusedLinearDPOFunction.apply(
+    loss1, aggregated_aux_outputs1, _, _, _ = LigerFusedLinearDPOFunction.apply(
         input1,
         weight1,
         target,

--- a/test/chunked_loss/test_grpo_loss.py
+++ b/test/chunked_loss/test_grpo_loss.py
@@ -745,7 +745,7 @@ def test_functional_correctness(
     old_per_token_logps = None
     ref_per_token_logps = None
 
-    loss1, aux1 = liger_fused_linear_grpo(
+    loss1, aux1, _, _, _ = liger_fused_linear_grpo(
         input1,
         weight1,
         selected_token_ids,
@@ -769,7 +769,7 @@ def test_functional_correctness(
         1,
     )
 
-    loss2, aux2 = LigerFusedLinearGRPOFunction.apply(
+    loss2, aux2, _, _, _ = LigerFusedLinearGRPOFunction.apply(
         input2,
         weight2,
         selected_token_ids,

--- a/test/chunked_loss/test_jsd_loss.py
+++ b/test/chunked_loss/test_jsd_loss.py
@@ -399,7 +399,7 @@ def test_correctness_functional(
 
     label = torch.randint(0, V, (B * T,), device=device, dtype=torch.long)
 
-    output1 = liger_fused_linear_jsd(
+    output1, *_ = liger_fused_linear_jsd(
         student_input1,
         student_weight1,
         teacher_input,
@@ -413,7 +413,7 @@ def test_correctness_functional(
         ignore_index,
         temperature,
     )
-    output2 = LigerFusedLinearJSDFunction.apply(
+    output2, *_ = LigerFusedLinearJSDFunction.apply(
         student_input2,
         student_weight2,
         teacher_input,

--- a/test/chunked_loss/test_kto_loss.py
+++ b/test/chunked_loss/test_kto_loss.py
@@ -366,7 +366,7 @@ def test_correctness_functional(B, T, H, V, scalar, dtype, atol, rtol, bias, ref
     ref_bias1 = _ref_bias.detach().clone().requires_grad_(True) if ref_bias else None
     ref_bias2 = _ref_bias.detach().clone().requires_grad_(True) if ref_bias else None
 
-    loss1, aggregated_aux_outputs1 = LigerFusedLinearKTOFunction.apply(
+    loss1, aggregated_aux_outputs1, _, _, _ = LigerFusedLinearKTOFunction.apply(
         input1,
         weight1,
         target,
@@ -377,7 +377,7 @@ def test_correctness_functional(B, T, H, V, scalar, dtype, atol, rtol, bias, ref
         ref_bias1,
         kl,
     )
-    loss2, aggregated_aux_outputs2 = liger_fused_linear_kto(
+    loss2, aggregated_aux_outputs2, _, _, _ = liger_fused_linear_kto(
         input2,
         weight2,
         target,

--- a/test/chunked_loss/test_orpo_loss.py
+++ b/test/chunked_loss/test_orpo_loss.py
@@ -252,8 +252,8 @@ def test_correctness_functional(B, T, H, V, scalar, dtype, atol, rtol, bias):
     bias1 = _bias.detach().clone().requires_grad_(True) if bias else None
     bias2 = _bias.detach().clone().requires_grad_(True) if bias else None
 
-    loss1, _ = LigerFusedLinearORPOFunction.apply(input1, weight1, target, bias1)
-    loss2, _ = liger_fused_linear_orpo(input2, weight2, target, bias2)
+    loss1, _, _, _, _ = LigerFusedLinearORPOFunction.apply(input1, weight1, target, bias1)
+    loss2, _, _, _, _ = liger_fused_linear_orpo(input2, weight2, target, bias2)
 
     assert_verbose_allclose(loss1, loss2, atol=atol, rtol=rtol)
 

--- a/test/chunked_loss/test_simpo_loss.py
+++ b/test/chunked_loss/test_simpo_loss.py
@@ -201,8 +201,8 @@ def test_correctness_functional(B, T, H, V, scalar, dtype, atol, rtol, bias):
     bias1 = _bias.detach().clone().requires_grad_(True) if bias else None
     bias2 = _bias.detach().clone().requires_grad_(True) if bias else None
 
-    loss1, aggregated_aux_outputs1 = LigerFusedLinearSimPOFunction.apply(input1, weight1, target, bias1)
-    loss2, aggregated_aux_outputs2 = liger_fused_linear_simpo(input2, weight2, target, bias2)
+    loss1, aggregated_aux_outputs1, _, _, _ = LigerFusedLinearSimPOFunction.apply(input1, weight1, target, bias1)
+    loss2, aggregated_aux_outputs2, _, _, _ = liger_fused_linear_simpo(input2, weight2, target, bias2)
 
     assert_verbose_allclose(loss1, loss2, atol=atol, rtol=rtol)
 

--- a/test/transformers/test_attn_res.py
+++ b/test/transformers/test_attn_res.py
@@ -68,7 +68,7 @@ def test_correctness(N, B, T, D, dtype, atol, rtol):
     # Reference
     ref = pytorch_attn_res(V, w_query, w_norm)
     # Triton
-    out = LigerAttnResFunction.apply(V, w_query, w_norm, 1e-6)
+    out = LigerAttnResFunction.apply(V, w_query, w_norm, 1e-6)[0]
 
     assert_verbose_allclose(ref, out, atol=atol, rtol=rtol)
 
@@ -113,7 +113,7 @@ def test_correctness_backward(N, B, T, D, dtype, atol, rtol):
     V_tri = V.clone().requires_grad_(True)
     wq_tri = w_query.clone().requires_grad_(True)
     wn_tri = w_norm.clone().requires_grad_(True)
-    h_tri = LigerAttnResFunction.apply(V_tri, wq_tri, wn_tri, 1e-6)
+    h_tri = LigerAttnResFunction.apply(V_tri, wq_tri, wn_tri, 1e-6)[0]
     h_tri.backward(do, retain_graph=True)
 
     assert_verbose_allclose(V_ref.grad, V_tri.grad, atol=atol, rtol=rtol)
@@ -136,8 +136,8 @@ def test_correctness_list_input(N, B, T, D):
 
     V_stacked = torch.stack(blocks)
 
-    out_stacked = LigerAttnResFunction.apply(V_stacked, w_query, w_norm, 1e-6)
-    out_list = LigerAttnResFunction.apply(torch.stack(blocks), w_query, w_norm, 1e-6)
+    out_stacked = LigerAttnResFunction.apply(V_stacked, w_query, w_norm, 1e-6)[0]
+    out_list = LigerAttnResFunction.apply(torch.stack(blocks), w_query, w_norm, 1e-6)[0]
 
     assert_verbose_allclose(out_stacked, out_list, atol=1e-6, rtol=1e-6)
 
@@ -163,7 +163,7 @@ def test_correctness_functional(N, B, T, D, dtype, atol, rtol):
     w_norm = torch.ones(D, device=device, dtype=dtype)
 
     # Direct function call
-    y1 = LigerAttnResFunction.apply(V, w_query, w_norm, 1e-6)
+    y1 = LigerAttnResFunction.apply(V, w_query, w_norm, 1e-6)[0]
     # Functional API
     y2 = liger_attn_res(V, w_query, w_norm, eps=1e-6)
 
@@ -177,7 +177,7 @@ def test_correctness_functional(N, B, T, D, dtype, atol, rtol):
     wn1 = w_norm.clone().requires_grad_(True)
     wn2 = w_norm.clone().requires_grad_(True)
 
-    y1 = LigerAttnResFunction.apply(V1, wq1, wn1, 1e-6)
+    y1 = LigerAttnResFunction.apply(V1, wq1, wn1, 1e-6)[0]
     y2 = liger_attn_res(V2, wq2, wn2, eps=1e-6)
 
     grad = torch.randn_like(y1)

--- a/test/transformers/test_cross_entropy.py
+++ b/test/transformers/test_cross_entropy.py
@@ -512,7 +512,7 @@ def _test_correctness_functional(
     )
     y1 = result.loss
     y1_z = result.z_loss
-    y2, y2_z, _, _ = LigerCrossEntropyFunction.apply(x2, target, None, 0, 1e-4, 0.1, "mean", 30.0, True, False, False)
+    y2, y2_z, _, _, _ = LigerCrossEntropyFunction.apply(x2, target, None, 0, 1e-4, 0.1, "mean", 30.0, True, False, False)
 
     assert torch.allclose(y1, y2, atol=atol, rtol=rtol)
     assert torch.allclose(y1_z, y2_z, atol=atol, rtol=rtol)

--- a/test/transformers/test_fused_add_rms_norm.py
+++ b/test/transformers/test_fused_add_rms_norm.py
@@ -202,7 +202,7 @@ def test_correctness_functional(bs, sl, hd, dtype, atol, rtol, reference, offset
     h, r = liger_fused_add_rms_norm(
         X=h1, R=r1, W=w, eps=1e-6, offset=offset, casting_mode=casting_mode, in_place=in_place
     )
-    ref_h, ref_r = LigerFusedAddRMSNormFunction.apply(h2, r2, w, 1e-6, offset, casting_mode, in_place)
+    ref_h, ref_r = LigerFusedAddRMSNormFunction.apply(h2, r2, w, 1e-6, offset, casting_mode, in_place)[:2]
 
     assert torch.allclose(h, ref_h, atol=atol, rtol=rtol)
     assert torch.allclose(r, ref_r, atol=atol, rtol=rtol)

--- a/test/transformers/test_geglu.py
+++ b/test/transformers/test_geglu.py
@@ -251,7 +251,7 @@ def test_correctness_functional(bsz, seq_len, size, dtype, atol, rtol):
     b2 = _b.clone().requires_grad_(True)
 
     y1 = liger_geglu(a=x1, b=b1)
-    y2 = LigerGELUMulFunction.apply(x2, b2)
+    y2 = LigerGELUMulFunction.apply(x2, b2)[0]
 
     assert torch.allclose(y1, y2, atol=atol, rtol=rtol)
 

--- a/test/transformers/test_jsd.py
+++ b/test/transformers/test_jsd.py
@@ -248,7 +248,7 @@ def _test_correctness_functional(B, T, V, beta, ignore_index, is_last_layer, dty
     indices_to_assign = torch.randperm(B * T)[:num_elements_to_assign]  # Randomly select indices
     label[indices_to_assign] = ignore_index
 
-    output = LigerJSDFunction.apply(x1, target, label, beta, ignore_index)
+    output, _ = LigerJSDFunction.apply(x1, target, label, beta, ignore_index)
     output2 = liger_jsd(
         input=x2,
         target=target,

--- a/test/transformers/test_layer_norm.py
+++ b/test/transformers/test_layer_norm.py
@@ -103,7 +103,7 @@ def test_liger_layer_norm_functional(
     b2 = b.clone().requires_grad_(True)
 
     y1 = liger_layer_norm(X=x1, W=w1, B=b1, eps=1e-6)
-    y2 = LigerLayerNormFunction.apply(x2, w2, b2, 1e-6)
+    y2 = LigerLayerNormFunction.apply(x2, w2, b2, 1e-6)[0]
 
     assert torch.allclose(y1, y2, atol=atol, rtol=rtol)
 

--- a/test/transformers/test_llama4_rope.py
+++ b/test/transformers/test_llama4_rope.py
@@ -122,7 +122,7 @@ def test_functional_correctness(bsz, seq_len, num_q_heads, num_kv_heads, head_di
     freqs_cis = rotary_emb(q1, pos_ids)
 
     functional_q, functional_k = liger_llama4_text_rotary_pos_emb(q1, k1, freqs_cis)
-    class_q, class_k = LigerLlama4RopeFunction.apply(q2, k2, freqs_cis)
+    class_q, class_k, _ = LigerLlama4RopeFunction.apply(q2, k2, freqs_cis)
 
     assert torch.allclose(functional_q, class_q, atol=atol, rtol=rtol)
     assert torch.allclose(functional_k, class_k, atol=atol, rtol=rtol)

--- a/test/transformers/test_poly_norm.py
+++ b/test/transformers/test_poly_norm.py
@@ -197,7 +197,7 @@ def test_correctness_functional(bs, sl, hd, dtype, atol, rtol):
     y1 = liger_poly_norm(x1, weight1, bias1, 1e-6)
 
     # Second call - Function.apply API (should be identical)
-    y2 = LigerPolyNormFunction.apply(x2, weight2, bias2, 1e-6)
+    y2 = LigerPolyNormFunction.apply(x2, weight2, bias2, 1e-6)[0]
 
     # Check forward pass
     assert torch.allclose(y1, y2, atol=atol, rtol=rtol)

--- a/test/transformers/test_qwen2vl_mrope.py
+++ b/test/transformers/test_qwen2vl_mrope.py
@@ -111,7 +111,7 @@ def test_functional_correctness(bsz, seq_len, num_q_heads, num_kv_heads, head_di
     cos, sin = rotary_emb(k1, pos_ids)
 
     functional_q, functional_k = liger_qwen2vl_mrope(q1, k1, cos, sin, mrope_section)
-    class_q, class_k = LigerQwen2VLMRopeFunction.apply(q2, k2, cos, sin, mrope_section)
+    class_q, class_k, _, _ = LigerQwen2VLMRopeFunction.apply(q2, k2, cos, sin, mrope_section)
 
     torch.testing.assert_close(functional_q, class_q, atol=atol, rtol=rtol)
     torch.testing.assert_close(functional_k, class_k, atol=atol, rtol=rtol)

--- a/test/transformers/test_relu_squared.py
+++ b/test/transformers/test_relu_squared.py
@@ -104,7 +104,7 @@ def test_liger_relu_squared_functional(shape, dtype, atol, rtol):
     x2 = _input.clone().requires_grad_(True)
 
     output1 = liger_relu_squared(x1)
-    output2 = LigerReLUSquaredFunction.apply(x2)
+    output2 = LigerReLUSquaredFunction.apply(x2)[0]
 
     assert_verbose_allclose(output1, output2, rtol=rtol, atol=atol)
 

--- a/test/transformers/test_rms_norm.py
+++ b/test/transformers/test_rms_norm.py
@@ -226,7 +226,7 @@ def test_correctness_functional(bs, sl, hd, dtype, atol, rtol, reference, offset
         w = None
 
     y1 = liger_rms_norm(X=h1, W=w, eps=1e-6, offset=offset, casting_mode=casting_mode)
-    y2 = LigerRMSNormFunction.apply(h2, w, 1e-6, offset, casting_mode)
+    y2 = LigerRMSNormFunction.apply(h2, w, 1e-6, offset, casting_mode)[0]
 
     assert torch.allclose(y1, y2, atol=atol, rtol=rtol)
 

--- a/test/transformers/test_rope.py
+++ b/test/transformers/test_rope.py
@@ -155,7 +155,7 @@ def test_functional_correctness(
     cos, sin = rotary_emb(k1, pos_ids)
 
     functional_q, functional_k = liger_rope(q=q1, k=k1, cos=cos, sin=sin)
-    class_q, class_k = LigerRopeFunction.apply(q2, k2, cos, sin)
+    class_q, class_k, _, _ = LigerRopeFunction.apply(q2, k2, cos, sin)
 
     assert torch.allclose(functional_q, class_q, atol=atol, rtol=rtol)
     assert torch.allclose(functional_k, class_k, atol=atol, rtol=rtol)

--- a/test/transformers/test_swiglu.py
+++ b/test/transformers/test_swiglu.py
@@ -396,7 +396,7 @@ def test_correctness_functional(bsz, seq_len, size, dtype, atol, rtol):
     b2 = _b.clone().requires_grad_(True)
 
     y1 = liger_swiglu(a=x1, b=b1)
-    y2 = LigerSiLUMulFunction.apply(x2, b2)
+    y2 = LigerSiLUMulFunction.apply(x2, b2)[0]
 
     assert torch.allclose(y1, y2, atol=atol, rtol=rtol)
 
@@ -446,8 +446,8 @@ def _test_dtensor_liger_silumul(rank, world_size, bsz, seq_len, hidden_size, dty
     a2 = _a.clone().detach().requires_grad_(True)
     b2 = _b.clone().detach().requires_grad_(True)
 
-    c1 = LigerSiLUMulFunction.apply(da, db)
-    c2 = LigerSiLUMulFunction.apply(a2, b2)
+    c1 = LigerSiLUMulFunction.apply(da, db)[0]
+    c2 = LigerSiLUMulFunction.apply(a2, b2)[0]
 
     torch.testing.assert_close(c1.full_tensor(), c2, atol=atol, rtol=rtol)
 


### PR DESCRIPTION
## Summary

Adds `setup_context` to `torch.autograd.Function` subclasses that use the legacy `forward(ctx, ...)` pattern, enabling compatibility with `torch.func` transforms (`torch.func.grad`, `torch.func.grad_and_value`, etc.).

Currently, any code that uses `torch.func.grad_and_value()` with Liger-Kernel enabled crashes:
```
RuntimeError: In order to use an autograd.Function with functorch transforms
(vmap, grad, jvp, jacrev, ...), it must override the setup_context staticmethod.
```

This affects using `torch.func.grad_and_value()` internally for chunked gradient computation.

## Details

For each `autograd.Function`:
1. Removed `ctx` from `forward()` signature
2. Added `setup_context(ctx, inputs, output)` to handle context setup
3. Updated `backward` signature to match new forward output count
4. Updated all callers to handle extra return values

Functions with `@amp_custom_fwd` / `@amp_custom_bwd` decorators were skipped — these need separate handling due to the decorator assuming `args[0]` is `ctx`.

## Testing Done

- Hardware Type: RTX 5060 Ti and H100
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
- Added functorch compatibility tests for each modified Function