### PR TITLE
Fix Nvidia CI

### DIFF
--- a/.github/workflows/nvi-ci.yml
+++ b/.github/workflows/nvi-ci.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Run tests
       run: |
-        modal run dev.modal.tests::liger_correctness_tests
+        modal run -m dev.modal.tests::liger_correctness_tests
 
   nvi-convergence-tests:
     if: github.event_name == 'merge_group'
@@ -66,7 +66,7 @@ jobs:
 
     - name: Run tests
       run: |
-        modal run dev.modal.tests::liger_convergence_tests
+        modal run -m dev.modal.tests::liger_convergence_tests
 
   nvi-correctness-tests-with-transformers-4-52-0:
     if: github.event_name == 'merge_group'
@@ -91,7 +91,7 @@ jobs:
 
     - name: Run tests
       run: |
-        modal run dev.modal.tests::liger_oldest_v4_correctness_tests
+        modal run -m dev.modal.tests::liger_oldest_v4_correctness_tests
 
 
   nvi-convergence-tests-with-transformers-4-52-0:
@@ -117,4 +117,4 @@ jobs:
 
     - name: Run tests
       run: |
-        modal run dev.modal.tests::liger_oldest_v4_convergence_tests
+        modal run -m dev.modal.tests::liger_oldest_v4_convergence_tests

--- a/.github/workflows/nvi-ci.yml
+++ b/.github/workflows/nvi-ci.yml
@@ -39,12 +39,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install modal
 
-    - name: Authenticate Modal
-      run: |
-        modal token set \
-        --token-id $MODAL_TOKEN_ID \
-        --token-secret $MODAL_TOKEN_SECRET
-
     - name: Run tests
       run: |
         modal run -m dev.modal.tests::liger_correctness_tests

--- a/.github/workflows/nvi-ci.yml
+++ b/.github/workflows/nvi-ci.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   nvi-correctness-tests:
-    if: github.event_name == 'merge_group'
+    #if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     env:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}

--- a/.github/workflows/nvi-ci.yml
+++ b/.github/workflows/nvi-ci.yml
@@ -39,6 +39,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install modal
 
+    - name: Authenticate Modal
+      run: |
+        modal token set \
+        --token-id $MODAL_TOKEN_ID \
+        --token-secret $MODAL_TOKEN_SECRET
+
     - name: Run tests
       run: |
         modal run -m dev.modal.tests::liger_correctness_tests


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->

Since the Nvidia CI is failing on main, this PR aims to fix this issue. I've added the missing `-m` flag as needed by the modal docs. Currently, the CI jobs are failing due to the auth secret token which could be expired, could you please check the same?

cc: @Tcc0403 

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
