### PR TITLE
[DPO] Add hinge, bco_pair, robust, exo_pair, discopop loss types

### DIFF
--- a/src/liger_kernel/chunked_loss/dpo_loss.py
+++ b/src/liger_kernel/chunked_loss/dpo_loss.py
@@ -14,6 +14,8 @@ class LigerFusedLinearDPOFunction(LigerFusedLinearPreferenceBase):
         ref_rejected_logps=None,
         beta=0.1,
         loss_type="sigmoid",
+        label_smoothing=0.0,
+        discopop_tau=0.05,
     ):
         """
         Paper: https://arxiv.org/pdf/2305.18290
@@ -36,6 +38,9 @@ class LigerFusedLinearDPOFunction(LigerFusedLinearPreferenceBase):
             ref_chosen_logps: Reference log probs of chosen tokens (batch_size,)
             ref_rejected_logps: Reference log probs of rejected tokens (batch_size,)
             beta: Weight for the direct preference loss
+            loss_type: Variant of DPO loss to compute
+            label_smoothing: Label smoothing for "robust" / "exo_pair" / cDPO
+            discopop_tau: Temperature for the DiscoPOP modulation term
         """
 
         if ref_chosen_logps is None:
@@ -49,26 +54,60 @@ class LigerFusedLinearDPOFunction(LigerFusedLinearPreferenceBase):
         chosen_rewards = beta * chosen_logratios
         rejected_rewards = beta * rejected_logratios
 
+        logits_diff = beta * (chosen_logratios - rejected_logratios)
+        n_pairs = full_target.shape[0] // 2
+
         if loss_type == "sigmoid":
-            logits_diff = beta * (chosen_logratios - rejected_logratios)
-            loss = -F.logsigmoid(logits_diff).sum() / (full_target.shape[0] // 2)
+            loss = -F.logsigmoid(logits_diff).sum() / n_pairs
 
-        elif loss_type == "apo_zero":
-            # Eqn (7) of the APO paper (https://huggingface.co/papers/2408.06266)
-            # Use this loss when you believe the chosen outputs are better than your model's default output
-            losses_chosen = 1 - F.sigmoid(beta * chosen_logratios)  # Increase chosen likelihood
-            losses_rejected = F.sigmoid(beta * rejected_logratios)
-            losses = losses_chosen + losses_rejected
-            loss = losses.sum() / (full_target.shape[0] // 2)
+        elif loss_type == "hinge":
+            # Hinge loss on the normalized likelihood: max(0, 1 - β * (chosen_logratios - rejected_logratios))
+            losses = torch.relu(1 - logits_diff)
+            loss = losses.sum() / n_pairs
 
-        elif loss_type == "apo_down":
-            # Eqn (8) of the APO paper (https://huggingface.co/papers/2408.06266)
-            # Use this loss when you believe the chosen outputs are worse than your model's default output.
-            # Decrease chosen likelihood and decrease rejected likelihood more
-            losses_chosen = F.sigmoid(beta * chosen_logratios)
-            losses_rejected = 1 - F.sigmoid(beta * (chosen_logratios - rejected_logratios))
-            losses = losses_chosen + losses_rejected
-            loss = losses.sum() / (full_target.shape[0] // 2)
+        elif loss_type == "ipo":
+            raise NotImplementedError(
+                "loss_type='ipo' is not yet supported by Liger DPO because it requires per-sample completion-token "
+                "counts to length-normalize the squared margin."
+            )
+
+        elif loss_type == "exo_pair":
+            # Implements EXO-pref from the paper https://huggingface.co/papers/2402.00856 (Eq. 16)
+            # Minimize KL(p_fθ || p_rh) for K=2; p_rh = [(1−ε), ε].
+            if label_smoothing <= 0.0:
+                raise ValueError("label_smoothing must be > 0 for loss_type='exo_pair'. The EXO paper recommends 1e-3.")
+            epsilon = torch.tensor(label_smoothing, device=chosen_logps.device)
+            qw = torch.sigmoid(logits_diff)
+            log_qw = F.logsigmoid(logits_diff)
+            log_pw = torch.log1p(-epsilon)
+            ql = torch.sigmoid(-logits_diff)
+            log_ql = F.logsigmoid(-logits_diff)
+            log_pl = torch.log(epsilon)
+            losses = qw * (log_qw - log_pw) + ql * (log_ql - log_pl)
+            loss = losses.sum() / n_pairs
+
+        elif loss_type == "nca_pair":
+            losses = (
+                -F.logsigmoid(chosen_rewards)
+                - 0.5 * F.logsigmoid(-chosen_rewards)
+                - 0.5 * F.logsigmoid(-rejected_rewards)
+            )
+            loss = losses.sum() / n_pairs
+
+        elif loss_type == "robust":
+            # cDPO / robust loss: assumes a fraction `label_smoothing` of preference labels are flipped.
+            if not (0.0 <= label_smoothing < 0.5):
+                raise ValueError(
+                    f"label_smoothing must lie in [0.0, 0.5) for loss_type='robust'. Got {label_smoothing}."
+                )
+            clean_loss_term = -(1 - label_smoothing) * F.logsigmoid(logits_diff)
+            flipped_loss_term = -label_smoothing * F.logsigmoid(-logits_diff)
+            losses = (clean_loss_term - flipped_loss_term) / (1 - 2 * label_smoothing)
+            loss = losses.sum() / n_pairs
+
+        elif loss_type == "bco_pair":
+            losses = -F.logsigmoid(chosen_rewards) - F.logsigmoid(-rejected_rewards)
+            loss = losses.sum() / n_pairs
 
         elif loss_type == "sppo_hard":
             # In the paper (https://huggingface.co/papers/2405.00675), SPPO employs a soft probability approach,
@@ -78,19 +117,37 @@ class LigerFusedLinearDPOFunction(LigerFusedLinearPreferenceBase):
             a = chosen_logps - ref_chosen_logps
             b = rejected_logps - ref_rejected_logps
             losses = (a - 0.5 / beta) ** 2 + (b + 0.5 / beta) ** 2
-            loss = losses.sum() / (full_target.shape[0] // 2)
+            loss = losses.sum() / n_pairs
 
-        elif loss_type == "nca_pair":
-            losses = (
-                -F.logsigmoid(chosen_rewards)
-                - 0.5 * F.logsigmoid(-chosen_rewards)
-                - 0.5 * F.logsigmoid(-rejected_rewards)
-            )
-            loss = losses.sum() / (full_target.shape[0] // 2)
+        elif loss_type == "apo_zero":
+            # Eqn (7) of the APO paper (https://huggingface.co/papers/2408.06266)
+            # Use this loss when you believe the chosen outputs are better than your model's default output
+            losses_chosen = 1 - F.sigmoid(beta * chosen_logratios)  # Increase chosen likelihood
+            losses_rejected = F.sigmoid(beta * rejected_logratios)
+            losses = losses_chosen + losses_rejected
+            loss = losses.sum() / n_pairs
+
+        elif loss_type == "apo_down":
+            # Eqn (8) of the APO paper (https://huggingface.co/papers/2408.06266)
+            # Use this loss when you believe the chosen outputs are worse than your model's default output.
+            # Decrease chosen likelihood and decrease rejected likelihood more
+            losses_chosen = F.sigmoid(beta * chosen_logratios)
+            losses_rejected = 1 - F.sigmoid(beta * (chosen_logratios - rejected_logratios))
+            losses = losses_chosen + losses_rejected
+            loss = losses.sum() / n_pairs
+
+        elif loss_type == "discopop":
+            # Eqn (5) of the DiscoPOP paper (https://huggingface.co/papers/2406.08414)
+            log_ratio_modulation = torch.sigmoid(logits_diff / discopop_tau)
+            logistic_component = -F.logsigmoid(logits_diff)
+            exp_component = torch.exp(-logits_diff)
+            losses = logistic_component * (1 - log_ratio_modulation) + exp_component * log_ratio_modulation
+            loss = losses.sum() / n_pairs
 
         else:
             raise ValueError(
-                f"Unsupported loss_type: {loss_type}. Supported types are: sigmoid, apo_zero, apo_down, sppo_hard, nca_pair"
+                f"Unsupported loss_type: {loss_type}. Supported types are: sigmoid, hinge, exo_pair, nca_pair, "
+                "robust, bco_pair, sppo_hard, apo_zero, apo_down, discopop"
             )
 
         return loss, chosen_rewards, rejected_rewards
@@ -114,6 +171,8 @@ class LigerFusedLinearDPOFunction(LigerFusedLinearPreferenceBase):
         average_log_prob=False,
         chunk_size=1,
         loss_type="sigmoid",
+        label_smoothing=0.0,
+        discopop_tau=0.05,
     ):
         """
         Fused linear layer with DPO loss.
@@ -132,6 +191,9 @@ class LigerFusedLinearDPOFunction(LigerFusedLinearPreferenceBase):
             use_ref_model (bool): Whether to use a reference model
             average_log_prob (bool): Whether to average the log probability per non-masked token
             chunk_size (int): Size of chunks for processing.
+            loss_type (str): Variant of DPO loss to compute.
+            label_smoothing (float): Label smoothing for "robust" / "exo_pair" / cDPO.
+            discopop_tau (float): Temperature for the DiscoPOP modulation term.
         Returns:
             torch.Tensor: Computed loss
         """
@@ -153,18 +215,33 @@ class LigerFusedLinearDPOFunction(LigerFusedLinearPreferenceBase):
             average_log_prob=average_log_prob,
             chunk_size=chunk_size,
             loss_type=loss_type,
+            label_smoothing=label_smoothing,
+            discopop_tau=discopop_tau,
         )
 
     @staticmethod
     def backward(ctx, *grad_output):
         grads = LigerFusedLinearPreferenceBase.backward(ctx, grad_output)[:4]
-        return *grads, None, None, None, None, None, None, None, None, None, None, None
+        return *grads, None, None, None, None, None, None, None, None, None, None, None, None, None
 
 
 class LigerFusedLinearDPOLoss(torch.nn.Module):
     """
     Fused linear layer with DPO loss.
     """
+
+    _SUPPORTED_LOSS_TYPES = {
+        "sigmoid",
+        "hinge",
+        "exo_pair",
+        "nca_pair",
+        "robust",
+        "bco_pair",
+        "sppo_hard",
+        "apo_zero",
+        "apo_down",
+        "discopop",
+    }
 
     def __init__(
         self,
@@ -176,6 +253,8 @@ class LigerFusedLinearDPOLoss(torch.nn.Module):
         average_log_prob: bool = False,
         chunk_size: int = 1,
         loss_type: str = "sigmoid",
+        label_smoothing: float = 0.0,
+        discopop_tau: float = 0.05,
     ):
         """
         Args:
@@ -186,6 +265,11 @@ class LigerFusedLinearDPOLoss(torch.nn.Module):
             use_ref_model (bool): Whether to use a reference model for the DPO loss.
             average_log_prob (bool): Whether to average the log probability per non-masked token.
             chunk_size (int): Size of chunks for processing.
+            loss_type (str): Variant of DPO loss to compute. One of:
+                "sigmoid", "hinge", "exo_pair", "nca_pair", "robust", "bco_pair",
+                "sppo_hard", "apo_zero", "apo_down", "discopop".
+            label_smoothing (float): Label smoothing for "robust" / "exo_pair" / cDPO.
+            discopop_tau (float): Temperature for the DiscoPOP modulation term.
         """
         super().__init__()
         self.ignore_index = ignore_index
@@ -196,9 +280,18 @@ class LigerFusedLinearDPOLoss(torch.nn.Module):
         self.average_log_prob = average_log_prob
         self.chunk_size = chunk_size
         self.loss_type = loss_type
-        supported_loss_types = {"sigmoid", "apo_zero", "apo_down", "sppo_hard", "nca_pair"}
-        if self.loss_type not in supported_loss_types:
-            raise ValueError(f"Unsupported loss_type: {self.loss_type}. Supported types are: {supported_loss_types}")
+        self.label_smoothing = label_smoothing
+        self.discopop_tau = discopop_tau
+        if self.loss_type not in self._SUPPORTED_LOSS_TYPES:
+            raise ValueError(
+                f"Unsupported loss_type: {self.loss_type}. Supported types are: {self._SUPPORTED_LOSS_TYPES}"
+            )
+        if self.loss_type == "exo_pair" and self.label_smoothing <= 0.0:
+            raise ValueError("label_smoothing must be > 0 for loss_type='exo_pair'. The EXO paper recommends 1e-3.")
+        if self.loss_type == "robust" and not (0.0 <= self.label_smoothing < 0.5):
+            raise ValueError(
+                f"label_smoothing must lie in [0.0, 0.5) for loss_type='robust'. Got {self.label_smoothing}."
+            )
 
     def forward(
         self,
@@ -226,4 +319,6 @@ class LigerFusedLinearDPOLoss(torch.nn.Module):
             self.average_log_prob,
             self.chunk_size,
             self.loss_type,
+            self.label_smoothing,
+            self.discopop_tau,
         )

--- a/test/chunked_loss/test_dpo_loss.py
+++ b/test/chunked_loss/test_dpo_loss.py
@@ -235,6 +235,188 @@ class HFNCAPAIRLoss(HFAlignmentLoss):
         return losses, chosen_rewards, rejected_rewards
 
 
+class HFHingeLoss(HFAlignmentLoss):
+    def __init__(
+        self,
+        ignore_index: int = -100,
+        beta: float = 0.1,
+        use_ref_model: bool = True,
+        compute_nll_loss: bool = False,
+    ):
+        super().__init__(
+            beta=beta,
+            ignore_index=ignore_index,
+            use_ref_model=use_ref_model,
+            compute_nll_loss=compute_nll_loss,
+        )
+
+    def alignment_loss(
+        self,
+        policy_chosen_logps: torch.FloatTensor,
+        policy_rejected_logps: torch.FloatTensor,
+        ref_chosen_logps: torch.FloatTensor,
+        ref_rejected_logps: torch.FloatTensor,
+    ):
+        chosen_logratios = policy_chosen_logps - ref_chosen_logps
+        rejected_logratios = policy_rejected_logps - ref_rejected_logps
+
+        chosen_rewards = self.beta * chosen_logratios
+        rejected_rewards = self.beta * rejected_logratios
+
+        logits_diff = self.beta * (chosen_logratios - rejected_logratios)
+        losses = torch.relu(1 - logits_diff)
+        return losses, chosen_rewards, rejected_rewards
+
+
+class HFBCOPAIRLoss(HFAlignmentLoss):
+    def __init__(
+        self,
+        ignore_index: int = -100,
+        beta: float = 0.1,
+        use_ref_model: bool = True,
+        compute_nll_loss: bool = False,
+    ):
+        super().__init__(
+            beta=beta,
+            ignore_index=ignore_index,
+            use_ref_model=use_ref_model,
+            compute_nll_loss=compute_nll_loss,
+        )
+
+    def alignment_loss(
+        self,
+        policy_chosen_logps: torch.FloatTensor,
+        policy_rejected_logps: torch.FloatTensor,
+        ref_chosen_logps: torch.FloatTensor,
+        ref_rejected_logps: torch.FloatTensor,
+    ):
+        chosen_logratios = policy_chosen_logps - ref_chosen_logps
+        rejected_logratios = policy_rejected_logps - ref_rejected_logps
+
+        chosen_rewards = self.beta * chosen_logratios
+        rejected_rewards = self.beta * rejected_logratios
+
+        losses = -F.logsigmoid(chosen_rewards) - F.logsigmoid(-rejected_rewards)
+        return losses, chosen_rewards, rejected_rewards
+
+
+class HFRobustLoss(HFAlignmentLoss):
+    def __init__(
+        self,
+        ignore_index: int = -100,
+        beta: float = 0.1,
+        use_ref_model: bool = True,
+        compute_nll_loss: bool = False,
+        label_smoothing: float = 0.1,
+    ):
+        super().__init__(
+            beta=beta,
+            ignore_index=ignore_index,
+            use_ref_model=use_ref_model,
+            compute_nll_loss=compute_nll_loss,
+        )
+        self.label_smoothing = label_smoothing
+
+    def alignment_loss(
+        self,
+        policy_chosen_logps: torch.FloatTensor,
+        policy_rejected_logps: torch.FloatTensor,
+        ref_chosen_logps: torch.FloatTensor,
+        ref_rejected_logps: torch.FloatTensor,
+    ):
+        chosen_logratios = policy_chosen_logps - ref_chosen_logps
+        rejected_logratios = policy_rejected_logps - ref_rejected_logps
+
+        chosen_rewards = self.beta * chosen_logratios
+        rejected_rewards = self.beta * rejected_logratios
+
+        logits_diff = self.beta * (chosen_logratios - rejected_logratios)
+        clean_loss_term = -(1 - self.label_smoothing) * F.logsigmoid(logits_diff)
+        flipped_loss_term = -self.label_smoothing * F.logsigmoid(-logits_diff)
+        losses = (clean_loss_term - flipped_loss_term) / (1 - 2 * self.label_smoothing)
+        return losses, chosen_rewards, rejected_rewards
+
+
+class HFEXOPAIRLoss(HFAlignmentLoss):
+    def __init__(
+        self,
+        ignore_index: int = -100,
+        beta: float = 0.1,
+        use_ref_model: bool = True,
+        compute_nll_loss: bool = False,
+        label_smoothing: float = 1e-3,
+    ):
+        super().__init__(
+            beta=beta,
+            ignore_index=ignore_index,
+            use_ref_model=use_ref_model,
+            compute_nll_loss=compute_nll_loss,
+        )
+        self.label_smoothing = label_smoothing
+
+    def alignment_loss(
+        self,
+        policy_chosen_logps: torch.FloatTensor,
+        policy_rejected_logps: torch.FloatTensor,
+        ref_chosen_logps: torch.FloatTensor,
+        ref_rejected_logps: torch.FloatTensor,
+    ):
+        chosen_logratios = policy_chosen_logps - ref_chosen_logps
+        rejected_logratios = policy_rejected_logps - ref_rejected_logps
+
+        chosen_rewards = self.beta * chosen_logratios
+        rejected_rewards = self.beta * rejected_logratios
+
+        logits_diff = self.beta * (chosen_logratios - rejected_logratios)
+        epsilon = torch.tensor(self.label_smoothing, device=policy_chosen_logps.device)
+        qw = torch.sigmoid(logits_diff)
+        log_qw = F.logsigmoid(logits_diff)
+        log_pw = torch.log1p(-epsilon)
+        ql = torch.sigmoid(-logits_diff)
+        log_ql = F.logsigmoid(-logits_diff)
+        log_pl = torch.log(epsilon)
+        losses = qw * (log_qw - log_pw) + ql * (log_ql - log_pl)
+        return losses, chosen_rewards, rejected_rewards
+
+
+class HFDiscoPOPLoss(HFAlignmentLoss):
+    def __init__(
+        self,
+        ignore_index: int = -100,
+        beta: float = 0.1,
+        use_ref_model: bool = True,
+        compute_nll_loss: bool = False,
+        discopop_tau: float = 0.05,
+    ):
+        super().__init__(
+            beta=beta,
+            ignore_index=ignore_index,
+            use_ref_model=use_ref_model,
+            compute_nll_loss=compute_nll_loss,
+        )
+        self.discopop_tau = discopop_tau
+
+    def alignment_loss(
+        self,
+        policy_chosen_logps: torch.FloatTensor,
+        policy_rejected_logps: torch.FloatTensor,
+        ref_chosen_logps: torch.FloatTensor,
+        ref_rejected_logps: torch.FloatTensor,
+    ):
+        chosen_logratios = policy_chosen_logps - ref_chosen_logps
+        rejected_logratios = policy_rejected_logps - ref_rejected_logps
+
+        chosen_rewards = self.beta * chosen_logratios
+        rejected_rewards = self.beta * rejected_logratios
+
+        logits_diff = self.beta * (chosen_logratios - rejected_logratios)
+        log_ratio_modulation = torch.sigmoid(logits_diff / self.discopop_tau)
+        logistic_component = -F.logsigmoid(logits_diff)
+        exp_component = torch.exp(-logits_diff)
+        losses = logistic_component * (1 - log_ratio_modulation) + exp_component * log_ratio_modulation
+        return losses, chosen_rewards, rejected_rewards
+
+
 class TorchLMHeadDPO(torch.nn.Module):
     def __init__(
         self,
@@ -410,6 +592,46 @@ class TorchLMHeadNCAPAIR(torch.nn.Module):
         )
 
 
+class TorchLMHeadGenericDPO(torch.nn.Module):
+    """Wrapper around an arbitrary HFAlignmentLoss subclass. Used for the new loss types."""
+
+    def __init__(
+        self,
+        H: int,
+        V: int,
+        dtype: torch.dtype,
+        hf_loss_cls,
+        bias: bool = False,
+        ref_bias: bool = False,
+        compute_nll_loss: bool = False,
+        ignore_index: int = -100,
+        beta: float = 0.1,
+        **hf_loss_kwargs,
+    ):
+        super().__init__()
+        self.lin = torch.nn.Linear(in_features=H, out_features=V, bias=bias, dtype=dtype)
+        self.ref_lin = torch.nn.Linear(in_features=H, out_features=V, bias=ref_bias, dtype=dtype)
+        self.loss = hf_loss_cls(
+            ignore_index=ignore_index,
+            beta=beta,
+            use_ref_model=True,
+            compute_nll_loss=compute_nll_loss,
+            **hf_loss_kwargs,
+        ).get_batch_loss_metrics
+
+    def forward(self, x, ref_x, y):
+        return self.loss(
+            self.lin.weight,
+            x,
+            y,
+            self.lin.bias,
+            ref_x,
+            self.ref_lin.weight,
+            self.ref_lin.bias,
+            average_log_prob=True,
+        )
+
+
 class LigerLMHeadDPO(torch.nn.Module):
     def __init__(
         self,
@@ -422,6 +644,8 @@ class LigerLMHeadDPO(torch.nn.Module):
         ignore_index: int = -100,
         beta: float = 0.1,
         loss_type: str = "sigmoid",
+        label_smoothing: float = 0.0,
+        discopop_tau: float = 0.05,
     ):
         super().__init__()
         self.lin = torch.nn.Linear(in_features=H, out_features=V, bias=bias, dtype=dtype)
@@ -433,6 +657,8 @@ class LigerLMHeadDPO(torch.nn.Module):
             compute_nll_loss=compute_nll_loss,
             average_log_prob=True,
             loss_type=loss_type,
+            label_smoothing=label_smoothing,
+            discopop_tau=discopop_tau,
         )
 
     def forward(self, x, ref_x, y):
@@ -925,14 +1151,177 @@ def test_correctness_functional_apo_loss_types(
         assert_verbose_allclose(bias1.grad, bias2.grad, atol=atol, rtol=rtol)
 
 
+@pytest.mark.parametrize(
+    "B, T, H, V",
+    [
+        (8, 128, 1024, 4096),
+        (3, 47, 31, 123),  # random shape
+    ],
+)
+@pytest.mark.parametrize(
+    "scalar, dtype, atol, rtol",
+    [
+        (1.0, torch.bfloat16, 5e-2, 5e-1),
+        (1.0, torch.float32, 1e-5, 5e-4),
+    ],
+)
+@pytest.mark.parametrize("bias", [True, False])
+@pytest.mark.parametrize("ref_bias", [True, False])
+@pytest.mark.parametrize("compute_nll_loss", [True, False])
+@pytest.mark.parametrize("ignore_index, beta", [(-100, 0.1), (42, 0.2)])
+@pytest.mark.parametrize(
+    "loss_type, hf_loss_cls, hf_kwargs, liger_kwargs",
+    [
+        ("hinge", HFHingeLoss, {}, {}),
+        ("bco_pair", HFBCOPAIRLoss, {}, {}),
+        ("robust", HFRobustLoss, {"label_smoothing": 0.1}, {"label_smoothing": 0.1}),
+        ("exo_pair", HFEXOPAIRLoss, {"label_smoothing": 1e-3}, {"label_smoothing": 1e-3}),
+        ("discopop", HFDiscoPOPLoss, {"discopop_tau": 0.05}, {"discopop_tau": 0.05}),
+    ],
+)
+def test_correctness_extra_loss_types(
+    B,
+    T,
+    H,
+    V,
+    scalar,
+    dtype,
+    atol,
+    rtol,
+    bias,
+    ref_bias,
+    compute_nll_loss,
+    ignore_index,
+    beta,
+    loss_type,
+    hf_loss_cls,
+    hf_kwargs,
+    liger_kwargs,
+):
+    B = 2 * B  # dpo loss requires B to be even
+
+    torch_lm_head = TorchLMHeadGenericDPO(
+        H=H,
+        V=V,
+        dtype=dtype,
+        hf_loss_cls=hf_loss_cls,
+        bias=bias,
+        ref_bias=ref_bias,
+        compute_nll_loss=compute_nll_loss,
+        ignore_index=ignore_index,
+        beta=beta,
+        **hf_kwargs,
+    )
+    liger_lm_head = LigerLMHeadDPO(
+        H=H,
+        V=V,
+        dtype=dtype,
+        bias=bias,
+        ref_bias=ref_bias,
+        compute_nll_loss=compute_nll_loss,
+        ignore_index=ignore_index,
+        beta=beta,
+        loss_type=loss_type,
+        **liger_kwargs,
+    )
+
+    torch_lm_head.lin.weight.data = liger_lm_head.lin.weight.data = torch.randn(V, H, device=device, dtype=dtype)
+    torch_lm_head.ref_lin.weight.data = liger_lm_head.ref_lin.weight.data = torch.randn(
+        V, H, device=device, dtype=dtype
+    )
+
+    if bias:
+        torch_lm_head.lin.bias.data = liger_lm_head.lin.bias.data = torch.randn(V, device=device, dtype=dtype)
+    if ref_bias:
+        torch_lm_head.ref_lin.bias.data = liger_lm_head.ref_lin.bias.data = torch.randn(V, device=device, dtype=dtype)
+
+    _input = torch.randn(B, T, H, device=device, dtype=dtype) * scalar
+    input1 = _input.detach().clone().requires_grad_(True)
+    input2 = _input.detach().clone().requires_grad_(True)
+
+    ref_input = torch.randn(B, T, H, device=device, dtype=dtype, requires_grad=False) * scalar
+
+    target = torch.randint(0, V, (B, T), device=device, dtype=torch.long)
+    num_elements_to_assign = torch.randint(1, B * T // 2, (1,)).item()
+    indices_to_assign = torch.randperm(B * T)[:num_elements_to_assign]
+    target.view(-1)[indices_to_assign] = ignore_index
+
+    loss1, aggregated_aux_outputs1 = torch_lm_head(input1, ref_input, target)
+    loss2, aggregated_aux_outputs2 = liger_lm_head(input2, ref_input, target)
+
+    assert_verbose_allclose(loss1, loss2, atol=atol, rtol=rtol)
+
+    assert len(aggregated_aux_outputs1) == len(aggregated_aux_outputs2)
+
+    for i in range(len(aggregated_aux_outputs1)):
+        if i > 4 and dtype == torch.bfloat16:
+            assert_verbose_allclose(
+                aggregated_aux_outputs1[i],
+                aggregated_aux_outputs2[i],
+                atol=5e-1,
+                rtol=rtol,
+            )
+            continue
+        assert_verbose_allclose(
+            aggregated_aux_outputs1[i],
+            aggregated_aux_outputs2[i],
+            atol=atol,
+            rtol=rtol,
+        )
+
+    loss1.backward()
+    loss2.backward()
+
+    assert_verbose_allclose(input1.grad, input2.grad, atol=atol, rtol=rtol)
+    assert_verbose_allclose(
+        torch_lm_head.lin.weight.grad,
+        liger_lm_head.lin.weight.grad,
+        atol=atol,
+        rtol=rtol,
+    )
+    if bias:
+        assert_verbose_allclose(
+            torch_lm_head.lin.bias.grad,
+            liger_lm_head.lin.bias.grad,
+            atol=atol,
+            rtol=rtol,
+        )
+
+
 def test_invalid_loss_type():
     """Test that invalid loss types raise ValueError"""
     with pytest.raises(ValueError, match="Unsupported loss_type"):
         LigerFusedLinearDPOLoss(loss_type="invalid_loss_type")
 
     # Test that valid loss types don't raise errors
-    valid_loss_types = ["sigmoid", "apo_zero", "apo_down", "sppo_hard", "nca_pair"]
+    valid_loss_types = [
+        "sigmoid",
+        "hinge",
+        "exo_pair",
+        "nca_pair",
+        "robust",
+        "bco_pair",
+        "sppo_hard",
+        "apo_zero",
+        "apo_down",
+        "discopop",
+    ]
+    extra_kwargs = {
+        "exo_pair": {"label_smoothing": 1e-3},
+        "robust": {"label_smoothing": 0.1},
+    }
     for loss_type in valid_loss_types:
-        # Should not raise an exception
-        loss_fn = LigerFusedLinearDPOLoss(loss_type=loss_type)
+        loss_fn = LigerFusedLinearDPOLoss(loss_type=loss_type, **extra_kwargs.get(loss_type, {}))
         assert loss_fn.loss_type == loss_type
+
+
+def test_label_smoothing_validation():
+    """Test that invalid label_smoothing values raise ValueError for the relevant loss types."""
+    with pytest.raises(ValueError, match="label_smoothing must be > 0 for loss_type='exo_pair'"):
+        LigerFusedLinearDPOLoss(loss_type="exo_pair", label_smoothing=0.0)
+
+    with pytest.raises(ValueError, match=r"label_smoothing must lie in \[0\.0, 0\.5\) for loss_type='robust'"):
+        LigerFusedLinearDPOLoss(loss_type="robust", label_smoothing=0.5)
+
+    with pytest.raises(ValueError, match=r"label_smoothing must lie in \[0\.0, 0\.5\) for loss_type='robust'"):
+        LigerFusedLinearDPOLoss(loss_type="robust", label_smoothing=-0.1)


### PR DESCRIPTION
Brings Liger's fused linear DPO loss closer to TRL's DPOTrainer by adding five additional loss variants on top of the existing sigmoid / apo_zero / apo_down / sppo_hard / nca_pair set:

- hinge: relu(1 - beta * (chosen - rejected))
- bco_pair: -logsigmoid(beta * chosen) - logsigmoid(-beta * rejected)
- robust (cDPO): label-smoothed sigmoid loss with flipped-pair correction
- exo_pair: KL(p_fθ || [1-eps, eps]) for K=2 (EXO-pref, paper 2402.00856)
- discopop: blended logistic / exponential loss (DiscoPOP, paper 2406.08414)

Also threads two new kwargs through LigerFusedLinearDPOLoss / LigerFusedLinearDPOFunction:

- label_smoothing (used by robust and exo_pair; validated at construction)
- discopop_tau (temperature for the DiscoPOP modulation term)

Tests: adds HF reference implementations for each new loss type and a parametrized test_correctness_extra_loss_types covering all five variants across bf16/fp32, with/without bias, with/without ref bias, and compute_nll_loss on/off (320 cases). Adds test_label_smoothing_validation for the label_smoothing range checks. The existing test_invalid_loss_type is updated to cover the new supported set.

All 800 DPO test cases pass on H100.

## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
