### PR TITLE
[fix] Distinguish the import path for compute_routing_metadata based on device type

### DIFF
--- a/src/liger_kernel/ops/backends/_ascend/ops/__init__.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/__init__.py
@@ -33,7 +33,6 @@ from liger_kernel.ops.backends._ascend.ops.fused_linear_jsd import LigerFusedLin
 from liger_kernel.ops.backends._ascend.ops.fused_linear_jsd import fused_linear_jsd_backward
 from liger_kernel.ops.backends._ascend.ops.fused_linear_jsd import fused_linear_jsd_forward
 from liger_kernel.ops.backends._ascend.ops.fused_moe import LigerFusedMoEFunction
-from liger_kernel.ops.backends._ascend.ops.fused_moe import compute_routing_metadata
 from liger_kernel.ops.backends._ascend.ops.fused_neighborhood_attention import LigerFusedNeighborhoodAttentionFunction
 from liger_kernel.ops.backends._ascend.ops.fused_neighborhood_attention import fused_neighborhood_attention_forward
 from liger_kernel.ops.backends._ascend.ops.geglu import LigerGELUMulFunction

--- a/test/transformers/test_fused_moe.py
+++ b/test/transformers/test_fused_moe.py
@@ -14,10 +14,14 @@ import torch
 import torch.nn as nn
 
 from liger_kernel.ops import LigerFusedMoEFunction
-from liger_kernel.ops import compute_routing_metadata
 from liger_kernel.utils import infer_device
 
 device = infer_device()
+
+if device == "npu":
+    from liger_kernel.ops.backends._ascend.ops.fused_moe import compute_routing_metadata
+else:
+    from liger_kernel.ops.fused_moe import compute_routing_metadata
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

As Title. 

Fix: https://github.com/linkedin/Liger-Kernel/pull/1183#discussion_r3163137729 

- Hardware Type: npu
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
