### PR TITLE
fix(glm4v): version-aware hidden_size/vocab_size for Glm4vConfig

### DIFF
--- a/src/liger_kernel/transformers/model/glm4v.py
+++ b/src/liger_kernel/transformers/model/glm4v.py
@@ -5,9 +5,29 @@ from typing import Union
 
 import torch
 
+from packaging import version
+from transformers import PretrainedConfig
+from transformers import __version__ as transformers_version
+
 from liger_kernel.transformers.model.loss_utils import LigerForCausalLMLoss
 from liger_kernel.transformers.model.loss_utils import unpack_cross_entropy_result
 from liger_kernel.transformers.model.output_classes import LigerCausalLMOutputWithPast
+
+_TRANSFORMERS_V5_OR_LATER: bool = version.parse(transformers_version) >= version.parse("5.0.0")
+
+
+def _get_hidden_size(config: PretrainedConfig) -> int:
+    """Get hidden_size from Glm4vConfig in a version-aware manner."""
+    if _TRANSFORMERS_V5_OR_LATER:
+        return config.text_config.hidden_size
+    return config.hidden_size
+
+
+def _get_vocab_size(config: PretrainedConfig) -> int:
+    """Get vocab_size from Glm4vConfig in a version-aware manner."""
+    if _TRANSFORMERS_V5_OR_LATER:
+        return config.text_config.vocab_size
+    return config.vocab_size
 
 
 def lce_forward(
@@ -130,7 +150,7 @@ def lce_forward(
             lm_head_weight=self.lm_head.weight,
             labels=labels,
             shift_labels=shift_labels,
-            hidden_size=self.config.hidden_size,
+            hidden_size=_get_hidden_size(self.config),
             **kwargs,
         )
         loss, _, token_accuracy, predicted_tokens = unpack_cross_entropy_result(result)
@@ -142,7 +162,7 @@ def lce_forward(
                 logits=logits,
                 labels=labels,
                 shift_labels=shift_labels,
-                vocab_size=self.config.vocab_size,
+                vocab_size=_get_vocab_size(self.config),
                 **kwargs,
             )
 

--- a/src/liger_kernel/transformers/model/glm4v_moe.py
+++ b/src/liger_kernel/transformers/model/glm4v_moe.py
@@ -4,9 +4,29 @@ from typing import Union
 
 import torch
 
+from packaging import version
+from transformers import PretrainedConfig
+from transformers import __version__ as transformers_version
+
 from liger_kernel.transformers.model.loss_utils import LigerForCausalLMLoss
 from liger_kernel.transformers.model.loss_utils import unpack_cross_entropy_result
 from liger_kernel.transformers.model.output_classes import LigerGlm4vMoeCausalLMOutputWithPast
+
+_TRANSFORMERS_V5_OR_LATER: bool = version.parse(transformers_version) >= version.parse("5.0.0")
+
+
+def _get_hidden_size(config: PretrainedConfig) -> int:
+    """Get hidden_size from Glm4vMoeConfig in a version-aware manner."""
+    if _TRANSFORMERS_V5_OR_LATER:
+        return config.text_config.hidden_size
+    return config.hidden_size
+
+
+def _get_vocab_size(config: PretrainedConfig) -> int:
+    """Get vocab_size from Glm4vMoeConfig in a version-aware manner."""
+    if _TRANSFORMERS_V5_OR_LATER:
+        return config.text_config.vocab_size
+    return config.vocab_size
 
 
 def lce_forward(
@@ -133,7 +153,7 @@ def lce_forward(
             lm_head_weight=self.lm_head.weight,
             labels=labels,
             shift_labels=shift_labels,
-            hidden_size=self.config.hidden_size,
+            hidden_size=_get_hidden_size(self.config),
             **kwargs,
         )
         loss, _, token_accuracy, predicted_tokens = unpack_cross_entropy_result(result)
@@ -145,7 +165,7 @@ def lce_forward(
                 logits=logits,
                 labels=labels,
                 shift_labels=shift_labels,
-                vocab_size=self.config.vocab_size,
+                vocab_size=_get_vocab_size(self.config),
                 **kwargs,
             )
 


### PR DESCRIPTION
Reading `config.hidden_size` and `config.vocab_size` directly in `glm4v.py` and `glm4v_moe.py` fails on transformers v5+, where `Glm4vConfig` and `Glm4vMoeConfig` are composite (`text_config` + `vision_config`) and the top-level fields are no longer present. Reported in #1152:

```
File ".../liger_kernel/transformers/model/glm4v.py", line 130, in lce_forward
    hidden_size=self.config.hidden_size,
AttributeError: 'Glm4vConfig' object has no attribute 'hidden_size'
```

Same shape PR #1062 already fixed for Qwen2-VL / Qwen2.5-VL — mirror that helper (`_get_hidden_size`, `_get_vocab_size`) gated on `transformers >= 5.0.0`, applied to both `glm4v.py` and `glm4v_moe.py`. Pre-v5 still works because the helpers fall back to the top-level attribute. Helper signatures are typed (`config: PretrainedConfig -> int`) and the version flag is annotated `bool`.

## Reproducer (transformers 5.7.0)

```python
from transformers import Glm4vConfig
cfg = Glm4vConfig(text_config={"hidden_size": 1024, "vocab_size": 32000})
cfg.text_config.hidden_size   # 1024
cfg.hidden_size               # AttributeError: 'Glm4vConfig' object has no attribute 'hidden_size'
```

Same shape reproduces for `Glm4vMoeConfig`. Identical to the trace in #1152.

After the helper change, both `_get_hidden_size(cfg)` and `_get_vocab_size(cfg)` route through `text_config` on v5+ and fall back to the top-level attribute pre-v5:

```
transformers=5.7.0  v5_or_later=True
_get_hidden_size(Glm4vConfig)    = 1024
_get_vocab_size(Glm4vConfig)     = 32000
_get_hidden_size(Glm4vMoeConfig) = 1024
_get_vocab_size(Glm4vMoeConfig)  = 32000
```

## Tests

End-to-end coverage already in place in `test/convergence/bf16/test_mini_models.py` and `test/convergence/fp32/test_mini_models.py` — both `mini_glm4v` and `mini_glm4v_moe` configs construct via the `text_config` sub-dict (lines 1245–1308 / 1311–1368), so CI exercises the fixed path on v5+ runners. No new test file added — matches the precedent set by PR #1062 (qwen2_vl fix), which also relied on the existing convergence tests rather than introducing a helper-level test layer.

Closes #1152.