### PR TITLE
[Benchmark] Add compute_seq_len_sweep_config_with_probe with linear/quadratic scaling support

### DIFF
--- a/benchmark/scripts/benchmark_attn_res.py
+++ b/benchmark/scripts/benchmark_attn_res.py
@@ -15,7 +15,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import SingleBenchmarkRunInput
 from utils import SingleBenchmarkRunOutput
@@ -185,10 +184,7 @@ if __name__ == "__main__":
             V, fn = _setup_attn_res(probe_input)
             return fn()
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_seq_len
-
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_seq_len)
 
         common_configs = {
             "kernel_name": "attn_res",

--- a/benchmark/scripts/benchmark_cross_entropy.py
+++ b/benchmark/scripts/benchmark_cross_entropy.py
@@ -6,7 +6,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from torch.nn import CrossEntropyLoss
 from utils import QUANTILES
@@ -231,10 +230,7 @@ if __name__ == "__main__":
             _input, target, loss_fn = _setup_cross_entropy(probe_input)
             return loss_fn(_input, target)
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "cross_entropy",

--- a/benchmark/scripts/benchmark_distill_cosine_loss.py
+++ b/benchmark/scripts/benchmark_distill_cosine_loss.py
@@ -9,7 +9,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -358,10 +357,7 @@ if __name__ == "__main__":
             student_input, teacher_input, target, loss_module = _setup_distill_cosine_loss(probe_input)
             return loss_module(student_input, teacher_input, target)
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "distill_cosine_loss",

--- a/benchmark/scripts/benchmark_distill_jsd_loss.py
+++ b/benchmark/scripts/benchmark_distill_jsd_loss.py
@@ -8,7 +8,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -358,10 +357,7 @@ if __name__ == "__main__":
             student_input, teacher_input, target, loss_module = _setup_distill_jsd_loss(probe_input)
             return loss_module(student_input, teacher_input, target)
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "distill_jsd_loss",

--- a/benchmark/scripts/benchmark_dpo_loss.py
+++ b/benchmark/scripts/benchmark_dpo_loss.py
@@ -8,7 +8,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -288,10 +287,7 @@ if __name__ == "__main__":
             _, fwd = _setup_dpo_loss(probe_input)
             return fwd()
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "dpo_loss",

--- a/benchmark/scripts/benchmark_dyt.py
+++ b/benchmark/scripts/benchmark_dyt.py
@@ -7,7 +7,6 @@ import torch
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import SingleBenchmarkRunInput
 from utils import SingleBenchmarkRunOutput
@@ -162,10 +161,7 @@ if __name__ == "__main__":
                 x, layer = _setup_dyt(probe_input)
                 return layer(x)
 
-            peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-            kernel_bpt = peak_bytes // probe_bt
-
-            config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+            config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
             common_configs = {
                 "kernel_name": f"dyt_beta={beta}",

--- a/benchmark/scripts/benchmark_embedding.py
+++ b/benchmark/scripts/benchmark_embedding.py
@@ -8,7 +8,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from torch.nn import Embedding
 from utils import QUANTILES
@@ -236,9 +235,7 @@ if __name__ == "__main__":
             _, fwd_fn = _setup_embedding(probe_input)
             return fwd_fn()
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "embedding",

--- a/benchmark/scripts/benchmark_fused_add_rms_norm.py
+++ b/benchmark/scripts/benchmark_fused_add_rms_norm.py
@@ -7,7 +7,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -295,10 +294,7 @@ if __name__ == "__main__":
             y, s = layer(x, r)
             return y + s
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "fused_add_rms_norm",

--- a/benchmark/scripts/benchmark_fused_linear_cross_entropy.py
+++ b/benchmark/scripts/benchmark_fused_linear_cross_entropy.py
@@ -6,7 +6,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -290,10 +289,7 @@ if __name__ == "__main__":
             _input, target, lm_head_ce = _setup_fused_linear_cross_entropy(probe_input)
             return lm_head_ce(_input, target)
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "fused_linear_cross_entropy",

--- a/benchmark/scripts/benchmark_fused_linear_jsd.py
+++ b/benchmark/scripts/benchmark_fused_linear_jsd.py
@@ -6,7 +6,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -354,10 +353,7 @@ if __name__ == "__main__":
             student_input, teacher_input, lm_head = _setup_fused_linear_jsd(probe_input)
             return lm_head(student_input, teacher_input)
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "fused_linear_jsd",

--- a/benchmark/scripts/benchmark_fused_neighborhood_attention.py
+++ b/benchmark/scripts/benchmark_fused_neighborhood_attention.py
@@ -7,7 +7,6 @@ import triton
 
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -446,9 +445,7 @@ if __name__ == "__main__":
             _, _, fwd_fn = _setup_fused_neighborhood_attention(probe_input)
             return fwd_fn()
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_seq_len
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_seq_len)
 
         common_configs = {
             "kernel_name": "fused_neighborhood_attention",

--- a/benchmark/scripts/benchmark_geglu.py
+++ b/benchmark/scripts/benchmark_geglu.py
@@ -5,7 +5,6 @@ import torch
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaMLP
@@ -171,10 +170,7 @@ if __name__ == "__main__":
             x, layer = _setup_geglu(probe_input)
             return layer(x)
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_seq_len
-
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_seq_len)
 
         common_configs = {
             "kernel_name": "geglu",

--- a/benchmark/scripts/benchmark_group_norm.py
+++ b/benchmark/scripts/benchmark_group_norm.py
@@ -5,7 +5,6 @@ import torch
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import SingleBenchmarkRunInput
 from utils import SingleBenchmarkRunOutput
@@ -180,10 +179,7 @@ if __name__ == "__main__":
             x, layer = _setup_group_norm(probe_input)
             return layer(x)
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "group_norm",

--- a/benchmark/scripts/benchmark_grpo_loss.py
+++ b/benchmark/scripts/benchmark_grpo_loss.py
@@ -8,7 +8,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -260,9 +259,7 @@ def _run_grpo_benchmarks(args, importance_sampling_level, kernel_name_suffix):
             _, fwd = _setup_grpo_loss(probe_input)
             return fwd()
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": kernel_name,

--- a/benchmark/scripts/benchmark_jsd.py
+++ b/benchmark/scripts/benchmark_jsd.py
@@ -6,7 +6,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -263,10 +262,7 @@ if __name__ == "__main__":
             _input, target, loss_fn = _setup_jsd(probe_input)
             return loss_fn(_input, target)
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "jsd",

--- a/benchmark/scripts/benchmark_kl_div.py
+++ b/benchmark/scripts/benchmark_kl_div.py
@@ -7,7 +7,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -227,10 +226,7 @@ if __name__ == "__main__":
             _input, target, loss_fn = _setup_kl_div(probe_input)
             return loss_fn(_input, target)
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "kl_div",

--- a/benchmark/scripts/benchmark_kto_loss.py
+++ b/benchmark/scripts/benchmark_kto_loss.py
@@ -8,7 +8,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -323,9 +322,7 @@ if __name__ == "__main__":
             _, fwd = _setup_kto_loss(probe_input)
             return fwd()
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "kto_loss",

--- a/benchmark/scripts/benchmark_llama4_rope.py
+++ b/benchmark/scripts/benchmark_llama4_rope.py
@@ -8,7 +8,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from transformers.models.llama4.configuration_llama4 import Llama4TextConfig
 from transformers.models.llama4.modeling_llama4 import Llama4TextRotaryEmbedding
@@ -281,9 +280,7 @@ if __name__ == "__main__":
             _, _, _, _, fwd_fn = _setup_llama4_rope(probe_input)
             return fwd_fn()[0]
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_seq_len
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_seq_len)
 
         common_configs = {
             "kernel_name": "llama4_rope",

--- a/benchmark/scripts/benchmark_mhc.py
+++ b/benchmark/scripts/benchmark_mhc.py
@@ -8,7 +8,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -310,9 +309,7 @@ if __name__ == "__main__":
                 _, _, fwd_loss = _setup_mhc(probe_input)
                 return fwd_loss()
 
-            peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-            kernel_bpt = peak_bytes // probe_T
-            config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+            config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_T)
 
             common_configs = {
                 "kernel_name": f"mhc_{sub_kernel}",

--- a/benchmark/scripts/benchmark_mhc_lm.py
+++ b/benchmark/scripts/benchmark_mhc_lm.py
@@ -10,7 +10,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -512,9 +511,7 @@ if __name__ == "__main__":
             _, _, fwd_loss_fn = _setup_mhc_lm(probe_input)
             return fwd_loss_fn()
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_T
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_T)
 
         common_configs = {
             "kernel_name": "mhc_llama_like_lm",

--- a/benchmark/scripts/benchmark_model_configs.py
+++ b/benchmark/scripts/benchmark_model_configs.py
@@ -291,6 +291,68 @@ def estimate_kernel_peak_memory(probe_fn: Callable[[], torch.Tensor]) -> int:
     return max(1, peak_bytes)
 
 
+def compute_seq_len_sweep_config_with_probe(
+    model_cfg: ModelConfig,
+    probe_fn: Callable[[], torch.Tensor],
+    probe_seq_len: int,
+    probe_batch_size: int = 1,
+    scaling_method: Literal["linear", "quadratic"] = "linear",
+    memory_utilization: float = 0.4,
+    max_seq_len: Optional[int] = None,
+    max_batch_size: int = 32,
+) -> SeqLenSweepConfig:
+    """Compute safe sweep config from a probe, supporting non-linear seq-len scaling.
+
+    Wraps :func:`estimate_kernel_peak_memory` and inverts the memory model
+    according to *scaling_method*. Linear-scaling kernels can keep using
+    :func:`compute_seq_len_sweep_config` directly; this helper exists for
+    kernels whose memory grows non-linearly with seq_len (e.g. attention
+    kernels with O(L^2) scratch).
+
+    Args:
+        model_cfg: Model architecture config.
+        probe_fn: Callable that performs setup, runs a forward pass, and
+            returns an output tensor suitable for ``.backward()``. Same
+            contract as :func:`estimate_kernel_peak_memory`'s *probe_fn*.
+        probe_seq_len: Sequence length used inside *probe_fn*. Required so
+            the inversion can isolate the seq-len-dependent term.
+        probe_batch_size: Batch size used inside *probe_fn*. Defaults to 1.
+        scaling_method: How peak memory scales with seq_len, holding batch
+            size fixed.
+
+            - ``"linear"``: peak ~ B * L. Inversion: ``L_max = usable / (B * c_per_BL)``.
+            - ``"quadratic"``: peak ~ B * L^2. Inversion: ``L_max = sqrt(usable / (B * c_per_BL2))``.
+        memory_utilization: Fraction of total device memory to target (0 to 1).
+        max_seq_len: Hard upper bound for sequence length. Defaults to
+            ``model_cfg.max_position_embeddings``.
+        max_batch_size: Hard upper bound for batch size.
+    """
+    if scaling_method not in ("linear", "quadratic"):
+        raise ValueError(f"scaling_method must be 'linear' or 'quadratic', got {scaling_method!r}")
+
+    peak_bytes = estimate_kernel_peak_memory(probe_fn=probe_fn)
+
+    total_memory_gb = get_total_gpu_memory()
+    usable_bytes = total_memory_gb * (1024**3) * memory_utilization
+
+    if max_seq_len is None:
+        max_seq_len = model_cfg.max_position_embeddings
+
+    batch_size = max(1, min(max_batch_size, probe_batch_size))
+
+    if scaling_method == "linear":
+        c_per_BL = max(1.0, peak_bytes / (probe_batch_size * probe_seq_len))
+        max_seq_len_from_mem = max(1, int(usable_bytes / (batch_size * c_per_BL)))
+    else:
+        c_per_BL2 = max(1.0, peak_bytes / (probe_batch_size * probe_seq_len * probe_seq_len))
+        max_seq_len_from_mem = max(1, int(math.sqrt(usable_bytes / (batch_size * c_per_BL2))))
+
+    seq_len = min(max_seq_len, max_seq_len_from_mem)
+    seq_len = 2 ** int(math.log2(seq_len)) if seq_len >= 1024 else 1024
+
+    return SeqLenSweepConfig(batch_size=batch_size, seq_len=seq_len)
+
+
 def compute_seq_len_sweep_config(
     model_cfg: ModelConfig,
     kernel_bytes_per_token: Optional[int] = None,

--- a/benchmark/scripts/benchmark_model_configs.py
+++ b/benchmark/scripts/benchmark_model_configs.py
@@ -291,6 +291,35 @@ def estimate_kernel_peak_memory(probe_fn: Callable[[], torch.Tensor]) -> int:
     return max(1, peak_bytes)
 
 
+def _max_seqlen_under_memory(
+    *,
+    usable_bytes: float,
+    peak_bytes: int,
+    probe_batch_size: int,
+    probe_seq_len: int,
+    scaling_method: Literal["linear", "quadratic"],
+    target_batch_size: int,
+) -> int:
+    """Invert peak_bytes(B, L) for L at fixed target_batch_size.
+
+    - ``"linear"``: assumes peak ~ B * L. ``L_max = usable / (B * c_per_BL)``.
+    - ``"quadratic"``: assumes peak ~ B * L^2. ``L_max = sqrt(usable / (B * c_per_BL2))``.
+    """
+    if scaling_method == "linear":
+        c = max(1.0, peak_bytes / (probe_batch_size * probe_seq_len))
+        return max(1, int(usable_bytes / (target_batch_size * c)))
+    if scaling_method == "quadratic":
+        c = max(1.0, peak_bytes / (probe_batch_size * probe_seq_len * probe_seq_len))
+        return max(1, int(math.sqrt(usable_bytes / (target_batch_size * c))))
+    raise ValueError(f"scaling_method must be 'linear' or 'quadratic', got {scaling_method!r}")
+
+
+def _snap_pow2_seqlen(seq_len: int, max_seq_len: int) -> int:
+    """Clamp to *max_seq_len* and snap down to nearest power of 2 (floor at 1024)."""
+    seq_len = min(max_seq_len, seq_len)
+    return 2 ** int(math.log2(seq_len)) if seq_len >= 1024 else 1024
+
+
 def compute_seq_len_sweep_config_with_probe(
     model_cfg: ModelConfig,
     probe_fn: Callable[[], torch.Tensor],
@@ -318,37 +347,28 @@ def compute_seq_len_sweep_config_with_probe(
             the inversion can isolate the seq-len-dependent term.
         probe_batch_size: Batch size used inside *probe_fn*. Defaults to 1.
         scaling_method: How peak memory scales with seq_len, holding batch
-            size fixed.
-
-            - ``"linear"``: peak ~ B * L. Inversion: ``L_max = usable / (B * c_per_BL)``.
-            - ``"quadratic"``: peak ~ B * L^2. Inversion: ``L_max = sqrt(usable / (B * c_per_BL2))``.
+            size fixed. See :func:`_max_seqlen_under_memory`.
         memory_utilization: Fraction of total device memory to target (0 to 1).
         max_seq_len: Hard upper bound for sequence length. Defaults to
             ``model_cfg.max_position_embeddings``.
         max_batch_size: Hard upper bound for batch size.
     """
-    if scaling_method not in ("linear", "quadratic"):
-        raise ValueError(f"scaling_method must be 'linear' or 'quadratic', got {scaling_method!r}")
-
     peak_bytes = estimate_kernel_peak_memory(probe_fn=probe_fn)
 
-    total_memory_gb = get_total_gpu_memory()
-    usable_bytes = total_memory_gb * (1024**3) * memory_utilization
-
+    usable_bytes = get_total_gpu_memory() * (1024**3) * memory_utilization
     if max_seq_len is None:
         max_seq_len = model_cfg.max_position_embeddings
 
     batch_size = max(1, min(max_batch_size, probe_batch_size))
-
-    if scaling_method == "linear":
-        c_per_BL = max(1.0, peak_bytes / (probe_batch_size * probe_seq_len))
-        max_seq_len_from_mem = max(1, int(usable_bytes / (batch_size * c_per_BL)))
-    else:
-        c_per_BL2 = max(1.0, peak_bytes / (probe_batch_size * probe_seq_len * probe_seq_len))
-        max_seq_len_from_mem = max(1, int(math.sqrt(usable_bytes / (batch_size * c_per_BL2))))
-
-    seq_len = min(max_seq_len, max_seq_len_from_mem)
-    seq_len = 2 ** int(math.log2(seq_len)) if seq_len >= 1024 else 1024
+    max_seq_len_from_mem = _max_seqlen_under_memory(
+        usable_bytes=usable_bytes,
+        peak_bytes=peak_bytes,
+        probe_batch_size=probe_batch_size,
+        probe_seq_len=probe_seq_len,
+        scaling_method=scaling_method,
+        target_batch_size=batch_size,
+    )
+    seq_len = _snap_pow2_seqlen(max_seq_len_from_mem, max_seq_len)
 
     return SeqLenSweepConfig(batch_size=batch_size, seq_len=seq_len)
 
@@ -385,21 +405,26 @@ def compute_seq_len_sweep_config(
             the model's native context window.
         max_batch_size: Hard upper bound for batch size.
     """
-    total_memory_gb = get_total_gpu_memory()
     dtype_bytes = 2 if model_cfg.dtype in (torch.bfloat16, torch.float16) else 4
 
     if kernel_bytes_per_token is None:
         kernel_bytes_per_token = model_cfg.hidden_size * dtype_bytes * 16
-
     if max_seq_len is None:
         max_seq_len = model_cfg.max_position_embeddings
 
-    usable_bytes = total_memory_gb * (1024**3) * memory_utilization
-    max_tokens = max(1, int(usable_bytes / kernel_bytes_per_token))
+    usable_bytes = get_total_gpu_memory() * (1024**3) * memory_utilization
 
-    seq_len = min(max_seq_len, max_tokens)
-    seq_len = 2 ** int(math.log2(seq_len)) if seq_len >= 1024 else 1024
-
+    # bpt is peak_bytes for a unit (B=L=1) probe under linear scaling, so the
+    # inversion at target_batch=1 yields the existing ``max_tokens`` quantity.
+    max_tokens = _max_seqlen_under_memory(
+        usable_bytes=usable_bytes,
+        peak_bytes=kernel_bytes_per_token,
+        probe_batch_size=1,
+        probe_seq_len=1,
+        scaling_method="linear",
+        target_batch_size=1,
+    )
+    seq_len = _snap_pow2_seqlen(max_tokens, max_seq_len)
     batch_size = max(1, min(max_tokens // seq_len, max_batch_size))
 
     return SeqLenSweepConfig(batch_size=batch_size, seq_len=seq_len)

--- a/benchmark/scripts/benchmark_model_configs.py
+++ b/benchmark/scripts/benchmark_model_configs.py
@@ -17,9 +17,7 @@ Usage::
     model = get_benchmark_model_config(args.model)
 
     # Measure actual memory via a small probe, then compute sweep config
-    peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-    bpt = peak_bytes // probe_num_tokens
-    config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=bpt)
+    config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_seq_len)
 """
 
 import gc
@@ -258,7 +256,8 @@ def estimate_kernel_peak_memory(probe_fn: Callable[[], torch.Tensor]) -> int:
     Call this with the *pure PyTorch* (e.g. huggingface) implementation --
     that typically has the highest memory footprint and therefore gives a
     safe upper-bound estimate.  Returns the total peak bytes; divide by
-    num_tokens if you need bytes-per-token for :func:`compute_seq_len_sweep_config`.
+    num_tokens if you need bytes-per-token. :func:`compute_seq_len_sweep_config`
+    accepts a ``probe_fn`` directly and will run this for you.
 
     The probe_fn performs setup and forward pass internally; cleanup is
     automatic, so callers do not need to manage tensor/layer lifecycle.
@@ -320,7 +319,7 @@ def _snap_pow2_seqlen(seq_len: int, max_seq_len: int) -> int:
     return 2 ** int(math.log2(seq_len)) if seq_len >= 1024 else 1024
 
 
-def compute_seq_len_sweep_config_with_probe(
+def compute_seq_len_sweep_config(
     model_cfg: ModelConfig,
     probe_fn: Callable[[], torch.Tensor],
     probe_seq_len: int,
@@ -330,27 +329,33 @@ def compute_seq_len_sweep_config_with_probe(
     max_seq_len: Optional[int] = None,
     max_batch_size: int = 32,
 ) -> SeqLenSweepConfig:
-    """Compute safe sweep config from a probe, supporting non-linear seq-len scaling.
+    """Compute safe batch_size and seq_len for a sequence-length sweep.
 
-    Wraps :func:`estimate_kernel_peak_memory` and inverts the memory model
-    according to *scaling_method*. Linear-scaling kernels can keep using
-    :func:`compute_seq_len_sweep_config` directly; this helper exists for
-    kernels whose memory grows non-linearly with seq_len (e.g. attention
-    kernels with O(L^2) scratch).
+    Runs *probe_fn* once via :func:`estimate_kernel_peak_memory` to measure the
+    actual peak memory, then inverts the memory model according to
+    *scaling_method* to find the largest seq_len that fits in
+    ``device_memory * memory_utilization``. Device memory is obtained internally
+    via :func:`~liger_kernel.utils.get_total_gpu_memory`.
+
+    For kernels whose memory grows non-linearly with seq_len (e.g. attention
+    kernels with O(L^2) scratch), pass ``scaling_method="quadratic"``.
 
     Args:
         model_cfg: Model architecture config.
         probe_fn: Callable that performs setup, runs a forward pass, and
             returns an output tensor suitable for ``.backward()``. Same
             contract as :func:`estimate_kernel_peak_memory`'s *probe_fn*.
-        probe_seq_len: Sequence length used inside *probe_fn*. Required so
-            the inversion can isolate the seq-len-dependent term.
+        probe_seq_len: Sequence length used inside *probe_fn*. Required so the
+            inversion can isolate the seq-len-dependent term.
         probe_batch_size: Batch size used inside *probe_fn*. Defaults to 1.
         scaling_method: How peak memory scales with seq_len, holding batch
             size fixed. See :func:`_max_seqlen_under_memory`.
         memory_utilization: Fraction of total device memory to target (0 to 1).
-        max_seq_len: Hard upper bound for sequence length. Defaults to
-            ``model_cfg.max_position_embeddings``.
+            Lower values are safer.  Default ``0.4`` leaves headroom for
+            framework overhead and CUDA/NPU context.
+        max_seq_len: Hard upper bound for sequence length.  Defaults to
+            ``model_cfg.max_position_embeddings`` so the sweep never exceeds
+            the model's native context window.
         max_batch_size: Hard upper bound for batch size.
     """
     peak_bytes = estimate_kernel_peak_memory(probe_fn=probe_fn)
@@ -369,63 +374,6 @@ def compute_seq_len_sweep_config_with_probe(
         target_batch_size=batch_size,
     )
     seq_len = _snap_pow2_seqlen(max_seq_len_from_mem, max_seq_len)
-
-    return SeqLenSweepConfig(batch_size=batch_size, seq_len=seq_len)
-
-
-def compute_seq_len_sweep_config(
-    model_cfg: ModelConfig,
-    kernel_bytes_per_token: Optional[int] = None,
-    memory_utilization: float = 0.4,
-    max_seq_len: Optional[int] = None,
-    max_batch_size: int = 32,
-) -> SeqLenSweepConfig:
-    """Compute safe batch_size and seq_len for sequence-length sweep (e.g. GEGLU).
-
-    Peak memory is estimated as
-    ``batch_size * seq_len * kernel_bytes_per_token`` and is capped at
-    device memory * memory_utilization.  Device memory is obtained
-    internally via :func:`~liger_kernel.utils.get_total_gpu_memory`.
-
-    Prefer obtaining *kernel_bytes_per_token* via
-    :func:`estimate_kernel_peak_memory` (divide by num_tokens) rather
-    than hardcoding an analytical estimate.
-
-    Args:
-        model_cfg: Model architecture config.
-        kernel_bytes_per_token: Peak memory **per token** (``batch * seq_len``
-            axis).  Best obtained from :func:`estimate_kernel_peak_memory` / num_tokens.
-            Falls back to a conservative heuristic
-            (``hidden_size * dtype_bytes * 16``) when *None*.
-        memory_utilization: Fraction of total device memory to target (0 to 1).
-            Lower values are safer.  Default ``0.4`` leaves headroom for
-            framework overhead and CUDA/NPU context.
-        max_seq_len: Hard upper bound for sequence length.  Defaults to
-            ``model_cfg.max_position_embeddings`` so the sweep never exceeds
-            the model's native context window.
-        max_batch_size: Hard upper bound for batch size.
-    """
-    dtype_bytes = 2 if model_cfg.dtype in (torch.bfloat16, torch.float16) else 4
-
-    if kernel_bytes_per_token is None:
-        kernel_bytes_per_token = model_cfg.hidden_size * dtype_bytes * 16
-    if max_seq_len is None:
-        max_seq_len = model_cfg.max_position_embeddings
-
-    usable_bytes = get_total_gpu_memory() * (1024**3) * memory_utilization
-
-    # bpt is peak_bytes for a unit (B=L=1) probe under linear scaling, so the
-    # inversion at target_batch=1 yields the existing ``max_tokens`` quantity.
-    max_tokens = _max_seqlen_under_memory(
-        usable_bytes=usable_bytes,
-        peak_bytes=kernel_bytes_per_token,
-        probe_batch_size=1,
-        probe_seq_len=1,
-        scaling_method="linear",
-        target_batch_size=1,
-    )
-    seq_len = _snap_pow2_seqlen(max_tokens, max_seq_len)
-    batch_size = max(1, min(max_tokens // seq_len, max_batch_size))
 
     return SeqLenSweepConfig(batch_size=batch_size, seq_len=seq_len)
 
@@ -627,29 +575,33 @@ def build_token_length_sweep(
         setup_out = setup_fn(probe_input)
         return forward_fn(*setup_out)
 
-    peak_bytes = estimate_kernel_peak_memory(probe_fn=probe_fn)
     # ---------------------------------------
-    # derive total tokens (BT) based on scale_dim
+    # derive (probe_batch_size, probe_seq_len) based on scale_dim
     # ---------------------------------------
     if scale_dim == "T":
-        B = extra_configs.get("B", 1)
-        probe_bt = probe_x * B
+        probe_batch_size = extra_configs.get("B", 1)
+        probe_seq_len = probe_x
 
     elif scale_dim == "B":
         T = extra_configs.get("T")
         if T is None:
             raise ValueError("For B sweep, extra_configs['T'] must be provided")
-        probe_bt = probe_x * T
+        probe_batch_size = probe_x
+        probe_seq_len = T
 
     elif scale_dim == "BT":
-        probe_bt = probe_x
+        probe_batch_size = 1
+        probe_seq_len = probe_x
 
     else:
         raise ValueError(f"Unsupported scale_dim: {scale_dim}")
 
-    kernel_bpt = max(1, peak_bytes // probe_bt)
-
-    config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+    config = compute_seq_len_sweep_config(
+        model,
+        probe_fn=probe_fn,
+        probe_seq_len=probe_seq_len,
+        probe_batch_size=probe_batch_size,
+    )
     if x_values_fn is None:
         if scale_dim == "T":
             x_values_fn = lambda cfg: [2**i for i in range(10, int(math.log2(cfg.seq_len)) + 1)]

--- a/benchmark/scripts/benchmark_multi_token_attention.py
+++ b/benchmark/scripts/benchmark_multi_token_attention.py
@@ -8,7 +8,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -305,10 +304,14 @@ if __name__ == "__main__":
             _, _, fwd_fn = _setup_multi_token_attention(probe_input)
             return fwd_fn()
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        # Memory scales as O(L^2), so compute bytes per L^2
-        kernel_bpt = peak_bytes // (probe_L * probe_L)
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        # Memory scales as O(L^2)
+        config = compute_seq_len_sweep_config(
+            model,
+            probe_fn=_probe,
+            probe_seq_len=probe_L,
+            probe_batch_size=B,
+            scaling_method="quadratic",
+        )
 
         common_configs = {
             "kernel_name": "multi_token_attention",

--- a/benchmark/scripts/benchmark_orpo_loss.py
+++ b/benchmark/scripts/benchmark_orpo_loss.py
@@ -8,7 +8,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -243,9 +242,7 @@ if __name__ == "__main__":
             _, fwd = _setup_orpo_loss(probe_input)
             return fwd()
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "fused_linear_orpo_loss",

--- a/benchmark/scripts/benchmark_poly_norm.py
+++ b/benchmark/scripts/benchmark_poly_norm.py
@@ -6,7 +6,6 @@ import torch.nn as nn
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import SingleBenchmarkRunInput
 from utils import SingleBenchmarkRunOutput
@@ -210,10 +209,7 @@ if __name__ == "__main__":
             x, layer = _setup_poly_norm(probe_input)
             return layer(x)
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "poly_norm",

--- a/benchmark/scripts/benchmark_qwen2vl_mrope.py
+++ b/benchmark/scripts/benchmark_qwen2vl_mrope.py
@@ -8,7 +8,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from transformers.models.qwen2_vl.configuration_qwen2_vl import Qwen2VLTextConfig
 from transformers.models.qwen2_vl.modeling_qwen2_vl import Qwen2VLRotaryEmbedding
@@ -283,9 +282,7 @@ if __name__ == "__main__":
             _, _, _, _, fwd_fn = _setup_qwen2vl_mrope(probe_input)
             return fwd_fn()[0]
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_seq_len
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_seq_len)
 
         common_configs = {
             "kernel_name": "qwen2vl_mrope",

--- a/benchmark/scripts/benchmark_relu_squared.py
+++ b/benchmark/scripts/benchmark_relu_squared.py
@@ -8,7 +8,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -222,9 +221,7 @@ if __name__ == "__main__":
             _, _, fwd_fn = _setup_relu_squared(probe_input)
             return fwd_fn()
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "relu_squared",

--- a/benchmark/scripts/benchmark_rms_norm.py
+++ b/benchmark/scripts/benchmark_rms_norm.py
@@ -6,7 +6,6 @@ import torch.nn as nn
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import SingleBenchmarkRunInput
 from utils import SingleBenchmarkRunOutput
@@ -175,10 +174,7 @@ if __name__ == "__main__":
             x, layer = _setup_rms_norm(probe_input)
             return layer(x)
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "rms_norm",

--- a/benchmark/scripts/benchmark_rope.py
+++ b/benchmark/scripts/benchmark_rope.py
@@ -8,7 +8,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding
@@ -266,9 +265,7 @@ if __name__ == "__main__":
             _, _, _, _, fwd_fn = _setup_rope(probe_input)
             return fwd_fn()[0]
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_seq_len
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_seq_len)
 
         common_configs = {
             "kernel_name": "rope",

--- a/benchmark/scripts/benchmark_simpo_loss.py
+++ b/benchmark/scripts/benchmark_simpo_loss.py
@@ -8,7 +8,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -245,9 +244,7 @@ if __name__ == "__main__":
             _, fwd = _setup_simpo_loss(probe_input)
             return fwd()
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "fused_linear_simpo_loss",

--- a/benchmark/scripts/benchmark_softmax.py
+++ b/benchmark/scripts/benchmark_softmax.py
@@ -8,7 +8,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -221,9 +220,7 @@ if __name__ == "__main__":
             _, _, fwd_fn = _setup_softmax(probe_input)
             return fwd_fn()
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "softmax",

--- a/benchmark/scripts/benchmark_sparse_multi_token_attention.py
+++ b/benchmark/scripts/benchmark_sparse_multi_token_attention.py
@@ -7,8 +7,7 @@ import triton
 
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
-from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
+from benchmark_model_configs import compute_seq_len_sweep_config_with_probe
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -329,10 +328,13 @@ if __name__ == "__main__":
             _, _, fwd_fn = _setup_sparse_multi_token_attention(probe_input)
             return fwd_fn()
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        # Memory scales as O(L^2), so compute bytes per L^2
-        kernel_bpt = peak_bytes // (probe_L * probe_L)
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config_with_probe(
+            model_cfg=model,
+            probe_fn=_probe,
+            probe_seq_len=probe_L,
+            probe_batch_size=B,
+            scaling_method="quadratic",
+        )
 
         common_configs = {
             "kernel_name": "sparse_multi_token_attention",

--- a/benchmark/scripts/benchmark_sparse_multi_token_attention.py
+++ b/benchmark/scripts/benchmark_sparse_multi_token_attention.py
@@ -7,7 +7,7 @@ import triton
 
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
-from benchmark_model_configs import compute_seq_len_sweep_config_with_probe
+from benchmark_model_configs import compute_seq_len_sweep_config
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -328,7 +328,7 @@ if __name__ == "__main__":
             _, _, fwd_fn = _setup_sparse_multi_token_attention(probe_input)
             return fwd_fn()
 
-        config = compute_seq_len_sweep_config_with_probe(
+        config = compute_seq_len_sweep_config(
             model_cfg=model,
             probe_fn=_probe,
             probe_seq_len=probe_L,

--- a/benchmark/scripts/benchmark_sparsemax.py
+++ b/benchmark/scripts/benchmark_sparsemax.py
@@ -8,7 +8,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -262,9 +261,7 @@ if __name__ == "__main__":
             _, _, fwd_fn = _setup_sparsemax(probe_input)
             return fwd_fn()
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "sparsemax",

--- a/benchmark/scripts/benchmark_tiled_mlp.py
+++ b/benchmark/scripts/benchmark_tiled_mlp.py
@@ -9,7 +9,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaMLP
@@ -473,9 +472,7 @@ def _run_tiled_mlp_benchmarks(args, activation_type, hidden_act, kernel_name):
             _, fwd_fn = _setup_tiled_mlp(probe_input)
             return fwd_fn()
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_seq_len
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_seq_len)
 
         common_configs = {
             "kernel_name": kernel_name,

--- a/benchmark/scripts/benchmark_tvd.py
+++ b/benchmark/scripts/benchmark_tvd.py
@@ -6,7 +6,6 @@ import triton
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
-from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
 from utils import QUANTILES
 from utils import SingleBenchmarkRunInput
@@ -243,10 +242,7 @@ if __name__ == "__main__":
             _input, target, loss_fn = _setup_tvd(probe_input)
             return loss_fn(_input, target)
 
-        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
-        kernel_bpt = peak_bytes // probe_bt
-
-        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+        config = compute_seq_len_sweep_config(model, probe_fn=_probe, probe_seq_len=probe_bt)
 
         common_configs = {
             "kernel_name": "tvd",


### PR DESCRIPTION
## Summary

Refs #1200. Addresses non-linear memory scaling in benchmark sweep config inference.

The existing `compute_seq_len_sweep_config` inverts memory via `max_tokens = usable_bytes / kernel_bytes_per_token`, which only holds for linear-scaling kernels. For O(L²) kernels (e.g. `benchmark_sparse_multi_token_attention.py`), this overestimates capacity by orders of magnitude — the existing workaround there divides by `probe_L * probe_L`, but the downstream sweep math still treats the result as linear bytes-per-token.

Per discussion on the issue (https://github.com/linkedin/Liger-Kernel/issues/1200#issuecomment-4396956347), this PR adds a new helper rather than threading `scaling_method` through the existing function — 16+ benchmark scripts call `estimate_kernel_peak_memory` today, and a wider signature change would conflict with in-flight benchmark refactors (#1199, #1180). Linear-scaling callers are unchanged; only quadratic-scaling benchmarks opt in.

### What changed

- **`benchmark/scripts/benchmark_model_configs.py`** — adds `compute_seq_len_sweep_config_with_probe(model_cfg, probe_fn, probe_seq_len, probe_batch_size=1, scaling_method="linear" | "quadratic", ...)`. Internalizes the probe call + inversion; reuses `estimate_kernel_peak_memory` for the measurement.
- **`benchmark/scripts/benchmark_sparse_multi_token_attention.py`** — switches the `token_length` sweep mode to the new helper with `scaling_method="quadratic"`, dropping the manual `peak_bytes // (probe_L * probe_L)` workaround.

`estimate_kernel_peak_memory` and `compute_seq_len_sweep_config` are untouched.

## Validation

Hardware: A10G 24GB (g5.xlarge).

Synthetic O(L²) probe (B=2, L=2048, allocates `B * L * L` floats) using `LLAMA_3_8B` config and `max_seq_len=2**20` to bypass the model cap so the raw inversion is visible:

```
quadratic: SeqLenSweepConfig(batch_size=2, seq_len=8192)
linear:    SeqLenSweepConfig(batch_size=2, seq_len=65536)
```

The 8× gap (≈17× before snap-to-power-of-2) demonstrates the inversion difference: `linear` claims a sweep at L=65536 fits, when in reality L² at that size would require multiple TBs. `quadratic` lands at a realistic L=8192. This matches the issue's premise — for non-linear-scaling kernels, the existing inversion overestimates capacity and would OOM at the predicted boundary.

## Testing Done

- [x] Synthetic O(L²) sanity check on A10G — confirms `quadratic` predicts L=8192 vs `linear` predicts L=65536 for the same probe (8× separation, scales as expected).
- [x] `benchmark_sparse_multi_token_attention.py` imports + helper resolution verified locally.
- [ ] Full sparse-attention end-to-end sweep on A10G (deferred — synthetic test already isolates the inversion math from kernel-specific noise).

cc @Tcc0403