### PR TITLE
[npu, feat] SwiGLU — multiplier API, mixed precision, UB/grid tune

### DIFF
--- a/src/liger_kernel/ops/backends/_ascend/ops/swiglu.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/swiglu.py
@@ -3,6 +3,7 @@ import triton
 import triton.language as tl
 
 from liger_kernel.ops.backends._ascend.ub_manager import compute_default_tiling_strategy
+from liger_kernel.ops.utils import ensure_contiguous
 from liger_kernel.ops.utils import get_npu_core_count
 
 # -----------------------------------------------------------------------------
@@ -24,8 +25,11 @@ def _swiglu_forward_kernel_flat(a_ptr, b_ptr, c_ptr, total_elements, BLOCK_SIZE:
         mask = offsets < total_elements
 
         a_val = tl.load(a_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
-        b_val = tl.load(b_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
-        res = (a_val * tl.sigmoid(a_val)) * b_val
+        b_val = tl.load(b_ptr + offsets, mask=mask, other=0.0)
+
+        sig_a = tl.sigmoid(a_val)
+        silu_a = a_val * sig_a
+        res = silu_a.cast(b_val.dtype) * b_val
         tl.store(c_ptr + offsets, res, mask=mask)
 
 
@@ -60,27 +64,21 @@ def _swiglu_backward_kernel_flat(dc_ptr, a_ptr, b_ptr, da_ptr, db_ptr, total_ele
 # -----------------------------------------------------------------------------
 
 
-def get_optimal_block_size(total_elements, is_backward=False):
-    """
-    Calculate optimal Block Size using compute_default_tiling_strategy
-    """
-    # 1. Set Memory Multiplier
-    # Forward is lighter, Backward requires more memory for intermediate variables
-    # 8.0 and 12.0 are empirical values based on Atlas 800I A2 UB (192KB)
-    multiplier = 12.0 if is_backward else 8.0
-
-    # 2. Call calculation function
-    # Treat input as 1D (total_elements,), only tiling on dim 0
+def get_optimal_block_size(total_elements, is_backward: bool = False):
+    # Align UB assumptions with ascend GEGLU; SwiLU backward uses fewer temporaries than GELU.
+    memory_multiplier = 6.0 if is_backward else 3.0
     tile_shapes = compute_default_tiling_strategy(
-        safety_margin=0.9, dtype_size=4, memory_multiplier=multiplier, shapes=((total_elements,),), tiling_dims=(0,)
+        safety_margin=0.9,
+        dtype_size=4,
+        memory_multiplier=memory_multiplier,
+        shapes=((total_elements,),),
+        tiling_dims=(0,),
     )
 
-    # 3. Parse result
     if tile_shapes and len(tile_shapes) > 0:
         block_size = tile_shapes[0][0]
         return max(256, block_size)
-    else:
-        return 2048
+    return 2048
 
 
 def swiglu_forward(a, b):
@@ -95,7 +93,8 @@ def swiglu_forward(a, b):
     block_size = get_optimal_block_size(total_elements, is_backward=False)
 
     num_cores = get_npu_core_count()
-    grid_size = min(num_cores, (total_elements + block_size - 1) // block_size)
+    # Avoid grid_size == 0 when num_vectorcore reports 0 (would fault the NPU).
+    grid_size = max(1, min(num_cores, (total_elements + block_size - 1) // block_size))
 
     _swiglu_forward_kernel_flat[(grid_size,)](a, b, c, total_elements, BLOCK_SIZE=block_size)
     return c
@@ -116,7 +115,7 @@ def swiglu_backward(a, b, dc):
     block_size = get_optimal_block_size(total_elements, is_backward=True)
 
     num_cores = get_npu_core_count()
-    grid_size = min(num_cores, (total_elements + block_size - 1) // block_size)
+    grid_size = max(1, min(num_cores, (total_elements + block_size - 1) // block_size))
 
     _swiglu_backward_kernel_flat[(grid_size,)](dc, a, b, grad_a, grad_b, total_elements, BLOCK_SIZE=block_size)
     return grad_a, grad_b
@@ -124,13 +123,29 @@ def swiglu_backward(a, b, dc):
 
 class LigerSiLUMulFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, a, b):
-        c = swiglu_forward(a, b)
-        ctx.save_for_backward(a, b)
+    @ensure_contiguous
+    def forward(ctx, a, b, gate_multiplier: float = 1.0, down_multiplier: float = 1.0):
+        gate_multiplier = float(gate_multiplier)
+        down_multiplier = float(down_multiplier)
+        ctx.gate_multiplier = gate_multiplier
+        ctx.down_multiplier = down_multiplier
+
+        a_in = a if gate_multiplier == 1.0 else a * gate_multiplier
+        c = swiglu_forward(a_in, b)
+        if down_multiplier != 1.0:
+            c = c * down_multiplier
+        ctx.save_for_backward(a_in, b)
         return c
 
     @staticmethod
+    @ensure_contiguous
     def backward(ctx, dc):
-        a, b = ctx.saved_tensors
-        grad_a, grad_b = swiglu_backward(a, b, dc)
-        return grad_a, grad_b
+        a_in, b = ctx.saved_tensors
+        gate_multiplier = ctx.gate_multiplier
+        down_multiplier = ctx.down_multiplier
+
+        if down_multiplier != 1.0:
+            dc = dc * down_multiplier
+        grad_a_in, grad_b = swiglu_backward(a_in, b, dc)
+        grad_a = grad_a_in if gate_multiplier == 1.0 else grad_a_in * gate_multiplier
+        return grad_a, grad_b, None, None


### PR DESCRIPTION
## Summary

- Liger-Kernel recently added `gate_multiplier` / `down_multiplier` to SwiGLU, which broke tests when the Ascend path did not match; this PR brings the NPU kernel and autograd wrapper in line with the main implementation.
- Includes small NPU SwiGLU performance tweaks, mainly by tightening mixed-precision handling (dtype placement in the forward/backward kernels).


## Details

- **`LigerSiLUMulFunction`**: Adds `gate_multiplier` and `down_multiplier` with the same semantics as `src/liger_kernel/ops/swiglu.py` (including `backward` returning `None` for the multiplier args); saves `a_in` for correct backward chains; `@ensure_contiguous` on `forward` / `backward`.
- **Forward kernel**: Loads `b` at native dtype; `silu(a)` in FP32, then `.cast(b.dtype) * b` to mirror the reference SwiGLU implementation (not widening `b` to FP32 for the multiply).
- **Backward kernel**: Keeps activation derivative math in FP32; uses FP32 intermediates for `dc` and `b` when forming `da`/`db`; stores `db` cast back to `dc`’s dtype.
- **Tiling**: `get_optimal_block_size` uses the same `memory_multiplier` values as Ascend GEGLU (`3` / `6`), with `dtype_size=4` and existing `safety_margin`.
- **Launch**: `grid_size = max(1, min(num_cores, …))` so core count reporting `0` does not produce an empty grid.


## Benchmark

### Baseline

Results: https://github.com/linkedin/Liger-Kernel/issues/1159#issuecomment-4109105113

### With this PR

| **SwiGLU forward (token length)** | **SwiGLU backward (token length)** |
|:-:|:-:|
| <img width="480" alt="swiglu_speed_forward_token_length" src="https://github.com/user-attachments/assets/ffd79f9b-34d7-440b-8c37-f188f58bc155" /> | <img width="480" alt="swiglu_speed_backward_token_length" src="https://github.com/user-attachments/assets/4b30040d-71c7-4a97-b8e1-9cb58cb634df" /> |
| **SwiGLU full (token length)** |  |
| <img width="480" alt="swiglu_speed_full_token_length" src="https://github.com/user-attachments/assets/619c7b4a-c6a1-4b76-ad10-9275e5fbffd7" /> |  |


## Test

```python
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/Liger-Kernel
configfile: pyproject.toml
plugins: asyncio-1.3.0, cov-7.1.0, rerunfailures-16.1, anyio-4.13.0, xdist-3.8.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 45 items                                                                                                                                                                                              

test/transformers/test_swiglu.py::test_correctness_llamamlp[dtype0-1.0-1e-05-2-256-256-512] PASSED                                                                                                        [  2%]
test/transformers/test_swiglu.py::test_correctness_llamamlp[dtype0-1.0-1e-05-6-42-123-431] PASSED                                                                                                         [  4%]
test/transformers/test_swiglu.py::test_correctness_llamamlp[dtype1-10000.0-0.01-2-256-256-512] PASSED                                                                                                     [  6%]
test/transformers/test_swiglu.py::test_correctness_llamamlp[dtype1-10000.0-0.01-6-42-123-431] PASSED                                                                                                      [  8%]
test/transformers/test_swiglu.py::test_correctness_mixtralblocksparsetop2mlp[dtype0-1.0-1e-05-2-256-256-512] SKIPPED (Skip for transformers >= v5.0.0)                                                    [ 11%]
test/transformers/test_swiglu.py::test_correctness_mixtralblocksparsetop2mlp[dtype0-1.0-1e-05-6-42-123-431] SKIPPED (Skip for transformers >= v5.0.0)                                                     [ 13%]
test/transformers/test_swiglu.py::test_correctness_mixtralblocksparsetop2mlp[dtype1-10000.0-0.01-2-256-256-512] SKIPPED (Skip for transformers >= v5.0.0)                                                 [ 15%]
test/transformers/test_swiglu.py::test_correctness_mixtralblocksparsetop2mlp[dtype1-10000.0-0.01-6-42-123-431] SKIPPED (Skip for transformers >= v5.0.0)                                                  [ 17%]
test/transformers/test_swiglu.py::test_correctness_mixtralexperts[dtype0-30-0.05-2-256-256-512] PASSED                                                                                                    [ 20%]
test/transformers/test_swiglu.py::test_correctness_mixtralexperts[dtype0-30-0.05-6-42-123-431] PASSED                                                                                                     [ 22%]
test/transformers/test_swiglu.py::test_correctness_mixtralexperts[dtype1-100.0-0.05-2-256-256-512] PASSED                                                                                                 [ 24%]
test/transformers/test_swiglu.py::test_correctness_mixtralexperts[dtype1-100.0-0.05-6-42-123-431] PASSED                                                                                                  [ 26%]
test/transformers/test_swiglu.py::test_correctness_phi3mlp[dtype0-1.0-1e-05-2-256-256-512] PASSED                                                                                                         [ 28%]
test/transformers/test_swiglu.py::test_correctness_phi3mlp[dtype0-1.0-1e-05-6-42-123-431] PASSED                                                                                                          [ 31%]
test/transformers/test_swiglu.py::test_correctness_phi3mlp[dtype1-10000.0-0.01-2-256-256-512] PASSED                                                                                                      [ 33%]
test/transformers/test_swiglu.py::test_correctness_phi3mlp[dtype1-10000.0-0.01-6-42-123-431] PASSED                                                                                                       [ 35%]
test/transformers/test_swiglu.py::test_correctness_functional[dtype0-1.0-1e-05-2-8-8] PASSED                                                                                                              [ 37%]
test/transformers/test_swiglu.py::test_correctness_functional[dtype0-1.0-1e-05-9-7-41] PASSED                                                                                                             [ 40%]
test/transformers/test_swiglu.py::test_correctness_functional[dtype1-10000.0-0.01-2-8-8] PASSED                                                                                                           [ 42%]
test/transformers/test_swiglu.py::test_correctness_functional[dtype1-10000.0-0.01-9-7-41] PASSED                                                                                                          [ 44%]
test/transformers/test_swiglu.py::test_correctness_silumul_with_multipliers[dtype0-0.001-1e-05-0.7-1.3-2-8-8] PASSED                                                                                      [ 46%]
test/transformers/test_swiglu.py::test_correctness_silumul_with_multipliers[dtype0-0.001-1e-05-0.7-1.3-9-7-41] PASSED                                                                                     [ 48%]
test/transformers/test_swiglu.py::test_correctness_silumul_with_multipliers[dtype0-0.001-1e-05-1.5-0.5-2-8-8] PASSED                                                                                      [ 51%]
test/transformers/test_swiglu.py::test_correctness_silumul_with_multipliers[dtype0-0.001-1e-05-1.5-0.5-9-7-41] PASSED                                                                                     [ 53%]
test/transformers/test_swiglu.py::test_correctness_silumul_with_multipliers[dtype0-0.001-1e-05-1.0-1.0-2-8-8] PASSED                                                                                      [ 55%]
test/transformers/test_swiglu.py::test_correctness_silumul_with_multipliers[dtype0-0.001-1e-05-1.0-1.0-9-7-41] PASSED                                                                                     [ 57%]
test/transformers/test_swiglu.py::test_correctness_silumul_with_multipliers[dtype1-0.1-0.01-0.7-1.3-2-8-8] PASSED                                                                                         [ 60%]
test/transformers/test_swiglu.py::test_correctness_silumul_with_multipliers[dtype1-0.1-0.01-0.7-1.3-9-7-41] PASSED                                                                                        [ 62%]
test/transformers/test_swiglu.py::test_correctness_silumul_with_multipliers[dtype1-0.1-0.01-1.5-0.5-2-8-8] PASSED                                                                                         [ 64%]
test/transformers/test_swiglu.py::test_correctness_silumul_with_multipliers[dtype1-0.1-0.01-1.5-0.5-9-7-41] PASSED                                                                                        [ 66%]
test/transformers/test_swiglu.py::test_correctness_silumul_with_multipliers[dtype1-0.1-0.01-1.0-1.0-2-8-8] PASSED                                                                                         [ 68%]
test/transformers/test_swiglu.py::test_correctness_silumul_with_multipliers[dtype1-0.1-0.01-1.0-1.0-9-7-41] PASSED                                                                                        [ 71%]
test/transformers/test_swiglu.py::test_silumul_default_multipliers_backward_compat PASSED                                                                                                                 [ 73%]
test/transformers/test_swiglu.py::test_correctness_falcon_h1_mlp[dtype0-1.0-1e-05-0.7-1.3-2-256-256-512] PASSED                                                                                           [ 75%]
test/transformers/test_swiglu.py::test_correctness_falcon_h1_mlp[dtype0-1.0-1e-05-0.7-1.3-6-42-123-431] PASSED                                                                                            [ 77%]
test/transformers/test_swiglu.py::test_correctness_falcon_h1_mlp[dtype0-1.0-1e-05-1.5-0.5-2-256-256-512] PASSED                                                                                           [ 80%]
test/transformers/test_swiglu.py::test_correctness_falcon_h1_mlp[dtype0-1.0-1e-05-1.5-0.5-6-42-123-431] PASSED                                                                                            [ 82%]
test/transformers/test_swiglu.py::test_correctness_falcon_h1_mlp[dtype1-10000.0-0.01-0.7-1.3-2-256-256-512] PASSED                                                                                        [ 84%]
test/transformers/test_swiglu.py::test_correctness_falcon_h1_mlp[dtype1-10000.0-0.01-0.7-1.3-6-42-123-431] PASSED                                                                                         [ 86%]
test/transformers/test_swiglu.py::test_correctness_falcon_h1_mlp[dtype1-10000.0-0.01-1.5-0.5-2-256-256-512] PASSED                                                                                        [ 88%]
test/transformers/test_swiglu.py::test_correctness_falcon_h1_mlp[dtype1-10000.0-0.01-1.5-0.5-6-42-123-431] PASSED                                                                                         [ 91%]
test/transformers/test_swiglu.py::test_dtensor_liger_silumul[dtype0-0.0001-1e-06-4-2-2-8] XFAIL (Pending multi-GPU host support. This test is expected to pass when run with multi-GPU host.)             [ 93%]
test/transformers/test_swiglu.py::test_dtensor_liger_silumul[dtype0-0.0001-1e-06-8-9-7-64] XFAIL (Pending multi-GPU host support. This test is expected to pass when run with multi-GPU host.)            [ 95%]
test/transformers/test_swiglu.py::test_dtensor_liger_silumul[dtype1-0.2-0.02-4-2-2-8] XFAIL (Pending multi-GPU host support. This test is expected to pass when run with multi-GPU host.)                 [ 97%]
test/transformers/test_swiglu.py::test_dtensor_liger_silumul[dtype1-0.2-0.02-8-9-7-64] XFAIL (Pending multi-GPU host support. This test is expected to pass when run with multi-GPU host.)                [100%]
```

## Testing Done

- Hardware Type: All NPUs.
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
