### PR TITLE
[Misc]: update transformers to v5.8.0

### DIFF
--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -1212,10 +1212,11 @@ def apply_liger_kernel_to_gemma3(
         if isinstance(model, Gemma3ForConditionalGeneration):
             if isinstance(model.model.vision_tower, SiglipVisionModel):
                 vision_tower = model.model.vision_tower
+                siglip_vision_model = getattr(vision_tower, "vision_model", vision_tower)
 
-                _patch_layer_norm_module(vision_tower.vision_model.post_layernorm)
+                _patch_layer_norm_module(siglip_vision_model.post_layernorm)
 
-                for layer in vision_tower.vision_model.encoder.layers:
+                for layer in siglip_vision_model.encoder.layers:
                     layer: SiglipEncoderLayer
                     if layer_norm:
                         _patch_layer_norm_module(layer.layer_norm1)
@@ -1458,10 +1459,11 @@ def apply_liger_kernel_to_paligemma(
             raise TypeError("model have to be of type PaliGemmaForConditionalGeneration")
 
         vision_tower: SiglipVisionModel = model.model.vision_tower
+        siglip_vision_model = getattr(vision_tower, "vision_model", vision_tower)
 
-        _patch_layer_norm_module(vision_tower.vision_model.post_layernorm)
+        _patch_layer_norm_module(siglip_vision_model.post_layernorm)
 
-        for layer in vision_tower.vision_model.encoder.layers:
+        for layer in siglip_vision_model.encoder.layers:
             layer: SiglipEncoderLayer
             if layer_norm:
                 _patch_layer_norm_module(layer.layer_norm1)

--- a/test/transformers/test_monkey_patch.py
+++ b/test/transformers/test_monkey_patch.py
@@ -1713,14 +1713,17 @@ def test_apply_liger_kernel_to_instance_for_paligemma():
 
         dummy_model_instance = PaliGemmaForConditionalGeneration(config)
         assert isinstance(dummy_model_instance, PaliGemmaForConditionalGeneration)
+        siglip_vision_model = getattr(
+            dummy_model_instance.model.vision_tower, "vision_model", dummy_model_instance.model.vision_tower
+        )
 
         # Check that model instance variables are not yet patched with Liger modules
         assert inspect.getsource(dummy_model_instance.forward) != inspect.getsource(paligemma_lce_forward)
-        assert inspect.getsource(
-            dummy_model_instance.model.vision_tower.vision_model.post_layernorm.forward
-        ) != inspect.getsource(LigerLayerNorm.forward)
+        assert inspect.getsource(siglip_vision_model.post_layernorm.forward) != inspect.getsource(
+            LigerLayerNorm.forward
+        )
 
-        for layer in dummy_model_instance.model.vision_tower.vision_model.encoder.layers:
+        for layer in siglip_vision_model.encoder.layers:
             assert inspect.getsource(layer.layer_norm1.forward) != inspect.getsource(LigerLayerNorm.forward)
             assert inspect.getsource(layer.layer_norm2.forward) != inspect.getsource(LigerLayerNorm.forward)
 
@@ -1729,11 +1732,11 @@ def test_apply_liger_kernel_to_instance_for_paligemma():
 
         # Check that the model's instance variables were correctly patched with Liger modules
         assert inspect.getsource(dummy_model_instance.forward) == inspect.getsource(paligemma_lce_forward)
-        assert inspect.getsource(
-            dummy_model_instance.model.vision_tower.vision_model.post_layernorm.forward
-        ) == inspect.getsource(LigerLayerNorm.forward)
+        assert inspect.getsource(siglip_vision_model.post_layernorm.forward) == inspect.getsource(
+            LigerLayerNorm.forward
+        )
 
-        for layer in dummy_model_instance.model.vision_tower.vision_model.encoder.layers:
+        for layer in siglip_vision_model.encoder.layers:
             assert inspect.getsource(layer.layer_norm1.forward) == inspect.getsource(LigerLayerNorm.forward)
             assert inspect.getsource(layer.layer_norm2.forward) == inspect.getsource(LigerLayerNorm.forward)
 
@@ -1818,18 +1821,23 @@ def test_apply_liger_kernel_to_instance_for_gemma3_conditional_generation():
             hidden_size=48,
             intermediate_size=64,
         )
-        config = transformers.models.gemma3.configuration_gemma3.Gemma3Config(text_config, vision_config)
+        config = transformers.models.gemma3.configuration_gemma3.Gemma3Config(
+            text_config=text_config, vision_config=vision_config
+        )
 
         dummy_model_instance = Gemma3ForConditionalGeneration._from_config(config)
         assert isinstance(dummy_model_instance, Gemma3ForConditionalGeneration)
+        siglip_vision_model = getattr(
+            dummy_model_instance.model.vision_tower, "vision_model", dummy_model_instance.model.vision_tower
+        )
 
         # Check that model instance variables are not yet patched with Liger modules
         assert inspect.getsource(dummy_model_instance.forward) != inspect.getsource(gemma3_multimodal_forward)
-        assert inspect.getsource(
-            dummy_model_instance.model.vision_tower.vision_model.post_layernorm.forward
-        ) != inspect.getsource(LigerLayerNorm.forward)
+        assert inspect.getsource(siglip_vision_model.post_layernorm.forward) != inspect.getsource(
+            LigerLayerNorm.forward
+        )
 
-        for layer in dummy_model_instance.model.vision_tower.vision_model.encoder.layers:
+        for layer in siglip_vision_model.encoder.layers:
             assert inspect.getsource(layer.layer_norm1.forward) != inspect.getsource(LigerLayerNorm.forward)
             assert inspect.getsource(layer.layer_norm2.forward) != inspect.getsource(LigerLayerNorm.forward)
 
@@ -1857,11 +1865,11 @@ def test_apply_liger_kernel_to_instance_for_gemma3_conditional_generation():
 
         # Check that the model's instance variables were correctly patched with Liger modules
         assert inspect.getsource(dummy_model_instance.forward) == inspect.getsource(gemma3_multimodal_forward)
-        assert inspect.getsource(
-            dummy_model_instance.model.vision_tower.vision_model.post_layernorm.forward
-        ) == inspect.getsource(LigerLayerNorm.forward)
+        assert inspect.getsource(siglip_vision_model.post_layernorm.forward) == inspect.getsource(
+            LigerLayerNorm.forward
+        )
 
-        for layer in dummy_model_instance.model.vision_tower.vision_model.encoder.layers:
+        for layer in siglip_vision_model.encoder.layers:
             assert inspect.getsource(layer.layer_norm1.forward) == inspect.getsource(LigerLayerNorm.forward)
             assert inspect.getsource(layer.layer_norm2.forward) == inspect.getsource(LigerLayerNorm.forward)
 


### PR DESCRIPTION
## Summary

Some test cases broke after the recent `transformers` update to `v5.8.0` https://github.com/huggingface/transformers/releases/tag/v5.8.0. We need to fix `monkey_patch`.

<img width="2204" height="69" alt="image" src="https://github.com/user-attachments/assets/2b1b413e-08ec-4006-8836-5c586d71000b" />


## Testing Done

### v5.2.0

```python
===================================================================================================== slowest durations =====================================================================================================
2.90s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2_5_vl_for_conditional_generation
2.90s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2_5_vl
1.16s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_llama4_for_conditional_generation
0.93s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_internvl
0.91s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_moe
0.88s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_smolvlm2
0.77s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_hunyuan_v1_moe
0.77s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_vl_moe_for_conditional_generation
0.77s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_hunyuan_v1_dense
0.73s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_gemma
0.72s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_gemma3_text
0.71s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_gemma2
0.69s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_falcon_h1_for_causal_lm
0.66s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_5_moe
0.65s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_5
0.64s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_glm4v_moe
0.63s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_vl_for_conditional_generation
0.62s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_llama4_for_causal_lm
0.57s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_gemma3_conditional_generation
0.54s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_glm4v
0.53s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_5_for_conditional_generation
0.50s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_mllama_for_conditional_generation
0.49s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_5_moe_for_conditional_generation
0.48s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_vl
0.46s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_next
0.45s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3
0.45s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_vl_moe
0.45s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_glm4
0.44s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_vl_moe_text
0.42s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2
0.41s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_5_moe_model
0.36s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_smollm3
0.34s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_vl_text
0.23s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_paligemma
0.18s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_nemotron
0.16s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_olmo3
0.16s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_olmo2
0.14s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_llama
0.12s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_mistral
0.11s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_phi3
0.11s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_ministral
0.11s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_mixtral
0.10s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_mllama_for_causal_lm
0.10s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2_vl_for_conditional_generation
0.08s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2_vl
0.04s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2_5_vl_text
0.02s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_pixtral_vision_model
0.01s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2_vl_text

(131 durations < 0.005s hidden.  Use -vv to show these durations.)
============================================================================================== 59 passed, 1 skipped in 38.87s ===============================================================================================
```

### v5.8.0

```python
===================================================================================================== slowest durations =====================================================================================================
1.01s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2_5_vl
0.99s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2_5_vl_for_conditional_generation
0.78s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_moe
0.70s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_falcon_h1_for_causal_lm
0.65s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_vl_moe_for_conditional_generation
0.62s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_llama4_for_conditional_generation
0.61s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_vl_for_conditional_generation
0.61s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_internvl
0.59s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_vl_moe
0.58s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_hunyuan_v1_moe
0.58s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_hunyuan_v1_dense
0.57s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_gemma4_text
0.54s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_gemma3_text
0.53s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_glm4v
0.52s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_gemma
0.52s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_gemma2
0.50s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_5
0.50s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_5_moe
0.49s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_mllama_for_conditional_generation
0.49s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_glm4v_moe
0.44s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_llama4_for_causal_lm
0.43s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_vl
0.35s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_vl_moe_text
0.34s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_smolvlm2
0.33s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_next
0.33s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3
0.32s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_vl_text
0.32s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_glm4
0.32s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2
0.28s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_smollm3
0.22s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_gemma3_conditional_generation
0.22s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_5_for_conditional_generation
0.21s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_paligemma
0.18s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_5_moe_for_conditional_generation
0.16s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_nemotron
0.12s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_olmo2
0.12s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_olmo3
0.12s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_llama
0.11s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_mllama_for_causal_lm
0.10s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen3_5_moe_model
0.09s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_phi3
0.09s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_mistral
0.09s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_ministral
0.08s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_mixtral
0.06s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2_vl_for_conditional_generation
0.06s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2_vl
0.02s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_pixtral_vision_model
0.01s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2_5_vl_text
0.01s call     test/transformers/test_monkey_patch.py::test_apply_liger_kernel_to_instance_for_qwen2_vl_text

(131 durations < 0.005s hidden.  Use -vv to show these durations.)
==================================================================================================== 60 passed in 35.61s ====================================================================================================
```

- Hardware Type: A800-80GB
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
