### PR TITLE
Add fused modulated RMSNorm

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ loss.backward()
 | **Kernel**                      | **API**                                                     |
 |---------------------------------|-------------------------------------------------------------|
 | RMSNorm                         | `liger_kernel.transformers.LigerRMSNorm`                    |
+| Modulated RMSNorm               | `liger_kernel.transformers.LigerModulatedRMSNorm`           |
 | LayerNorm                       | `liger_kernel.transformers.LigerLayerNorm`                  |
 | RoPE                            | `liger_kernel.transformers.liger_rotary_pos_emb`            |
 | SwiGLU                          | `liger_kernel.transformers.LigerSwiGLUMLP`                  |

--- a/benchmark/scripts/benchmark_modulated_rms_norm.py
+++ b/benchmark/scripts/benchmark_modulated_rms_norm.py
@@ -1,13 +1,17 @@
 import math
+import os
+import sys
 
 import torch
-import torch.nn as nn
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from benchmark_model_configs import MODEL_REGISTRY
 from benchmark_model_configs import compute_model_config_sweep_config
 from benchmark_model_configs import compute_seq_len_sweep_config
 from benchmark_model_configs import estimate_kernel_peak_memory
 from benchmark_model_configs import get_benchmark_model_config
+from test.transformers.test_modulated_rms_norm import ModulatedRMSNormReference
 from utils import SingleBenchmarkRunInput
 from utils import SingleBenchmarkRunOutput
 from utils import parse_benchmark_script_args
@@ -16,49 +20,9 @@ from utils import run_memory_benchmark
 from utils import run_speed_benchmark
 
 from liger_kernel.transformers.modulated_rms_norm import LigerModulatedRMSNorm
-from liger_kernel.transformers.rms_norm import LigerRMSNorm
 from liger_kernel.utils import infer_device
 
 device = infer_device()
-
-
-class NaiveModulatedRMSNorm(nn.Module):
-    def __init__(self, hidden_size, eps=1e-6):
-        """
-        Naive implementation of modulated RMSNorm: y = (1 + scale) * RMSNorm(x) + shift.
-        """
-        super().__init__()
-        self.weight = nn.Parameter(torch.ones(hidden_size))
-        self.variance_epsilon = eps
-
-    def forward(self, hidden_states, scale, shift=None):
-        input_dtype = hidden_states.dtype
-        normed = hidden_states.to(torch.float32)
-        variance = normed.pow(2).mean(-1, keepdim=True)
-        normed = normed * torch.rsqrt(variance + self.variance_epsilon)
-        normed = self.weight * normed.to(input_dtype)
-        output = normed * (1 + scale)
-        if shift is not None:
-            output = output + shift
-        return output
-
-
-class LigerRMSNormWithNaiveModulation(nn.Module):
-    def __init__(self, hidden_size, eps=1e-6):
-        """
-        LigerRMSNormWithNaiveModulation is equivalent to NaiveModulatedRMSNorm above, but
-        uses the LigerRMSNorm kernel for the base normalization step (modulation is
-        applied in eager PyTorch). Useful to isolate the benefit of fusing modulation
-        into the norm kernel.
-        """
-        super().__init__()
-        self.rms_norm = LigerRMSNorm(hidden_size=hidden_size, eps=eps, in_place=False)
-
-    def forward(self, hidden_states, scale, shift=None):
-        output = self.rms_norm(hidden_states) * (1 + scale)
-        if shift is not None:
-            output = output + shift
-        return output
 
 
 def _setup_modulated_rms_norm(input: SingleBenchmarkRunInput):
@@ -79,10 +43,8 @@ def _setup_modulated_rms_norm(input: SingleBenchmarkRunInput):
 
     if input.kernel_provider == "liger":
         layer = LigerModulatedRMSNorm(hidden_size=hidden_size, eps=eps, in_place=False).to(device)
-    elif input.kernel_provider == "liger_rms_norm":
-        layer = LigerRMSNormWithNaiveModulation(hidden_size=hidden_size, eps=eps).to(device)
     elif input.kernel_provider == "huggingface":
-        layer = NaiveModulatedRMSNorm(hidden_size=hidden_size, eps=eps).to(device)
+        layer = ModulatedRMSNormReference(hidden_size=hidden_size, eps=eps).to(device)
     else:
         raise ValueError(f"Invalid provider: {input.kernel_provider} for ModulatedRMSNorm")
     return x, scale, shift, layer
@@ -174,7 +136,7 @@ if __name__ == "__main__":
             "x_name": "model_config",
             "x_label": "model configuration",
             "x_values": [cfg.name for cfg in sweep.model_configs],
-            "kernel_providers": ["liger", "liger_rms_norm", "huggingface"],
+            "kernel_providers": ["liger", "huggingface"],
             "extra_benchmark_configs": [
                 {
                     "model_configs": model_configs_info,
@@ -228,7 +190,7 @@ if __name__ == "__main__":
             "x_name": "BT",
             "x_label": "B * T",
             "x_values": [2**i for i in range(10, int(math.log2(config.batch_size * config.seq_len)) + 1)],
-            "kernel_providers": ["liger", "liger_rms_norm", "huggingface"],
+            "kernel_providers": ["liger", "huggingface"],
             "extra_benchmark_configs": [
                 {
                     "hidden_size": model.hidden_size,

--- a/benchmark/scripts/benchmark_modulated_rms_norm.py
+++ b/benchmark/scripts/benchmark_modulated_rms_norm.py
@@ -22,8 +22,11 @@ from liger_kernel.utils import infer_device
 device = infer_device()
 
 
-class TorchModulatedRMSNorm(nn.Module):
+class NaiveModulatedRMSNorm(nn.Module):
     def __init__(self, hidden_size, eps=1e-6):
+        """
+        Naive implementation of modulated RMSNorm: y = (1 + scale) * RMSNorm(x) + shift.
+        """
         super().__init__()
         self.weight = nn.Parameter(torch.ones(hidden_size))
         self.variance_epsilon = eps
@@ -40,8 +43,14 @@ class TorchModulatedRMSNorm(nn.Module):
         return output
 
 
-class LigerRMSNormWithTorchModulation(nn.Module):
+class LigerRMSNormWithNaiveModulation(nn.Module):
     def __init__(self, hidden_size, eps=1e-6):
+        """
+        LigerRMSNormWithNaiveModulation is equivalent to NaiveModulatedRMSNorm above, but
+        uses the LigerRMSNorm kernel for the base normalization step (modulation is
+        applied in eager PyTorch). Useful to isolate the benefit of fusing modulation
+        into the norm kernel.
+        """
         super().__init__()
         self.rms_norm = LigerRMSNorm(hidden_size=hidden_size, eps=eps, in_place=False)
 
@@ -53,6 +62,7 @@ class LigerRMSNormWithTorchModulation(nn.Module):
 
 
 def _setup_modulated_rms_norm(input: SingleBenchmarkRunInput):
+    """Create input tensors and ModulatedRMSNorm layer from benchmark config."""
     cfg = input.extra_benchmark_config
     hidden_size = cfg["hidden_size"]
     eps = cfg["eps"]
@@ -70,9 +80,9 @@ def _setup_modulated_rms_norm(input: SingleBenchmarkRunInput):
     if input.kernel_provider == "liger":
         layer = LigerModulatedRMSNorm(hidden_size=hidden_size, eps=eps, in_place=False).to(device)
     elif input.kernel_provider == "liger_rms_norm":
-        layer = LigerRMSNormWithTorchModulation(hidden_size=hidden_size, eps=eps).to(device)
-    elif input.kernel_provider == "torch":
-        layer = TorchModulatedRMSNorm(hidden_size=hidden_size, eps=eps).to(device)
+        layer = LigerRMSNormWithNaiveModulation(hidden_size=hidden_size, eps=eps).to(device)
+    elif input.kernel_provider == "huggingface":
+        layer = NaiveModulatedRMSNorm(hidden_size=hidden_size, eps=eps).to(device)
     else:
         raise ValueError(f"Invalid provider: {input.kernel_provider} for ModulatedRMSNorm")
     return x, scale, shift, layer
@@ -136,7 +146,7 @@ if __name__ == "__main__":
             def _probe():
                 probe_input = SingleBenchmarkRunInput(
                     x=probe_bt,
-                    kernel_provider="torch",
+                    kernel_provider="huggingface",
                     extra_benchmark_config={
                         "hidden_size": model_cfg.hidden_size,
                         "dtype": model_cfg.dtype,
@@ -164,7 +174,7 @@ if __name__ == "__main__":
             "x_name": "model_config",
             "x_label": "model configuration",
             "x_values": [cfg.name for cfg in sweep.model_configs],
-            "kernel_providers": ["liger", "liger_rms_norm", "torch"],
+            "kernel_providers": ["liger", "liger_rms_norm", "huggingface"],
             "extra_benchmark_configs": [
                 {
                     "model_configs": model_configs_info,
@@ -197,7 +207,7 @@ if __name__ == "__main__":
         def _probe():
             probe_input = SingleBenchmarkRunInput(
                 x=probe_bt,
-                kernel_provider="torch",
+                kernel_provider="huggingface",
                 extra_benchmark_config={
                     "hidden_size": model.hidden_size,
                     "dtype": model.dtype,
@@ -218,7 +228,7 @@ if __name__ == "__main__":
             "x_name": "BT",
             "x_label": "B * T",
             "x_values": [2**i for i in range(10, int(math.log2(config.batch_size * config.seq_len)) + 1)],
-            "kernel_providers": ["liger", "liger_rms_norm", "torch"],
+            "kernel_providers": ["liger", "liger_rms_norm", "huggingface"],
             "extra_benchmark_configs": [
                 {
                     "hidden_size": model.hidden_size,

--- a/benchmark/scripts/benchmark_modulated_rms_norm.py
+++ b/benchmark/scripts/benchmark_modulated_rms_norm.py
@@ -1,0 +1,246 @@
+import math
+
+import torch
+import torch.nn as nn
+
+from benchmark_model_configs import MODEL_REGISTRY
+from benchmark_model_configs import compute_model_config_sweep_config
+from benchmark_model_configs import compute_seq_len_sweep_config
+from benchmark_model_configs import estimate_kernel_peak_memory
+from benchmark_model_configs import get_benchmark_model_config
+from utils import SingleBenchmarkRunInput
+from utils import SingleBenchmarkRunOutput
+from utils import parse_benchmark_script_args
+from utils import run_benchmarks
+from utils import run_memory_benchmark
+from utils import run_speed_benchmark
+
+from liger_kernel.transformers.modulated_rms_norm import LigerModulatedRMSNorm
+from liger_kernel.transformers.rms_norm import LigerRMSNorm
+from liger_kernel.utils import infer_device
+
+device = infer_device()
+
+
+class TorchModulatedRMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states, scale, shift=None):
+        input_dtype = hidden_states.dtype
+        normed = hidden_states.to(torch.float32)
+        variance = normed.pow(2).mean(-1, keepdim=True)
+        normed = normed * torch.rsqrt(variance + self.variance_epsilon)
+        normed = self.weight * normed.to(input_dtype)
+        output = normed * (1 + scale)
+        if shift is not None:
+            output = output + shift
+        return output
+
+
+class LigerRMSNormWithTorchModulation(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6):
+        super().__init__()
+        self.rms_norm = LigerRMSNorm(hidden_size=hidden_size, eps=eps, in_place=False)
+
+    def forward(self, hidden_states, scale, shift=None):
+        output = self.rms_norm(hidden_states) * (1 + scale)
+        if shift is not None:
+            output = output + shift
+        return output
+
+
+def _setup_modulated_rms_norm(input: SingleBenchmarkRunInput):
+    cfg = input.extra_benchmark_config
+    hidden_size = cfg["hidden_size"]
+    eps = cfg["eps"]
+    has_shift = cfg["has_shift"]
+    x = torch.randn(
+        input.x,
+        hidden_size,
+        device=device,
+        dtype=cfg["dtype"],
+        requires_grad=True,
+    )
+    scale = (torch.randn_like(x) * 0.1).requires_grad_(True)
+    shift = (torch.randn_like(x) * 0.1).requires_grad_(True) if has_shift else None
+
+    if input.kernel_provider == "liger":
+        layer = LigerModulatedRMSNorm(hidden_size=hidden_size, eps=eps, in_place=False).to(device)
+    elif input.kernel_provider == "liger_rms_norm":
+        layer = LigerRMSNormWithTorchModulation(hidden_size=hidden_size, eps=eps).to(device)
+    elif input.kernel_provider == "torch":
+        layer = TorchModulatedRMSNorm(hidden_size=hidden_size, eps=eps).to(device)
+    else:
+        raise ValueError(f"Invalid provider: {input.kernel_provider} for ModulatedRMSNorm")
+    return x, scale, shift, layer
+
+
+def _input_tensors(x, scale, shift):
+    tensors = [x, scale]
+    if shift is not None:
+        tensors.append(shift)
+    return tensors
+
+
+def bench_speed_modulated_rms_norm(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
+    x, scale, shift, layer = _setup_modulated_rms_norm(input)
+    return run_speed_benchmark(
+        lambda: layer(x, scale, shift), input.kernel_operation_mode, _input_tensors(x, scale, shift)
+    )
+
+
+def bench_memory_modulated_rms_norm(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
+    x, scale, shift, layer = _setup_modulated_rms_norm(input)
+    return run_memory_benchmark(lambda: layer(x, scale, shift), input.kernel_operation_mode)
+
+
+def _resolve_model_config_modulated_rms_norm(input: SingleBenchmarkRunInput):
+    cfg = input.extra_benchmark_config
+    model_info = cfg["model_configs"][input.x]
+    return _setup_modulated_rms_norm(
+        SingleBenchmarkRunInput(
+            x=cfg["BT"],
+            kernel_provider=input.kernel_provider,
+            extra_benchmark_config={
+                "hidden_size": model_info["hidden_size"],
+                "dtype": model_info["dtype"],
+                "eps": cfg["eps"],
+                "has_shift": cfg["has_shift"],
+            },
+        )
+    )
+
+
+def bench_speed_modulated_rms_norm_model_config(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
+    x, scale, shift, layer = _resolve_model_config_modulated_rms_norm(input)
+    return run_speed_benchmark(
+        lambda: layer(x, scale, shift), input.kernel_operation_mode, _input_tensors(x, scale, shift)
+    )
+
+
+def bench_memory_modulated_rms_norm_model_config(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
+    x, scale, shift, layer = _resolve_model_config_modulated_rms_norm(input)
+    return run_memory_benchmark(lambda: layer(x, scale, shift), input.kernel_operation_mode)
+
+
+if __name__ == "__main__":
+    args = parse_benchmark_script_args()
+
+    if args.sweep_mode == "model_config":
+        all_model_configs = list(MODEL_REGISTRY.values())
+
+        def _probe_factory(model_cfg, probe_bt):
+            def _probe():
+                probe_input = SingleBenchmarkRunInput(
+                    x=probe_bt,
+                    kernel_provider="torch",
+                    extra_benchmark_config={
+                        "hidden_size": model_cfg.hidden_size,
+                        "dtype": model_cfg.dtype,
+                        "eps": 1e-6,
+                        "has_shift": True,
+                    },
+                )
+                x, scale, shift, layer = _setup_modulated_rms_norm(probe_input)
+                return layer(x, scale, shift)
+
+            return _probe
+
+        sweep = compute_model_config_sweep_config(all_model_configs, probe_fn_factory=_probe_factory, bt=args.bt)
+
+        model_configs_info = {
+            cfg.name: {
+                "hidden_size": cfg.hidden_size,
+                "dtype": cfg.dtype,
+            }
+            for cfg in sweep.model_configs
+        }
+
+        common_configs = {
+            "kernel_name": "modulated_rms_norm",
+            "x_name": "model_config",
+            "x_label": "model configuration",
+            "x_values": [cfg.name for cfg in sweep.model_configs],
+            "kernel_providers": ["liger", "liger_rms_norm", "torch"],
+            "extra_benchmark_configs": [
+                {
+                    "model_configs": model_configs_info,
+                    "BT": sweep.bt,
+                    "eps": 1e-6,
+                    "has_shift": True,
+                }
+            ],
+            "overwrite": args.overwrite,
+        }
+
+        run_benchmarks(
+            bench_test_fn=bench_speed_modulated_rms_norm_model_config,
+            kernel_operation_modes=["full", "forward", "backward"],
+            metric_name="speed",
+            metric_unit="ms",
+            **common_configs,
+        )
+        run_benchmarks(
+            bench_test_fn=bench_memory_modulated_rms_norm_model_config,
+            kernel_operation_modes=["full"],
+            metric_name="memory",
+            metric_unit="MB",
+            **common_configs,
+        )
+    else:
+        model = get_benchmark_model_config(args.model)
+        probe_bt = 1024
+
+        def _probe():
+            probe_input = SingleBenchmarkRunInput(
+                x=probe_bt,
+                kernel_provider="torch",
+                extra_benchmark_config={
+                    "hidden_size": model.hidden_size,
+                    "dtype": model.dtype,
+                    "eps": 1e-6,
+                    "has_shift": True,
+                },
+            )
+            x, scale, shift, layer = _setup_modulated_rms_norm(probe_input)
+            return layer(x, scale, shift)
+
+        peak_bytes = estimate_kernel_peak_memory(probe_fn=_probe)
+        kernel_bpt = peak_bytes // probe_bt
+
+        config = compute_seq_len_sweep_config(model, kernel_bytes_per_token=kernel_bpt)
+
+        common_configs = {
+            "kernel_name": "modulated_rms_norm",
+            "x_name": "BT",
+            "x_label": "B * T",
+            "x_values": [2**i for i in range(10, int(math.log2(config.batch_size * config.seq_len)) + 1)],
+            "kernel_providers": ["liger", "liger_rms_norm", "torch"],
+            "extra_benchmark_configs": [
+                {
+                    "hidden_size": model.hidden_size,
+                    "dtype": model.dtype,
+                    "eps": 1e-6,
+                    "has_shift": True,
+                }
+            ],
+            "overwrite": args.overwrite,
+        }
+
+        run_benchmarks(
+            bench_test_fn=bench_speed_modulated_rms_norm,
+            kernel_operation_modes=["full", "forward", "backward"],
+            metric_name="speed",
+            metric_unit="ms",
+            **common_configs,
+        )
+        run_benchmarks(
+            bench_test_fn=bench_memory_modulated_rms_norm,
+            kernel_operation_modes=["full"],
+            metric_name="memory",
+            metric_unit="MB",
+            **common_configs,
+        )

--- a/docs/Low-Level-APIs.md
+++ b/docs/Low-Level-APIs.md
@@ -26,6 +26,32 @@ implementations in PyTorch.
 !!! Example "Try it out"
     You can experiment as shown in this example [here](https://colab.research.google.com/drive/1CQYhul7MVG5F0gmqTBbx1O1HgolPgF0M?usp=sharing).
 
+### Modulated RMS Norm
+
+Modulated RMS Norm fuses RMSNorm with optional affine conditioning, a pattern commonly used in [FiLM](https://ojs.aaai.org/index.php/AAAI/article/view/11671) / [AdaLN](https://www.wpeebles.com/DiT.html)-style diffusion transformer blocks:
+
+```python
+y = rms_norm(x, weight, eps) * (1 + scale) + shift
+```
+
+`scale` and `shift` can be shared across tokens, shared per batch item, or provided per token. When `shift` is provided, it must follow the same broadcasting pattern as `scale`.
+
+```python
+import torch
+from liger_kernel.transformers import LigerModulatedRMSNorm
+
+hidden_size = 4096
+norm = LigerModulatedRMSNorm(hidden_size=hidden_size).cuda()
+
+x = torch.randn(2, 1024, hidden_size, device="cuda", dtype=torch.bfloat16)
+scale = torch.randn(2, hidden_size, device="cuda", dtype=torch.bfloat16)
+shift = torch.randn(2, hidden_size, device="cuda", dtype=torch.bfloat16)
+
+y = norm(x, scale, shift)
+```
+
+Functional API: `liger_kernel.transformers.functional.liger_modulated_rms_norm`
+
 ### RoPE
 
 RoPE (Rotary Position Embedding) enhances the positional encoding used in transformer models.

--- a/docs/Low-Level-APIs.md
+++ b/docs/Low-Level-APIs.md
@@ -3,6 +3,7 @@
 | **Kernel**                      | **API**                                                     |
 |---------------------------------|-------------------------------------------------------------|
 | RMSNorm                         | `liger_kernel.transformers.LigerRMSNorm`                    |
+| Modulated RMSNorm               | `liger_kernel.transformers.LigerModulatedRMSNorm`           |
 | LayerNorm                       | `liger_kernel.transformers.LigerLayerNorm`                  |
 | RoPE                            | `liger_kernel.transformers.liger_rotary_pos_emb`            |
 | SwiGLU                          | `liger_kernel.transformers.LigerSwiGLUMLP`                  |

--- a/src/liger_kernel/ops/__init__.py
+++ b/src/liger_kernel/ops/__init__.py
@@ -67,6 +67,9 @@ from liger_kernel.ops.llama4_rope import LigerLlama4RopeFunction  # noqa: F401
 from liger_kernel.ops.mhc import LigerMHCCoeffsFunction  # noqa: F401
 from liger_kernel.ops.mhc import LigerMHCPostResFunction  # noqa: F401
 from liger_kernel.ops.mhc import LigerMHCPreFunction  # noqa: F401
+from liger_kernel.ops.modulated_rms_norm import LigerModulatedRMSNormFunction  # noqa: F401
+from liger_kernel.ops.modulated_rms_norm import modulated_rms_norm_backward  # noqa: F401
+from liger_kernel.ops.modulated_rms_norm import modulated_rms_norm_forward  # noqa: F401
 from liger_kernel.ops.multi_token_attention import LigerMultiTokenAttentionFunction  # noqa: F401
 from liger_kernel.ops.poly_norm import LigerPolyNormFunction  # noqa: F401
 from liger_kernel.ops.poly_norm import poly_norm_backward  # noqa: F401

--- a/src/liger_kernel/ops/modulated_rms_norm.py
+++ b/src/liger_kernel/ops/modulated_rms_norm.py
@@ -1,0 +1,488 @@
+"""
+This file extends Liger RMSNorm, which incorporates code from Unsloth licensed
+under the Apache License, Version 2.0. See src/liger_kernel/ops/rms_norm.py for
+the original attribution.
+"""
+
+import math
+import operator
+
+import torch
+import triton
+import triton.language as tl
+
+from liger_kernel.ops.utils import calculate_settings
+from liger_kernel.ops.utils import compare_version
+from liger_kernel.ops.utils import ensure_contiguous
+from liger_kernel.ops.utils import get_npu_core_count
+from liger_kernel.ops.utils import set_large_grf_mode
+from liger_kernel.ops.utils import torch_to_triton_dtype
+from liger_kernel.utils import is_npu_available
+
+if compare_version("triton", operator.ge, "3.0.0") and not is_npu_available():
+    try:
+        from triton.language.extra.libdevice import rsqrt
+    except ModuleNotFoundError:
+        from triton.language.extra.cuda.libdevice import rsqrt
+else:
+    from triton.language.math import rsqrt
+
+
+_CASTING_MODE_NONE: tl.constexpr = tl.constexpr(-1)
+_CASTING_MODE_LLAMA: tl.constexpr = tl.constexpr(0)
+_CASTING_MODE_GEMMA: tl.constexpr = tl.constexpr(1)
+
+
+@triton.jit
+def _modulated_rms_norm_forward_kernel(
+    Y_ptr,
+    Y_row_stride,
+    X_ptr,
+    X_row_stride,
+    W_ptr,
+    W_row_stride,
+    Scale_ptr,
+    Scale_row_stride,
+    Shift_ptr,
+    Shift_row_stride,
+    RSTD_ptr,
+    RSTD_row_stride,
+    n_cols,
+    eps,
+    offset,
+    casting_mode: tl.constexpr,
+    elementwise_affine: tl.constexpr,
+    has_shift: tl.constexpr,
+    rows_per_modulation: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    mod_row_idx = row_idx // rows_per_modulation
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    mask = col_offsets < n_cols
+
+    y_base = Y_ptr + row_idx * Y_row_stride
+    x_base = X_ptr + row_idx * X_row_stride
+    scale_base = Scale_ptr + mod_row_idx * Scale_row_stride
+    rstd_base = RSTD_ptr + row_idx * RSTD_row_stride
+
+    X_row = tl.load(x_base + col_offsets, mask=mask, other=0)
+    X_row_dtype = X_row.dtype
+    Scale_row = tl.load(scale_base + col_offsets, mask=mask, other=0.0)
+    if elementwise_affine:
+        W_row = tl.load(W_ptr + col_offsets, mask=mask, other=0.0)
+    if has_shift:
+        shift_base = Shift_ptr + mod_row_idx * Shift_row_stride
+        Shift_row = tl.load(shift_base + col_offsets, mask=mask, other=0.0)
+
+    if casting_mode == _CASTING_MODE_LLAMA:
+        X_row = X_row.to(tl.float32)
+
+    if casting_mode == _CASTING_MODE_GEMMA:
+        if elementwise_affine:
+            W_row = W_row.to(tl.float32)
+        X_row = X_row.to(tl.float32)
+
+    if casting_mode == _CASTING_MODE_NONE:
+        eps = eps.to(X_row_dtype)
+        offset = offset.to(X_row_dtype)
+
+    mean_square = tl.sum(X_row * X_row, axis=0) / n_cols
+    rstd = rsqrt(mean_square + eps)
+    tl.store(rstd_base, rstd)
+
+    X_row = X_row * rstd
+
+    if casting_mode == _CASTING_MODE_LLAMA:
+        X_row = X_row.to(X_row_dtype)
+
+    if elementwise_affine:
+        Y_row = X_row * (offset + W_row)
+    else:
+        Y_row = X_row
+
+    if casting_mode == _CASTING_MODE_GEMMA:
+        Y_row = Y_row.to(X_row_dtype)
+
+    Y_row = Y_row * (1.0 + Scale_row)
+    if has_shift:
+        Y_row = Y_row + Shift_row
+
+    tl.store(y_base + col_offsets, Y_row, mask=mask)
+
+
+@triton.jit
+def _modulated_rms_norm_backward_kernel(
+    dY_ptr,
+    dY_row_stride,
+    dX_ptr,
+    dX_row_stride,
+    X_ptr,
+    X_row_stride,
+    X_dtype: tl.constexpr,
+    W_ptr,
+    W_row_stride,
+    Scale_ptr,
+    Scale_row_stride,
+    RSTD_ptr,
+    RSTD_row_stride,
+    dW_ptr,
+    dW_row_stride,
+    dScale_ptr,
+    dScale_row_stride,
+    dShift_ptr,
+    dShift_row_stride,
+    n_rows,
+    n_cols,
+    offset,
+    rows_per_program,
+    casting_mode: tl.constexpr,
+    elementwise_affine: tl.constexpr,
+    has_shift: tl.constexpr,
+    rows_per_modulation: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row_block_id = tl.program_id(0).to(tl.int64)
+    row_start = row_block_id * rows_per_program
+    row_end = min((row_block_id + 1) * rows_per_program, n_rows)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    mask = col_offsets < n_cols
+
+    if elementwise_affine:
+        dW_row = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        W_row = tl.load(W_ptr + col_offsets, mask=mask, other=0.0)
+        W_row = W_row + offset
+
+    for row_idx in range(row_start, row_end):
+        mod_row_idx = row_idx // rows_per_modulation
+        dy_base = dY_ptr + row_idx * dY_row_stride
+        dx_base = dX_ptr + row_idx * dX_row_stride
+        x_base = X_ptr + row_idx * X_row_stride
+        scale_base = Scale_ptr + mod_row_idx * Scale_row_stride
+        rstd_base = RSTD_ptr + row_idx * RSTD_row_stride
+        dscale_base = dScale_ptr + mod_row_idx * dScale_row_stride
+
+        dY_row = tl.load(dy_base + col_offsets, mask=mask, other=0.0)
+        X_row = tl.load(x_base + col_offsets, mask=mask, other=0.0)
+        Scale_row = tl.load(scale_base + col_offsets, mask=mask, other=0.0)
+        rstd_row = tl.load(rstd_base)
+
+        X_row = X_row.to(tl.float32)
+        X_norm = X_row * rstd_row
+        Mod_row = 1.0 + Scale_row
+        dRms_row = dY_row * Mod_row
+
+        if casting_mode == _CASTING_MODE_LLAMA:
+            X_norm_for_output = X_norm.to(X_dtype)
+            if elementwise_affine:
+                rms_output = X_norm_for_output * W_row
+                m = (dRms_row * W_row).to(tl.float32)
+            else:
+                rms_output = X_norm_for_output
+                m = dRms_row.to(tl.float32)
+
+        elif casting_mode == _CASTING_MODE_GEMMA:
+            dRms_row = dRms_row.to(tl.float32)
+            if elementwise_affine:
+                rms_output = (X_norm * W_row).to(X_dtype)
+                m = dRms_row * W_row
+            else:
+                rms_output = X_norm.to(X_dtype)
+                m = dRms_row
+
+        else:
+            if elementwise_affine:
+                rms_output = X_norm * W_row
+                m = dRms_row * W_row
+            else:
+                rms_output = X_norm
+                m = dRms_row
+
+        dX_row = rstd_row * m
+        dX_row += rstd_row * (-(1 / n_cols) * rstd_row * rstd_row * tl.sum(m * X_row, axis=0) * X_row)
+
+        if elementwise_affine:
+            if casting_mode == _CASTING_MODE_LLAMA:
+                dW_row += dRms_row * X_norm.to(X_dtype)
+            else:
+                dW_row += dRms_row * X_norm
+
+        dScale_row = dY_row * rms_output
+        if rows_per_modulation == 1:
+            tl.store(dscale_base + col_offsets, dScale_row, mask=mask)
+        else:
+            tl.atomic_add(dscale_base + col_offsets, dScale_row, sem="relaxed", mask=mask)
+        if has_shift:
+            dshift_base = dShift_ptr + mod_row_idx * dShift_row_stride
+            if rows_per_modulation == 1:
+                tl.store(dshift_base + col_offsets, dY_row, mask=mask)
+            else:
+                tl.atomic_add(dshift_base + col_offsets, dY_row, sem="relaxed", mask=mask)
+
+        tl.store(dx_base + col_offsets, dX_row.to(X_dtype), mask=mask)
+
+    if elementwise_affine:
+        tl.store(dW_ptr + row_block_id * dW_row_stride + col_offsets, dW_row, mask=mask)
+
+
+_str_to_casting_mode = {
+    "llama": _CASTING_MODE_LLAMA.value,
+    "gemma": _CASTING_MODE_GEMMA.value,
+    "none": _CASTING_MODE_NONE.value,
+}
+
+
+def _check_modulation_shape(X, scale, shift):
+    dim = X.shape[-1]
+    n_rows = X.numel() // dim
+    scale = scale.view(-1, dim)
+    scale_rows = scale.shape[0]
+    assert scale_rows > 0, "Scale must have at least one row."
+    assert n_rows % scale_rows == 0, "Scale rows must divide hidden state rows for broadcasting."
+
+    if shift is not None:
+        shift = shift.view(-1, dim)
+        assert shift.shape[0] == scale_rows, "Shift must use the same broadcast rows as scale."
+
+    return scale_rows, n_rows // scale_rows
+
+
+def modulated_rms_norm_forward(X, W, scale, shift, eps, offset, casting_mode):
+    if not isinstance(casting_mode, int):
+        assert casting_mode in _str_to_casting_mode, f"Invalid casting mode: {casting_mode}"
+        casting_mode = _str_to_casting_mode[casting_mode]
+    else:
+        assert casting_mode in _str_to_casting_mode.values(), f"Invalid casting mode: {casting_mode}"
+
+    shape = X.shape
+    dim = shape[-1]
+    scale_rows, rows_per_modulation = _check_modulation_shape(X, scale, shift)
+
+    X = X.view(-1, dim)
+    scale = scale.view(scale_rows, dim)
+    n_rows, n_cols = X.shape
+    BLOCK_SIZE, num_warps = calculate_settings(n_cols)
+
+    Y = torch.empty((n_rows, n_cols), dtype=X.dtype, device=X.device)
+    rstd_dtype = torch.float32 if casting_mode in (_CASTING_MODE_LLAMA.value, _CASTING_MODE_GEMMA.value) else X.dtype
+    RSTD = torch.empty(n_rows, dtype=rstd_dtype, device=X.device)
+
+    if W is not None:
+        assert X.shape[1] == W.shape[0], "Incompatible hidden size dimension between X and W."
+        elementwise_affine = True
+    else:
+        elementwise_affine = False
+
+    has_shift = shift is not None
+    if has_shift:
+        shift = shift.view(scale_rows, dim)
+    else:
+        shift = scale
+
+    kernel_args = {}
+    if X.device.type == "xpu":
+        set_large_grf_mode(kernel_args)
+
+    _modulated_rms_norm_forward_kernel[(n_rows,)](
+        Y,
+        Y.stride(0),
+        X,
+        X.stride(0),
+        W,
+        W.stride(0) if elementwise_affine else 0,
+        scale,
+        scale.stride(0),
+        shift,
+        shift.stride(0) if has_shift else 0,
+        RSTD,
+        RSTD.stride(0),
+        n_cols,
+        eps,
+        offset,
+        casting_mode,
+        elementwise_affine=elementwise_affine,
+        has_shift=has_shift,
+        rows_per_modulation=rows_per_modulation,
+        BLOCK_SIZE=BLOCK_SIZE,
+        num_warps=num_warps,
+        **kernel_args,
+    )
+
+    return Y.view(*shape), RSTD, BLOCK_SIZE, num_warps, casting_mode, rows_per_modulation
+
+
+def modulated_rms_norm_backward(
+    dY,
+    X,
+    W,
+    scale,
+    shift,
+    RSTD,
+    offset,
+    casting_mode,
+    BLOCK_SIZE,
+    num_warps,
+    rows_per_modulation,
+    in_place,
+):
+    shape = dY.shape
+    dim = shape[-1]
+    dY = dY.view(-1, dim)
+    X = X.view(-1, dim)
+    scale_shape = scale.shape
+    scale = scale.view(-1, dim)
+    n_rows, n_cols = dY.shape
+    scale_rows = scale.shape[0]
+
+    sm_count = 1
+    if X.device.type == "cuda":
+        sm_count = torch.cuda.get_device_properties(X.device).multi_processor_count
+    elif X.device.type == "xpu":
+        sm_count = torch.xpu.get_device_properties(X.device).gpu_eu_count
+    elif X.device.type == "npu":
+        sm_count = get_npu_core_count()
+
+    elementwise_affine = W is not None
+    if elementwise_affine:
+        _dW = torch.empty((sm_count, n_cols), dtype=torch.float32, device=W.device)
+    else:
+        _dW = None
+
+    modulation_grad_dtype = scale.dtype if rows_per_modulation == 1 else torch.float32
+    dScale = torch.empty((scale_rows, n_cols), dtype=modulation_grad_dtype, device=scale.device)
+    if rows_per_modulation != 1:
+        dScale.zero_()
+
+    has_shift = shift is not None
+    if has_shift:
+        shift_shape = shift.shape
+        shift = shift.view(scale_rows, dim)
+        modulation_grad_dtype = shift.dtype if rows_per_modulation == 1 else torch.float32
+        dShift = torch.empty((scale_rows, n_cols), dtype=modulation_grad_dtype, device=shift.device)
+        if rows_per_modulation != 1:
+            dShift.zero_()
+    else:
+        shift_shape = None
+        dShift = dScale
+
+    if n_cols > BLOCK_SIZE:
+        raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+    rows_per_program = math.ceil(n_rows / sm_count)
+    grid = (sm_count,)
+
+    if in_place is True:
+        dX = dY
+    else:
+        dX = torch.empty_like(dY)
+
+    kernel_args = {}
+    if X.device.type == "xpu":
+        set_large_grf_mode(kernel_args)
+
+    _modulated_rms_norm_backward_kernel[grid](
+        dY,
+        dY.stride(0),
+        dX,
+        dX.stride(0),
+        X,
+        X.stride(0),
+        torch_to_triton_dtype[X.dtype],
+        W,
+        W.stride(0) if elementwise_affine else 0,
+        scale,
+        scale.stride(0),
+        RSTD,
+        RSTD.stride(0),
+        _dW,
+        _dW.stride(0) if elementwise_affine else 0,
+        dScale,
+        dScale.stride(0),
+        dShift,
+        dShift.stride(0) if has_shift else 0,
+        n_rows,
+        n_cols,
+        offset,
+        rows_per_program,
+        casting_mode,
+        elementwise_affine=elementwise_affine,
+        has_shift=has_shift,
+        rows_per_modulation=rows_per_modulation,
+        BLOCK_SIZE=BLOCK_SIZE,
+        num_warps=num_warps,
+        **kernel_args,
+    )
+
+    dX = dX.view(*shape)
+    dW = _dW.sum(dim=0).to(W.dtype) if elementwise_affine else None
+    dScale = dScale.to(scale.dtype).view(*scale_shape) if dScale.dtype != scale.dtype else dScale.view(*scale_shape)
+    if has_shift:
+        dShift = dShift.to(shift.dtype).view(*shift_shape) if dShift.dtype != shift.dtype else dShift.view(*shift_shape)
+    else:
+        dShift = None
+
+    return dX, dW, dScale, dShift
+
+
+class LigerModulatedRMSNormFunction(torch.autograd.Function):
+    @staticmethod
+    @ensure_contiguous
+    def forward(ctx, X, W, scale, shift, eps, offset=0.0, casting_mode="llama", in_place=True):
+        Y, RSTD, BLOCK_SIZE, num_warps, casting_mode, rows_per_modulation = modulated_rms_norm_forward(
+            X,
+            W,
+            scale,
+            shift,
+            eps,
+            offset,
+            casting_mode,
+        )
+        ctx.offset = offset
+        ctx.casting_mode = casting_mode
+        ctx.in_place = in_place
+        ctx.BLOCK_SIZE = BLOCK_SIZE
+        ctx.num_warps = num_warps
+        ctx.rows_per_modulation = rows_per_modulation
+        ctx.has_weight = W is not None
+        ctx.has_shift = shift is not None
+        if W is not None and shift is not None:
+            ctx.save_for_backward(X, W, scale, shift, RSTD)
+        elif W is not None:
+            ctx.save_for_backward(X, W, scale, RSTD)
+        elif shift is not None:
+            ctx.save_for_backward(X, scale, shift, RSTD)
+        else:
+            ctx.save_for_backward(X, scale, RSTD)
+        return Y
+
+    @staticmethod
+    @ensure_contiguous
+    def backward(ctx, dY):
+        if ctx.has_weight and ctx.has_shift:
+            X, W, scale, shift, RSTD = ctx.saved_tensors
+        elif ctx.has_weight:
+            X, W, scale, RSTD = ctx.saved_tensors
+            shift = None
+        elif ctx.has_shift:
+            X, scale, shift, RSTD = ctx.saved_tensors
+            W = None
+        else:
+            X, scale, RSTD = ctx.saved_tensors
+            W = None
+            shift = None
+
+        dX, dW, dScale, dShift = modulated_rms_norm_backward(
+            dY,
+            X,
+            W,
+            scale,
+            shift,
+            RSTD,
+            ctx.offset,
+            ctx.casting_mode,
+            ctx.BLOCK_SIZE,
+            ctx.num_warps,
+            ctx.rows_per_modulation,
+            ctx.in_place,
+        )
+
+        return dX, dW, dScale, dShift, None, None, None, None

--- a/src/liger_kernel/ops/modulated_rms_norm.py
+++ b/src/liger_kernel/ops/modulated_rms_norm.py
@@ -234,15 +234,14 @@ _str_to_casting_mode = {
 
 def _check_modulation_shape(X, scale, shift):
     dim = X.shape[-1]
+    assert scale.numel() % dim == 0, "Scale element count must be a multiple of the hidden size."
     n_rows = X.numel() // dim
-    scale = scale.view(-1, dim)
-    scale_rows = scale.shape[0]
+    scale_rows = scale.numel() // dim
     assert scale_rows > 0, "Scale must have at least one row."
     assert n_rows % scale_rows == 0, "Scale rows must divide hidden state rows for broadcasting."
 
     if shift is not None:
-        shift = shift.view(-1, dim)
-        assert shift.shape[0] == scale_rows, "Shift must use the same broadcast rows as scale."
+        assert shift.numel() == scale_rows * dim, "Shift must use the same broadcast rows as scale."
 
     return scale_rows, n_rows // scale_rows
 
@@ -424,9 +423,28 @@ def modulated_rms_norm_backward(
 
 
 class LigerModulatedRMSNormFunction(torch.autograd.Function):
+    """
+    Performs modulated RMSNorm in a single fused kernel: ``y = (1 + scale) * RMSNorm(x) + shift``.
+
+    The base RMSNorm matches ``LigerRMSNormFunction`` semantics (``offset``, ``casting_mode``,
+    ``in_place`` behave identically). On top of that, ``scale`` and the optional ``shift`` apply
+    an affine modulation commonly used in Diffusion Transformer style architectures (AdaLN).
+
+    Broadcasting of ``scale`` / ``shift`` is determined by the leading shape, given hidden size H
+    and a flattened token count N = X.numel() / H:
+    - shape ``(H,)`` or ``(1, H)``: shared across every token (N rows reuse one modulation row).
+    - shape ``(B, H)`` with 3D X of shape ``(B, T, H)``: shared along the sequence axis.
+    - shape ``(N, H)`` (or matching X): per-token modulation, no atomic accumulation needed.
+    In general, ``scale.numel() // H`` must divide N. ``shift`` (if provided) must broadcast
+    identically to ``scale``.
+    """
+
     @staticmethod
     @ensure_contiguous
     def forward(ctx, X, W, scale, shift, eps, offset=0.0, casting_mode="llama", in_place=True):
+        if isinstance(X, torch.distributed.tensor.DTensor):
+            # Match LigerRMSNormFunction: gather TP-sharded input to a local tensor.
+            X = X.full_tensor()
         Y, RSTD, BLOCK_SIZE, num_warps, casting_mode, rows_per_modulation = modulated_rms_norm_forward(
             X,
             W,
@@ -457,6 +475,8 @@ class LigerModulatedRMSNormFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
     def backward(ctx, dY):
+        if isinstance(dY, torch.distributed.tensor.DTensor):
+            dY = dY.full_tensor()
         if ctx.has_weight and ctx.has_shift:
             X, W, scale, shift, RSTD = ctx.saved_tensors
         elif ctx.has_weight:

--- a/src/liger_kernel/transformers/__init__.py
+++ b/src/liger_kernel/transformers/__init__.py
@@ -15,6 +15,7 @@ from liger_kernel.transformers.layer_norm import LigerLayerNorm  # noqa: F401
 from liger_kernel.transformers.llama4_rope import liger_llama4_text_rotary_pos_emb  # noqa: F401
 from liger_kernel.transformers.llama4_rope import liger_llama4_vision_rotary_pos_emb  # noqa: F401
 from liger_kernel.transformers.mhc import LigerMHC  # noqa: F401
+from liger_kernel.transformers.modulated_rms_norm import LigerModulatedRMSNorm  # noqa: F401
 from liger_kernel.transformers.multi_token_attention import LigerMultiTokenAttention  # noqa: F401
 from liger_kernel.transformers.poly_norm import LigerPolyNorm  # noqa: F401
 from liger_kernel.transformers.relu_squared import LigerReLUSquared  # noqa: F401
@@ -174,6 +175,7 @@ __all__ = [
     "LigerJSD",
     "LigerLayerNorm",
     "LigerFusedAddRMSNorm",
+    "LigerModulatedRMSNorm",
     "LigerPolyNorm",
     "LigerReLUSquared",
     "LigerRMSNorm",

--- a/src/liger_kernel/transformers/functional.py
+++ b/src/liger_kernel/transformers/functional.py
@@ -18,6 +18,7 @@ from liger_kernel.ops import LigerLayerNormFunction
 from liger_kernel.ops import LigerMHCCoeffsFunction
 from liger_kernel.ops import LigerMHCPostResFunction
 from liger_kernel.ops import LigerMHCPreFunction
+from liger_kernel.ops import LigerModulatedRMSNormFunction
 from liger_kernel.ops import LigerMultiTokenAttentionFunction
 from liger_kernel.ops import LigerPolyNormFunction
 from liger_kernel.ops import LigerQwen2VLMRopeFunction
@@ -293,6 +294,19 @@ def liger_relu_squared(x):
 
 def liger_rms_norm(X, W, eps, offset: float = 0.0, casting_mode: str = "llama", in_place: bool = True):
     return LigerRMSNormFunction.apply(X, W, eps, offset, casting_mode, in_place)
+
+
+def liger_modulated_rms_norm(
+    X,
+    W,
+    scale,
+    shift=None,
+    eps: float = 1e-6,
+    offset: float = 0.0,
+    casting_mode: str = "llama",
+    in_place: bool = True,
+):
+    return LigerModulatedRMSNormFunction.apply(X, W, scale, shift, eps, offset, casting_mode, in_place)
 
 
 def liger_poly_norm(X, W, B, eps=1e-6, in_place=True):

--- a/src/liger_kernel/transformers/modulated_rms_norm.py
+++ b/src/liger_kernel/transformers/modulated_rms_norm.py
@@ -5,6 +5,24 @@ from liger_kernel.ops import LigerModulatedRMSNormFunction
 
 
 class LigerModulatedRMSNorm(nn.Module):
+    """
+    Fused modulated RMSNorm module: ``y = (1 + scale) * RMSNorm(x) + shift``.
+
+    Semantics of ``eps``, ``offset``, ``casting_mode`` and ``in_place`` mirror
+    :class:`liger_kernel.transformers.LigerRMSNorm`. ``scale`` and the optional
+    ``shift`` follow the broadcast rules documented on
+    :class:`liger_kernel.ops.LigerModulatedRMSNormFunction`.
+
+    Args:
+        hidden_size: trailing dimension over which RMS is computed.
+        eps: epsilon added to mean-square inside ``rsqrt``.
+        offset: constant added to the weight, e.g. ``1.0`` for Gemma-style norms.
+        casting_mode: ``"llama"`` / ``"gemma"`` / ``"none"`` — see ``LigerRMSNormFunction``.
+        init_fn: ``"ones"`` or ``"zeros"`` for the (optional) weight initialization.
+        in_place: whether the backward kernel writes ``dX`` over ``dY`` to save memory.
+        elementwise_affine: if False, no learnable weight is allocated.
+    """
+
     def __init__(
         self,
         hidden_size,

--- a/src/liger_kernel/transformers/modulated_rms_norm.py
+++ b/src/liger_kernel/transformers/modulated_rms_norm.py
@@ -1,0 +1,50 @@
+import torch
+import torch.nn as nn
+
+from liger_kernel.ops import LigerModulatedRMSNormFunction
+
+
+class LigerModulatedRMSNorm(nn.Module):
+    def __init__(
+        self,
+        hidden_size,
+        eps=1e-6,
+        offset=0.0,
+        casting_mode="llama",
+        init_fn="ones",
+        in_place=True,
+        elementwise_affine=True,
+    ):
+        super().__init__()
+        assert init_fn in [
+            "ones",
+            "zeros",
+        ], f"init_fn must be either 'ones' or 'zeros', got {init_fn}"
+        self.elementwise_affine = elementwise_affine
+        if self.elementwise_affine:
+            self.weight = nn.Parameter(torch.ones(hidden_size) if init_fn == "ones" else torch.zeros(hidden_size))
+        else:
+            self.register_parameter("weight", None)
+        self.variance_epsilon = eps
+        self.offset = offset
+        self.casting_mode = casting_mode
+        self.in_place = in_place
+
+    def forward(self, hidden_states, scale, shift=None):
+        return LigerModulatedRMSNormFunction.apply(
+            hidden_states,
+            self.weight,
+            scale,
+            shift,
+            self.variance_epsilon,
+            self.offset,
+            self.casting_mode,
+            self.in_place,
+        )
+
+    def extra_repr(self):
+        weight_shape = tuple(self.weight.shape) if self.weight is not None else None
+        return (
+            f"weight_shape={weight_shape}, eps={self.variance_epsilon}, offset={self.offset}, "
+            f"casting_mode={self.casting_mode}, in_place={self.in_place}"
+        )

--- a/test/transformers/test_modulated_rms_norm.py
+++ b/test/transformers/test_modulated_rms_norm.py
@@ -18,6 +18,12 @@ device = infer_device()
 set_seed(42)
 torch.use_deterministic_algorithms(True)
 
+#  Only setting torch.use_deterministic_algorithms(True) might throw the following error:
+#  RuntimeError: Deterministic behavior was enabled with either `torch.use_deterministic_algorithms(True)` or `at::Context::setDeterministicAlgorithms(true)`,
+#  but this operation is not deterministic because it uses CuBLAS and you have CUDA >= 10.2. To enable deterministic behavior in this case, you must set an
+#  environment variable before running your PyTorch application: CUBLAS_WORKSPACE_CONFIG=:4096:8 or CUBLAS_WORKSPACE_CONFIG=:16:8. For more information,
+#  go to https://docs.nvidia.com/cuda/cublas/index.html#results-reproducibility
+
 if device == "cuda":
     os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
 
@@ -240,12 +246,23 @@ def test_mixed_dtype_modulation(scale_mode, has_shift):
         assert_verbose_allclose(shift_ref.grad, shift_triton.grad, atol=2e-1, rtol=2e-2)
 
 
+@pytest.mark.parametrize(
+    "dtype, atol, rtol",
+    [
+        (torch.float32, 1e-4, 1e-6),
+        pytest.param(
+            torch.bfloat16,
+            2e-1,
+            2e-2,
+            marks=pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this GPU"),
+        ),
+    ],
+)
 @pytest.mark.parametrize("in_place", [True, False])
 @pytest.mark.parametrize("has_shift", [True, False])
 @pytest.mark.parametrize("elementwise_affine", [True, False])
-def test_functional_correctness(in_place, has_shift, elementwise_affine):
+def test_correctness_functional(dtype, atol, rtol, in_place, has_shift, elementwise_affine):
     bs, sl, hd = 2, 3, 8
-    dtype = torch.float32
     tensor = torch.randn(bs, sl, hd, device=device, dtype=dtype)
     scale = torch.randn(bs, hd, device=device, dtype=dtype) * 0.1
     shift = torch.randn(bs, hd, device=device, dtype=dtype) * 0.1 if has_shift else None
@@ -263,15 +280,15 @@ def test_functional_correctness(in_place, has_shift, elementwise_affine):
     y1 = liger_modulated_rms_norm(h1, w1, scale1, shift1, in_place=in_place)
     y2 = LigerModulatedRMSNormFunction.apply(h2, w2, scale2, shift2, 1e-6, 0.0, "llama", in_place)
 
-    assert_verbose_allclose(y1, y2, atol=1e-4, rtol=1e-6)
+    assert_verbose_allclose(y1, y2, atol=atol, rtol=rtol)
 
     grad = torch.randn_like(y2)
     y1.backward(grad.clone())
     y2.backward(grad.clone())
 
-    assert_verbose_allclose(h1.grad, h2.grad, atol=1e-4, rtol=1e-6)
-    assert_verbose_allclose(scale1.grad, scale2.grad, atol=1e-4, rtol=1e-6)
+    assert_verbose_allclose(h1.grad, h2.grad, atol=atol, rtol=rtol)
+    assert_verbose_allclose(scale1.grad, scale2.grad, atol=atol, rtol=rtol)
     if has_shift:
-        assert_verbose_allclose(shift1.grad, shift2.grad, atol=1e-4, rtol=1e-6)
+        assert_verbose_allclose(shift1.grad, shift2.grad, atol=atol, rtol=rtol)
     if elementwise_affine:
-        assert_verbose_allclose(w1.grad, w2.grad, atol=1e-4, rtol=1e-6)
+        assert_verbose_allclose(w1.grad, w2.grad, atol=atol, rtol=rtol)

--- a/test/transformers/test_modulated_rms_norm.py
+++ b/test/transformers/test_modulated_rms_norm.py
@@ -1,0 +1,226 @@
+import os
+
+import pytest
+import torch
+import torch.nn as nn
+
+from test.utils import assert_verbose_allclose
+from test.utils import set_seed
+from test.utils import supports_bfloat16
+
+from liger_kernel.ops import LigerModulatedRMSNormFunction
+from liger_kernel.transformers.functional import liger_modulated_rms_norm
+from liger_kernel.transformers.modulated_rms_norm import LigerModulatedRMSNorm
+from liger_kernel.utils import infer_device
+
+device = infer_device()
+
+set_seed(42)
+torch.use_deterministic_algorithms(True)
+
+if device == "cuda":
+    os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+
+
+def _broadcast_modulation(modulation, hidden_states):
+    if modulation.dim() == 1:
+        return modulation
+    if modulation.shape == hidden_states.shape:
+        return modulation
+    if hidden_states.dim() == 3 and modulation.dim() == 2 and modulation.shape[0] == hidden_states.shape[0]:
+        return modulation[:, None, :]
+    if hidden_states.dim() == 2 and modulation.dim() == 2 and hidden_states.shape[0] % modulation.shape[0] == 0:
+        rows_per_modulation = hidden_states.shape[0] // modulation.shape[0]
+        return modulation.repeat_interleave(rows_per_modulation, dim=0)
+    raise AssertionError("Unsupported modulation shape for reference implementation.")
+
+
+class ModulatedRMSNormReference(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6, offset=0.0, casting_mode="llama", elementwise_affine=True):
+        super().__init__()
+        self.elementwise_affine = elementwise_affine
+        if self.elementwise_affine:
+            self.weight = nn.Parameter(torch.ones(hidden_size))
+        else:
+            self.register_parameter("weight", None)
+        self.eps = eps
+        self.offset = offset
+        self.casting_mode = casting_mode
+
+    def _norm(self, hidden_states):
+        input_dtype = hidden_states.dtype
+
+        if self.casting_mode == "llama":
+            normed = hidden_states.to(torch.float32)
+            variance = normed.pow(2).mean(-1, keepdim=True)
+            normed = normed * torch.rsqrt(variance + self.eps)
+            normed = normed.to(input_dtype)
+            if self.elementwise_affine:
+                normed = normed * (self.offset + self.weight)
+            return normed
+
+        if self.casting_mode == "gemma":
+            normed = hidden_states.to(torch.float32)
+            variance = normed.pow(2).mean(-1, keepdim=True)
+            normed = normed * torch.rsqrt(variance + self.eps)
+            if self.elementwise_affine:
+                normed = normed * (self.offset + self.weight.float())
+            return normed.to(input_dtype)
+
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        normed = hidden_states * torch.rsqrt(variance + self.eps)
+        if self.elementwise_affine:
+            normed = normed * (self.offset + self.weight)
+        return normed
+
+    def forward(self, hidden_states, scale, shift=None):
+        normed = self._norm(hidden_states)
+        scale = _broadcast_modulation(scale, hidden_states)
+        output = normed * (1 + scale)
+        if shift is not None:
+            shift = _broadcast_modulation(shift, hidden_states)
+            output = output + shift
+        return output
+
+
+def _make_modulation(shape, hd, scale_mode, dtype):
+    if scale_mode == "global":
+        mod_shape = (hd,)
+    elif scale_mode == "batch":
+        bs = shape[0]
+        mod_shape = (bs, hd)
+    elif scale_mode == "row":
+        mod_shape = shape
+    else:
+        raise ValueError(f"Unsupported scale mode: {scale_mode}")
+    scale = torch.randn(mod_shape, device=device, dtype=dtype) * 0.1
+    shift = torch.randn(mod_shape, device=device, dtype=dtype) * 0.1
+    return scale, shift
+
+
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
+@pytest.mark.parametrize(
+    "bs, sl, hd",
+    [
+        (2, 16, 512),
+        (5, 7, 123),
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype, atol, rtol",
+    [
+        (torch.float32, 1e-4, 1e-6),
+        pytest.param(
+            torch.bfloat16,
+            2e-1,
+            2e-2,
+            marks=pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this GPU"),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "offset, casting_mode",
+    [
+        (0.0, "llama"),
+        (1.0, "gemma"),
+        pytest.param(
+            0.0,
+            "none",
+            marks=pytest.mark.skipif(device == "npu", reason="Ascend NPU does not support this test"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("scale_mode", ["global", "batch", "row"])
+@pytest.mark.parametrize("has_shift", [True, False])
+@pytest.mark.parametrize("elementwise_affine", [True, False])
+def test_correctness(bs, sl, hd, dtype, atol, rtol, offset, casting_mode, scale_mode, has_shift, elementwise_affine):
+    shape = (bs, sl, hd)
+    tensor = torch.randn(shape, device=device, dtype=dtype)
+    scale, shift = _make_modulation(shape, hd, scale_mode, dtype)
+    shift = shift if has_shift else None
+
+    h1 = tensor.clone().requires_grad_(True)
+    h2 = tensor.clone().requires_grad_(True)
+    scale1 = scale.clone().requires_grad_(True)
+    scale2 = scale.clone().requires_grad_(True)
+    shift1 = shift.clone().requires_grad_(True) if shift is not None else None
+    shift2 = shift.clone().requires_grad_(True) if shift is not None else None
+
+    grad = torch.randn(shape, device=device, dtype=dtype)
+
+    ref = (
+        ModulatedRMSNormReference(
+            hidden_size=hd,
+            offset=offset,
+            casting_mode=casting_mode,
+            elementwise_affine=elementwise_affine,
+        )
+        .to(device)
+        .to(dtype)
+    )
+    triton_mod = (
+        LigerModulatedRMSNorm(
+            hidden_size=hd,
+            offset=offset,
+            casting_mode=casting_mode,
+            in_place=False,
+            elementwise_affine=elementwise_affine,
+        )
+        .to(device)
+        .to(dtype)
+    )
+
+    if elementwise_affine:
+        with torch.no_grad():
+            triton_mod.weight.copy_(ref.weight)
+
+    ref_out = ref(h1, scale1, shift1)
+    triton_out = triton_mod(h2, scale2, shift2)
+
+    ref_out.backward(grad, retain_graph=True)
+    triton_out.backward(grad, retain_graph=True)
+
+    assert_verbose_allclose(ref_out, triton_out, atol=atol, rtol=rtol)
+    assert_verbose_allclose(h1.grad, h2.grad, atol=atol, rtol=rtol, max_print=20)
+    assert_verbose_allclose(scale1.grad, scale2.grad, atol=atol, rtol=rtol, max_print=20)
+    if has_shift:
+        assert_verbose_allclose(shift1.grad, shift2.grad, atol=atol, rtol=rtol, max_print=20)
+    if elementwise_affine:
+        assert_verbose_allclose(ref.weight.grad, triton_mod.weight.grad, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("in_place", [True, False])
+@pytest.mark.parametrize("has_shift", [True, False])
+@pytest.mark.parametrize("elementwise_affine", [True, False])
+def test_functional_correctness(in_place, has_shift, elementwise_affine):
+    bs, sl, hd = 2, 3, 8
+    dtype = torch.float32
+    tensor = torch.randn(bs, sl, hd, device=device, dtype=dtype)
+    scale = torch.randn(bs, hd, device=device, dtype=dtype) * 0.1
+    shift = torch.randn(bs, hd, device=device, dtype=dtype) * 0.1 if has_shift else None
+    weight = torch.randn(hd, device=device, dtype=dtype) if elementwise_affine else None
+
+    h1 = tensor.clone().requires_grad_(True)
+    h2 = tensor.clone().requires_grad_(True)
+    scale1 = scale.clone().requires_grad_(True)
+    scale2 = scale.clone().requires_grad_(True)
+    shift1 = shift.clone().requires_grad_(True) if shift is not None else None
+    shift2 = shift.clone().requires_grad_(True) if shift is not None else None
+    w1 = weight.clone().requires_grad_(True) if weight is not None else None
+    w2 = weight.clone().requires_grad_(True) if weight is not None else None
+
+    y1 = liger_modulated_rms_norm(h1, w1, scale1, shift1, in_place=in_place)
+    y2 = LigerModulatedRMSNormFunction.apply(h2, w2, scale2, shift2, 1e-6, 0.0, "llama", in_place)
+
+    assert_verbose_allclose(y1, y2, atol=1e-4, rtol=1e-6)
+
+    grad = torch.randn_like(y2)
+    y1.backward(grad.clone())
+    y2.backward(grad.clone())
+
+    assert_verbose_allclose(h1.grad, h2.grad, atol=1e-4, rtol=1e-6)
+    assert_verbose_allclose(scale1.grad, scale2.grad, atol=1e-4, rtol=1e-6)
+    if has_shift:
+        assert_verbose_allclose(shift1.grad, shift2.grad, atol=1e-4, rtol=1e-6)
+    if elementwise_affine:
+        assert_verbose_allclose(w1.grad, w2.grad, atol=1e-4, rtol=1e-6)

--- a/test/transformers/test_modulated_rms_norm.py
+++ b/test/transformers/test_modulated_rms_norm.py
@@ -189,6 +189,57 @@ def test_correctness(bs, sl, hd, dtype, atol, rtol, offset, casting_mode, scale_
         assert_verbose_allclose(ref.weight.grad, triton_mod.weight.grad, atol=atol, rtol=rtol)
 
 
+@pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this GPU")
+@pytest.mark.parametrize("scale_mode", ["global", "batch", "row"])
+@pytest.mark.parametrize("has_shift", [True, False])
+def test_mixed_dtype_modulation(scale_mode, has_shift):
+    """
+    X in bf16, scale/shift in fp32: a common DiT/AdaLN setup. Verifies the kernel
+    handles mismatched modulation dtype (atomic_add path requires an implicit cast),
+    preserves X.dtype on the output, and produces scale/shift gradients in their
+    original (fp32) dtype.
+    """
+    bs, sl, hd = 2, 4, 64
+    shape = (bs, sl, hd)
+    x_dtype = torch.bfloat16
+    mod_dtype = torch.float32
+
+    tensor = torch.randn(shape, device=device, dtype=x_dtype)
+    scale, shift = _make_modulation(shape, hd, scale_mode, mod_dtype)
+    shift = shift if has_shift else None
+
+    h_triton = tensor.clone().requires_grad_(True)
+    scale_triton = scale.clone().requires_grad_(True)
+    shift_triton = shift.clone().requires_grad_(True) if shift is not None else None
+
+    grad = torch.randn(shape, device=device, dtype=x_dtype)
+
+    triton_mod = LigerModulatedRMSNorm(hidden_size=hd, in_place=False).to(device).to(x_dtype)
+    triton_out = triton_mod(h_triton, scale_triton, shift_triton)
+    assert triton_out.dtype == x_dtype, "Liger must preserve X dtype on output"
+
+    triton_out.backward(grad)
+    assert scale_triton.grad.dtype == mod_dtype
+    if has_shift:
+        assert shift_triton.grad.dtype == mod_dtype
+
+    # Reference: do the whole computation in fp32, then compare against bf16 triton out.
+    h_ref = tensor.clone().float().requires_grad_(True)
+    scale_ref = scale.clone().requires_grad_(True)
+    shift_ref = shift.clone().requires_grad_(True) if shift is not None else None
+    ref = ModulatedRMSNormReference(hidden_size=hd).to(device).to(torch.float32)
+    with torch.no_grad():
+        ref.weight.copy_(triton_mod.weight.float())
+    ref_out_fp32 = ref(h_ref, scale_ref, shift_ref)
+    ref_out_fp32.backward(grad.float())
+
+    assert_verbose_allclose(ref_out_fp32.bfloat16(), triton_out, atol=2e-1, rtol=2e-2)
+    assert_verbose_allclose(h_ref.grad.bfloat16(), h_triton.grad, atol=2e-1, rtol=2e-2)
+    assert_verbose_allclose(scale_ref.grad, scale_triton.grad, atol=2e-1, rtol=2e-2)
+    if has_shift:
+        assert_verbose_allclose(shift_ref.grad, shift_triton.grad, atol=2e-1, rtol=2e-2)
+
+
 @pytest.mark.parametrize("in_place", [True, False])
 @pytest.mark.parametrize("has_shift", [True, False])
 @pytest.mark.parametrize("elementwise_affine", [True, False])

--- a/test/transformers/test_modulated_rms_norm.py
+++ b/test/transformers/test_modulated_rms_norm.py
@@ -28,19 +28,6 @@ if device == "cuda":
     os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
 
 
-def _broadcast_modulation(modulation, hidden_states):
-    if modulation.dim() == 1:
-        return modulation
-    if modulation.shape == hidden_states.shape:
-        return modulation
-    if hidden_states.dim() == 3 and modulation.dim() == 2 and modulation.shape[0] == hidden_states.shape[0]:
-        return modulation[:, None, :]
-    if hidden_states.dim() == 2 and modulation.dim() == 2 and hidden_states.shape[0] % modulation.shape[0] == 0:
-        rows_per_modulation = hidden_states.shape[0] // modulation.shape[0]
-        return modulation.repeat_interleave(rows_per_modulation, dim=0)
-    raise AssertionError("Unsupported modulation shape for reference implementation.")
-
-
 class ModulatedRMSNormReference(nn.Module):
     def __init__(self, hidden_size, eps=1e-6, offset=0.0, casting_mode="llama", elementwise_affine=True):
         super().__init__()
@@ -52,6 +39,19 @@ class ModulatedRMSNormReference(nn.Module):
         self.eps = eps
         self.offset = offset
         self.casting_mode = casting_mode
+
+    @staticmethod
+    def _broadcast_modulation(modulation, hidden_states):
+        if modulation.dim() == 1:
+            return modulation
+        if modulation.shape == hidden_states.shape:
+            return modulation
+        if hidden_states.dim() == 3 and modulation.dim() == 2 and modulation.shape[0] == hidden_states.shape[0]:
+            return modulation[:, None, :]
+        if hidden_states.dim() == 2 and modulation.dim() == 2 and hidden_states.shape[0] % modulation.shape[0] == 0:
+            rows_per_modulation = hidden_states.shape[0] // modulation.shape[0]
+            return modulation.repeat_interleave(rows_per_modulation, dim=0)
+        raise AssertionError("Unsupported modulation shape for reference implementation.")
 
     def _norm(self, hidden_states):
         input_dtype = hidden_states.dtype
@@ -81,10 +81,10 @@ class ModulatedRMSNormReference(nn.Module):
 
     def forward(self, hidden_states, scale, shift=None):
         normed = self._norm(hidden_states)
-        scale = _broadcast_modulation(scale, hidden_states)
+        scale = self._broadcast_modulation(scale, hidden_states)
         output = normed * (1 + scale)
         if shift is not None:
-            shift = _broadcast_modulation(shift, hidden_states)
+            shift = self._broadcast_modulation(shift, hidden_states)
             output = output + shift
         return output
 
@@ -108,8 +108,8 @@ def _make_modulation(shape, hd, scale_mode, dtype):
 @pytest.mark.parametrize(
     "bs, sl, hd",
     [
-        (2, 16, 512),
-        (5, 7, 123),
+        (2, 128, 512),
+        (5, 123, 123),
     ],
 )
 @pytest.mark.parametrize(
@@ -118,7 +118,7 @@ def _make_modulation(shape, hd, scale_mode, dtype):
         (torch.float32, 1e-4, 1e-6),
         pytest.param(
             torch.bfloat16,
-            2e-1,
+            1e-1,
             2e-2,
             marks=pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this GPU"),
         ),
@@ -129,17 +129,17 @@ def _make_modulation(shape, hd, scale_mode, dtype):
     [
         (0.0, "llama"),
         (1.0, "gemma"),
-        pytest.param(
-            0.0,
-            "none",
-            marks=pytest.mark.skipif(device == "npu", reason="Ascend NPU does not support this test"),
-        ),
+        (0.0, "none"),
     ],
 )
 @pytest.mark.parametrize("scale_mode", ["global", "batch", "row"])
 @pytest.mark.parametrize("has_shift", [True, False])
 @pytest.mark.parametrize("elementwise_affine", [True, False])
+@pytest.mark.skipif(device == "npu", reason="Ascend NPU does not support this test")
 def test_correctness(bs, sl, hd, dtype, atol, rtol, offset, casting_mode, scale_mode, has_shift, elementwise_affine):
+    if dtype == torch.bfloat16 and casting_mode == "none":
+        atol = 2e-1
+
     shape = (bs, sl, hd)
     tensor = torch.randn(shape, device=device, dtype=dtype)
     scale, shift = _make_modulation(shape, hd, scale_mode, dtype)
@@ -239,11 +239,11 @@ def test_mixed_dtype_modulation(scale_mode, has_shift):
     ref_out_fp32 = ref(h_ref, scale_ref, shift_ref)
     ref_out_fp32.backward(grad.float())
 
-    assert_verbose_allclose(ref_out_fp32.bfloat16(), triton_out, atol=2e-1, rtol=2e-2)
-    assert_verbose_allclose(h_ref.grad.bfloat16(), h_triton.grad, atol=2e-1, rtol=2e-2)
-    assert_verbose_allclose(scale_ref.grad, scale_triton.grad, atol=2e-1, rtol=2e-2)
+    assert_verbose_allclose(ref_out_fp32.bfloat16(), triton_out, atol=1e-1, rtol=2e-2)
+    assert_verbose_allclose(h_ref.grad.bfloat16(), h_triton.grad, atol=1e-1, rtol=2e-2)
+    assert_verbose_allclose(scale_ref.grad, scale_triton.grad, atol=1e-1, rtol=2e-2)
     if has_shift:
-        assert_verbose_allclose(shift_ref.grad, shift_triton.grad, atol=2e-1, rtol=2e-2)
+        assert_verbose_allclose(shift_ref.grad, shift_triton.grad, atol=1e-1, rtol=2e-2)
 
 
 @pytest.mark.parametrize(
@@ -252,7 +252,7 @@ def test_mixed_dtype_modulation(scale_mode, has_shift):
         (torch.float32, 1e-4, 1e-6),
         pytest.param(
             torch.bfloat16,
-            2e-1,
+            1e-1,
             2e-2,
             marks=pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this GPU"),
         ),


### PR DESCRIPTION
## Summary

Adds a fused Modulated RMSNorm kernel for the common pattern:

```python
y = rms_norm(x, weight, eps) * (1 + scale) + shift
```

This is intended for FiLM/AdaRMSNorm-style modulation where RMSNorm output is scaled and optionally shifted by per-hidden-dimension modulation tensors.

Related issue: #1224

## Changes

- Add `LigerModulatedRMSNormFunction` with fused forward/backward Triton kernels.
- Add `LigerModulatedRMSNorm` module wrapper and `liger_modulated_rms_norm` functional API.
- Support optional RMSNorm weight, optional shift, and existing RMSNorm casting modes: `llama`, `gemma`, `none`.
- Support modulation shapes that flatten to `(hidden,)`, `(batch, hidden)`, or row-wise `(batch, seq, hidden)` when rows divide the hidden-state rows.
- Add correctness tests across fp32/bf16, casting modes, modulation broadcast modes, optional shift, and optional affine weight.
- Add benchmark script for speed and memory comparison.

## Benchmark

Environment: NVIDIA GeForce RTX 3090, bf16, hidden size 4096, row-wise `scale` and `shift`.

### Speed, p50 ms

| BT | Mode | Fused | LigerRMSNorm + torch mod | Speedup |
|---:|---|---:|---:|---:|
| 1024 | forward | 0.0430 | 0.1091 | 2.5x |
| 1024 | backward | 0.0763 | 0.1403 | 1.8x |
| 1024 | full | 0.1403 | 0.2642 | 1.9x |
| 4096 | forward | 0.1546 | 0.3999 | 2.6x |
| 4096 | backward | 0.2540 | 0.4895 | 1.9x |
| 4096 | full | 0.4787 | 1.3793 | 2.9x |

### Memory, p50 MB

| BT | Mode | Fused | LigerRMSNorm + torch mod | Savings |
|---:|---|---:|---:|---:|
| 1024 | forward | 32.02 | 56.02 | 42.8% |
| 1024 | backward | 89.33 | 97.33 | 8.2% |
| 1024 | full | 89.33 | 97.33 | 8.2% |
| 4096 | forward | 128.03 | 224.03 | 42.9% |
| 4096 | backward | 353.34 | 385.34 | 8.3% |
| 4096 | full | 353.34 | 385.34 | 8.3% |
