### PR TITLE
[NPU, Feat] Pin triton-ascend to v3.2.0 for npu

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,10 @@ def get_default_dependencies():
             "torch>=2.6.0",
         ]
     # TODO: Currently, triton-ascend is not compatible with torch 2.7.1. We will upgrade it later.
+    # TODO: triton-ascend v3.2.1 is expected to release soon with some incompatible API changes.
+    # Until we adapt to those changes, pin triton-ascend to v3.2.0.
     elif platform == "npu":
-        return ["torch==2.6.0", "torch_npu==2.6.0", "triton-ascend"]
+        return ["torch==2.6.0", "torch_npu==2.6.0", "triton-ascend==3.2.0"]
 
 
 def get_optional_dependencies():


### PR DESCRIPTION
## Summary

`triton-ascend` has released v3.2.1: https://github.com/triton-lang/triton-ascend/releases/tag/v3.2.1, but it hasn't been published to PyPI yet. v3.2.1 includes some breaking changes from v3.2.0, so we need to pin the `triton-ascend` version in `setup.py` to avoid breaking users.

## Testing Done


- Hardware Type: All NPUs.
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
