### PR TITLE
Fix broken gemma3 multimodal forward

### DIFF
--- a/src/liger_kernel/transformers/model/gemma3.py
+++ b/src/liger_kernel/transformers/model/gemma3.py
@@ -246,35 +246,17 @@ def multimodal_forward(
     logits = None
     token_accuracy = None
     predicted_tokens = None
-    if skip_logits and labels is None:
-        raise ValueError("skip_logits is True, but labels is None")
+    if skip_logits and labels is None and shift_labels is None:
+        raise ValueError("skip_logits is True, but both labels and shift_labels are None")
 
     if skip_logits is None:
-        skip_logits = self.training and (labels is not None)
+        skip_logits = self.training and (labels is not None or shift_labels is not None)
 
     if skip_logits:
-        shift_hidden_states = kept_hidden_states[..., :-1, :]
-        shift_labels = labels[..., 1:]
-
-        hidden_device = shift_hidden_states.device
-        if attention_mask is not None:
-            # we use the input attention mask to shift the hidden_states and labels, because it is 2D.
-            # we also crop attn mask in case it is longer, which happens in PrefixTuning with peft
-            shift_attention_mask = attention_mask[:, -shift_hidden_states.shape[1] :].to(hidden_device)
-            shift_hidden_states = shift_hidden_states[shift_attention_mask.to(hidden_device) != 0].contiguous()
-            shift_labels = shift_labels[shift_attention_mask.to(shift_labels.device) != 0].contiguous()
-        else:
-            shift_hidden_states = shift_hidden_states.contiguous()
-            shift_labels = shift_labels.contiguous()
-
-        # Flatten hidden state
-        shift_hidden_states = shift_hidden_states.view(-1, self.config.text_config.hidden_size)
-        shift_labels = shift_labels.view(-1).to(hidden_device)
-
         result = LigerForCausalLMLoss(
-            hidden_states=shift_hidden_states,
+            hidden_states=kept_hidden_states,
             lm_head_weight=self.lm_head.weight,
-            labels=shift_labels,
+            labels=labels,
             hidden_size=self.config.text_config.hidden_size,
             shift_labels=shift_labels,
             final_logit_softcapping=getattr(self.config.text_config, "final_logit_softcapping", None),
@@ -284,30 +266,12 @@ def multimodal_forward(
 
     else:
         logits = self.lm_head(kept_hidden_states)
-        if labels is not None:
+        if labels is not None or shift_labels is not None:
             # Upcast to float if we need to compute the loss to avoid potential precision issues
             logits = logits.float()
-            shift_logits = logits[..., :-1, :]
-            shift_labels = labels[..., 1:]
-            if attention_mask is not None:
-                # we use the input attention mask to shift the logits and labels, because it is 2D.
-                # we also crop attn mask in case it is longer, which happens in PrefixTuning with peft
-                shift_attention_mask = attention_mask[:, -shift_logits.shape[1] :].to(logits.device)
-                shift_logits = shift_logits[shift_attention_mask.to(logits.device) != 0].contiguous()
-                shift_labels = shift_labels[shift_attention_mask.to(shift_labels.device) != 0].contiguous()
-            else:
-                shift_logits = shift_logits.contiguous()
-                shift_labels = shift_labels.contiguous()
-            # Flatten the tokens
-            loss_fct = nn.CrossEntropyLoss()
-
-            flat_logits = shift_logits.view(-1, self.config.text_config.vocab_size)
-            flat_labels = shift_labels.view(-1).to(shift_logits.device)
-            loss = loss_fct(flat_logits, flat_labels)
-        elif shift_labels is not None:
-            # Upcast to float if we need to compute the loss to avoid potential precision issues
-            logits = logits.float()
-            shift_logits = logits[..., :-1, :]
+            if shift_labels is None:
+                shift_labels = labels[..., 1:]
+            shift_logits = logits[..., : shift_labels.shape[1], :]
             if attention_mask is not None:
                 # we use the input attention mask to shift the logits and labels, because it is 2D.
                 # we also crop attn mask in case it is longer, which happens in PrefixTuning with peft

--- a/src/liger_kernel/transformers/model/paligemma.py
+++ b/src/liger_kernel/transformers/model/paligemma.py
@@ -152,37 +152,17 @@ def lce_forward(
     token_accuracy = None
     predicted_tokens = None
 
-    if skip_logits and labels is None:
-        raise ValueError("skip_logits is True, but labels is None")
+    if skip_logits and labels is None and shift_labels is None:
+        raise ValueError("skip_logits is True, but both labels and shift_labels are None")
 
     if skip_logits is None:
-        skip_logits = self.training and (labels is not None)
+        skip_logits = self.training and (labels is not None or shift_labels is not None)
 
     if skip_logits:
-        shift_hidden_states = hidden_states[..., :-1, :]
-        shift_labels = labels[..., 1:]
-
-        hidden_device = shift_hidden_states.device
-
-        if attention_mask is not None:
-            # we use the input attention mask to shift the hidden_states and labels, because it is 2D.
-            # we also crop attn mask in case it is longer, which happens in PrefixTuning with peft
-            shift_attention_mask = attention_mask[:, -shift_hidden_states.shape[1] :].to(hidden_device)
-            shift_hidden_states = shift_hidden_states[shift_attention_mask.to(hidden_device) != 0].contiguous()
-            shift_labels = shift_labels[shift_attention_mask.to(shift_labels.device) != 0].contiguous()
-        else:
-            shift_hidden_states = shift_hidden_states.contiguous()
-            shift_labels = shift_labels.contiguous()
-
-        # Flatten hidden state
-        shift_hidden_states = shift_hidden_states.view(-1, self.config.text_config.hidden_size)
-        shift_labels = shift_labels.view(-1).to(hidden_device)
-
-        # Use LigerForCausalLMLoss with accuracy support and pass already shifted labels
         result = LigerForCausalLMLoss(
-            hidden_states=shift_hidden_states,
+            hidden_states=hidden_states,
             lm_head_weight=self.language_model.lm_head.weight,
-            labels=None,
+            labels=labels,
             shift_labels=shift_labels,
             hidden_size=self.config.text_config.hidden_size,
             **lm_kwargs,
@@ -190,30 +170,12 @@ def lce_forward(
         loss, _, token_accuracy, predicted_tokens = unpack_cross_entropy_result(result)
     else:
         logits = self.language_model.lm_head(hidden_states)
-        if labels is not None:
+        if labels is not None or shift_labels is not None:
             # Upcast to float if we need to compute the loss to avoid potential precision issues
             logits = logits.float()
-            shift_logits = logits[..., :-1, :]
-            shift_labels = labels[..., 1:]
-            if attention_mask is not None:
-                # we use the input attention mask to shift the logits and labels, because it is 2D.
-                # we also crop attn mask in case it is longer, which happens in PrefixTuning with peft
-                shift_attention_mask = attention_mask[:, -shift_logits.shape[1] :].to(logits.device)
-                shift_logits = shift_logits[shift_attention_mask.to(logits.device) != 0].contiguous()
-                shift_labels = shift_labels[shift_attention_mask.to(shift_labels.device) != 0].contiguous()
-            else:
-                shift_logits = shift_logits.contiguous()
-                shift_labels = shift_labels.contiguous()
-            # Flatten the tokens
-            loss_fct = CrossEntropyLoss()
-
-            flat_logits = shift_logits.view(-1, self.config.text_config.vocab_size)
-            flat_labels = shift_labels.view(-1).to(shift_logits.device)
-            loss = loss_fct(flat_logits, flat_labels)
-        elif shift_labels is not None:
-            # Upcast to float if we need to compute the loss to avoid potential precision issues
-            logits = logits.float()
-            shift_logits = logits[..., :-1, :]
+            if shift_labels is None:
+                shift_labels = labels[..., 1:]
+            shift_logits = logits[..., : shift_labels.shape[1], :]
             if attention_mask is not None:
                 # we use the input attention mask to shift the logits and labels, because it is 2D.
                 # we also crop attn mask in case it is longer, which happens in PrefixTuning with peft


### PR DESCRIPTION
## Summary
Fixes three bugs in multimodal_forward() for Gemma3ForConditionalGeneration by aligning its skip_logits=True (CCE) branch with what causal_forward() already does for the text-only path.

The current convergence test (mini_gemma3 with fused_linear_cross_entropy=False) doesn't exercise either of the buggy code paths, which is why none of these have been caught before.

## Details

**Bug 1: shift_labels silently overwritten (skip_logits branch)**

```python
shift_labels = lm_kwargs.pop("shift_labels", None)
...
if skip_logits:
    shift_hidden_states = kept_hidden_states[..., :-1, :]
    shift_labels = labels[..., 1:]   # <-- discards the popped shift_labels
```

Any caller-supplied pre-shifted shift_labels is silently discarded.

**Bug 2: wrong output length (skip_logits branch)**

The manual pre-shift produces length T-1 tensors and then passes them as both labels= and shift_labels= into LigerForCausalLMLoss. The kernel honors the provided shift_labels (skipping its own pad-then-slice), so per-token output has length T-1 instead of T.

**Bug 3: latent shape mismatch in non-skip_logits branch**

Both the `if labels is not None` and `elif shift_labels is not None` sub-branches hardcode `shift_logits = logits[..., :-1, :]` (length T-1). That's correct for labels[..., 1:] (length T-1), but with a length-T pre-shifted shift_labels (the pad-then-slice convention), the subsequent CrossEntropyLoss shape-mismatches.

**The fix**
- skip_logits path: mirror causal_forward() – pass un-shifted kept_hidden_states and labels to LigerForCausalLMLoss with the popped shift_labels forwarded verbatim.
- non-skip_logits path: collapse the two near-identical if/elif branches into one, and slice shift_logits to match shift_labels.shape[1] so both length-T-1 (drop-first) and length-T (pad-then-slice) conventions work without shape mismatch.

## Testing Done

Apart from running the standard tests below, I also tried fine-tuning Gemma3 on multimodal data. On the current main branch and the latest release (0.8.0), fine-tuning fails with the shape mismatch error e.g. when calling `loss.view_as(input_ids)` (Bug 2), while it works with the fix and shows reasonable train/val losses.

- Hardware Type: H100-80Gb
- [x] run `make test` to ensure correctness -- 3705 passed, 25 failed, 882 skipped. The 25 failures are all in unrelated modules (chunked_loss, flex_attention, fused_linear_jsd, fused_neighborhood_attention, swiglu, plus one low-level liger_fused_linear_cross_entropy structured-output test that does not touch multimodal_forward). The most directly relevant existing test, test_apply_liger_kernel_to_instance_for_gemma3_conditional_generation (which compares inspect.getsource of the bound forward against multimodal_forward), passes.
- [x] run `make checkstyle` to ensure code style -- passes (278 files, all checks passed)
- [x] run `make test-convergence` to ensure convergence -- the fp32/test_mini_models.py session hit 19 pre-existing failures across non-gemma3-multimodal models. Re-ran the convergence tests that actually exercise the modified function directly: 1) fp32 test_mini_models_multimodal.py::mini_gemma3 — PASSED 2) bf16 test_mini_models_multimodal.py::mini_gemma3
