### PR TITLE
Improve ROCm source install extras

### DIFF
--- a/.github/workflows/amd-ci.yml
+++ b/.github/workflows/amd-ci.yml
@@ -7,12 +7,18 @@ on:
     paths:
       - "src/**"
       - "test/**"
+      - "setup.py"
+      - "pyproject.toml"
+      - ".github/workflows/amd-ci.yml"
   pull_request:
     branches:
       - main
     paths:
       - "src/**"
       - "test/**"
+      - "setup.py"
+      - "pyproject.toml"
+      - ".github/workflows/amd-ci.yml"
   merge_group:
     branches:
       - main
@@ -28,7 +34,7 @@ jobs:
     runs-on: linux-mi300-gpu-1
     strategy:
       matrix:
-        rocm_version: ['6.3']
+        rocm_version: ['7.1']
 
     steps:
     - name: Checkout code
@@ -43,8 +49,8 @@ jobs:
       run: |
         rocm-smi
         python -m pip install --upgrade pip
-        pip install -e .[dev]
-        pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm${{ matrix.rocm_version }}/
+        pip3 install torch torchvision --index-url https://download.pytorch.org/whl/rocm${{ matrix.rocm_version }}
+        pip install -e ".[dev]"
     
     - name: List Python Environments
       run: python -m pip list

--- a/README.md
+++ b/README.md
@@ -132,8 +132,7 @@ y = orpo_loss(lm_head.weight, x, target)
 - `triton >= 3.0.0` Install from pypi. (e.g. `pip install triton==3.0.0`)
 
 ```bash
-pip install -e .[dev]
-pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.3/
+pip3 install torch torchvision --index-url https://download.pytorch.org/whl/rocm7.2
 ```
 
 ### Optional Dependencies
@@ -164,10 +163,17 @@ git clone https://github.com/linkedin/Liger-Kernel.git
 cd Liger-Kernel
 
 # Install Default Dependencies
-# Setup.py will detect whether you are using AMD or NVIDIA
+# Setup.py will detect the local backend and select default dependencies.
+# On ROCm, install ROCm PyTorch first from the PyTorch ROCm index.
 pip install -e .
 
 # Setup Development Dependencies
+pip install -e ".[dev]"
+
+# ROCm source installs
+pip3 install torch torchvision --index-url https://download.pytorch.org/whl/rocm7.2
+# Then choose one:
+pip install -e .
 pip install -e ".[dev]"
 
 # Setup cuTile Dependencies
@@ -176,8 +182,6 @@ pip install -e ".[cutile]"
 # Or install cuTile with the optional tileiras compiler
 pip install -e ".[cutile-tileiras]"
 
-# NOTE -> For AMD users only
-pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.3/
 ```
 
 ### Enable cuTile Backend

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,10 +117,17 @@ git clone https://github.com/linkedin/Liger-Kernel.git
 cd Liger-Kernel
 
 # Install Default Dependencies
-# Setup.py will detect whether you are using AMD or NVIDIA
+# Setup.py will detect the local backend and select default dependencies.
+# On ROCm, install ROCm PyTorch first from the PyTorch ROCm index.
 pip install -e .
 
 # Setup Development Dependencies
+pip install -e ".[dev]"
+
+# ROCm source installs
+pip3 install torch torchvision --index-url https://download.pytorch.org/whl/rocm7.2
+# Then choose one:
+pip install -e .
 pip install -e ".[dev]"
 ```
 
@@ -135,6 +142,8 @@ pip install -e ".[dev]"
 
     - `torch >= 2.5.0` Install according to the instruction in Pytorch official webpage.
     - `triton >= 3.0.0` Install from pypi. (e.g. `pip install triton==3.0.0`)
+    - For ROCm source installs, install ROCm PyTorch first and then use `pip install -e .`.
+    - For ROCm source development, install ROCm PyTorch first and then use `pip install -e ".[dev]"`.
 
 !!!Tip "Optional Dependencies "
 

--- a/setup.py
+++ b/setup.py
@@ -39,25 +39,25 @@ def get_optional_dependencies():
     cutile_tileiras_deps = [
         "cuda-tile[tileiras]",
     ]
-
+    dev_deps = [
+        "transformers>=4.52.0",
+        "matplotlib>=3.7.2",
+        "ruff>=0.12.0",
+        "pytest>=7.1.2",
+        "pytest-xdist",
+        "pytest-cov",
+        "pytest-asyncio",
+        "pytest-rerunfailures",
+        "datasets>=2.19.2",
+        "seaborn",
+        "mkdocs-material",
+        "torchvision>=0.20",
+        "prek>=0.2.28",
+    ]
     return {
         "cutile": cutile_deps,
         "cutile-tileiras": cutile_tileiras_deps,
-        "dev": [
-            "transformers>=4.52.0",
-            "matplotlib>=3.7.2",
-            "ruff>=0.12.0",
-            "pytest>=7.1.2",
-            "pytest-xdist",
-            "pytest-cov",
-            "pytest-asyncio",
-            "pytest-rerunfailures",
-            "datasets>=2.19.2",
-            "seaborn",
-            "mkdocs-material",
-            "torchvision>=0.20",
-            "prek>=0.2.28",
-        ],
+        "dev": dev_deps,
     }
 
 


### PR DESCRIPTION
## Summary
Update ROCm source install instructions to install ROCm PyTorch wheels before installing Liger, so `pip install -e .` and `pip install -e ".[dev]"` work without replacing the ROCm torch stack. Align AMD CI with the same install order and ROCm wheel index.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
