### PR TITLE
Import ORPO from trl.experimental

### DIFF
--- a/examples/alignment/run_orpo.py
+++ b/examples/alignment/run_orpo.py
@@ -3,7 +3,11 @@ import torch
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer
-from trl import ORPOConfig  # noqa: F401
+
+try:
+    from trl.experimental.orpo import ORPOConfig  # noqa: F401
+except ImportError:
+    from trl import ORPOConfig  # noqa: F401
 
 from liger_kernel.transformers.trainer import LigerORPOTrainer  # noqa: F401
 

--- a/src/liger_kernel/transformers/trainer/orpo_trainer.py
+++ b/src/liger_kernel/transformers/trainer/orpo_trainer.py
@@ -8,7 +8,12 @@ import torch
 import torch.nn as nn
 
 from torch.distributed.fsdp import FullyShardedDataParallel
-from trl.trainer import ORPOTrainer
+
+try:
+    # TRL moved ORPO into trl.experimental; fall back to the old location for older TRL.
+    from trl.experimental.orpo import ORPOTrainer
+except ImportError:
+    from trl.trainer import ORPOTrainer
 
 from liger_kernel.chunked_loss import LigerFusedLinearORPOLoss
 from liger_kernel.transformers.fsdp import _FSDPForwardRedirection


### PR DESCRIPTION
`LigerORPOTrainer` imports `from trl.trainer import ORPOTrainer`, but recent trl moved ORPO into `trl.experimental.orpo`. `trl.trainer` is a lazy module and no longer exposes `ORPOTrainer`/`ORPOConfig`, so on a current trl that import just raises and `LigerORPOTrainer` can't be imported at all.

This tries `trl.experimental.orpo` first and falls back to the old `trl.trainer` location for older trl, so both work. Same change for the `run_orpo` example's `ORPOConfig` import.

Verified the old path is gone on current trl (`trl.trainer.ORPOTrainer` now raises `AttributeError`) and the experimental path resolves.