### PR TITLE
[NPU] optimize layer_norm for A3(X86)

### DIFF
--- a/src/liger_kernel/ops/backends/_ascend/ops/layer_norm.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/layer_norm.py
@@ -1,3 +1,7 @@
+"""Ascend LayerNorm: UB-aware fused 2D, row, or column-tiled Triton kernels."""
+
+import functools
+
 import torch
 import triton
 import triton.language as tl
@@ -8,13 +12,17 @@ from liger_kernel.ops.backends._ascend.ub_manager import compute_default_tiling_
 from liger_kernel.ops.utils import ensure_contiguous
 from liger_kernel.ops.utils import get_npu_core_count
 
-# -----------------------------------------------------------------------------
-# Optimized Forward Kernel - No Tiling (for n_cols <= 2048)
-# -----------------------------------------------------------------------------
+# Peak live fp32 2D tiles in fused forward (single X load, x_hat, Y).
+_FUSED_FWD_MEM_MULT = 6.0
+# Tighter estimate for full-width (4096) 2-row fused tiles: X_f32 + Y_f32 only.
+_FUSED_FWD_MEM_MULT_WIDE = 4.0
+# Peak live fp32 vectors in per-program backward reduction.
+_FUSED_BWD_MEM_MULT = 8.0
+_UB_SAFETY_MARGIN = 0.85
 
 
 @triton.jit
-def _layer_norm_forward_kernel_no_tiling(
+def _layer_norm_forward_row(
     Y_ptr,
     Y_row_stride,
     X_ptr,
@@ -28,86 +36,41 @@ def _layer_norm_forward_kernel_no_tiling(
     n_rows: tl.constexpr,
     n_cols: tl.constexpr,
     eps: tl.constexpr,
-    n_cols_inv: tl.constexpr,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
 ):
-    """
-    OPTIMIZED NPU layer_norm forward kernel for small n_cols (<= 2048).
+    """Grid-stride row forward when BLOCK_SIZE covers n_cols (no column mask).
 
-    Key optimizations:
-    1. Pre-compute n_cols_inv to avoid repeated scalar division
-    2. Hoist W and B loads outside the loop (already done)
-    3. Minimize per-iteration scalar operations
-    4. Use vectorized operations for mask handling
-    5. Optimize cache hints for memory access patterns
-    6. Reduce type conversions by keeping intermediate results in float32
+    One vector load per row; mean and rstd use E[x^2] - mean^2 in fp32, then affine.
     """
     pid = tl.program_id(0)
     num_progs = tl.num_programs(0)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    n_cols_inv = 1.0 / n_cols
 
-    # Pre-compute grid stride constants (done once, not per iteration)
-    grid_stride = num_progs * BLOCK_SIZE_M
-    num_iterations = tl.cdiv(n_rows, grid_stride)
+    W_row = tl.load(W_ptr + col_offsets)
+    B_row = tl.load(B_ptr + col_offsets)
 
-    col_offsets = tl.arange(0, BLOCK_SIZE_N)
-    col_mask = col_offsets < n_cols
-    row_offsets = tl.arange(0, BLOCK_SIZE_M)
+    for row_idx in tl.range(pid, n_rows, num_progs):
+        row_X_ptr = X_ptr + row_idx * X_row_stride
+        row_Y_ptr = Y_ptr + row_idx * Y_row_stride
+        row_Mean_ptr = Mean_ptr + row_idx * Mean_row_stride
+        row_RSTD_ptr = RSTD_ptr + row_idx * RSTD_row_stride
 
-    # Load W and B once (already optimized - kept outside loop)
-    W_row = tl.load(W_ptr + col_offsets, mask=col_mask, other=0.0).to(tl.float32)
-    B_row = tl.load(B_ptr + col_offsets, mask=col_mask, other=0.0).to(tl.float32)
+        X_row = tl.load(row_X_ptr + col_offsets)
+        X_f32 = X_row.to(tl.float32)
+        mean = tl.sum(X_f32, axis=0) * n_cols_inv
+        mean_sq = tl.sum(X_f32 * X_f32, axis=0) * n_cols_inv
+        rstd = rsqrt(mean_sq - mean * mean + eps)
 
-    base_row_idx = pid * BLOCK_SIZE_M
-
-    # Grid-stride loop over row blocks
-    for i in range(num_iterations):
-        row_idx = i * grid_stride + base_row_idx + row_offsets
-        row_mask = row_idx < n_rows
-
-        block_mask = row_mask[:, None] & col_mask[None, :]
-
-        X_block_ptr = X_ptr + row_idx[:, None] * X_row_stride + col_offsets[None, :]
-
-        X_rows = tl.load(
-            X_block_ptr,
-            mask=block_mask,
-            other=0.0,
-            cache_modifier=".cg",
-        ).to(tl.float32)
-
-        # Compute mean with vectorized operations
-        row_sum = tl.sum(X_rows, axis=1)
-        mean_rows = row_sum * n_cols_inv  # Multiplication is faster than division
-
-        # Center the data (vectorized operation)
-        X_centered = X_rows - mean_rows[:, None]
-
-        X_centered_masked = tl.where(block_mask, X_centered, 0.0)
-        var_rows = tl.sum(X_centered_masked * X_centered_masked, axis=1) * n_cols_inv
-
-        rstd_rows = rsqrt(var_rows + eps)
-
-        Mean_ptr_offset = Mean_ptr + row_idx * Mean_row_stride
-        RSTD_ptr_offset = RSTD_ptr + row_idx * RSTD_row_stride
-
-        tl.store(Mean_ptr_offset, mean_rows, mask=row_mask)
-        tl.store(RSTD_ptr_offset, rstd_rows, mask=row_mask)
-
-        Y_f32 = X_centered * rstd_rows[:, None] * W_row[None, :] + B_row[None, :]
-
-        # Store output with coalesced memory access
-        Y_block_ptr = Y_ptr + row_idx[:, None] * Y_row_stride + col_offsets[None, :]
-        tl.store(Y_block_ptr, Y_f32, mask=block_mask)
-
-
-# -----------------------------------------------------------------------------
-# Forward Kernel - With Tiling (for n_cols > 2048)
-# -----------------------------------------------------------------------------
+        tl.store(row_Mean_ptr, mean)
+        tl.store(row_RSTD_ptr, rstd)
+        x_hat = ((X_f32 - mean) * rstd).to(X_row.dtype)
+        Y_row = x_hat * W_row + B_row
+        tl.store(row_Y_ptr + col_offsets, Y_row)
 
 
 @triton.jit
-def _layer_norm_forward_kernel_npu(
+def _layer_norm_forward_fused_2d(
     Y_ptr,
     Y_row_stride,
     X_ptr,
@@ -120,179 +83,110 @@ def _layer_norm_forward_kernel_npu(
     RSTD_row_stride,
     n_rows: tl.constexpr,
     n_cols: tl.constexpr,
-    eps,
+    eps: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
+    ROWS_PER_BLOCK: tl.constexpr,
 ):
-    """NPU-optimized layer_norm forward kernel with column blocking."""
-    pid = tl.program_id(0)
-    num_progs = tl.num_programs(0)
-    num_col_blocks = tl.cdiv(n_cols, BLOCK_SIZE)
+    """2D fused forward: ROWS_PER_BLOCK rows x full n_cols, no column mask (E[x^2]-mean^2)."""
+    row_block_start = tl.program_id(0) * ROWS_PER_BLOCK
+    row_block_step = tl.num_programs(0) * ROWS_PER_BLOCK
 
-    offsets = tl.arange(0, BLOCK_SIZE)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    row_offsets = tl.arange(0, ROWS_PER_BLOCK)
     n_cols_inv = 1.0 / n_cols
 
-    for row_idx in range(pid, n_rows, num_progs):
-        Y_row_ptr = Y_ptr + row_idx * Y_row_stride
-        X_row_ptr = X_ptr + row_idx * X_row_stride
-        Mean_row_ptr = Mean_ptr + row_idx * Mean_row_stride
-        RSTD_row_ptr = RSTD_ptr + row_idx * RSTD_row_stride
+    W_f32 = tl.load(W_ptr + col_offsets).to(tl.float32)
+    B_f32 = tl.load(B_ptr + col_offsets).to(tl.float32)
 
-        row_sum = 0.0
+    for row_block_idx in tl.range(row_block_start, n_rows, row_block_step):
+        row_idx = row_block_idx + row_offsets
+        row_mask = row_idx < n_rows
 
-        for col_block_idx in range(num_col_blocks):
-            col_start = col_block_idx * BLOCK_SIZE
-            col_offsets = col_start + offsets
-            mask = col_offsets < n_cols
+        X_rows = tl.load(
+            X_ptr + row_idx[:, None] * X_row_stride + col_offsets[None, :],
+            mask=row_mask[:, None],
+            other=0.0,
+        )
+        X_f32 = X_rows.to(tl.float32)
 
-            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0, cache_modifier=".cg").to(tl.float32)
+        mean_rows = tl.sum(X_f32, axis=1) * n_cols_inv
+        mean_sq_rows = tl.sum(X_f32 * X_f32, axis=1) * n_cols_inv
+        rstd_rows = rsqrt(mean_sq_rows - mean_rows * mean_rows + eps)
 
-            row_sum += tl.sum(X_block)
+        tl.store(Mean_ptr + row_idx * Mean_row_stride, mean_rows, mask=row_mask)
+        tl.store(RSTD_ptr + row_idx * RSTD_row_stride, rstd_rows, mask=row_mask)
 
-        mean = row_sum * n_cols_inv
-
-        var_sum = 0.0
-
-        for col_block_idx in range(num_col_blocks):
-            col_start = col_block_idx * BLOCK_SIZE
-            col_offsets = col_start + offsets
-            mask = col_offsets < n_cols
-
-            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0, cache_modifier=".cg").to(tl.float32)
-
-            X_centered = X_block - mean
-            var_sum += tl.sum(tl.where(mask, X_centered * X_centered, 0.0))
-
-        var = var_sum * n_cols_inv
-        rstd = rsqrt(var + eps)
-
-        tl.store(Mean_row_ptr, mean)
-        tl.store(RSTD_row_ptr, rstd)
-
-        for col_block_idx in range(num_col_blocks):
-            col_start = col_block_idx * BLOCK_SIZE
-            col_offsets = col_start + offsets
-            mask = col_offsets < n_cols
-
-            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0, cache_modifier=".ca").to(tl.float32)
-            W_block = tl.load(W_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
-            B_block = tl.load(B_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
-
-            X_centered = X_block - mean
-            Y_f32 = X_centered * rstd * W_block + B_block
-
-            tl.store(Y_row_ptr + col_offsets, Y_f32.to(X_block.dtype), mask=mask)
-
-
-# -----------------------------------------------------------------------------
-# Optimized Backward Kernel - No Tiling (for n_cols <= 2048)
-# -----------------------------------------------------------------------------
+        Y_f32 = (X_f32 - mean_rows[:, None]) * rstd_rows[:, None] * W_f32[None, :] + B_f32[None, :]
+        tl.store(
+            Y_ptr + row_idx[:, None] * Y_row_stride + col_offsets[None, :],
+            Y_f32.to(X_rows.dtype),
+            mask=row_mask[:, None],
+        )
 
 
 @triton.jit
-def _layer_norm_backward_kernel_no_tiling(
+def _layer_norm_forward_tiled(
+    Y_ptr,
+    Y_row_stride,
     X_ptr,
     X_row_stride,
     W_ptr,
+    B_ptr,
     Mean_ptr,
     Mean_row_stride,
     RSTD_ptr,
     RSTD_row_stride,
-    DX_ptr,
-    DX_row_stride,
-    DW_scratch_ptr,
-    DW_scratch_stride,
-    DB_scratch_ptr,
-    DB_scratch_stride,
-    DY_ptr,
-    DY_row_stride,
     n_rows: tl.constexpr,
     n_cols: tl.constexpr,
-    n_cols_inv: tl.constexpr,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
+    eps: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
 ):
-    """
-    OPTIMIZED NPU layer_norm backward kernel for small n_cols (<= 2048).
-
-    Key optimizations:
-    1. Pre-compute n_cols_inv to avoid repeated division
-    2. Minimize scalar operations in the hot path
-    3. Reduce redundant mask computations
-    4. Optimize memory access patterns with better cache hints
-    5. Keep intermediate results in float32 to reduce conversions
-    6. Use vectorized operations throughout
-    """
+    """Fallback forward kernel that tiles columns when a full row does not fit UB."""
     pid = tl.program_id(0)
     num_progs = tl.num_programs(0)
+    num_col_blocks = tl.cdiv(n_cols, BLOCK_SIZE)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    n_cols_inv = 1.0 / n_cols
 
-    grid_stride = num_progs * BLOCK_SIZE_M
-    num_iterations = tl.cdiv(n_rows, grid_stride)
-
-    col_offsets = tl.arange(0, BLOCK_SIZE_N)
-    col_mask = col_offsets < n_cols
-    row_offsets = tl.arange(0, BLOCK_SIZE_M)
-
-    W_row = tl.load(W_ptr + col_offsets, mask=col_mask, other=0.0).to(tl.float32)
-
-    # Per-program accumulators for dW/dB
-    dW_acc = tl.zeros([BLOCK_SIZE_N], dtype=tl.float32)
-    dB_acc = tl.zeros([BLOCK_SIZE_N], dtype=tl.float32)
-
-    base_row_idx = pid * BLOCK_SIZE_M
-
-    # Grid-stride loop over row blocks
-    for i in range(num_iterations):
-        row_idx = i * grid_stride + base_row_idx + row_offsets
-        row_mask = row_idx < n_rows
-
-        # Pre-compute block mask once
-        block_mask = row_mask[:, None] & col_mask[None, :]
-
-        X_block_ptr = X_ptr + row_idx[:, None] * X_row_stride + col_offsets[None, :]
-        DY_block_ptr = DY_ptr + row_idx[:, None] * DY_row_stride + col_offsets[None, :]
+    for row_idx in tl.range(pid, n_rows, num_progs):
+        X_row_ptr = X_ptr + row_idx * X_row_stride
+        Y_row_ptr = Y_ptr + row_idx * Y_row_stride
         Mean_row_ptr = Mean_ptr + row_idx * Mean_row_stride
         RSTD_row_ptr = RSTD_ptr + row_idx * RSTD_row_stride
 
-        # Load all required data with appropriate cache hints
-        # .cg = cache global (read once, don't pollute cache)
-        X_rows = tl.load(X_block_ptr, mask=block_mask, other=0.0, cache_modifier=".cg").to(tl.float32)
-        DY_rows = tl.load(DY_block_ptr, mask=block_mask, other=0.0, cache_modifier=".cg").to(tl.float32)
-        mean_rows = tl.load(Mean_row_ptr, mask=row_mask, other=0.0).to(tl.float32)
-        rstd_rows = tl.load(RSTD_row_ptr, mask=row_mask, other=0.0).to(tl.float32)
+        # Three passes (mean, variance, affine): each needs a full column sweep.
+        row_sum = 0.0
+        for col_block_idx in range(num_col_blocks):
+            col_offsets = col_block_idx * BLOCK_SIZE + offsets
+            mask = col_offsets < n_cols
+            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
+            row_sum += tl.sum(X_block)
+        mean = row_sum * n_cols_inv
 
-        x_hat = (X_rows - mean_rows[:, None]) * rstd_rows[:, None]
-        wdy = W_row[None, :] * DY_rows
+        var_sum = 0.0
+        for col_block_idx in range(num_col_blocks):
+            col_offsets = col_block_idx * BLOCK_SIZE + offsets
+            mask = col_offsets < n_cols
+            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
+            x_hat = X_block - mean
+            var_sum += tl.sum(tl.where(mask, x_hat * x_hat, 0.0))
 
-        x_hat_wdy_masked = tl.where(block_mask, x_hat * wdy, 0.0)
-        wdy_masked = tl.where(block_mask, wdy, 0.0)
+        rstd = rsqrt(var_sum * n_cols_inv + eps)
+        tl.store(Mean_row_ptr, mean)
+        tl.store(RSTD_row_ptr, rstd)
 
-        c1 = tl.sum(x_hat_wdy_masked, axis=1) * n_cols_inv
-        c2 = tl.sum(wdy_masked, axis=1) * n_cols_inv
-
-        DX_f32 = (wdy - (x_hat * c1[:, None] + c2[:, None])) * rstd_rows[:, None]
-
-        # Store dX with coalesced memory access
-        DX_block_ptr = DX_ptr + row_idx[:, None] * DX_row_stride + col_offsets[None, :]
-        tl.store(DX_block_ptr, DX_f32.to(X_ptr.dtype.element_ty), mask=block_mask)
-
-        dW_acc += tl.sum(tl.where(block_mask, DY_rows * x_hat, 0.0), axis=0)
-        dB_acc += tl.sum(tl.where(block_mask, DY_rows, 0.0), axis=0)
-
-    # Write accumulated gradients to scratch buffers
-    DW_scratch_offset = DW_scratch_ptr + pid * DW_scratch_stride + col_offsets
-    DB_scratch_offset = DB_scratch_ptr + pid * DB_scratch_stride + col_offsets
-
-    tl.store(DW_scratch_offset, dW_acc, mask=col_mask)
-    tl.store(DB_scratch_offset, dB_acc, mask=col_mask)
-
-
-# -----------------------------------------------------------------------------
-# Backward Kernel - With Tiling (for n_cols > 2048)
-# -----------------------------------------------------------------------------
+        for col_block_idx in range(num_col_blocks):
+            col_offsets = col_block_idx * BLOCK_SIZE + offsets
+            mask = col_offsets < n_cols
+            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
+            W_block = tl.load(W_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
+            B_block = tl.load(B_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
+            Y_f32 = (X_block - mean) * rstd * W_block + B_block
+            tl.store(Y_row_ptr + col_offsets, Y_f32.to(X_block.dtype), mask=mask)
 
 
 @triton.jit
-def _layer_norm_backward_kernel_npu(
+def _layer_norm_backward_rows(
     X_ptr,
     X_row_stride,
     W_ptr,
@@ -310,15 +204,77 @@ def _layer_norm_backward_kernel_npu(
     n_cols: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
-    """NPU-optimized layer_norm backward kernel with column blocking."""
+    """Grid-stride row backward when BLOCK_SIZE covers n_cols.
+
+    Each program scans a row subset, writes dX, and atomically accumulates dW/dB.
+    """
+    pid = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+
+    cols = tl.arange(0, BLOCK_SIZE)
+    mask = cols < n_cols
+    n_cols_inv = 1.0 / n_cols
+
+    w = tl.load(W_ptr + cols, mask=mask, other=0.0)
+    w_f32 = w.to(tl.float32)
+    dW_row = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+    dB_row = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+
+    for row_idx in tl.range(pid, n_rows, num_progs):
+        row_X_ptr = X_ptr + row_idx * X_row_stride
+        row_DX_ptr = DX_ptr + row_idx * DX_row_stride
+        row_DY_ptr = DY_ptr + row_idx * DY_row_stride
+        row_Mean_ptr = Mean_ptr + row_idx * Mean_row_stride
+        row_RSTD_ptr = RSTD_ptr + row_idx * RSTD_row_stride
+
+        x = tl.load(row_X_ptr + cols, mask=mask, other=0.0)
+        dy = tl.load(row_DY_ptr + cols, mask=mask, other=0.0)
+        mean = tl.load(row_Mean_ptr).to(tl.float32)
+        rstd = tl.load(row_RSTD_ptr).to(tl.float32)
+
+        x_f32 = x.to(tl.float32)
+        dy_f32 = dy.to(tl.float32)
+        x_hat = (x_f32 - mean) * rstd
+        wdy = w_f32 * dy_f32
+        c1 = tl.sum(x_hat * wdy, axis=0) * n_cols_inv
+        c2 = tl.sum(wdy, axis=0) * n_cols_inv
+        dx = (wdy - (x_hat * c1 + c2)) * rstd
+
+        tl.store(row_DX_ptr + cols, dx.to(x.dtype), mask=mask)
+        dW_row += dy_f32 * x_hat
+        dB_row += dy_f32
+
+    tl.atomic_add(DW_ptr + cols, dW_row, mask=mask)
+    tl.atomic_add(DB_ptr + cols, dB_row, mask=mask)
+
+
+@triton.jit
+def _layer_norm_backward_tiled(
+    X_ptr,
+    X_row_stride,
+    W_ptr,
+    Mean_ptr,
+    Mean_row_stride,
+    RSTD_ptr,
+    RSTD_row_stride,
+    DX_ptr,
+    DX_row_stride,
+    DW_ptr,
+    DB_ptr,
+    DY_ptr,
+    DY_row_stride,
+    n_rows: tl.constexpr,
+    n_cols: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Fallback backward kernel using column tiles and per-tile atomics."""
     pid = tl.program_id(0)
     num_progs = tl.num_programs(0)
     num_col_blocks = tl.cdiv(n_cols, BLOCK_SIZE)
-
     offsets = tl.arange(0, BLOCK_SIZE)
     n_cols_inv = 1.0 / n_cols
 
-    for row_idx in range(pid, n_rows, num_progs):
+    for row_idx in tl.range(pid, n_rows, num_progs):
         X_row_ptr = X_ptr + row_idx * X_row_stride
         DY_row_ptr = DY_ptr + row_idx * DY_row_stride
         DX_row_ptr = DX_ptr + row_idx * DX_row_stride
@@ -330,19 +286,14 @@ def _layer_norm_backward_kernel_npu(
 
         sum_x_hat_wdy = 0.0
         sum_wdy = 0.0
-
         for col_block_idx in range(num_col_blocks):
-            col_start = col_block_idx * BLOCK_SIZE
-            col_offsets = col_start + offsets
+            col_offsets = col_block_idx * BLOCK_SIZE + offsets
             mask = col_offsets < n_cols
-
             X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
             DY_block = tl.load(DY_row_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
             W_block = tl.load(W_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
-
             x_hat = (X_block - mean) * rstd
             wdy = W_block * DY_block
-
             sum_x_hat_wdy += tl.sum(tl.where(mask, x_hat * wdy, 0.0))
             sum_wdy += tl.sum(tl.where(mask, wdy, 0.0))
 
@@ -350,106 +301,99 @@ def _layer_norm_backward_kernel_npu(
         c2 = sum_wdy * n_cols_inv
 
         for col_block_idx in range(num_col_blocks):
-            col_start = col_block_idx * BLOCK_SIZE
-            col_offsets = col_start + offsets
+            col_offsets = col_block_idx * BLOCK_SIZE + offsets
             mask = col_offsets < n_cols
-
             X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
             DY_block = tl.load(DY_row_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
             W_block = tl.load(W_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
-
             x_hat = (X_block - mean) * rstd
             wdy = W_block * DY_block
-
             DX_block = (wdy - (x_hat * c1 + c2)) * rstd
             tl.store(DX_row_ptr + col_offsets, DX_block.to(X_ptr.dtype.element_ty), mask=mask)
 
-            dW_block = DY_block * x_hat
-            dB_block = DY_block
-
-            tl.atomic_add(DW_ptr + col_offsets, dW_block, mask=mask)
-            tl.atomic_add(DB_ptr + col_offsets, dB_block, mask=mask)
+            tl.atomic_add(DW_ptr + col_offsets, DY_block * x_hat, mask=mask)
+            tl.atomic_add(DB_ptr + col_offsets, DY_block, mask=mask)
 
 
-# -----------------------------------------------------------------------------
-# Helper Functions
-# -----------------------------------------------------------------------------
-
-
-def get_optimal_block_size(n_cols, is_forward: bool):
-    """
-    Calculate optimal block size using compute_default_tiling_strategy.
-
-    Memory analysis for forward pass (per row):
-    - Load: X_block, W_block, B_block (3 blocks)
-    - Store: Y_block, Mean, RSTD (3 blocks)
-    - Compute: X_centered, Y intermediate (2 blocks)
-    - Total: conservative estimate 10 blocks of memory
-
-    Memory analysis for backward pass (per row):
-    - Load: X_block, DY_block, W_block, Mean, RSTD, existing_DW, existing_DB (7 blocks)
-    - Store: DX_block, new_DW, new_DB (3 blocks)
-    - Compute: x_hat, wdy, DX intermediate, dW_block, dB_block (5 blocks)
-    - Total: conservative estimate 15 blocks of memory
-
-    Args:
-        n_cols: Number of columns in the tensor
-        is_forward: Whether this is for forward pass (True) or backward pass (False)
-
-    Returns:
-        Optimal block size
-    """
-    if n_cols <= 2048:
-        return triton.next_power_of_2(n_cols)
-
-    memory_multiplier = 10.0 if is_forward else 15.0
-
+def _safe_column_block(n_cols: int, memory_multiplier: float) -> int:
+    """Largest power-of-2 column tile that fits in UB for 1D vector kernels."""
     tile_shapes = compute_default_tiling_strategy(
-        safety_margin=0.9,
+        safety_margin=_UB_SAFETY_MARGIN,
         dtype_size=4,
         memory_multiplier=memory_multiplier,
         shapes=((n_cols,),),
         tiling_dims=(0,),
     )
-
-    if tile_shapes and len(tile_shapes) > 0:
-        block_size = tile_shapes[0][0]
-        return max(2048, block_size)
-    else:
-        return 2048
+    if tile_shapes:
+        return max(128, tile_shapes[0][0])
+    return 1024
 
 
-def _compute_grid_size(n_rows: int, block_size_m: int, num_cores: int) -> int:
+def _safe_fused_rows_per_block(n_cols: int, col_block: int) -> int:
+    """Max row tile count for fused 2D kernel at a fixed column width."""
+    desired_rows = 8
+    mem_mult = _FUSED_FWD_MEM_MULT_WIDE if col_block >= n_cols and n_cols >= 2048 else _FUSED_FWD_MEM_MULT
+    tile_shapes = compute_default_tiling_strategy(
+        safety_margin=_UB_SAFETY_MARGIN,
+        dtype_size=4,
+        memory_multiplier=mem_mult,
+        shapes=((desired_rows, col_block),),
+        tiling_dims=(0,),
+    )
+    if tile_shapes:
+        return max(1, tile_shapes[0][0])
+    return 1
+
+
+@functools.lru_cache(maxsize=32)
+def _fused_forward_tile(n_cols: int) -> tuple[int, int, bool]:
     """
-    Compute the effective grid size for no-tiling kernels.
-
-    OPTIMIZATION: Balances parallelism with overhead
-    - Ensures enough work per program to amortize launch costs
-    - Avoids launching idle programs
-    - Caps at 2x core count for hardware concurrency
-    """
-    num_row_blocks = triton.cdiv(n_rows, block_size_m)
-
-    return min(num_cores * 2, num_row_blocks)
-
-
-# -----------------------------------------------------------------------------
-# Forward and Backward Functions
-# -----------------------------------------------------------------------------
-
-
-def layer_norm_forward(X, W, B, eps):
-    """
-    NPU-optimized forward pass for LayerNorm.
-
-    Args:
-        X: Input tensor of shape (..., hidden_size)
-        W: Weight tensor of shape (hidden_size,)
-        B: Bias tensor of shape (hidden_size,)
-        eps: Small constant for numerical stability
+    Plan fused-2D vs column-tiled forward.
 
     Returns:
-        Tuple of (output, input, mean, rstd)
+        (col_block, rows_per_block, use_fused_2d)
+    """
+    safe_col = _safe_column_block(n_cols, _FUSED_FWD_MEM_MULT)
+    col_pow2 = triton.next_power_of_2(n_cols)
+    col_block = min(col_pow2, safe_col)
+    # Mask-free kernels assume BLOCK_SIZE == n_cols; padded pow2 tiles need column masks.
+    if col_block < n_cols or col_pow2 > n_cols:
+        return _safe_column_block(n_cols, 8.0), 1, False
+
+    rows_per_block = _safe_fused_rows_per_block(n_cols, col_block)
+    return col_block, rows_per_block, True
+
+
+def _forward_grid_size(n_rows: int, num_cores: int) -> int:
+    """Launch count for mask-free row forward (oversubscribe vs. core count by n_rows)."""
+    if n_rows <= 1024:
+        return min(num_cores * 2, n_rows)
+    if n_rows >= 8192:
+        return min(num_cores * 4, n_rows)
+    if n_rows >= 4096:
+        return min(num_cores * 2, n_rows)
+    return min(num_cores, n_rows)
+
+
+def _backward_grid_size(n_rows: int, num_cores: int) -> int:
+    """Launch count for full-width row backward (one program per core, capped by n_rows)."""
+    return min(num_cores, n_rows)
+
+
+def layer_norm_forward(
+    X: torch.Tensor,
+    W: torch.Tensor,
+    B: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Forward LayerNorm on Ascend.
+
+    Dispatches mask-free row or fused-2D kernels when UB fits full-width tiles;
+    otherwise uses a three-pass column-tiled kernel with 2x grid oversubscription.
+
+    Returns:
+        (Y, X, Mean, RSTD) with Y reshaped to the input layout; X is the 2D view.
     """
     shape = X.shape
     dim = shape[-1]
@@ -462,43 +406,55 @@ def layer_norm_forward(X, W, B, eps):
             f"must match weight size (W.shape[0]={W.shape[0]})"
         )
 
-    # Get optimal block sizes
-    BLOCK_SIZE = get_optimal_block_size(n_cols, True)
-    BLOCK_SIZE_M = 2048 // BLOCK_SIZE
-
-    # Allocate output tensors
     Y = torch.empty((n_rows, n_cols), dtype=X.dtype, device=X.device)
-    Mean = torch.empty(n_rows, dtype=X.dtype, device=X.device)
-    RSTD = torch.empty(n_rows, dtype=X.dtype, device=X.device)
+    Mean = torch.empty(n_rows, dtype=torch.float32, device=X.device)
+    RSTD = torch.empty(n_rows, dtype=torch.float32, device=X.device)
 
     num_cores = get_npu_core_count()
+    col_block, rows_per_block, use_fused = _fused_forward_tile(n_cols)
 
-    # Choose kernel
-    if n_cols <= 2048:
-        grid_size = _compute_grid_size(n_rows, BLOCK_SIZE_M, num_cores)
-        n_cols_inv = 1.0 / float(n_cols)
-
-        _layer_norm_forward_kernel_no_tiling[(grid_size,)](
-            Y,
-            Y.stride(0),
-            X,
-            X.stride(0),
-            W,
-            B,
-            Mean,
-            Mean.stride(0),
-            RSTD,
-            RSTD.stride(0),
-            n_rows,
-            n_cols,
-            eps,
-            n_cols_inv,
-            BLOCK_SIZE_M=BLOCK_SIZE_M,
-            BLOCK_SIZE_N=BLOCK_SIZE,
-        )
+    if use_fused:
+        if rows_per_block <= 1:
+            num_programs = _forward_grid_size(n_rows, num_cores)
+            _layer_norm_forward_row[(num_programs,)](
+                Y,
+                Y.stride(0),
+                X,
+                X.stride(0),
+                W,
+                B,
+                Mean,
+                Mean.stride(0),
+                RSTD,
+                RSTD.stride(0),
+                n_rows,
+                n_cols,
+                eps,
+                BLOCK_SIZE=col_block,
+            )
+        else:
+            num_row_blocks = triton.cdiv(n_rows, rows_per_block)
+            num_programs = min(num_cores, num_row_blocks)
+            _layer_norm_forward_fused_2d[(num_programs,)](
+                Y,
+                Y.stride(0),
+                X,
+                X.stride(0),
+                W,
+                B,
+                Mean,
+                Mean.stride(0),
+                RSTD,
+                RSTD.stride(0),
+                n_rows,
+                n_cols,
+                eps,
+                BLOCK_SIZE=col_block,
+                ROWS_PER_BLOCK=rows_per_block,
+            )
     else:
-        grid_size = min(num_cores, n_rows)
-        _layer_norm_forward_kernel_npu[(grid_size,)](
+        num_programs = min(num_cores * 2, n_rows)
+        _layer_norm_forward_tiled[(num_programs,)](
             Y,
             Y.stride(0),
             X,
@@ -512,81 +468,51 @@ def layer_norm_forward(X, W, B, eps):
             n_rows,
             n_cols,
             eps,
-            BLOCK_SIZE=BLOCK_SIZE,
+            BLOCK_SIZE=col_block,
         )
 
     return Y.view(*shape), X, Mean, RSTD
 
 
-def layer_norm_backward(dY, X, W, B, Mean, RSTD):
+def layer_norm_backward(
+    dY: torch.Tensor,
+    X: torch.Tensor,
+    W: torch.Tensor,
+    _B: torch.Tensor,
+    Mean: torch.Tensor,
+    RSTD: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
-    NPU-optimized backward pass for LayerNorm.
-
+    Backward LayerNorm matching tensors saved by layer_norm_forward (_B unused).
     Args:
         dY: Gradient of output
         X: Input tensor
         W: Weight tensor
-        B: Bias tensor
+        _B: Bias tensor
         Mean: Pre-computed mean
         RSTD: Pre-computed reciprocal standard deviation
 
     Returns:
         Tuple of (input_grad, weight_grad, bias_grad)
     """
+
     shape = dY.shape
     dim = shape[-1]
     dY = dY.view(-1, dim)
     n_rows, n_cols = dY.shape
 
-    # Get optimal block sizes
-    BLOCK_SIZE = get_optimal_block_size(n_cols, False)
-    BLOCK_SIZE_M = 2048 // BLOCK_SIZE
-
     num_cores = get_npu_core_count()
-
-    # Allocate gradient tensors
     DX = torch.empty((n_rows, n_cols), dtype=X.dtype, device=X.device)
+    safe_col = _safe_column_block(n_cols, _FUSED_BWD_MEM_MULT)
+    col_block = min(triton.next_power_of_2(n_cols), safe_col)
 
-    # Choose kernel
-    if n_cols <= 2048:
-        grid_size = _compute_grid_size(n_rows, BLOCK_SIZE_M, num_cores)
-        DW_scratch = torch.empty((grid_size, n_cols), dtype=torch.float32, device=W.device)
-        DB_scratch = torch.empty((grid_size, n_cols), dtype=torch.float32, device=W.device)
+    DW = torch.zeros(n_cols, dtype=torch.float32, device=W.device)
+    DB = torch.zeros(n_cols, dtype=torch.float32, device=W.device)
 
-        n_cols_inv = 1.0 / float(n_cols)
+    if col_block >= n_cols:
+        grid_size = _backward_grid_size(n_rows, num_cores)
 
-        _layer_norm_backward_kernel_no_tiling[(grid_size,)](
-            X,
-            X.stride(0),
-            W,
-            Mean,
-            Mean.stride(0),
-            RSTD,
-            RSTD.stride(0),
-            DX,
-            DX.stride(0),
-            DW_scratch,
-            DW_scratch.stride(0),
-            DB_scratch,
-            DB_scratch.stride(0),
-            dY,
-            dY.stride(0),
-            n_rows,
-            n_cols,
-            n_cols_inv,
-            BLOCK_SIZE_M=BLOCK_SIZE_M,
-            BLOCK_SIZE_N=BLOCK_SIZE,
-        )
-
-        DW = DW_scratch.sum(dim=0)
-        DB = DB_scratch.sum(dim=0)
-    else:
-        grid_size = min(num_cores, n_rows)
-
-        DW = torch.zeros(n_cols, dtype=torch.float32, device=W.device)
-        DB = torch.zeros(n_cols, dtype=torch.float32, device=W.device)
-
-        _layer_norm_backward_kernel_npu[(grid_size,)](
+        _layer_norm_backward_rows[(grid_size,)](
             X,
             X.stride(0),
             W,
@@ -602,34 +528,46 @@ def layer_norm_backward(dY, X, W, B, Mean, RSTD):
             dY.stride(0),
             n_rows,
             n_cols,
-            BLOCK_SIZE=BLOCK_SIZE,
+            BLOCK_SIZE=col_block,
+        )
+    else:
+        col_block = _safe_column_block(n_cols, 10.0)
+        num_programs = min(num_cores * 2, n_rows)
+
+        _layer_norm_backward_tiled[(num_programs,)](
+            X,
+            X.stride(0),
+            W,
+            Mean,
+            Mean.stride(0),
+            RSTD,
+            RSTD.stride(0),
+            DX,
+            DX.stride(0),
+            DW,
+            DB,
+            dY,
+            dY.stride(0),
+            n_rows,
+            n_cols,
+            BLOCK_SIZE=col_block,
         )
 
-    return DX.view(*shape), DW.to(W.dtype), DB.to(B.dtype)
+    return DX.view(*shape), DW.to(W.dtype), DB.to(_B.dtype)
 
 
 # -----------------------------------------------------------------------------
 # Autograd Function
-# -----------------------------------------------------------------------------
+# ---
 
 
 class LigerLayerNormFunction(torch.autograd.Function):
-    """
-    OPTIMIZED NPU LayerNorm operation.
-
-    Key optimizations for no-tiling kernels:
-    1. Pre-compute 1/n_cols to avoid scalar division (40.6% → <30% target)
-    2. Minimize per-iteration scalar operations in grid-stride loops
-    3. Hoist constant computations outside loops
-    4. Use vectorized operations throughout
-    5. Optimize memory access patterns with better cache hints
-    6. Reduce type conversions by keeping intermediates in float32
-    7. Improve grid sizing for better work distribution
-    """
+    """torch.autograd.Function for Ascend UB-aware LayerNorm kernels."""
 
     @staticmethod
     @ensure_contiguous
     def forward(ctx, X, W, B, eps):
+        """Forward pass; saves X, W, B, Mean, and RSTD for backward."""
         Y, X, Mean, RSTD = layer_norm_forward(X, W, B, eps)
         ctx.save_for_backward(X, W, B, Mean, RSTD)
         return Y
@@ -637,6 +575,7 @@ class LigerLayerNormFunction(torch.autograd.Function):
     @staticmethod
     @ensure_contiguous
     def backward(ctx, dY):
+        """Backward pass; returns (dX, dW, dB, None) for non-differentiable eps."""
         X, W, B, Mean, RSTD = ctx.saved_tensors
         DX, DW, DB = layer_norm_backward(dY, X, W, B, Mean, RSTD)
         return DX, DW, DB, None


### PR DESCRIPTION
## Summary

improve LayerNorm throughput on Ascend A3 for common hidden sizes (e.g. 4096) while staying within UB limits.

## Details

Replace the fixed n_cols<=2048 split with UB-based tiling that picks mask-free row, fused multi-row 2D, or column-tiled forward kernels. Use E[x^2]-mean^2 for fused paths, store Mean/RSTD in fp32, and tune grid size for Ascend910 token counts. Backward now accumulates dW/dB via atomic_add instead of per-program scratch buffers.

## Testing Done

forward:
<img width="1286" height="378" alt="image" src="https://github.com/user-attachments/assets/4da0279b-3560-43b3-98a7-5213499aaaab" />

backward:
<img width="1515" height="449" alt="image" src="https://github.com/user-attachments/assets/cc5b7147-d6b3-4a37-86e9-c0657d1a1285" />

full:
<img width="1568" height="457" alt="image" src="https://github.com/user-attachments/assets/65e3d75b-89fe-4f85-b641-a3ed1382efcc" />


ut:
<img width="1093" height="376" alt="image" src="https://github.com/user-attachments/assets/cbf56231-d3b6-43c8-847b-a6bba0261397" />

tested with Atlas 800T-A3 x86

- Hardware Type: <BLANK>
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
