### PR TITLE
[NPU] remove ineffective params for ASCEND NPU

### DIFF
--- a/src/liger_kernel/ops/backends/_ascend/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/cross_entropy.py
@@ -133,7 +133,6 @@ def liger_cross_entropy_forward_kernel(
                     logits_row_ptr + X_offsets,
                     mask=X_offsets < n_cols,
                     other=float("-inf"),
-                    eviction_policy="evict_first",
                 ).cast(tl.float32)
                 if HAS_SOFTCAPPING:
                     X_block = softcap * tanh(X_block / softcap)
@@ -248,7 +247,6 @@ def liger_cross_entropy_forward_kernel_plain(
             logits_row_ptr + offs,
             mask=offs < n_cols,
             other=float("-inf"),
-            eviction_policy="evict_first",
         ).cast(tl.float32)
         block_max = tl.max(x)
         m_new = tl.maximum(m, block_max)
@@ -356,7 +354,6 @@ def liger_cross_entropy_backward_kernel_no_weight(
                     X_ptr + X_ptr_offset + X_offsets,
                     mask=X_offsets < n_cols,
                     other=float("-inf"),
-                    eviction_policy="evict_first",
                 ).cast(tl.float32)
                 grad = tl.exp(X_block - lse) * final_scale
                 tl.store(dX_ptr + dX_ptr_offset + X_offsets, grad, mask=X_offsets < n_cols)
@@ -461,7 +458,6 @@ def liger_cross_entropy_backward_kernel(
                     X_ptr + X_ptr_offset + X_offsets,
                     mask=X_offsets < n_cols,
                     other=float("-inf"),
-                    eviction_policy="evict_first",
                 ).cast(tl.float32)
                 if HAS_SOFTCAPPING:
                     intermediate = tanh(X_block / softcap)

--- a/src/liger_kernel/ops/backends/_ascend/ops/fused_add_rms_norm.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/fused_add_rms_norm.py
@@ -89,13 +89,11 @@ def _fused_add_rms_norm_forward_kernel_no_tiling(
             X_ptr + row_idx[:, None] * X_row_stride + col_offsets[None, :],
             mask=block_mask,
             other=0.0,
-            eviction_policy="evict_first",
         )
         R_rows = tl.load(
             R_ptr + row_idx[:, None] * R_row_stride + col_offsets[None, :],
             mask=block_mask,
             other=0.0,
-            eviction_policy="evict_first",
         )
         S_rows = X_rows + R_rows
 
@@ -114,7 +112,6 @@ def _fused_add_rms_norm_forward_kernel_no_tiling(
             S_ptr + row_idx[:, None] * S_row_stride + col_offsets[None, :],
             S_rows,
             mask=block_mask,
-            cache_modifier=".cg",
         )
         tl.store(RSTD_ptr + row_idx * RSTD_row_stride, rstd_rows, mask=row_mask)
 
@@ -195,12 +192,12 @@ def _fused_add_rms_norm_forward_kernel_npu(
             col_offsets = col_start + offsets
             mask = col_offsets < n_cols
 
-            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0, eviction_policy="evict_first")
-            R_block = tl.load(R_row_ptr + col_offsets, mask=mask, other=0.0, eviction_policy="evict_first")
+            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0)
+            R_block = tl.load(R_row_ptr + col_offsets, mask=mask, other=0.0)
             S_block = X_block + R_block
 
             # Store S_row
-            tl.store(S_row_ptr + col_offsets, S_block, mask=mask, cache_modifier=".cg")
+            tl.store(S_row_ptr + col_offsets, S_block, mask=mask)
 
             if casting_mode == _CASTING_MODE_LLAMA or casting_mode == _CASTING_MODE_GEMMA:
                 S_block = S_block.to(tl.float32)
@@ -223,7 +220,7 @@ def _fused_add_rms_norm_forward_kernel_npu(
             mask = col_offsets < n_cols
 
             # Load S_block (already computed in first pass)
-            S_block = tl.load(S_row_ptr + col_offsets, mask=mask, other=0.0, cache_modifier=".ca")
+            S_block = tl.load(S_row_ptr + col_offsets, mask=mask, other=0.0)
             W_block = tl.load(W_ptr + col_offsets, mask=mask, other=0.0)
 
             # Apply casting based on mode
@@ -314,13 +311,11 @@ def _fused_add_rms_norm_backward_kernel_no_tiling(
             dY_ptr + row_idx[:, None] * dY_row_stride + col_offsets[None, :],
             mask=block_mask,
             other=0.0,
-            eviction_policy="evict_first",
         )
         X_rows = tl.load(
             X_ptr + row_idx[:, None] * X_row_stride + col_offsets[None, :],
             mask=block_mask,
             other=0.0,
-            eviction_policy="evict_first",
         )
 
         # Load rstd for all rows in the block

--- a/src/liger_kernel/ops/backends/_ascend/ops/fused_moe_kernels.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/fused_moe_kernels.py
@@ -222,7 +222,6 @@ def _fused_up_proj_swiglu_kernel(
             x_ptrs,
             mask=row_mask[:, None] & k_mask[None, :],
             other=0.0,
-            eviction_policy="evict_first",  # token rows not reused; free L2 for weights
         )
 
         w_mask = n_mask[:, None] & k_mask[None, :]

--- a/src/liger_kernel/ops/backends/_ascend/ops/poly_norm.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/poly_norm.py
@@ -65,7 +65,6 @@ def _poly_norm_forward_kernel_no_tiling(
             X_ptr + row_idx[:, None] * X_row_stride + col_offsets[None, :],
             mask=block_mask,
             other=0.0,
-            cache_modifier=".cg",
         )
 
         X_f32 = X_rows.to(tl.float32)
@@ -171,7 +170,7 @@ def _poly_norm_forward_kernel_npu(
             col_offsets = col_start + offsets
             mask = col_offsets < n_cols
 
-            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0, cache_modifier=".cg").to(tl.float32)
+            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
 
             # Compute powers
             X_pow3 = X_block * X_block * X_block
@@ -203,7 +202,7 @@ def _poly_norm_forward_kernel_npu(
             mask = col_offsets < n_cols
 
             # Load input
-            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0, cache_modifier=".ca").to(tl.float32)
+            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
 
             # Compute powers
             X_pow3 = X_block * X_block * X_block
@@ -291,13 +290,11 @@ def _poly_norm_backward_kernel_no_tiling(
             X_ptr + row_idx[:, None] * X_row_stride + col_offsets[None, :],
             mask=block_mask,
             other=0.0,
-            cache_modifier=".cg",
         )
         dY_rows = tl.load(
             dY_ptr + row_idx[:, None] * dY_row_stride + col_offsets[None, :],
             mask=block_mask,
             other=0.0,
-            cache_modifier=".cg",
         )
 
         # Load cached rstd values (3 values per row)

--- a/src/liger_kernel/ops/backends/_ascend/ops/rms_norm.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/rms_norm.py
@@ -86,7 +86,6 @@ def _rms_norm_forward_kernel_no_tiling(
             X_ptr + row_idx[:, None] * X_row_stride + col_offsets[None, :],
             mask=block_mask,
             other=0.0,
-            eviction_policy="evict_first",
         )
 
         # Compute sum_square for all rows
@@ -193,7 +192,7 @@ def _rms_norm_forward_kernel_tiled(
             col_offsets = col_start + offsets
             mask = col_offsets < n_cols
 
-            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0, eviction_policy="evict_first")
+            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0)
 
             if casting_mode == _CASTING_MODE_LLAMA or casting_mode == _CASTING_MODE_GEMMA:
                 X_block = X_block.to(tl.float32)
@@ -216,7 +215,7 @@ def _rms_norm_forward_kernel_tiled(
             mask = col_offsets < n_cols
 
             # Load X_block
-            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0, cache_modifier=".ca")
+            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0)
 
             if elementwise_affine:
                 W_block = tl.load(W_ptr + col_offsets, mask=mask, other=0.0)
@@ -313,13 +312,11 @@ def _rms_norm_backward_kernel_no_tiling(
             dY_ptr + row_idx[:, None] * dY_row_stride + col_offsets[None, :],
             mask=block_mask,
             other=0.0,
-            eviction_policy="evict_first",
         )
         X_rows = tl.load(
             X_ptr + row_idx[:, None] * X_row_stride + col_offsets[None, :],
             mask=block_mask,
             other=0.0,
-            eviction_policy="evict_first",
         )
 
         # Load rstd for all rows in the block
@@ -428,14 +425,14 @@ def _rms_norm_backward_kernel_tiled(
             col_offsets = col_start + offsets
             mask = col_offsets < n_cols
 
-            dY_block = tl.load(dY_row_ptr + col_offsets, mask=mask, other=0.0, eviction_policy="evict_first")
-            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0, eviction_policy="evict_first")
+            dY_block = tl.load(dY_row_ptr + col_offsets, mask=mask, other=0.0)
+            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0)
 
             # Convert to fp32 for computation
             X_block = X_block.to(tl.float32)
 
             if elementwise_affine:
-                W_block = tl.load(W_ptr + col_offsets, mask=mask, other=0.0, eviction_policy="evict_first")
+                W_block = tl.load(W_ptr + col_offsets, mask=mask, other=0.0)
                 W_offset = W_block + offset
 
                 # Compute m based on casting mode

--- a/src/liger_kernel/ops/backends/_ascend/ops/softmax.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/softmax.py
@@ -99,9 +99,7 @@ def _softmax_multi_block_forward_kernel(
         for start in tl.range(0, n_cols, BLOCK_SIZE):
             idx = start + col_offsets
             mask = idx < n_cols
-            xblk = tl.load(
-                row_start_ptr + idx, mask=mask, other=float("-inf"), eviction_policy="evict_first", cache_modifier=".ca"
-            )
+            xblk = tl.load(row_start_ptr + idx, mask=mask, other=float("-inf"))
             blk_max = tl.max(xblk, axis=0)
             new_m = tl.maximum(m, blk_max)
             d = d * tl.exp(m - new_m) + tl.sum(tl.exp(xblk - new_m), axis=0)
@@ -110,11 +108,9 @@ def _softmax_multi_block_forward_kernel(
         for start in tl.range(0, n_cols, BLOCK_SIZE):
             idx = start + col_offsets
             mask = idx < n_cols
-            xblk = tl.load(
-                row_start_ptr + idx, mask=mask, other=float("-inf"), eviction_policy="evict_first", cache_modifier=".ca"
-            )
+            xblk = tl.load(row_start_ptr + idx, mask=mask, other=float("-inf"))
             yblk = tl.exp(xblk - m) / d
-            tl.store(Y_ptr + row_idx * Y_row_stride + idx, yblk, mask=mask, cache_modifier=".cs")
+            tl.store(Y_ptr + row_idx * Y_row_stride + idx, yblk, mask=mask)
 
 
 @triton.jit
@@ -218,19 +214,17 @@ def _softmax_multi_block_backward_kernel(
         for start in tl.range(0, n_cols, BLOCK_SIZE):
             idx = start + col_offsets
             mask = idx < n_cols
-            dy_blk = tl.load(dy_start_ptr + idx, mask=mask, other=0.0, eviction_policy="evict_first")
-            y_blk = tl.load(
-                y_start_ptr + idx, mask=mask, other=0.0, eviction_policy="evict_first", cache_modifier=".ca"
-            )
+            dy_blk = tl.load(dy_start_ptr + idx, mask=mask, other=0.0)
+            y_blk = tl.load(y_start_ptr + idx, mask=mask, other=0.0)
             acc += tl.sum(dy_blk * y_blk, axis=0)
 
         for start in tl.range(0, n_cols, BLOCK_SIZE):
             idx = start + col_offsets
             mask = idx < n_cols
             dy_blk = tl.load(dy_start_ptr + idx, mask=mask, other=0.0)
-            y_blk = tl.load(y_start_ptr + idx, mask=mask, other=0.0, cache_modifier=".ca")
+            y_blk = tl.load(y_start_ptr + idx, mask=mask, other=0.0)
             dx_blk = y_blk * (dy_blk - acc)
-            tl.store(dx_ptr + row_idx * dx_stride + idx, dx_blk, mask=mask, cache_modifier=".wb")
+            tl.store(dx_ptr + row_idx * dx_stride + idx, dx_blk, mask=mask)
 
 
 def _softmax_forward(x):

--- a/src/liger_kernel/ops/backends/_ascend/ops/sparsemax.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/sparsemax.py
@@ -47,7 +47,6 @@ def _sparsemax_forward_kernel(
             ptr_sorted_x_data_row + offs,
             mask=mask,
             other=-float("inf"),
-            cache_modifier=".cg",
         ).to(tl.float32)
 
         z_valid = tl.where(mask, z_sorted_block, 0.0)
@@ -68,7 +67,6 @@ def _sparsemax_forward_kernel(
             ptr_x_data_row + offs,
             mask=mask,
             other=0.0,
-            cache_modifier=".cg",
         ).to(tl.float32)
 
         y = tl.maximum(x_block - tau, 0.0)
@@ -77,7 +75,6 @@ def _sparsemax_forward_kernel(
             ptr_output_row + offs,
             y.to(ptr_output_row.dtype.element_ty),
             mask=mask,
-            cache_modifier=".cs",
         )
 
 
@@ -128,7 +125,7 @@ def _sparsemax_forward_tiled_kernel(
             idx = tile * BLOCK_SIZE + offs
             mask = idx < n_cols
 
-            z = tl.load(sorted_row_ptr + idx, mask=mask, other=0.0, cache_modifier=".ca").to(tl.float32)
+            z = tl.load(sorted_row_ptr + idx, mask=mask, other=0.0).to(tl.float32)
 
             cssv = tl.cumsum(z, axis=0) + running_sum
             r = (idx + 1).to(tl.float32)
@@ -148,10 +145,10 @@ def _sparsemax_forward_tiled_kernel(
             idx = tile * BLOCK_SIZE + offs
             mask = idx < n_cols
 
-            x = tl.load(x_row_ptr + idx, mask=mask, other=0.0, cache_modifier=".ca").to(tl.float32)
+            x = tl.load(x_row_ptr + idx, mask=mask, other=0.0).to(tl.float32)
             y = tl.maximum(x - tau, 0.0)
 
-            tl.store(out_row_ptr + idx, y.to(out_row_ptr.dtype.element_ty), mask=mask, cache_modifier=".cs")
+            tl.store(out_row_ptr + idx, y.to(out_row_ptr.dtype.element_ty), mask=mask)
 
 
 @triton.jit
@@ -230,7 +227,7 @@ def _sparsemax_backward_tiled_kernel(
         for i in tl.range(0, tl.cdiv(n_cols, BLOCK_SIZE)):
             offs_iter = i * BLOCK_SIZE + offs
             mask_iter = offs_iter < n_cols
-            o_val = tl.load(o_row + offs_iter, mask=mask_iter, other=0.0, cache_modifier=".ca").to(tl.float32)
+            o_val = tl.load(o_row + offs_iter, mask=mask_iter, other=0.0).to(tl.float32)
             go_val = tl.load(go_row + offs_iter, mask=mask_iter, other=0.0).to(tl.float32)
             supp = o_val > 0
             go_sum += tl.sum(tl.where(supp, go_val, 0.0))
@@ -239,7 +236,7 @@ def _sparsemax_backward_tiled_kernel(
         for i in tl.range(0, tl.cdiv(n_cols, BLOCK_SIZE)):
             offs_iter = i * BLOCK_SIZE + offs
             mask_iter = offs_iter < n_cols
-            o_val = tl.load(o_row + offs_iter, mask=mask_iter, other=0.0, cache_modifier=".ca").to(tl.float32)
+            o_val = tl.load(o_row + offs_iter, mask=mask_iter, other=0.0).to(tl.float32)
             go_val = tl.load(go_row + offs_iter, mask=mask_iter, other=0.0).to(tl.float32)
 
             supp = o_val > 0
@@ -248,7 +245,7 @@ def _sparsemax_backward_tiled_kernel(
                 go_val - tl.cast(go_sum / tl.maximum(supp_cnt, 1e-6), gi_row.dtype.element_ty).to(tl.float32),
                 0.0,
             )
-            tl.store(gi_row + offs_iter, gi_val.to(gi_row.dtype.element_ty), mask=mask_iter, cache_modifier=".cs")
+            tl.store(gi_row + offs_iter, gi_val.to(gi_row.dtype.element_ty), mask=mask_iter)
 
 
 def sparsemax_forward(x, dim):

--- a/test/transformers/test_fused_add_rms_norm.py
+++ b/test/transformers/test_fused_add_rms_norm.py
@@ -124,6 +124,7 @@ class GemmaAddRMSNorm(nn.Module):
     ],
 )
 def test_correctness(bs, sl, hd, dtype, atol, rtol, reference, offset, casting_mode, in_place):
+    set_seed(42)
     _tensor = torch.randn(bs, sl, hd, device=device, dtype=dtype)
     _residual = torch.randn(bs, sl, hd, device=device, dtype=dtype)
 


### PR DESCRIPTION
## Summary

remove ineffective params for ASCEND NPU and fix ut.

## Details

1. Refer to docs at: https://github.com/triton-lang/triton-ascend/blob/e9fcd7ddabbbc6de9579a18e507e8f12afbc840c/docs/zh/triton_api/Memory_Pointer_Ops/tl.store.md?plain=1#L31-L32 cache_modifier and eviction_policy are ineffective for Ascend devices. so, remove these params from ascend ops.

2. When running the full set of unit tests, certain test cases for the fused_add_rms_norm kernel fail, whereas standalone unit test execution for this kernel passes without issues. Further investigation shows that the full-test suite generates different random input values which hit an edge case: under bfloat16 with casting_mode="none", the numerical error of weight.grad sits right at the tolerance threshold. We fix the random seed to enforce identical random inputs.

## Testing Done

<img width="2212" height="364" alt="image" src="https://github.com/user-attachments/assets/24dfef68-c1a4-449b-b4bf-03a9a21dd18c" />

Tested with Atlas 800T A3(X86)


- Hardware Type: <BLANK>
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
