### PR TITLE
Add inplace=False to liger_cross_entropy to fix upstream gradient corruption (#272)

### DIFF
--- a/src/liger_kernel/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cross_entropy.py
@@ -336,6 +336,11 @@ def cross_entropy_forward(
     BT, V = _input.shape
     n_rows = BT
 
+    # Capture requires_grad before any clone/contiguous below. Those run inside
+    # the autograd Function (grad disabled), so the resulting tensor would report
+    # requires_grad=False and the kernel would skip writing the gradient.
+    requires_grad = _input.requires_grad
+
     BLOCK_SIZE = min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
 
     # unreduced loss
@@ -417,7 +422,7 @@ def cross_entropy_forward(
         BLOCK_SIZE=BLOCK_SIZE,
         HAS_WEIGHT=True if weight is not None else False,
         HAS_SOFTCAPPING=True if softcap is not None else False,
-        HAS_GRADIENTS=_input.requires_grad,
+        HAS_GRADIENTS=requires_grad,
         # TODO: 32 seems to give the best performance
         # Performance is quite sensitive to num_warps
         num_warps=32 if not is_hip() else 16,

--- a/src/liger_kernel/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cross_entropy.py
@@ -323,6 +323,7 @@ def cross_entropy_forward(
     return_z_loss,
     return_token_accuracy=False,
     return_predicted_tokens=False,
+    inplace=True,
 ):
     assert isinstance(return_z_loss, bool), f"return_z_loss must be True or False. Got: {return_z_loss}"
     assert isinstance(return_token_accuracy, bool), (
@@ -371,6 +372,17 @@ def cross_entropy_forward(
         _input = _input.contiguous()
     if target.stride(-1) != 1:
         target = target.contiguous()
+
+    # The kernel below stores the gradient back into its input buffer to save
+    # memory. When `inplace=False`, operate on a copy so the caller's tensor is
+    # not silently overwritten. This matters when an upstream op (e.g. softmax)
+    # saved this exact tensor for its own backward: because the gradient is
+    # written by a Triton kernel, PyTorch's version counter is not bumped and the
+    # in-place-correctness check never fires, so the upstream op would otherwise
+    # compute wrong gradients with no error. See
+    # https://github.com/linkedin/Liger-Kernel/issues/272
+    if not inplace:
+        _input = _input.clone()
 
     # Here we use a trick to store X_ptr gradient in X_ptr so we can save memory
     liger_cross_entropy_kernel[(n_rows,)](
@@ -473,6 +485,7 @@ class LigerCrossEntropyFunction(torch.autograd.Function):
         return_z_loss: bool = False,
         return_token_accuracy: bool = False,
         return_predicted_tokens: bool = False,
+        inplace: bool = True,
     ):
         """
         The forward pass of the Liger Cross Entropy loss.
@@ -490,6 +503,7 @@ class LigerCrossEntropyFunction(torch.autograd.Function):
         return_z_loss (bool): When `return_z_loss` is `True`, returns (loss, z_loss, token_accuracy, predicted_tokens) instead of (loss, None, None, None). Default: `False`
         return_token_accuracy (bool): When `return_token_accuracy` is `True`, computes and returns per-token accuracy without materializing logits. Default: `False`
         return_predicted_tokens (bool): When `return_predicted_tokens` is `True`, returns per-token predicted class indices (argmax) without materializing logits. Default: `False`
+        inplace (bool): When `True` (default), the gradient is stored in-place in `_input` to save memory. Set to `False` when `_input` is reused by an upstream op (e.g. the output of a softmax), so its values are not corrupted by the in-place gradient write. See https://github.com/linkedin/Liger-Kernel/issues/272. Default: `True`
 
         Returns:
         tuple: A tuple with the computed losses, accuracy, and predicted tokens: (loss, z_loss, token_accuracy, predicted_tokens). z_loss, token_accuracy, and predicted_tokens are None if not requested.
@@ -508,6 +522,7 @@ class LigerCrossEntropyFunction(torch.autograd.Function):
             return_z_loss,
             return_token_accuracy,
             return_predicted_tokens,
+            inplace,
         )
         # TODO: investigation
         # If we don't detach the _input tensor, the memory will double
@@ -555,4 +570,5 @@ class LigerCrossEntropyFunction(torch.autograd.Function):
             None,
             None,
             None,
+            None,  # inplace
         )

--- a/src/liger_kernel/transformers/functional.py
+++ b/src/liger_kernel/transformers/functional.py
@@ -55,6 +55,7 @@ def liger_cross_entropy(
     return_z_loss: bool = False,
     return_token_accuracy: bool = False,
     return_predicted_tokens: bool = False,
+    inplace: bool = True,
 ):
     loss, z_loss, token_accuracy, predicted_tokens = LigerCrossEntropyFunction.apply(
         input,
@@ -68,6 +69,7 @@ def liger_cross_entropy(
         return_z_loss,
         return_token_accuracy,
         return_predicted_tokens,
+        inplace,
     )
 
     if not return_z_loss and not return_token_accuracy and not return_predicted_tokens:

--- a/test/transformers/test_cross_entropy.py
+++ b/test/transformers/test_cross_entropy.py
@@ -1265,3 +1265,40 @@ def test_correctness_with_predicted_tokens(B, T, V, ignore_index, dtype):
     # Verify backward still works
     result.loss.backward()
     assert _input.grad is not None
+
+
+def _grad_through_softmax(cross_entropy_fn, logits_p, target, **kwargs):
+    # softmax -> cross_entropy -> backward; return grad w.r.t. the pre-softmax input
+    _p = logits_p.clone().detach().requires_grad_(True)
+    p = torch.nn.functional.softmax(_p, dim=-1)
+    loss = cross_entropy_fn(p, target, **kwargs)
+    loss.backward()
+    return _p.grad.clone(), loss.detach()
+
+
+def test_cross_entropy_inplace_does_not_corrupt_upstream_grad():
+    """Regression test for #272.
+
+    liger_cross_entropy stores its gradient in-place into its input via a Triton
+    kernel, which does not bump PyTorch's version counter. When the input is the
+    output of an upstream op (softmax here), the default in-place path corrupts
+    that op's saved tensor and yields a wrong gradient. inplace=False must match
+    the torch.nn.functional.cross_entropy reference.
+    """
+    set_seed(42)
+    logits_p = torch.randn(8, 8, device=device)
+    target = torch.randint(0, 8, (8,), device=device, dtype=torch.long)
+
+    ref_grad, ref_loss = _grad_through_softmax(F.cross_entropy, logits_p, target)
+
+    # default (in-place) path: same loss, but the upstream gradient is corrupted
+    inplace_grad, inplace_loss = _grad_through_softmax(liger_cross_entropy, logits_p, target)
+    assert torch.allclose(inplace_loss, ref_loss, atol=1e-4, rtol=1e-4)
+    assert not torch.allclose(inplace_grad, ref_grad, atol=1e-4, rtol=1e-4), (
+        "expected the in-place path to corrupt the upstream gradient (the bug in #272)"
+    )
+
+    # inplace=False must preserve the input and produce the correct upstream gradient
+    safe_grad, safe_loss = _grad_through_softmax(liger_cross_entropy, logits_p, target, inplace=False)
+    assert torch.allclose(safe_loss, ref_loss, atol=1e-4, rtol=1e-4)
+    assert torch.allclose(safe_grad, ref_grad, atol=1e-4, rtol=1e-4)


### PR DESCRIPTION
### Problem (#272)

`liger_cross_entropy` stores its backward gradient **in-place into its input tensor** via a Triton `tl.store`. Triton writes don't bump PyTorch's tensor version counter, so autograd's in-place-correctness check never fires. When the input is the output of an upstream op (e.g. a `softmax`) that saved it for its own backward, that tensor is silently overwritten and the upstream op computes **wrong gradients with no error** — the exact scenario in #272.

### Fix

Thread an `inplace` flag (default `True`, so existing behavior and the memory savings are unchanged) through `liger_cross_entropy` → `LigerCrossEntropyFunction` → `cross_entropy_forward`. When `inplace=False`, the gradient is computed into a clone of the input, leaving the caller's tensor intact.

One subtlety worth calling out: the clone happens inside `autograd.Function.forward` (grad disabled), so the clone reports `requires_grad=False`. Since the kernel only writes the gradient when `HAS_GRADIENTS` is true, I capture `requires_grad` from the original input *before* cloning — otherwise the kernel would skip the gradient write entirely.

### Verification (NVIDIA T4)

Ran the issue's reproducer (`softmax(_p) → cross_entropy → backward`) on a GPU, comparing the gradient w.r.t. the pre-softmax input against `F.cross_entropy`:

```
reference (F.cross_entropy) _p.grad[0]: [ 0.00168,  0.00287,  0.00029,  0.00546, -0.01822,  0.00242,  0.00231,  0.00319]
liger default (in-place)    _p.grad[0]: [ 2.1e-05,  3.5e-05,  6.8e-06,  6.7e-05,  0.01325,  3.0e-05,  2.8e-05,  3.9e-05]  -> matches ref: False  (the bug)
liger inplace=False         _p.grad[0]: [ 0.00168,  0.00287,  0.00029,  0.00546, -0.01822,  0.00242,  0.00231,  0.00319]  -> matches ref: True
loss matches ref: True
```

Added `test/transformers/test_cross_entropy.py::test_cross_entropy_inplace_does_not_corrupt_upstream_grad`, which asserts the default path corrupts the upstream gradient (reproducing the bug) and that `inplace=False` matches the `F.cross_entropy` reference.

Fixes #272
