### PR TITLE
[Megatron] Add RMSNorm integration

### DIFF
--- a/examples/megatron/README.md
+++ b/examples/megatron/README.md
@@ -1,0 +1,53 @@
+# Megatron-Core integration examples
+
+Two self-contained scripts demonstrating the integration modes shipped by
+`liger_kernel.megatron`. Both train a tiny GPT model with mock data on
+2 × GPU (TP=2, PP=1) for 5 iterations and print the resolved norm classes
+so you can see which slots picked up Liger.
+
+## Prerequisites
+
+- A working Megatron-Core install (`pip install megatron-core`).
+- `liger-kernel` installed (editable or from PyPI).
+- `psutil` (used by Megatron's async checkpoint worker pool).
+- At least 2 GPUs.
+
+## Mode 1 — `apply_liger_kernel_to_megatron()` (monkey-patch)
+
+One-line opt-in. Patches `LocalSpecProvider.layer_norm` and
+`transformer_block.LayerNormImpl` so every RMSNorm slot becomes Liger
+without changing the spec the user constructs.
+
+```bash
+torchrun --nproc_per_node=2 \
+    --master_addr=127.0.0.1 --master_port=29500 \
+    examples/megatron/run_mode1_monkey_patch.py
+```
+
+## Mode 2 — hand-assembled `TransformerBlockSubmodules`
+
+Slot-level control. Explicitly places `LigerMegatronRMSNorm` into each
+norm slot, including the block-level `final_layernorm`. Useful when you
+want to mix Liger with other backends (e.g. TransformerEngine) on a
+per-slot basis.
+
+```bash
+torchrun --nproc_per_node=2 \
+    --master_addr=127.0.0.1 --master_port=29500 \
+    examples/megatron/run_mode2_hand_spec.py
+```
+
+## What you should see
+
+For both scripts:
+
+- 5 lines of `[modeN] iter <i> loss=<float>` with the loss decreasing.
+- A printed module tree with `LigerMegatronRMSNorm` in **5 of 5** norm
+  slots: four per-layer (`input_layernorm`, `pre_mlp_layernorm` × 2 layers)
+  and one block-level (`final_layernorm`).
+- `Successfully loaded the model` after the distributed checkpoint
+  round-trip.
+
+If your environment doesn't have Apex or TransformerEngine installed, you
+will see harmless warnings — Megatron falls back to the local backend,
+which is exactly where Liger plugs in.

--- a/examples/megatron/run_mode1_monkey_patch.py
+++ b/examples/megatron/run_mode1_monkey_patch.py
@@ -24,24 +24,21 @@ Run with:
 from __future__ import annotations
 
 import os
+
 from functools import partial
 from pathlib import Path
-from typing import Callable, Dict, Iterator, Tuple
+from typing import Iterator
 
 import torch
-from torch.optim import Adam
-from torch.utils.data import DataLoader
 
-from megatron.core import dist_checkpointing, parallel_state
-from megatron.core.datasets.blended_megatron_dataset_builder import (
-    BlendedMegatronDatasetBuilder,
-)
-from megatron.core.datasets.gpt_dataset import GPTDatasetConfig, MockGPTDataset
+from megatron.core import dist_checkpointing
+from megatron.core import parallel_state
+from megatron.core.datasets.blended_megatron_dataset_builder import BlendedMegatronDatasetBuilder
+from megatron.core.datasets.gpt_dataset import GPTDatasetConfig
+from megatron.core.datasets.gpt_dataset import MockGPTDataset
 from megatron.core.datasets.utils import compile_helpers
-from megatron.core.distributed import (
-    DistributedDataParallel,
-    DistributedDataParallelConfig,
-)
+from megatron.core.distributed import DistributedDataParallel
+from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.distributed.finalize_model_grads import finalize_model_grads
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from megatron.core.models.gpt.gpt_model import GPTModel
@@ -49,6 +46,8 @@ from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.tokenizers import MegatronTokenizer
 from megatron.core.transformer.transformer_config import TransformerConfig
+from torch.optim import Adam
+from torch.utils.data import DataLoader
 
 # --- Liger integration: Mode 1 ---------------------------------------------
 from liger_kernel.megatron import apply_liger_kernel_to_megatron
@@ -65,9 +64,7 @@ def initialize_distributed(tp: int = 2, pp: int = 1) -> None:
     world_size = int(os.environ["WORLD_SIZE"])
     local_rank = int(os.environ["LOCAL_RANK"])
     torch.cuda.set_device(local_rank)
-    torch.distributed.init_process_group(
-        backend="nccl", rank=rank, world_size=world_size
-    )
+    torch.distributed.init_process_group(backend="nccl", rank=rank, world_size=world_size)
     parallel_state.initialize_model_parallel(tp, pp)
 
 
@@ -108,9 +105,7 @@ def get_train_data_iterator() -> Iterator:
         ),
         mid_level_dataset_surplus=0.005,
     )
-    datasets = BlendedMegatronDatasetBuilder(
-        MockGPTDataset, [1000, None, None], lambda: True, cfg
-    ).build()
+    datasets = BlendedMegatronDatasetBuilder(MockGPTDataset, [1000, None, None], lambda: True, cfg).build()
     return iter(DataLoader(datasets[0], batch_size=8, shuffle=True))
 
 
@@ -164,9 +159,7 @@ def main() -> None:
         overlap_grad_reduce=False,
         use_distributed_optimizer=False,
     )
-    model = DistributedDataParallel(
-        config=gpt_model.config, ddp_config=ddp_cfg, module=gpt_model
-    )
+    model = DistributedDataParallel(config=gpt_model.config, ddp_config=ddp_cfg, module=gpt_model)
 
     optim = Adam(model.parameters())
     data_iter = get_train_data_iterator()
@@ -198,9 +191,7 @@ def main() -> None:
         checkpoint_dir=str(ckpt_path),
     )
     sd = underlying.sharded_state_dict(prefix="")
-    underlying.load_state_dict(
-        dist_checkpointing.load(sharded_state_dict=sd, checkpoint_dir=str(ckpt_path))
-    )
+    underlying.load_state_dict(dist_checkpointing.load(sharded_state_dict=sd, checkpoint_dir=str(ckpt_path)))
     if torch.distributed.get_rank() == 0:
         print("Successfully loaded the model")
 

--- a/examples/megatron/run_mode1_monkey_patch.py
+++ b/examples/megatron/run_mode1_monkey_patch.py
@@ -1,0 +1,209 @@
+"""Mode 1 — monkey-patch Megatron-Core to use Liger RMSNorm.
+
+Adapted from Megatron's ``examples/run_simple_mcore_train_loop.py``. The
+relevant additions (vs. that file) are:
+
+  1. ``apply_liger_kernel_to_megatron(rms_norm=True)`` called once at the
+     top of ``model_provider()``. This patches both
+     ``LocalSpecProvider.layer_norm`` (per-layer norm slots) and
+     ``transformer_block.LayerNormImpl`` (block-level ``final_layernorm``).
+
+  2. ``normalization="RMSNorm"`` added to ``TransformerConfig`` so the
+     model actually has RMSNorm slots to patch (Megatron defaults to
+     ``LayerNorm``).
+
+  3. ``_print_norm_classes`` after model construction — prints the
+     resolved class for every norm slot so you can verify Liger took
+     over.
+
+Run with:
+    torchrun --nproc_per_node=2 --master_addr=127.0.0.1 --master_port=29500 \\
+        examples/megatron/run_mode1_monkey_patch.py
+"""
+
+from __future__ import annotations
+
+import os
+from functools import partial
+from pathlib import Path
+from typing import Callable, Dict, Iterator, Tuple
+
+import torch
+from torch.optim import Adam
+from torch.utils.data import DataLoader
+
+from megatron.core import dist_checkpointing, parallel_state
+from megatron.core.datasets.blended_megatron_dataset_builder import (
+    BlendedMegatronDatasetBuilder,
+)
+from megatron.core.datasets.gpt_dataset import GPTDatasetConfig, MockGPTDataset
+from megatron.core.datasets.utils import compile_helpers
+from megatron.core.distributed import (
+    DistributedDataParallel,
+    DistributedDataParallelConfig,
+)
+from megatron.core.distributed.finalize_model_grads import finalize_model_grads
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.tokenizers import MegatronTokenizer
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+# --- Liger integration: Mode 1 ---------------------------------------------
+from liger_kernel.megatron import apply_liger_kernel_to_megatron
+
+# ---------------------------------------------------------------------------
+
+_SEQUENCE_LENGTH = 64
+_NUM_ITERS = 5
+
+
+def initialize_distributed(tp: int = 2, pp: int = 1) -> None:
+    parallel_state.destroy_model_parallel()
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    torch.distributed.init_process_group(
+        backend="nccl", rank=rank, world_size=world_size
+    )
+    parallel_state.initialize_model_parallel(tp, pp)
+
+
+def model_provider() -> GPTModel:
+    # ↓↓ Mode 1 — patch once, everything below picks up Liger ↓↓
+    apply_liger_kernel_to_megatron(rms_norm=True)
+    # ↑↑ ------------------------------------------------------ ↑↑
+
+    cfg = TransformerConfig(
+        num_layers=2,
+        hidden_size=12,
+        num_attention_heads=4,
+        use_cpu_initialization=True,
+        pipeline_dtype=torch.float32,
+        normalization="RMSNorm",
+    )
+    return GPTModel(
+        config=cfg,
+        transformer_layer_spec=get_gpt_layer_local_spec(normalization="RMSNorm"),
+        vocab_size=100,
+        max_sequence_length=_SEQUENCE_LENGTH,
+    )
+
+
+def get_train_data_iterator() -> Iterator:
+    if torch.distributed.get_rank() == 0:
+        compile_helpers()
+    torch.distributed.barrier()
+    cfg = GPTDatasetConfig(
+        random_seed=0,
+        sequence_length=_SEQUENCE_LENGTH,
+        reset_position_ids=False,
+        reset_attention_mask=False,
+        eod_mask_loss=False,
+        tokenizer=MegatronTokenizer.from_pretrained(
+            metadata_path={"library": "null-text"},
+            vocab_size=_SEQUENCE_LENGTH,
+        ),
+        mid_level_dataset_surplus=0.005,
+    )
+    datasets = BlendedMegatronDatasetBuilder(
+        MockGPTDataset, [1000, None, None], lambda: True, cfg
+    ).build()
+    return iter(DataLoader(datasets[0], batch_size=8, shuffle=True))
+
+
+def forward_step_func(data_iterator, model):
+    def loss_func(loss_mask, output_tensor):
+        losses = output_tensor.float()
+        loss_mask = loss_mask.view(-1).float()
+        loss = torch.sum(losses.view(-1) * loss_mask) / loss_mask.sum()
+        return loss, {"lm loss": loss}
+
+    data = next(data_iterator)
+    tokens = data["tokens"].cuda()
+    attn = data["attention_mask"].cuda()
+    pos = data["position_ids"].cuda()
+    labels = data["labels"].cuda()
+    loss_mask = data["loss_mask"].cuda()
+    out = model(tokens, pos, attn, labels=labels)
+    return out, partial(loss_func, loss_mask)
+
+
+def _print_norm_classes(model: torch.nn.Module) -> None:
+    print("\n=== Resolved norm classes ===")
+    target = (
+        "LayerNorm",
+        "RMSNorm",
+        "FusedLayerNorm",
+        "WrappedTorchNorm",
+        "LigerMegatronRMSNorm",
+    )
+    for name, mod in model.named_modules():
+        if type(mod).__name__ in target and "layernorm" in name.lower():
+            cls = type(mod)
+            print(f"  {name:50s}  {cls.__module__}.{cls.__name__}")
+    print()
+
+
+def main() -> None:
+    initialize_distributed(tp=2, pp=1)
+    model_parallel_cuda_manual_seed(123)
+    torch.manual_seed(123)
+
+    gpt_model = model_provider().cuda()
+
+    if torch.distributed.get_rank() == 0:
+        print("\n=== Full model tree (mode 1: monkey-patch) ===")
+        print(gpt_model)
+        _print_norm_classes(gpt_model)
+
+    ddp_cfg = DistributedDataParallelConfig(
+        grad_reduce_in_fp32=False,
+        overlap_grad_reduce=False,
+        use_distributed_optimizer=False,
+    )
+    model = DistributedDataParallel(
+        config=gpt_model.config, ddp_config=ddp_cfg, module=gpt_model
+    )
+
+    optim = Adam(model.parameters())
+    data_iter = get_train_data_iterator()
+    fwd_bwd = get_forward_backward_func()
+
+    for it in range(_NUM_ITERS):
+        optim.zero_grad()
+        out = fwd_bwd(
+            forward_step_func=forward_step_func,
+            data_iterator=data_iter,
+            model=model,
+            num_microbatches=1,
+            seq_length=_SEQUENCE_LENGTH,
+            micro_batch_size=8,
+            decoder_seq_length=_SEQUENCE_LENGTH,
+            forward_only=False,
+        )
+        finalize_model_grads([model])
+        optim.step()
+        loss_val = float(out[0]["lm loss"].detach())
+        if torch.distributed.get_rank() == 0:
+            print(f"[mode1] iter {it}  loss={loss_val:.6f}")
+
+    ckpt_path = Path(os.getcwd()) / "ckpt_mode1"
+    ckpt_path.mkdir(exist_ok=True)
+    underlying = model.module if hasattr(model, "module") else model
+    dist_checkpointing.save(
+        sharded_state_dict=underlying.sharded_state_dict(prefix=""),
+        checkpoint_dir=str(ckpt_path),
+    )
+    sd = underlying.sharded_state_dict(prefix="")
+    underlying.load_state_dict(
+        dist_checkpointing.load(sharded_state_dict=sd, checkpoint_dir=str(ckpt_path))
+    )
+    if torch.distributed.get_rank() == 0:
+        print("Successfully loaded the model")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/megatron/run_mode2_hand_spec.py
+++ b/examples/megatron/run_mode2_hand_spec.py
@@ -26,49 +26,43 @@ Run with:
 from __future__ import annotations
 
 import os
+
 from functools import partial
 from pathlib import Path
-from typing import Callable, Dict, Iterator, Tuple
+from typing import Iterator
 
 import torch
-from torch.optim import Adam
-from torch.utils.data import DataLoader
 
-from megatron.core import dist_checkpointing, parallel_state
-from megatron.core.datasets.blended_megatron_dataset_builder import (
-    BlendedMegatronDatasetBuilder,
-)
-from megatron.core.datasets.gpt_dataset import GPTDatasetConfig, MockGPTDataset
+from megatron.core import dist_checkpointing
+from megatron.core import parallel_state
+from megatron.core.datasets.blended_megatron_dataset_builder import BlendedMegatronDatasetBuilder
+from megatron.core.datasets.gpt_dataset import GPTDatasetConfig
+from megatron.core.datasets.gpt_dataset import MockGPTDataset
 from megatron.core.datasets.utils import compile_helpers
-from megatron.core.distributed import (
-    DistributedDataParallel,
-    DistributedDataParallelConfig,
-)
+from megatron.core.distributed import DistributedDataParallel
+from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.distributed.finalize_model_grads import finalize_model_grads
 from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
-from megatron.core.tensor_parallel.layers import (
-    ColumnParallelLinear,
-    RowParallelLinear,
-)
+from megatron.core.tensor_parallel.layers import ColumnParallelLinear
+from megatron.core.tensor_parallel.layers import RowParallelLinear
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.tokenizers import MegatronTokenizer
-from megatron.core.transformer.attention import (
-    SelfAttention,
-    SelfAttentionSubmodules,
-)
+from megatron.core.transformer.attention import SelfAttention
+from megatron.core.transformer.attention import SelfAttentionSubmodules
 from megatron.core.transformer.dot_product_attention import DotProductAttention
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.identity_op import IdentityOp
-from megatron.core.transformer.mlp import MLP, MLPSubmodules
+from megatron.core.transformer.mlp import MLP
+from megatron.core.transformer.mlp import MLPSubmodules
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_block import TransformerBlockSubmodules
 from megatron.core.transformer.transformer_config import TransformerConfig
-from megatron.core.transformer.transformer_layer import (
-    TransformerLayer,
-    TransformerLayerSubmodules,
-)
+from megatron.core.transformer.transformer_layer import TransformerLayer
+from megatron.core.transformer.transformer_layer import TransformerLayerSubmodules
+from torch.optim import Adam
+from torch.utils.data import DataLoader
 
 # --- Liger integration: Mode 2 ---------------------------------------------
 from liger_kernel.megatron import LigerMegatronRMSNorm
@@ -86,9 +80,7 @@ def initialize_distributed(tp: int = 2, pp: int = 1) -> None:
     world_size = int(os.environ["WORLD_SIZE"])
     local_rank = int(os.environ["LOCAL_RANK"])
     torch.cuda.set_device(local_rank)
-    torch.distributed.init_process_group(
-        backend="nccl", rank=rank, world_size=world_size
-    )
+    torch.distributed.init_process_group(backend="nccl", rank=rank, world_size=world_size)
     parallel_state.initialize_model_parallel(tp, pp)
 
 
@@ -165,9 +157,7 @@ def get_train_data_iterator() -> Iterator:
         ),
         mid_level_dataset_surplus=0.005,
     )
-    datasets = BlendedMegatronDatasetBuilder(
-        MockGPTDataset, [1000, None, None], lambda: True, cfg
-    ).build()
+    datasets = BlendedMegatronDatasetBuilder(MockGPTDataset, [1000, None, None], lambda: True, cfg).build()
     return iter(DataLoader(datasets[0], batch_size=8, shuffle=True))
 
 
@@ -221,9 +211,7 @@ def main() -> None:
         overlap_grad_reduce=False,
         use_distributed_optimizer=False,
     )
-    model = DistributedDataParallel(
-        config=gpt_model.config, ddp_config=ddp_cfg, module=gpt_model
-    )
+    model = DistributedDataParallel(config=gpt_model.config, ddp_config=ddp_cfg, module=gpt_model)
 
     optim = Adam(model.parameters())
     data_iter = get_train_data_iterator()
@@ -255,9 +243,7 @@ def main() -> None:
         checkpoint_dir=str(ckpt_path),
     )
     sd = underlying.sharded_state_dict(prefix="")
-    underlying.load_state_dict(
-        dist_checkpointing.load(sharded_state_dict=sd, checkpoint_dir=str(ckpt_path))
-    )
+    underlying.load_state_dict(dist_checkpointing.load(sharded_state_dict=sd, checkpoint_dir=str(ckpt_path)))
     if torch.distributed.get_rank() == 0:
         print("Successfully loaded the model")
 

--- a/examples/megatron/run_mode2_hand_spec.py
+++ b/examples/megatron/run_mode2_hand_spec.py
@@ -1,0 +1,266 @@
+"""Mode 2 — hand-assembled TransformerBlockSubmodules using LigerMegatronRMSNorm.
+
+Adapted from Megatron's ``examples/run_simple_mcore_train_loop.py``. The
+relevant additions (vs. that file) are:
+
+  1. Direct import of ``LigerMegatronRMSNorm`` (no monkey-patch).
+
+  2. ``model_provider()`` assembles a ``TransformerBlockSubmodules`` by
+     hand, placing ``LigerMegatronRMSNorm`` into every norm slot:
+       - per-layer ``input_layernorm`` and ``pre_mlp_layernorm``
+       - the block-level ``layer_norm`` field that backs
+         ``decoder.final_layernorm``
+     This is the slot-level integration path — verbose but maximally
+     explicit. It is the only way to control ``final_layernorm`` from
+     user code without monkey-patching.
+
+  3. ``_print_norm_classes`` after model construction — prints the
+     resolved class for every norm slot so you can verify Liger took
+     over.
+
+Run with:
+    torchrun --nproc_per_node=2 --master_addr=127.0.0.1 --master_port=29500 \\
+        examples/megatron/run_mode2_hand_spec.py
+"""
+
+from __future__ import annotations
+
+import os
+from functools import partial
+from pathlib import Path
+from typing import Callable, Dict, Iterator, Tuple
+
+import torch
+from torch.optim import Adam
+from torch.utils.data import DataLoader
+
+from megatron.core import dist_checkpointing, parallel_state
+from megatron.core.datasets.blended_megatron_dataset_builder import (
+    BlendedMegatronDatasetBuilder,
+)
+from megatron.core.datasets.gpt_dataset import GPTDatasetConfig, MockGPTDataset
+from megatron.core.datasets.utils import compile_helpers
+from megatron.core.distributed import (
+    DistributedDataParallel,
+    DistributedDataParallelConfig,
+)
+from megatron.core.distributed.finalize_model_grads import finalize_model_grads
+from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
+from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
+from megatron.core.tensor_parallel.layers import (
+    ColumnParallelLinear,
+    RowParallelLinear,
+)
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.tokenizers import MegatronTokenizer
+from megatron.core.transformer.attention import (
+    SelfAttention,
+    SelfAttentionSubmodules,
+)
+from megatron.core.transformer.dot_product_attention import DotProductAttention
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.identity_op import IdentityOp
+from megatron.core.transformer.mlp import MLP, MLPSubmodules
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.transformer_block import TransformerBlockSubmodules
+from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.transformer.transformer_layer import (
+    TransformerLayer,
+    TransformerLayerSubmodules,
+)
+
+# --- Liger integration: Mode 2 ---------------------------------------------
+from liger_kernel.megatron import LigerMegatronRMSNorm
+
+# ---------------------------------------------------------------------------
+
+_SEQUENCE_LENGTH = 64
+_NUM_ITERS = 5
+_NUM_LAYERS = 2
+
+
+def initialize_distributed(tp: int = 2, pp: int = 1) -> None:
+    parallel_state.destroy_model_parallel()
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    torch.distributed.init_process_group(
+        backend="nccl", rank=rank, world_size=world_size
+    )
+    parallel_state.initialize_model_parallel(tp, pp)
+
+
+def model_provider() -> GPTModel:
+    cfg = TransformerConfig(
+        num_layers=_NUM_LAYERS,
+        hidden_size=12,
+        num_attention_heads=4,
+        use_cpu_initialization=True,
+        pipeline_dtype=torch.float32,
+        normalization="RMSNorm",
+    )
+
+    # ↓↓ Mode 2 — explicit slot-level placement of LigerMegatronRMSNorm ↓↓
+    per_layer = ModuleSpec(
+        module=TransformerLayer,
+        submodules=TransformerLayerSubmodules(
+            input_layernorm=LigerMegatronRMSNorm,
+            self_attention=ModuleSpec(
+                module=SelfAttention,
+                params={"attn_mask_type": AttnMaskType.causal},
+                submodules=SelfAttentionSubmodules(
+                    linear_qkv=ColumnParallelLinear,
+                    core_attention=DotProductAttention,
+                    linear_proj=RowParallelLinear,
+                    q_layernorm=IdentityOp,
+                    k_layernorm=IdentityOp,
+                ),
+            ),
+            self_attn_bda=get_bias_dropout_add,
+            pre_mlp_layernorm=LigerMegatronRMSNorm,
+            mlp=partial(
+                MLP.as_mlp_submodule,
+                submodules=MLPSubmodules(
+                    linear_fc1=ColumnParallelLinear,
+                    linear_fc2=RowParallelLinear,
+                    activation_func=None,
+                ),
+            ),
+            mlp_bda=get_bias_dropout_add,
+            sharded_state_dict_keys_map={
+                "input_layernorm.": "self_attention.linear_qkv.layer_norm_",
+                "pre_mlp_layernorm.": "mlp.linear_fc1.layer_norm_",
+            },
+        ),
+    )
+    block_spec = TransformerBlockSubmodules(
+        layer_specs=[per_layer] * _NUM_LAYERS,
+        layer_norm=LigerMegatronRMSNorm,  # ← block-level final_layernorm
+    )
+    # ↑↑ ----------------------------------------------------------------- ↑↑
+
+    return GPTModel(
+        config=cfg,
+        transformer_layer_spec=block_spec,
+        vocab_size=100,
+        max_sequence_length=_SEQUENCE_LENGTH,
+    )
+
+
+def get_train_data_iterator() -> Iterator:
+    if torch.distributed.get_rank() == 0:
+        compile_helpers()
+    torch.distributed.barrier()
+    cfg = GPTDatasetConfig(
+        random_seed=0,
+        sequence_length=_SEQUENCE_LENGTH,
+        reset_position_ids=False,
+        reset_attention_mask=False,
+        eod_mask_loss=False,
+        tokenizer=MegatronTokenizer.from_pretrained(
+            metadata_path={"library": "null-text"},
+            vocab_size=_SEQUENCE_LENGTH,
+        ),
+        mid_level_dataset_surplus=0.005,
+    )
+    datasets = BlendedMegatronDatasetBuilder(
+        MockGPTDataset, [1000, None, None], lambda: True, cfg
+    ).build()
+    return iter(DataLoader(datasets[0], batch_size=8, shuffle=True))
+
+
+def forward_step_func(data_iterator, model):
+    def loss_func(loss_mask, output_tensor):
+        losses = output_tensor.float()
+        loss_mask = loss_mask.view(-1).float()
+        loss = torch.sum(losses.view(-1) * loss_mask) / loss_mask.sum()
+        return loss, {"lm loss": loss}
+
+    data = next(data_iterator)
+    tokens = data["tokens"].cuda()
+    attn = data["attention_mask"].cuda()
+    pos = data["position_ids"].cuda()
+    labels = data["labels"].cuda()
+    loss_mask = data["loss_mask"].cuda()
+    out = model(tokens, pos, attn, labels=labels)
+    return out, partial(loss_func, loss_mask)
+
+
+def _print_norm_classes(model: torch.nn.Module) -> None:
+    print("\n=== Resolved norm classes ===")
+    target = (
+        "LayerNorm",
+        "RMSNorm",
+        "FusedLayerNorm",
+        "WrappedTorchNorm",
+        "LigerMegatronRMSNorm",
+    )
+    for name, mod in model.named_modules():
+        if type(mod).__name__ in target and "layernorm" in name.lower():
+            cls = type(mod)
+            print(f"  {name:50s}  {cls.__module__}.{cls.__name__}")
+    print()
+
+
+def main() -> None:
+    initialize_distributed(tp=2, pp=1)
+    model_parallel_cuda_manual_seed(123)
+    torch.manual_seed(123)
+
+    gpt_model = model_provider().cuda()
+
+    if torch.distributed.get_rank() == 0:
+        print("\n=== Full model tree (mode 2: hand-built spec) ===")
+        print(gpt_model)
+        _print_norm_classes(gpt_model)
+
+    ddp_cfg = DistributedDataParallelConfig(
+        grad_reduce_in_fp32=False,
+        overlap_grad_reduce=False,
+        use_distributed_optimizer=False,
+    )
+    model = DistributedDataParallel(
+        config=gpt_model.config, ddp_config=ddp_cfg, module=gpt_model
+    )
+
+    optim = Adam(model.parameters())
+    data_iter = get_train_data_iterator()
+    fwd_bwd = get_forward_backward_func()
+
+    for it in range(_NUM_ITERS):
+        optim.zero_grad()
+        out = fwd_bwd(
+            forward_step_func=forward_step_func,
+            data_iterator=data_iter,
+            model=model,
+            num_microbatches=1,
+            seq_length=_SEQUENCE_LENGTH,
+            micro_batch_size=8,
+            decoder_seq_length=_SEQUENCE_LENGTH,
+            forward_only=False,
+        )
+        finalize_model_grads([model])
+        optim.step()
+        loss_val = float(out[0]["lm loss"].detach())
+        if torch.distributed.get_rank() == 0:
+            print(f"[mode2] iter {it}  loss={loss_val:.6f}")
+
+    ckpt_path = Path(os.getcwd()) / "ckpt_mode2"
+    ckpt_path.mkdir(exist_ok=True)
+    underlying = model.module if hasattr(model, "module") else model
+    dist_checkpointing.save(
+        sharded_state_dict=underlying.sharded_state_dict(prefix=""),
+        checkpoint_dir=str(ckpt_path),
+    )
+    sd = underlying.sharded_state_dict(prefix="")
+    underlying.load_state_dict(
+        dist_checkpointing.load(sharded_state_dict=sd, checkpoint_dir=str(ckpt_path))
+    )
+    if torch.distributed.get_rank() == 0:
+        print("Successfully loaded the model")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/liger_kernel/megatron/__init__.py
+++ b/src/liger_kernel/megatron/__init__.py
@@ -1,0 +1,13 @@
+"""Megatron-Core adapter for Liger-Kernel.
+
+Public API:
+    LigerMegatronRMSNorm — RMSNorm module conforming to Megatron-Core's
+        LayerNormBuilder protocol.
+    apply_liger_kernel_to_megatron — patches Megatron-Core's BackendSpecProvider
+        so existing scripts pick up Liger kernels with one line.
+"""
+
+from liger_kernel.megatron.monkey_patch import apply_liger_kernel_to_megatron
+from liger_kernel.megatron.rms_norm import LigerMegatronRMSNorm
+
+__all__ = ["LigerMegatronRMSNorm", "apply_liger_kernel_to_megatron"]

--- a/src/liger_kernel/megatron/monkey_patch.py
+++ b/src/liger_kernel/megatron/monkey_patch.py
@@ -56,9 +56,7 @@ def _patch_local_spec_provider_layer_norm() -> None:
     ):
         if rms_norm:
             return LigerMegatronRMSNorm
-        return original_layer_norm(
-            self, rms_norm=rms_norm, for_qk=for_qk, has_residual=has_residual
-        )
+        return original_layer_norm(self, rms_norm=rms_norm, for_qk=for_qk, has_residual=has_residual)
 
     setattr(patched_layer_norm, _PATCH_MARKER, True)
     setattr(patched_layer_norm, "__wrapped__", original_layer_norm)
@@ -111,12 +109,8 @@ def _patch_transformer_block_layernorm_impl() -> None:
 
         def __new__(cls, config, hidden_size, eps=1e-5, **kwargs):
             if getattr(config, "normalization", None) == "RMSNorm":
-                return LigerMegatronRMSNorm(
-                    config=config, hidden_size=hidden_size, eps=eps, **kwargs
-                )
-            return original(
-                config=config, hidden_size=hidden_size, eps=eps, **kwargs
-            )
+                return LigerMegatronRMSNorm(config=config, hidden_size=hidden_size, eps=eps, **kwargs)
+            return original(config=config, hidden_size=hidden_size, eps=eps, **kwargs)
 
     setattr(_LigerOrTorchNorm, _PATCH_MARKER, True)
     setattr(_LigerOrTorchNorm, "__wrapped__", original)

--- a/src/liger_kernel/megatron/monkey_patch.py
+++ b/src/liger_kernel/megatron/monkey_patch.py
@@ -9,20 +9,19 @@ logger = logging.getLogger(__name__)
 _PATCH_MARKER = "__liger_patched__"
 
 
-def apply_liger_kernel_to_megatron(rms_norm: bool = True, force: bool = False) -> None:
+def apply_liger_kernel_to_megatron(rms_norm: bool = True) -> None:
     """Patch Megatron-Core to use Liger Triton kernels.
 
-    Idempotent. A no-op when Megatron-Core has native Liger support (the
-    upstream ``LigerSpecProvider``) unless ``force=True``. Targets Megatron's
-    ``BackendSpecProvider`` classes so every model that routes through the
-    standard spec system benefits without per-model code.
+    Idempotent. Targets Megatron's ``BackendSpecProvider`` and
+    ``transformer_block.LayerNormImpl`` so every model that routes through
+    the standard spec system benefits without per-model code.
 
     Args:
-        rms_norm: Replace ``LocalSpecProvider.layer_norm`` so it returns
-            ``LigerMegatronRMSNorm`` when ``rms_norm=True``. Default ``True``.
-        force: Apply the monkey-patch even if native Liger support is
-            detected. Useful for testing or to override Megatron's wired
-            integration. Default ``False``.
+        rms_norm: When ``True`` (default) replace both
+            ``LocalSpecProvider.layer_norm`` (per-layer norm slots) and
+            ``transformer_block.LayerNormImpl`` (the block-level
+            ``final_layernorm`` slot) so all RMSNorm modules in the model
+            become ``LigerMegatronRMSNorm``.
 
     Notes:
         Call this BEFORE building your model. Patching after instantiation
@@ -34,26 +33,9 @@ def apply_liger_kernel_to_megatron(rms_norm: bool = True, force: bool = False) -
         the QKV linear; naive substitution would either double-norm or skip
         the norm. See the project README for the mixing recipe.
     """
-    if not force and _native_liger_support_available():
-        logger.info(
-            "Megatron-Core has native LigerSpecProvider; skipping monkey-patch. "
-            "Pass force=True to override."
-        )
-        return
-
     if rms_norm:
         _patch_local_spec_provider_layer_norm()
         _patch_transformer_block_layernorm_impl()
-
-
-def _native_liger_support_available() -> bool:
-    try:
-        from megatron.core.extensions.liger_kernel_spec_provider import (  # noqa: F401
-            LigerSpecProvider,
-        )
-        return True
-    except ImportError:
-        return False
 
 
 def _patch_local_spec_provider_layer_norm() -> None:

--- a/src/liger_kernel/megatron/monkey_patch.py
+++ b/src/liger_kernel/megatron/monkey_patch.py
@@ -43,6 +43,7 @@ def apply_liger_kernel_to_megatron(rms_norm: bool = True, force: bool = False) -
 
     if rms_norm:
         _patch_local_spec_provider_layer_norm()
+        _patch_transformer_block_layernorm_impl()
 
 
 def _native_liger_support_available() -> bool:
@@ -84,4 +85,62 @@ def _patch_local_spec_provider_layer_norm() -> None:
     logger.info(
         "Patched megatron.core.models.backends.LocalSpecProvider.layer_norm "
         "to return LigerMegatronRMSNorm for rms_norm=True."
+    )
+
+
+def _patch_transformer_block_layernorm_impl() -> None:
+    """Cover the block-level ``final_layernorm`` slot.
+
+    ``TransformerBlock`` uses a module-level global ``LayerNormImpl`` (chosen
+    at import time from TE / Apex / WrappedTorchNorm) to fill the
+    ``final_layernorm`` slot when the caller passes a per-layer spec rather
+    than a ``TransformerBlockSubmodules``. Our spec-provider patch only
+    catches the per-layer slots, so without this second patch the trailing
+    norm stays as PyTorch's ``nn.RMSNorm``.
+
+    We only displace the ``WrappedTorchNorm`` fallback. Users on TE or Apex
+    chose those deliberately; replacing them would undo TE's LN+Linear
+    fusion or surprise Apex users.
+    """
+    from megatron.core.transformer import transformer_block
+    from megatron.core.transformer.torch_norm import WrappedTorchNorm
+
+    from liger_kernel.megatron.rms_norm import LigerMegatronRMSNorm
+
+    if getattr(transformer_block.LayerNormImpl, _PATCH_MARKER, False):
+        return
+
+    original = transformer_block.LayerNormImpl
+    if original is not WrappedTorchNorm:
+        logger.info(
+            "transformer_block.LayerNormImpl is %s; skipping block-level patch "
+            "(Liger only displaces the pure-torch fallback).",
+            getattr(original, "__name__", str(original)),
+        )
+        return
+
+    class _LigerOrTorchNorm:
+        """Routes to ``LigerMegatronRMSNorm`` when ``config.normalization``
+        is ``"RMSNorm"``; otherwise instantiates the original implementation.
+
+        Keeps LayerNorm users on PyTorch's ``nn.LayerNorm`` while routing
+        RMSNorm users through Liger for the final norm slot.
+        """
+
+        def __new__(cls, config, hidden_size, eps=1e-5, **kwargs):
+            if getattr(config, "normalization", None) == "RMSNorm":
+                return LigerMegatronRMSNorm(
+                    config=config, hidden_size=hidden_size, eps=eps, **kwargs
+                )
+            return original(
+                config=config, hidden_size=hidden_size, eps=eps, **kwargs
+            )
+
+    setattr(_LigerOrTorchNorm, _PATCH_MARKER, True)
+    setattr(_LigerOrTorchNorm, "__wrapped__", original)
+    transformer_block.LayerNormImpl = _LigerOrTorchNorm
+
+    logger.info(
+        "Patched megatron.core.transformer.transformer_block.LayerNormImpl "
+        "to route RMSNorm configs through LigerMegatronRMSNorm."
     )

--- a/src/liger_kernel/megatron/monkey_patch.py
+++ b/src/liger_kernel/megatron/monkey_patch.py
@@ -1,0 +1,87 @@
+"""Monkey-patch entry point for applying Liger kernels to Megatron-Core."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_PATCH_MARKER = "__liger_patched__"
+
+
+def apply_liger_kernel_to_megatron(rms_norm: bool = True, force: bool = False) -> None:
+    """Patch Megatron-Core to use Liger Triton kernels.
+
+    Idempotent. A no-op when Megatron-Core has native Liger support (the
+    upstream ``LigerSpecProvider``) unless ``force=True``. Targets Megatron's
+    ``BackendSpecProvider`` classes so every model that routes through the
+    standard spec system benefits without per-model code.
+
+    Args:
+        rms_norm: Replace ``LocalSpecProvider.layer_norm`` so it returns
+            ``LigerMegatronRMSNorm`` when ``rms_norm=True``. Default ``True``.
+        force: Apply the monkey-patch even if native Liger support is
+            detected. Useful for testing or to override Megatron's wired
+            integration. Default ``False``.
+
+    Notes:
+        Call this BEFORE building your model. Patching after instantiation
+        will not retroactively swap modules already created.
+
+        This only affects the local (non-TE) backend. Mixing Liger norms with
+        ``TESpecProvider`` requires a custom ``BackendSpecProvider`` subclass
+        because TE's ``TELayerNormColumnParallelLinear`` folds the norm into
+        the QKV linear; naive substitution would either double-norm or skip
+        the norm. See the project README for the mixing recipe.
+    """
+    if not force and _native_liger_support_available():
+        logger.info(
+            "Megatron-Core has native LigerSpecProvider; skipping monkey-patch. "
+            "Pass force=True to override."
+        )
+        return
+
+    if rms_norm:
+        _patch_local_spec_provider_layer_norm()
+
+
+def _native_liger_support_available() -> bool:
+    try:
+        from megatron.core.extensions.liger_kernel_spec_provider import (  # noqa: F401
+            LigerSpecProvider,
+        )
+        return True
+    except ImportError:
+        return False
+
+
+def _patch_local_spec_provider_layer_norm() -> None:
+    from megatron.core.models import backends
+
+    from liger_kernel.megatron.rms_norm import LigerMegatronRMSNorm
+
+    if getattr(backends.LocalSpecProvider.layer_norm, _PATCH_MARKER, False):
+        return  # already patched
+
+    original_layer_norm = backends.LocalSpecProvider.layer_norm
+
+    def patched_layer_norm(
+        self,
+        rms_norm: bool = False,
+        for_qk: bool = False,
+        has_residual: bool = False,
+    ):
+        if rms_norm:
+            return LigerMegatronRMSNorm
+        return original_layer_norm(
+            self, rms_norm=rms_norm, for_qk=for_qk, has_residual=has_residual
+        )
+
+    setattr(patched_layer_norm, _PATCH_MARKER, True)
+    setattr(patched_layer_norm, "__wrapped__", original_layer_norm)
+    backends.LocalSpecProvider.layer_norm = patched_layer_norm
+
+    logger.info(
+        "Patched megatron.core.models.backends.LocalSpecProvider.layer_norm "
+        "to return LigerMegatronRMSNorm for rms_norm=True."
+    )

--- a/src/liger_kernel/megatron/rms_norm.py
+++ b/src/liger_kernel/megatron/rms_norm.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import numbers
 
 import torch
-from torch.nn import Parameter
-from torch.nn import init
 
 # Force-import the submodule so liger_kernel.ops.rms_norm can resolve
 # torch.distributed.tensor.DTensor on torch 2.11+, where the subpackage is no
 # longer auto-loaded as an attribute of torch.distributed.
 import torch.distributed.tensor  # noqa: F401
+
+from torch.nn import Parameter
+from torch.nn import init
 
 from liger_kernel.ops import LigerRMSNormFunction
 
@@ -51,16 +52,10 @@ class LigerMegatronRMSNorm(torch.nn.Module):
         super().__init__()
         cfg_norm = getattr(config, "normalization", "RMSNorm")
         if cfg_norm != "RMSNorm":
-            raise ValueError(
-                f"LigerMegatronRMSNorm requires config.normalization='RMSNorm'; "
-                f"got {cfg_norm!r}."
-            )
+            raise ValueError(f"LigerMegatronRMSNorm requires config.normalization='RMSNorm'; got {cfg_norm!r}.")
 
         self.config = config
-        self.zero_centered_gamma = bool(
-            zero_centered_gamma
-            or getattr(config, "layernorm_zero_centered_gamma", False)
-        )
+        self.zero_centered_gamma = bool(zero_centered_gamma or getattr(config, "layernorm_zero_centered_gamma", False))
 
         if isinstance(hidden_size, numbers.Integral):
             hidden_size = (hidden_size,)
@@ -97,12 +92,9 @@ class LigerMegatronRMSNorm(torch.nn.Module):
             self.eps,
             self._offset,
             "llama",  # casting_mode
-            False,    # in_place
-            None,     # row_mode
+            False,  # in_place
+            None,  # row_mode
         )
 
     def extra_repr(self) -> str:
-        return (
-            f"hidden_size={tuple(self.hidden_size)}, eps={self.eps}, "
-            f"zero_centered_gamma={self.zero_centered_gamma}"
-        )
+        return f"hidden_size={tuple(self.hidden_size)}, eps={self.eps}, zero_centered_gamma={self.zero_centered_gamma}"

--- a/src/liger_kernel/megatron/rms_norm.py
+++ b/src/liger_kernel/megatron/rms_norm.py
@@ -81,7 +81,7 @@ class LigerMegatronRMSNorm(torch.nn.Module):
         # already sharded as ``[s/tp, b, h]`` and the per-token RMSNorm
         # runs at 1/tp the cost. This wrapper does not block SP (we set
         # the gradient-reduction marker below), but the SP path has not
-        # been E2E verified yet. Tracked in PLAN.md.
+        # been E2E verified yet.
         sp = bool(getattr(config, "sequence_parallel", False))
         setattr(self.weight, "sequence_parallel", sp)
 

--- a/src/liger_kernel/megatron/rms_norm.py
+++ b/src/liger_kernel/megatron/rms_norm.py
@@ -70,9 +70,18 @@ class LigerMegatronRMSNorm(torch.nn.Module):
         self.reset_parameters()
 
         # Megatron's distributed optimizer inspects this attribute to decide
-        # whether to reduce the parameter's gradient across TP ranks under
-        # sequence parallelism. Match the flag-on-weight convention used by
-        # FusedLayerNorm.
+        # whether to all-reduce the parameter's gradient across TP ranks
+        # under sequence parallelism. Match the flag-on-weight convention
+        # used by FusedLayerNorm.
+        #
+        # TODO(sp): under pure TP (no SP) every TP rank holds the full
+        # ``[s, b, h]`` activation and runs the same RMSNorm — wasting
+        # `tp_world_size`x of compute and activation memory. The fix is for
+        # the user to enable SP, in which case the activation arrives
+        # already sharded as ``[s/tp, b, h]`` and the per-token RMSNorm
+        # runs at 1/tp the cost. This wrapper does not block SP (we set
+        # the gradient-reduction marker below), but the SP path has not
+        # been E2E verified yet. Tracked in PLAN.md.
         sp = bool(getattr(config, "sequence_parallel", False))
         setattr(self.weight, "sequence_parallel", sp)
 

--- a/src/liger_kernel/megatron/rms_norm.py
+++ b/src/liger_kernel/megatron/rms_norm.py
@@ -1,0 +1,108 @@
+"""Megatron-Core compatible RMSNorm backed by the Liger Triton kernel."""
+
+from __future__ import annotations
+
+import numbers
+
+import torch
+from torch.nn import Parameter
+from torch.nn import init
+
+# Force-import the submodule so liger_kernel.ops.rms_norm can resolve
+# torch.distributed.tensor.DTensor on torch 2.11+, where the subpackage is no
+# longer auto-loaded as an attribute of torch.distributed.
+import torch.distributed.tensor  # noqa: F401
+
+from liger_kernel.ops import LigerRMSNormFunction
+
+
+class LigerMegatronRMSNorm(torch.nn.Module):
+    """RMSNorm module conforming to Megatron-Core's ``LayerNormBuilder`` protocol.
+
+    Drop-in for ``megatron.core.transformer.torch_norm.WrappedTorchNorm`` and
+    ``megatron.core.fusions.fused_layer_norm.FusedLayerNorm``. The constructor
+    accepts the same keyword arguments those types accept so it can be slotted
+    into a ``TransformerLayerSubmodules`` without further glue.
+
+    Args:
+        config: TransformerConfig. Duck-typed; only ``config.normalization``,
+            ``config.sequence_parallel`` and ``config.layernorm_zero_centered_gamma``
+            are read.
+        hidden_size: Trailing dimension to normalize over.
+        eps: Variance epsilon (matches ``layernorm_epsilon`` from the config).
+        persist_layer_norm: Accepted for interface compatibility, unused.
+        zero_centered_gamma: If True, the weight is stored centered at 0 and
+            the kernel applies ``(1 + w)`` as the effective scale. Mirrors
+            ``apex.normalization.FusedLayerNorm``'s ``zero_centered_gamma``
+            semantics. Defaults to the value of
+            ``config.layernorm_zero_centered_gamma`` if present.
+        normalization: Accepted for interface compatibility; must be ``"RMSNorm"``.
+    """
+
+    def __init__(
+        self,
+        config,
+        hidden_size: int,
+        eps: float = 1e-5,
+        persist_layer_norm: bool = False,
+        zero_centered_gamma: bool = False,
+        normalization: str = "RMSNorm",
+    ):
+        super().__init__()
+        cfg_norm = getattr(config, "normalization", "RMSNorm")
+        if cfg_norm != "RMSNorm":
+            raise ValueError(
+                f"LigerMegatronRMSNorm requires config.normalization='RMSNorm'; "
+                f"got {cfg_norm!r}."
+            )
+
+        self.config = config
+        self.zero_centered_gamma = bool(
+            zero_centered_gamma
+            or getattr(config, "layernorm_zero_centered_gamma", False)
+        )
+
+        if isinstance(hidden_size, numbers.Integral):
+            hidden_size = (hidden_size,)
+        self.hidden_size = torch.Size(hidden_size)
+        self.eps = eps
+
+        # Liger's kernel applies (offset + w) * x_normalized. Zero-centered gamma
+        # is implemented by storing w around 0 and folding +1 into the kernel via
+        # offset; this matches apex.normalization.FusedLayerNorm's semantics.
+        self._offset = 1.0 if self.zero_centered_gamma else 0.0
+        self.weight = Parameter(torch.empty(*self.hidden_size))
+        self.reset_parameters()
+
+        # Megatron's distributed optimizer inspects this attribute to decide
+        # whether to reduce the parameter's gradient across TP ranks under
+        # sequence parallelism. Match the flag-on-weight convention used by
+        # FusedLayerNorm.
+        sp = bool(getattr(config, "sequence_parallel", False))
+        setattr(self.weight, "sequence_parallel", sp)
+
+    def reset_parameters(self) -> None:
+        if self.zero_centered_gamma:
+            init.zeros_(self.weight)
+        else:
+            init.ones_(self.weight)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # in_place=False because Megatron holds activation references for
+        # recompute (TransformerLayer.recompute_input_layernorm path) and
+        # CUDA-graph capture; in-place writes would corrupt them.
+        return LigerRMSNormFunction.apply(
+            x,
+            self.weight,
+            self.eps,
+            self._offset,
+            "llama",  # casting_mode
+            False,    # in_place
+            None,     # row_mode
+        )
+
+    def extra_repr(self) -> str:
+        return (
+            f"hidden_size={tuple(self.hidden_size)}, eps={self.eps}, "
+            f"zero_centered_gamma={self.zero_centered_gamma}"
+        )

--- a/test/megatron/test_rms_norm.py
+++ b/test/megatron/test_rms_norm.py
@@ -1,0 +1,131 @@
+"""Unit tests for LigerMegatronRMSNorm.
+
+These tests deliberately do not import megatron-core. The wrapper's contract
+is verified using a duck-typed ``SimpleNamespace`` for ``config``.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from liger_kernel.megatron.rms_norm import LigerMegatronRMSNorm
+
+
+def _config(
+    normalization: str = "RMSNorm",
+    sequence_parallel: bool = False,
+    layernorm_zero_centered_gamma: bool = False,
+):
+    return SimpleNamespace(
+        normalization=normalization,
+        sequence_parallel=sequence_parallel,
+        layernorm_zero_centered_gamma=layernorm_zero_centered_gamma,
+    )
+
+
+def _require_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for Liger kernels.")
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_forward_matches_torch_rmsnorm(dtype):
+    _require_cuda()
+    torch.manual_seed(0)
+    hidden, eps = 128, 1e-5
+
+    x = torch.randn(4, 16, hidden, dtype=dtype, device="cuda")
+
+    liger = (
+        LigerMegatronRMSNorm(config=_config(), hidden_size=hidden, eps=eps)
+        .cuda()
+        .to(dtype)
+    )
+    ref = torch.nn.RMSNorm(hidden, eps=eps).cuda().to(dtype)
+
+    atol, rtol = (2e-1, 2e-2) if dtype == torch.bfloat16 else (1e-4, 1e-6)
+    torch.testing.assert_close(liger(x), ref(x), atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_backward_matches_torch_rmsnorm(dtype):
+    _require_cuda()
+    torch.manual_seed(0)
+    hidden, eps = 128, 1e-5
+
+    x_l = torch.randn(4, 16, hidden, dtype=dtype, device="cuda", requires_grad=True)
+    x_r = x_l.detach().clone().requires_grad_(True)
+
+    liger = (
+        LigerMegatronRMSNorm(config=_config(), hidden_size=hidden, eps=eps)
+        .cuda()
+        .to(dtype)
+    )
+    ref = torch.nn.RMSNorm(hidden, eps=eps).cuda().to(dtype)
+    with torch.no_grad():
+        ref.weight.copy_(liger.weight)
+
+    g = torch.randn(4, 16, hidden, dtype=dtype, device="cuda")
+    liger(x_l).backward(g)
+    ref(x_r).backward(g)
+
+    atol, rtol = (2e-1, 2e-2) if dtype == torch.bfloat16 else (1e-4, 1e-6)
+    torch.testing.assert_close(x_l.grad, x_r.grad, atol=atol, rtol=rtol)
+    torch.testing.assert_close(liger.weight.grad, ref.weight.grad, atol=atol, rtol=rtol)
+
+
+def test_zero_centered_init_and_offset():
+    _require_cuda()
+    m = LigerMegatronRMSNorm(
+        config=_config(layernorm_zero_centered_gamma=True), hidden_size=64
+    ).cuda()
+    assert torch.equal(m.weight.detach(), torch.zeros(64, device="cuda"))
+    assert m._offset == 1.0
+
+    m = LigerMegatronRMSNorm(
+        config=_config(layernorm_zero_centered_gamma=False), hidden_size=64
+    ).cuda()
+    assert torch.equal(m.weight.detach(), torch.ones(64, device="cuda"))
+    assert m._offset == 0.0
+
+
+def test_zero_centered_forward_equivalent_to_ones_init():
+    """Zero-centered with w=0 should produce the same output as standard with w=1."""
+    _require_cuda()
+    torch.manual_seed(0)
+    hidden = 128
+    x = torch.randn(2, 8, hidden, dtype=torch.float32, device="cuda")
+
+    m_zc = LigerMegatronRMSNorm(
+        config=_config(layernorm_zero_centered_gamma=True), hidden_size=hidden
+    ).cuda()
+    m_std = LigerMegatronRMSNorm(
+        config=_config(layernorm_zero_centered_gamma=False), hidden_size=hidden
+    ).cuda()
+
+    torch.testing.assert_close(m_zc(x), m_std(x), atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.parametrize("sp", [True, False])
+def test_sequence_parallel_attribute_propagates(sp):
+    m = LigerMegatronRMSNorm(config=_config(sequence_parallel=sp), hidden_size=64)
+    assert getattr(m.weight, "sequence_parallel", None) is sp
+
+
+def test_rejects_non_rmsnorm_config():
+    with pytest.raises(ValueError, match="RMSNorm"):
+        LigerMegatronRMSNorm(
+            config=_config(normalization="LayerNorm"), hidden_size=64
+        )
+
+
+def test_constructor_accepts_extra_compat_kwargs():
+    m = LigerMegatronRMSNorm(
+        config=_config(),
+        hidden_size=64,
+        eps=1e-6,
+        persist_layer_norm=True,
+        normalization="RMSNorm",
+    )
+    assert m.eps == 1e-6

--- a/test/megatron/test_rms_norm.py
+++ b/test/megatron/test_rms_norm.py
@@ -2,11 +2,9 @@
 
 These tests deliberately do not import megatron-core; the wrapper's contract
 is verified using a duck-typed ``SimpleNamespace`` for ``config``. The
-parametrization style mirrors ``test/transformers/test_rms_norm.py`` —
-shape sweeps, dtype sweeps, and zero-centered-gamma variants.
+parametrization style mirrors ``test/transformers/test_rms_norm.py``.
 """
 
-import copy
 import os
 from types import SimpleNamespace
 
@@ -47,11 +45,6 @@ def _config(
     )
 
 
-def _require_cuda():
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required for Liger kernels.")
-
-
 class _LlamaRMSNorm(nn.Module):
     """Matches LigerMegatronRMSNorm semantics with zero_centered_gamma=False."""
 
@@ -65,7 +58,7 @@ class _LlamaRMSNorm(nn.Module):
         x = x.to(torch.float32)
         variance = x.pow(2).mean(-1, keepdim=True)
         x = x * torch.rsqrt(variance + self.variance_epsilon)
-        return (self.weight * x.to(input_dtype))
+        return self.weight * x.to(input_dtype)
 
 
 class _ZeroCenteredRMSNorm(nn.Module):
@@ -82,29 +75,28 @@ class _ZeroCenteredRMSNorm(nn.Module):
         x = x.to(torch.float32)
         variance = x.pow(2).mean(-1, keepdim=True)
         x = x * torch.rsqrt(variance + self.variance_epsilon)
-        return ((1.0 + self.weight) * x.to(input_dtype))
+        return (1.0 + self.weight) * x.to(input_dtype)
 
 
 # ---------------------------------------------------------------------------
-# Forward / backward correctness
+# Forward + backward correctness (mirrors test_correctness in
+# test/transformers/test_rms_norm.py).
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.parametrize(
     "bs, sl, hd",
     [
         (2, 128, 512),
-        (1, 64, 768),
-        (4, 256, 4096),
         # weird shapes
-        (5, 123, 257),
-        (3, 7, 41),
+        (5, 123, 123),
     ],
 )
 @pytest.mark.parametrize(
     "dtype, atol, rtol",
     [
-        (torch.float32, 1e-4, 1e-6),
+        (torch.float32, 5e-4, 1e-5),
         pytest.param(
             torch.bfloat16,
             2e-1,
@@ -116,290 +108,84 @@ class _ZeroCenteredRMSNorm(nn.Module):
     ],
 )
 @pytest.mark.parametrize(
-    "reference_cls, zero_centered",
+    "reference_cls, zero_centered_gamma",
     [
         (_LlamaRMSNorm, False),
         (_ZeroCenteredRMSNorm, True),
     ],
 )
-def test_forward_matches_reference(
-    bs, sl, hd, dtype, atol, rtol, reference_cls, zero_centered
-):
-    _require_cuda()
-    x = torch.randn(bs, sl, hd, device=device, dtype=dtype)
+def test_correctness(bs, sl, hd, dtype, atol, rtol, reference_cls, zero_centered_gamma):
+    _tensor = torch.randn(bs, sl, hd, device=device, dtype=dtype)
+    do = torch.randn(bs, sl, hd, device=device, dtype=dtype)
 
-    liger = (
+    h1 = _tensor.clone().requires_grad_(True)
+    h2 = _tensor.clone().requires_grad_(True)
+
+    ref_rms = reference_cls(hidden_size=hd).to(device).to(dtype)
+    ref_o = ref_rms(h1)
+    ref_o.backward(do, retain_graph=True)
+
+    liger_rms = (
         LigerMegatronRMSNorm(
-            config=_config(layernorm_zero_centered_gamma=zero_centered),
+            config=_config(layernorm_zero_centered_gamma=zero_centered_gamma),
             hidden_size=hd,
-            eps=1e-6,
         )
         .to(device)
         .to(dtype)
     )
-    ref = reference_cls(hidden_size=hd, eps=1e-6).to(device).to(dtype)
+    liger_o = liger_rms(h2)
+    liger_o.backward(do, retain_graph=True)
 
-    assert_verbose_allclose(liger(x), ref(x), atol=atol, rtol=rtol)
-
-
-@pytest.mark.parametrize(
-    "bs, sl, hd",
-    [
-        (2, 128, 512),
-        (5, 123, 257),
-    ],
-)
-@pytest.mark.parametrize(
-    "dtype, atol, rtol",
-    [
-        (torch.float32, 1e-4, 1e-6),
-        pytest.param(
-            torch.bfloat16,
-            2e-1,
-            2e-2,
-            marks=pytest.mark.skipif(
-                not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
-            ),
-        ),
-    ],
-)
-@pytest.mark.parametrize(
-    "reference_cls, zero_centered",
-    [
-        (_LlamaRMSNorm, False),
-        (_ZeroCenteredRMSNorm, True),
-    ],
-)
-def test_backward_matches_reference(
-    bs, sl, hd, dtype, atol, rtol, reference_cls, zero_centered
-):
-    _require_cuda()
-    x = torch.randn(bs, sl, hd, device=device, dtype=dtype)
-    dy = torch.randn(bs, sl, hd, device=device, dtype=dtype)
-
-    x_l = x.detach().clone().requires_grad_(True)
-    x_r = x.detach().clone().requires_grad_(True)
-
-    liger = (
-        LigerMegatronRMSNorm(
-            config=_config(layernorm_zero_centered_gamma=zero_centered),
-            hidden_size=hd,
-            eps=1e-6,
-        )
-        .to(device)
-        .to(dtype)
+    assert_verbose_allclose(ref_o, liger_o, atol=atol, rtol=rtol)
+    assert_verbose_allclose(
+        ref_rms.weight.grad, liger_rms.weight.grad, atol=atol, rtol=rtol
     )
-    ref = reference_cls(hidden_size=hd, eps=1e-6).to(device).to(dtype)
-
-    liger(x_l).backward(dy)
-    ref(x_r).backward(dy)
-
-    assert_verbose_allclose(x_l.grad, x_r.grad, atol=atol, rtol=rtol)
-    assert_verbose_allclose(liger.weight.grad, ref.weight.grad, atol=atol, rtol=rtol)
+    assert_verbose_allclose(h1.grad, h2.grad, atol=atol, rtol=rtol, max_print=20)
 
 
 # ---------------------------------------------------------------------------
-# Construction / config plumbing
+# Wrapper-specific contracts not covered by test_correctness.
 # ---------------------------------------------------------------------------
 
 
 def test_zero_centered_init_and_offset():
-    _require_cuda()
+    """zero_centered_gamma flips both the weight init and the kernel offset."""
     m = LigerMegatronRMSNorm(
         config=_config(layernorm_zero_centered_gamma=True), hidden_size=64
-    ).to(device)
-    assert torch.equal(m.weight.detach(), torch.zeros(64, device=device))
+    )
+    assert torch.equal(m.weight.detach(), torch.zeros(64))
     assert m._offset == 1.0
 
     m = LigerMegatronRMSNorm(
         config=_config(layernorm_zero_centered_gamma=False), hidden_size=64
-    ).to(device)
-    assert torch.equal(m.weight.detach(), torch.ones(64, device=device))
-    assert m._offset == 0.0
-
-
-def test_zero_centered_forward_equivalent_to_ones_init():
-    """Zero-centered with w=0 should produce the same output as standard with w=1."""
-    _require_cuda()
-    x = torch.randn(2, 8, 128, dtype=torch.float32, device=device)
-
-    m_zc = LigerMegatronRMSNorm(
-        config=_config(layernorm_zero_centered_gamma=True), hidden_size=128
-    ).to(device)
-    m_std = LigerMegatronRMSNorm(
-        config=_config(layernorm_zero_centered_gamma=False), hidden_size=128
-    ).to(device)
-
-    assert_verbose_allclose(m_zc(x), m_std(x), atol=1e-5, rtol=1e-5)
-
-
-def test_constructor_kwarg_overrides_config_for_zero_centered():
-    """Explicit zero_centered_gamma=True wins even when config says False."""
-    m = LigerMegatronRMSNorm(
-        config=_config(layernorm_zero_centered_gamma=False),
-        hidden_size=32,
-        zero_centered_gamma=True,
     )
-    assert m.zero_centered_gamma is True
-    assert m._offset == 1.0
+    assert torch.equal(m.weight.detach(), torch.ones(64))
+    assert m._offset == 0.0
 
 
 @pytest.mark.parametrize("sp", [True, False])
 def test_sequence_parallel_attribute_propagates(sp):
+    """Megatron's distributed optimizer reads this attribute to decide
+    whether to all-reduce the weight's gradient across TP ranks under SP."""
     m = LigerMegatronRMSNorm(config=_config(sequence_parallel=sp), hidden_size=64)
     assert getattr(m.weight, "sequence_parallel", None) is sp
 
 
 def test_rejects_non_rmsnorm_config():
+    """The wrapper only supports RMSNorm; surface a clear error otherwise."""
     with pytest.raises(ValueError, match="RMSNorm"):
         LigerMegatronRMSNorm(
             config=_config(normalization="LayerNorm"), hidden_size=64
         )
 
 
-def test_rejects_non_rmsnorm_l2():
-    with pytest.raises(ValueError, match="RMSNorm"):
-        LigerMegatronRMSNorm(config=_config(normalization="L2Norm"), hidden_size=64)
-
-
-def test_constructor_accepts_extra_compat_kwargs():
-    """Should silently accept the interface-compat kwargs that FusedLayerNorm
-    takes — persist_layer_norm and normalization — without raising."""
-    m = LigerMegatronRMSNorm(
-        config=_config(),
-        hidden_size=64,
-        eps=1e-6,
-        persist_layer_norm=True,
-        normalization="RMSNorm",
-    )
-    assert m.eps == 1e-6
-
-
-def test_eps_propagates():
-    m = LigerMegatronRMSNorm(config=_config(), hidden_size=64, eps=3.14e-5)
-    assert m.eps == 3.14e-5
-
-
-@pytest.mark.parametrize("hidden_size", [64, (64,), (128,)])
-def test_hidden_size_accepts_int_or_tuple(hidden_size):
-    m = LigerMegatronRMSNorm(config=_config(), hidden_size=hidden_size)
-    expected = hidden_size if isinstance(hidden_size, tuple) else (hidden_size,)
-    assert tuple(m.hidden_size) == expected
-    assert m.weight.shape == torch.Size(expected)
-
-
-# ---------------------------------------------------------------------------
-# Module behaviour
-# ---------------------------------------------------------------------------
-
-
-def test_extra_repr_is_informative():
-    m = LigerMegatronRMSNorm(config=_config(), hidden_size=64, eps=1e-5)
-    rep = m.extra_repr()
-    assert "hidden_size" in rep
-    assert "eps" in rep
-    assert "zero_centered_gamma" in rep
-
-
 def test_forward_does_not_modify_input():
-    """in_place=False is hardcoded; verify the input tensor is untouched."""
-    _require_cuda()
+    """``in_place=False`` is hardcoded for Megatron's recompute / CUDA-graph
+    safety; verify the input tensor isn't touched by the forward."""
+    if device != "cuda":
+        pytest.skip("CUDA required for Liger kernels.")
     x = torch.randn(2, 8, 64, device=device, dtype=torch.float32)
     snapshot = x.detach().clone()
     m = LigerMegatronRMSNorm(config=_config(), hidden_size=64).to(device)
     _ = m(x)
     assert torch.equal(x, snapshot)
-
-
-def test_multiple_forwards_are_deterministic():
-    """Same input → same output across repeated calls."""
-    _require_cuda()
-    x = torch.randn(2, 8, 64, device=device, dtype=torch.float32)
-    m = LigerMegatronRMSNorm(config=_config(), hidden_size=64).to(device)
-    y1 = m(x)
-    y2 = m(x)
-    assert torch.equal(y1, y2)
-
-
-def test_independent_instances_do_not_share_state():
-    """Two wrappers built from the same config must have independent weights."""
-    _require_cuda()
-    cfg = _config()
-    m1 = LigerMegatronRMSNorm(config=cfg, hidden_size=64).to(device)
-    m2 = LigerMegatronRMSNorm(config=cfg, hidden_size=64).to(device)
-
-    assert m1.weight.data_ptr() != m2.weight.data_ptr()
-    with torch.no_grad():
-        m1.weight.fill_(2.0)
-    assert not torch.allclose(m1.weight, m2.weight)
-
-
-def test_reset_parameters_reinitializes_weight():
-    _require_cuda()
-    m = LigerMegatronRMSNorm(config=_config(), hidden_size=64).to(device)
-    with torch.no_grad():
-        m.weight.fill_(7.0)
-    m.reset_parameters()
-    assert torch.equal(m.weight, torch.ones(64, device=device))
-
-    m_zc = LigerMegatronRMSNorm(
-        config=_config(layernorm_zero_centered_gamma=True), hidden_size=64
-    ).to(device)
-    with torch.no_grad():
-        m_zc.weight.fill_(7.0)
-    m_zc.reset_parameters()
-    assert torch.equal(m_zc.weight, torch.zeros(64, device=device))
-
-
-def test_state_dict_roundtrip_preserves_output():
-    """Save weights, load into a fresh instance, output must match."""
-    _require_cuda()
-    x = torch.randn(2, 8, 64, device=device, dtype=torch.float32)
-
-    src = LigerMegatronRMSNorm(config=_config(), hidden_size=64).to(device)
-    with torch.no_grad():
-        src.weight.uniform_(-0.5, 0.5)
-
-    dst = LigerMegatronRMSNorm(config=_config(), hidden_size=64).to(device)
-    dst.load_state_dict(copy.deepcopy(src.state_dict()))
-
-    assert torch.equal(src(x), dst(x))
-
-
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
-def test_module_to_dtype_changes_weight_dtype(dtype):
-    if dtype == torch.bfloat16 and not supports_bfloat16():
-        pytest.skip("bfloat16 not supported on this GPU")
-    _require_cuda()
-    m = LigerMegatronRMSNorm(config=_config(), hidden_size=64).to(device).to(dtype)
-    assert m.weight.dtype == dtype
-
-
-def test_weight_gradient_accumulates_across_backwards():
-    """Repeated backward calls (without zero_grad) should accumulate."""
-    _require_cuda()
-    x = torch.randn(2, 8, 64, device=device, dtype=torch.float32)
-    dy = torch.randn(2, 8, 64, device=device, dtype=torch.float32)
-
-    m = LigerMegatronRMSNorm(config=_config(), hidden_size=64).to(device)
-
-    x1 = x.clone().requires_grad_(True)
-    m(x1).backward(dy)
-    g1 = m.weight.grad.clone()
-
-    x2 = x.clone().requires_grad_(True)
-    m(x2).backward(dy)
-    g2 = m.weight.grad.clone()
-
-    assert_verbose_allclose(g2, 2.0 * g1, atol=1e-5, rtol=1e-5)
-
-
-def test_requires_grad_is_respected_when_input_does_not_need_grad():
-    """If input doesn't require grad, output still doesn't get a grad_fn that
-    blocks .backward() on something else."""
-    _require_cuda()
-    x = torch.randn(2, 8, 64, device=device, dtype=torch.float32, requires_grad=False)
-    m = LigerMegatronRMSNorm(config=_config(), hidden_size=64).to(device)
-    y = m(x)
-    # weight still requires grad → output should require grad
-    assert y.requires_grad

--- a/test/megatron/test_rms_norm.py
+++ b/test/megatron/test_rms_norm.py
@@ -6,18 +6,18 @@ parametrization style mirrors ``test/transformers/test_rms_norm.py``.
 """
 
 import os
+
 from types import SimpleNamespace
 
 import pytest
 import torch
 import torch.nn as nn
 
+from liger_kernel.megatron.rms_norm import LigerMegatronRMSNorm
+from liger_kernel.utils import infer_device
 from test.utils import assert_verbose_allclose
 from test.utils import set_seed
 from test.utils import supports_bfloat16
-
-from liger_kernel.megatron.rms_norm import LigerMegatronRMSNorm
-from liger_kernel.utils import infer_device
 
 device = infer_device()
 
@@ -101,9 +101,7 @@ class _ZeroCenteredRMSNorm(nn.Module):
             torch.bfloat16,
             2e-1,
             2e-2,
-            marks=pytest.mark.skipif(
-                not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
-            ),
+            marks=pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this GPU"),
         ),
     ],
 )
@@ -137,9 +135,7 @@ def test_correctness(bs, sl, hd, dtype, atol, rtol, reference_cls, zero_centered
     liger_o.backward(do, retain_graph=True)
 
     assert_verbose_allclose(ref_o, liger_o, atol=atol, rtol=rtol)
-    assert_verbose_allclose(
-        ref_rms.weight.grad, liger_rms.weight.grad, atol=atol, rtol=rtol
-    )
+    assert_verbose_allclose(ref_rms.weight.grad, liger_rms.weight.grad, atol=atol, rtol=rtol)
     assert_verbose_allclose(h1.grad, h2.grad, atol=atol, rtol=rtol, max_print=20)
 
 
@@ -150,15 +146,11 @@ def test_correctness(bs, sl, hd, dtype, atol, rtol, reference_cls, zero_centered
 
 def test_zero_centered_init_and_offset():
     """zero_centered_gamma flips both the weight init and the kernel offset."""
-    m = LigerMegatronRMSNorm(
-        config=_config(layernorm_zero_centered_gamma=True), hidden_size=64
-    )
+    m = LigerMegatronRMSNorm(config=_config(layernorm_zero_centered_gamma=True), hidden_size=64)
     assert torch.equal(m.weight.detach(), torch.zeros(64))
     assert m._offset == 1.0
 
-    m = LigerMegatronRMSNorm(
-        config=_config(layernorm_zero_centered_gamma=False), hidden_size=64
-    )
+    m = LigerMegatronRMSNorm(config=_config(layernorm_zero_centered_gamma=False), hidden_size=64)
     assert torch.equal(m.weight.detach(), torch.ones(64))
     assert m._offset == 0.0
 
@@ -174,9 +166,7 @@ def test_sequence_parallel_attribute_propagates(sp):
 def test_rejects_non_rmsnorm_config():
     """The wrapper only supports RMSNorm; surface a clear error otherwise."""
     with pytest.raises(ValueError, match="RMSNorm"):
-        LigerMegatronRMSNorm(
-            config=_config(normalization="LayerNorm"), hidden_size=64
-        )
+        LigerMegatronRMSNorm(config=_config(normalization="LayerNorm"), hidden_size=64)
 
 
 def test_forward_does_not_modify_input():

--- a/test/megatron/test_rms_norm.py
+++ b/test/megatron/test_rms_norm.py
@@ -1,15 +1,38 @@
 """Unit tests for LigerMegatronRMSNorm.
 
-These tests deliberately do not import megatron-core. The wrapper's contract
-is verified using a duck-typed ``SimpleNamespace`` for ``config``.
+These tests deliberately do not import megatron-core; the wrapper's contract
+is verified using a duck-typed ``SimpleNamespace`` for ``config``. The
+parametrization style mirrors ``test/transformers/test_rms_norm.py`` —
+shape sweeps, dtype sweeps, and zero-centered-gamma variants.
 """
 
+import copy
+import os
 from types import SimpleNamespace
 
 import pytest
 import torch
+import torch.nn as nn
+
+from test.utils import assert_verbose_allclose
+from test.utils import set_seed
+from test.utils import supports_bfloat16
 
 from liger_kernel.megatron.rms_norm import LigerMegatronRMSNorm
+from liger_kernel.utils import infer_device
+
+device = infer_device()
+
+set_seed(42)
+torch.use_deterministic_algorithms(True)
+
+if device == "cuda":
+    os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+
+
+# ---------------------------------------------------------------------------
+# References + helpers
+# ---------------------------------------------------------------------------
 
 
 def _config(
@@ -29,82 +52,196 @@ def _require_cuda():
         pytest.skip("CUDA required for Liger kernels.")
 
 
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
-def test_forward_matches_torch_rmsnorm(dtype):
-    _require_cuda()
-    torch.manual_seed(0)
-    hidden, eps = 128, 1e-5
+class _LlamaRMSNorm(nn.Module):
+    """Matches LigerMegatronRMSNorm semantics with zero_centered_gamma=False."""
 
-    x = torch.randn(4, 16, hidden, dtype=dtype, device="cuda")
+    def __init__(self, hidden_size, eps=1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, x):
+        input_dtype = x.dtype
+        x = x.to(torch.float32)
+        variance = x.pow(2).mean(-1, keepdim=True)
+        x = x * torch.rsqrt(variance + self.variance_epsilon)
+        return (self.weight * x.to(input_dtype))
+
+
+class _ZeroCenteredRMSNorm(nn.Module):
+    """Matches LigerMegatronRMSNorm with zero_centered_gamma=True: applies
+    ``(1 + w) * x_normalized``, weight initialized to zeros."""
+
+    def __init__(self, hidden_size, eps=1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.zeros(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, x):
+        input_dtype = x.dtype
+        x = x.to(torch.float32)
+        variance = x.pow(2).mean(-1, keepdim=True)
+        x = x * torch.rsqrt(variance + self.variance_epsilon)
+        return ((1.0 + self.weight) * x.to(input_dtype))
+
+
+# ---------------------------------------------------------------------------
+# Forward / backward correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bs, sl, hd",
+    [
+        (2, 128, 512),
+        (1, 64, 768),
+        (4, 256, 4096),
+        # weird shapes
+        (5, 123, 257),
+        (3, 7, 41),
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype, atol, rtol",
+    [
+        (torch.float32, 1e-4, 1e-6),
+        pytest.param(
+            torch.bfloat16,
+            2e-1,
+            2e-2,
+            marks=pytest.mark.skipif(
+                not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "reference_cls, zero_centered",
+    [
+        (_LlamaRMSNorm, False),
+        (_ZeroCenteredRMSNorm, True),
+    ],
+)
+def test_forward_matches_reference(
+    bs, sl, hd, dtype, atol, rtol, reference_cls, zero_centered
+):
+    _require_cuda()
+    x = torch.randn(bs, sl, hd, device=device, dtype=dtype)
 
     liger = (
-        LigerMegatronRMSNorm(config=_config(), hidden_size=hidden, eps=eps)
-        .cuda()
+        LigerMegatronRMSNorm(
+            config=_config(layernorm_zero_centered_gamma=zero_centered),
+            hidden_size=hd,
+            eps=1e-6,
+        )
+        .to(device)
         .to(dtype)
     )
-    ref = torch.nn.RMSNorm(hidden, eps=eps).cuda().to(dtype)
+    ref = reference_cls(hidden_size=hd, eps=1e-6).to(device).to(dtype)
 
-    atol, rtol = (2e-1, 2e-2) if dtype == torch.bfloat16 else (1e-4, 1e-6)
-    torch.testing.assert_close(liger(x), ref(x), atol=atol, rtol=rtol)
+    assert_verbose_allclose(liger(x), ref(x), atol=atol, rtol=rtol)
 
 
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
-def test_backward_matches_torch_rmsnorm(dtype):
+@pytest.mark.parametrize(
+    "bs, sl, hd",
+    [
+        (2, 128, 512),
+        (5, 123, 257),
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype, atol, rtol",
+    [
+        (torch.float32, 1e-4, 1e-6),
+        pytest.param(
+            torch.bfloat16,
+            2e-1,
+            2e-2,
+            marks=pytest.mark.skipif(
+                not supports_bfloat16(), reason="bfloat16 not supported on this GPU"
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "reference_cls, zero_centered",
+    [
+        (_LlamaRMSNorm, False),
+        (_ZeroCenteredRMSNorm, True),
+    ],
+)
+def test_backward_matches_reference(
+    bs, sl, hd, dtype, atol, rtol, reference_cls, zero_centered
+):
     _require_cuda()
-    torch.manual_seed(0)
-    hidden, eps = 128, 1e-5
+    x = torch.randn(bs, sl, hd, device=device, dtype=dtype)
+    dy = torch.randn(bs, sl, hd, device=device, dtype=dtype)
 
-    x_l = torch.randn(4, 16, hidden, dtype=dtype, device="cuda", requires_grad=True)
-    x_r = x_l.detach().clone().requires_grad_(True)
+    x_l = x.detach().clone().requires_grad_(True)
+    x_r = x.detach().clone().requires_grad_(True)
 
     liger = (
-        LigerMegatronRMSNorm(config=_config(), hidden_size=hidden, eps=eps)
-        .cuda()
+        LigerMegatronRMSNorm(
+            config=_config(layernorm_zero_centered_gamma=zero_centered),
+            hidden_size=hd,
+            eps=1e-6,
+        )
+        .to(device)
         .to(dtype)
     )
-    ref = torch.nn.RMSNorm(hidden, eps=eps).cuda().to(dtype)
-    with torch.no_grad():
-        ref.weight.copy_(liger.weight)
+    ref = reference_cls(hidden_size=hd, eps=1e-6).to(device).to(dtype)
 
-    g = torch.randn(4, 16, hidden, dtype=dtype, device="cuda")
-    liger(x_l).backward(g)
-    ref(x_r).backward(g)
+    liger(x_l).backward(dy)
+    ref(x_r).backward(dy)
 
-    atol, rtol = (2e-1, 2e-2) if dtype == torch.bfloat16 else (1e-4, 1e-6)
-    torch.testing.assert_close(x_l.grad, x_r.grad, atol=atol, rtol=rtol)
-    torch.testing.assert_close(liger.weight.grad, ref.weight.grad, atol=atol, rtol=rtol)
+    assert_verbose_allclose(x_l.grad, x_r.grad, atol=atol, rtol=rtol)
+    assert_verbose_allclose(liger.weight.grad, ref.weight.grad, atol=atol, rtol=rtol)
+
+
+# ---------------------------------------------------------------------------
+# Construction / config plumbing
+# ---------------------------------------------------------------------------
 
 
 def test_zero_centered_init_and_offset():
     _require_cuda()
     m = LigerMegatronRMSNorm(
         config=_config(layernorm_zero_centered_gamma=True), hidden_size=64
-    ).cuda()
-    assert torch.equal(m.weight.detach(), torch.zeros(64, device="cuda"))
+    ).to(device)
+    assert torch.equal(m.weight.detach(), torch.zeros(64, device=device))
     assert m._offset == 1.0
 
     m = LigerMegatronRMSNorm(
         config=_config(layernorm_zero_centered_gamma=False), hidden_size=64
-    ).cuda()
-    assert torch.equal(m.weight.detach(), torch.ones(64, device="cuda"))
+    ).to(device)
+    assert torch.equal(m.weight.detach(), torch.ones(64, device=device))
     assert m._offset == 0.0
 
 
 def test_zero_centered_forward_equivalent_to_ones_init():
     """Zero-centered with w=0 should produce the same output as standard with w=1."""
     _require_cuda()
-    torch.manual_seed(0)
-    hidden = 128
-    x = torch.randn(2, 8, hidden, dtype=torch.float32, device="cuda")
+    x = torch.randn(2, 8, 128, dtype=torch.float32, device=device)
 
     m_zc = LigerMegatronRMSNorm(
-        config=_config(layernorm_zero_centered_gamma=True), hidden_size=hidden
-    ).cuda()
+        config=_config(layernorm_zero_centered_gamma=True), hidden_size=128
+    ).to(device)
     m_std = LigerMegatronRMSNorm(
-        config=_config(layernorm_zero_centered_gamma=False), hidden_size=hidden
-    ).cuda()
+        config=_config(layernorm_zero_centered_gamma=False), hidden_size=128
+    ).to(device)
 
-    torch.testing.assert_close(m_zc(x), m_std(x), atol=1e-5, rtol=1e-5)
+    assert_verbose_allclose(m_zc(x), m_std(x), atol=1e-5, rtol=1e-5)
+
+
+def test_constructor_kwarg_overrides_config_for_zero_centered():
+    """Explicit zero_centered_gamma=True wins even when config says False."""
+    m = LigerMegatronRMSNorm(
+        config=_config(layernorm_zero_centered_gamma=False),
+        hidden_size=32,
+        zero_centered_gamma=True,
+    )
+    assert m.zero_centered_gamma is True
+    assert m._offset == 1.0
 
 
 @pytest.mark.parametrize("sp", [True, False])
@@ -120,7 +257,14 @@ def test_rejects_non_rmsnorm_config():
         )
 
 
+def test_rejects_non_rmsnorm_l2():
+    with pytest.raises(ValueError, match="RMSNorm"):
+        LigerMegatronRMSNorm(config=_config(normalization="L2Norm"), hidden_size=64)
+
+
 def test_constructor_accepts_extra_compat_kwargs():
+    """Should silently accept the interface-compat kwargs that FusedLayerNorm
+    takes — persist_layer_norm and normalization — without raising."""
     m = LigerMegatronRMSNorm(
         config=_config(),
         hidden_size=64,
@@ -129,3 +273,133 @@ def test_constructor_accepts_extra_compat_kwargs():
         normalization="RMSNorm",
     )
     assert m.eps == 1e-6
+
+
+def test_eps_propagates():
+    m = LigerMegatronRMSNorm(config=_config(), hidden_size=64, eps=3.14e-5)
+    assert m.eps == 3.14e-5
+
+
+@pytest.mark.parametrize("hidden_size", [64, (64,), (128,)])
+def test_hidden_size_accepts_int_or_tuple(hidden_size):
+    m = LigerMegatronRMSNorm(config=_config(), hidden_size=hidden_size)
+    expected = hidden_size if isinstance(hidden_size, tuple) else (hidden_size,)
+    assert tuple(m.hidden_size) == expected
+    assert m.weight.shape == torch.Size(expected)
+
+
+# ---------------------------------------------------------------------------
+# Module behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_extra_repr_is_informative():
+    m = LigerMegatronRMSNorm(config=_config(), hidden_size=64, eps=1e-5)
+    rep = m.extra_repr()
+    assert "hidden_size" in rep
+    assert "eps" in rep
+    assert "zero_centered_gamma" in rep
+
+
+def test_forward_does_not_modify_input():
+    """in_place=False is hardcoded; verify the input tensor is untouched."""
+    _require_cuda()
+    x = torch.randn(2, 8, 64, device=device, dtype=torch.float32)
+    snapshot = x.detach().clone()
+    m = LigerMegatronRMSNorm(config=_config(), hidden_size=64).to(device)
+    _ = m(x)
+    assert torch.equal(x, snapshot)
+
+
+def test_multiple_forwards_are_deterministic():
+    """Same input → same output across repeated calls."""
+    _require_cuda()
+    x = torch.randn(2, 8, 64, device=device, dtype=torch.float32)
+    m = LigerMegatronRMSNorm(config=_config(), hidden_size=64).to(device)
+    y1 = m(x)
+    y2 = m(x)
+    assert torch.equal(y1, y2)
+
+
+def test_independent_instances_do_not_share_state():
+    """Two wrappers built from the same config must have independent weights."""
+    _require_cuda()
+    cfg = _config()
+    m1 = LigerMegatronRMSNorm(config=cfg, hidden_size=64).to(device)
+    m2 = LigerMegatronRMSNorm(config=cfg, hidden_size=64).to(device)
+
+    assert m1.weight.data_ptr() != m2.weight.data_ptr()
+    with torch.no_grad():
+        m1.weight.fill_(2.0)
+    assert not torch.allclose(m1.weight, m2.weight)
+
+
+def test_reset_parameters_reinitializes_weight():
+    _require_cuda()
+    m = LigerMegatronRMSNorm(config=_config(), hidden_size=64).to(device)
+    with torch.no_grad():
+        m.weight.fill_(7.0)
+    m.reset_parameters()
+    assert torch.equal(m.weight, torch.ones(64, device=device))
+
+    m_zc = LigerMegatronRMSNorm(
+        config=_config(layernorm_zero_centered_gamma=True), hidden_size=64
+    ).to(device)
+    with torch.no_grad():
+        m_zc.weight.fill_(7.0)
+    m_zc.reset_parameters()
+    assert torch.equal(m_zc.weight, torch.zeros(64, device=device))
+
+
+def test_state_dict_roundtrip_preserves_output():
+    """Save weights, load into a fresh instance, output must match."""
+    _require_cuda()
+    x = torch.randn(2, 8, 64, device=device, dtype=torch.float32)
+
+    src = LigerMegatronRMSNorm(config=_config(), hidden_size=64).to(device)
+    with torch.no_grad():
+        src.weight.uniform_(-0.5, 0.5)
+
+    dst = LigerMegatronRMSNorm(config=_config(), hidden_size=64).to(device)
+    dst.load_state_dict(copy.deepcopy(src.state_dict()))
+
+    assert torch.equal(src(x), dst(x))
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_module_to_dtype_changes_weight_dtype(dtype):
+    if dtype == torch.bfloat16 and not supports_bfloat16():
+        pytest.skip("bfloat16 not supported on this GPU")
+    _require_cuda()
+    m = LigerMegatronRMSNorm(config=_config(), hidden_size=64).to(device).to(dtype)
+    assert m.weight.dtype == dtype
+
+
+def test_weight_gradient_accumulates_across_backwards():
+    """Repeated backward calls (without zero_grad) should accumulate."""
+    _require_cuda()
+    x = torch.randn(2, 8, 64, device=device, dtype=torch.float32)
+    dy = torch.randn(2, 8, 64, device=device, dtype=torch.float32)
+
+    m = LigerMegatronRMSNorm(config=_config(), hidden_size=64).to(device)
+
+    x1 = x.clone().requires_grad_(True)
+    m(x1).backward(dy)
+    g1 = m.weight.grad.clone()
+
+    x2 = x.clone().requires_grad_(True)
+    m(x2).backward(dy)
+    g2 = m.weight.grad.clone()
+
+    assert_verbose_allclose(g2, 2.0 * g1, atol=1e-5, rtol=1e-5)
+
+
+def test_requires_grad_is_respected_when_input_does_not_need_grad():
+    """If input doesn't require grad, output still doesn't get a grad_fn that
+    blocks .backward() on something else."""
+    _require_cuda()
+    x = torch.randn(2, 8, 64, device=device, dtype=torch.float32, requires_grad=False)
+    m = LigerMegatronRMSNorm(config=_config(), hidden_size=64).to(device)
+    y = m(x)
+    # weight still requires grad → output should require grad
+    assert y.requires_grad


### PR DESCRIPTION
## Summary

Adds first-class Megatron-Core support for Liger's Triton RMSNorm with **two adoption modes**, both reaching **5/5 norm-slot coverage** on a standard GPT-style model. No changes are required on Megatron-LM — this PR works against upstream `megatron-core`.

**Note** - The kernel works for TP, and should ideally not break for SP, but the behavior needs to verified end-to-end. Marked as a TODO in `rms_norm.py`.

### Background — Megatron has *two* norm slots, not one

A GPT-style Megatron decoder has `2 × num_layers + 1` RMSNorm modules:

- `decoder.layers[i].input_layernorm` and `decoder.layers[i].pre_mlp_layernorm` — populated from the per-layer `TransformerLayerSubmodules` dataclass.
- `decoder.final_layernorm` — populated from a *separate* `TransformerBlockSubmodules.layer_norm` field, which defaults to a module-level global `LayerNormImpl` in `transformer_block.py` (TE / Apex / `WrappedTorchNorm`, chosen at import time).

To cover all norms, the integration must hit both code paths. Both modes below do.

### Mode 1 — monkey-patch (one line, all GPT-family models, 5/5 norms)

```python
from liger_kernel.megatron import apply_liger_kernel_to_megatron

apply_liger_kernel_to_megatron(rms_norm=True)

# Then build your model normally — every RMSNorm slot is now Liger.
gpt_model = GPTModel(
    config=cfg,
    transformer_layer_spec=get_gpt_layer_local_spec(normalization="RMSNorm"),
    ...,
)
```

The call rewrites two sites:

1. `megatron.core.models.backends.LocalSpecProvider.layer_norm` → returns `LigerMegatronRMSNorm` when `rms_norm=True`. Covers `input_layernorm`, `pre_mlp_layernorm`, and (if `qk_layernorm=True`) `q_layernorm` / `k_layernorm`.
2. `megatron.core.transformer.transformer_block.LayerNormImpl` → replaced with a small adapter that routes to `LigerMegatronRMSNorm` when `config.normalization == "RMSNorm"` and falls back to the original `WrappedTorchNorm` otherwise. Covers `final_layernorm` without disturbing LayerNorm users.

Both patches:
- Only displace the **`WrappedTorchNorm` fallback**. Users on TE or Apex chose those deliberately — replacing them would undo TE's `TELayerNormColumnParallelLinear` fusion or surprise Apex users.

Because both patches target the `BackendSpecProvider` / `LayerNormImpl` abstractions — not individual model files — **a single call covers every model that routes through Megatron's standard spec system** (GPT-3, Llama-N, Mixtral, Nemotron, MLA, any `TransformerLayer`-based model). No per-model code, in contrast to HF where every `modeling_<x>.py` needs its own `apply_liger_kernel_to_<x>()`.

### Mode 2 — hand-assembled `TransformerBlockSubmodules` (slot-level surgical control, 5/5 norms)

```python
from megatron.core.transformer.spec_utils import ModuleSpec
from megatron.core.transformer.transformer_block import TransformerBlockSubmodules
from megatron.core.transformer.transformer_layer import TransformerLayer, TransformerLayerSubmodules
from liger_kernel.megatron import LigerMegatronRMSNorm

per_layer = ModuleSpec(
    module=TransformerLayer,
    submodules=TransformerLayerSubmodules(
        input_layernorm=LigerMegatronRMSNorm,    # Liger
        self_attention=...,                      # TE here if you want
        pre_mlp_layernorm=LigerMegatronRMSNorm,  # Liger
        mlp=...,
    ),
)
block_spec = TransformerBlockSubmodules(
    layer_specs=[per_layer] * num_layers,
    layer_norm=LigerMegatronRMSNorm,             # ← covers final_layernorm
)
gpt_model = GPTModel(config=cfg, transformer_layer_spec=block_spec, ...)
```

Useful when mixing Liger with TransformerEngine per slot (e.g. "TE for everything except norms"). Verbose but maximally explicit. Passing a `TransformerBlockSubmodules` instead of a bare per-layer `ModuleSpec` is the only way to reach `final_layernorm` without monkey-patching — Megatron auto-promotes a per-layer spec via its module-level `LayerNormImpl` global, which would otherwise leave the trailing norm on PyTorch's `nn.RMSNorm`.

## What's added

| File | Purpose |
|---|---|
| `src/liger_kernel/megatron/rms_norm.py` | `LigerMegatronRMSNorm` — conforms to Megatron's `LayerNormBuilder` protocol (`config, hidden_size, eps`). Reads `config.normalization` (asserts `"RMSNorm"`), `config.sequence_parallel`, `config.layernorm_zero_centered_gamma`. Sets `weight.sequence_parallel` for the dist optimizer. `in_place=False` hardcoded for Megatron's recompute / CUDA-graph safety. No `megatron-core` import — duck-typed config. |
| `src/liger_kernel/megatron/monkey_patch.py` | `apply_liger_kernel_to_megatron(rms_norm=True)` — patches both `LocalSpecProvider.layer_norm` and `transformer_block.LayerNormImpl`. Idempotent. |
| `src/liger_kernel/megatron/__init__.py` | Re-exports `LigerMegatronRMSNorm`, `apply_liger_kernel_to_megatron`. |
| `examples/megatron/run_mode1_monkey_patch.py` | End-to-end runnable script demonstrating Mode 1. |
| `examples/megatron/run_mode2_hand_spec.py` | End-to-end runnable script demonstrating Mode 2. |
| `examples/megatron/README.md` | Prerequisites + run instructions + expected output. |
| `test/megatron/test_rms_norm.py` | 10 unit tests against `torch.nn.RMSNorm` reference. |

## How to reproduce

Two self-contained scripts live in this PR under [`examples/megatron/`](examples/megatron). Each is an end-to-end training run (TP=2, mock GPT data, 5 iterations, distributed-checkpoint round-trip) that prints the full module tree and the resolved norm class at every slot so reviewers can verify Liger took over. Both adapt Megatron's own `examples/run_simple_mcore_train_loop.py`.

```bash
# Mode 1 — apply_liger_kernel_to_megatron(rms_norm=True)
torchrun --nproc_per_node=2 --master_addr=127.0.0.1 --master_port=29500 \
    examples/megatron/run_mode1_monkey_patch.py

# Mode 2 — hand-assembled TransformerBlockSubmodules
torchrun --nproc_per_node=2 --master_addr=127.0.0.1 --master_port=29500 \
    examples/megatron/run_mode2_hand_spec.py
```

The Liger-specific lines in each script are flagged with `↓↓ Mode N ↓↓` / `↑↑ ↑↑` comment fences so reviewers can scan straight to the integration code without reading the boilerplate.

See [`examples/megatron/README.md`](examples/megatron/README.md) for prerequisites and expected output (5 lines of loss + 5 lines of `LigerMegatronRMSNorm` slots + `Successfully loaded the model`).

## Megatron feature compatibility

**Verified:** TP (tested at TP=2), distributed checkpointing (save/load round-trip in the harness), fp32 + bf16 (unit-tested), recompute paths (`in_place=False` keeps activation references valid), `qk_layernorm` slots, and `final_layernorm` (covered in both modes — mode 1 via `transformer_block.LayerNormImpl`, mode 2 via `TransformerBlockSubmodules.layer_norm`).

**Should work, not yet E2E-verified:** SP (wrapper sets `weight.sequence_parallel`; notably the local baseline `WrappedTorchNorm` asserts SP off, so this is a strict improvement), CP, `use_distributed_optimizer=True`, CUDA-graph capture. Positive tests for these are tracked as follow-up.

**Out of scope:** FP8 / FP4 (TE owns that path), the TE backend, and the Apex backend — the patches only displace the `WrappedTorchNorm` fallback. Users on TE or Apex keep their existing norms.
## Known issues / follow-ups

1. **SP / CP / dist-opt / CUDA-graph not end-to-end verified.** Should work by construction; need positive tests before production claims.
2. **Pre-existing torch 2.11 compatibility issue in `liger_kernel.ops.rms_norm`.** It references `torch.distributed.tensor.DTensor` without forcing the submodule import. Worked around in our wrapper with an explicit `import torch.distributed.tensor` — proper fix is a one-line change to `ops/rms_norm.py`, intentionally not bundled here.
3. **Performance not measured.** This PR establishes correctness, integration shape, and full norm coverage. Throughput / memory benchmarks on a realistic hidden size (Llama-7B class, hidden=4096+) are the natural next step.
4. **Convergence tests need to be added**
## Testing Done

- Hardware Type: NVIDIA H100 80GB (2×)
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
