### PR TITLE
[NPU] optimize embedding for A3(X86)

### DIFF
--- a/src/liger_kernel/ops/backends/_ascend/ops/embedding.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/embedding.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 import torch
 import triton
 import triton.language as tl
@@ -5,6 +7,27 @@ import triton.language as tl
 from liger_kernel.ops.backends._ascend.ub_manager import compute_default_tiling_strategy
 from liger_kernel.ops.utils import ensure_contiguous
 from liger_kernel.ops.utils import get_npu_core_count
+
+# Ascend UB capacity is 192 KB.
+_ASCEND_UB_CAPACITY_BITS = 1572864
+_UB_MULTIPLIER = 3.2
+_UB_SAFETY = 0.85
+
+# Wide embeddings (embedding_dim >= threshold) use large N tiles tuned on Ascend910 bf16.
+_WIDE_EMBEDDING_THRESHOLD = 2048
+_FORWARD_MAX_BLOCK_N = 512
+_FORWARD_WIDE_BLOCK_N_CANDIDATES = (4096, 2048, 1024, 512)
+
+# Ascend910 bf16 2D forward compile limits: max BLOCK_SIZE_M per BLOCK_SIZE_N.
+_FORWARD_COMPILED_MAX_M = {
+    4096: 6,
+    2048: 12,
+    1024: 18,
+    512: 37,
+    256: 75,
+    128: 126,
+    64: 128,
+}
 
 
 @triton.jit
@@ -32,13 +55,13 @@ def embedding_forward_kernel(
         start_n = block_n * BLOCK_SIZE_N
 
         offsets_m = start_m + tl.arange(0, BLOCK_SIZE_M)
+        offsets_m = tl.max_contiguous(offsets_m, BLOCK_SIZE_M)
         mask_m = offsets_m < n_elements
-
         indices = tl.load(indices_ptr + offsets_m, mask=mask_m, other=0)
 
         offsets_n = start_n + tl.arange(0, BLOCK_SIZE_N)
+        offsets_n = tl.max_contiguous(offsets_n, BLOCK_SIZE_N)
         mask_n = offsets_n < embedding_dim
-
         block_mask = mask_m[:, None] & mask_n[None, :]
 
         embedding_offsets = indices[:, None] * embedding_dim + offsets_n[None, :]
@@ -49,15 +72,100 @@ def embedding_forward_kernel(
         )
 
         output_offsets = offsets_m[:, None] * embedding_dim + offsets_n[None, :]
-        tl.store(
-            output_ptr + output_offsets,
-            embeddings,
-            mask=block_mask,
-        )
+        tl.store(output_ptr + output_offsets, embeddings, mask=block_mask)
+
+
+@triton.jit
+def embedding_forward_kernel_mouter(
+    embeddings_ptr,
+    indices_ptr,
+    output_ptr,
+    n_elements,
+    embedding_dim: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+
+    grid_m = tl.cdiv(n_elements, BLOCK_SIZE_M)
+    grid_n = tl.cdiv(embedding_dim, BLOCK_SIZE_N)
+
+    for block_m in tl.range(pid, grid_m, num_progs):
+        start_m = block_m * BLOCK_SIZE_M
+
+        offsets_m = start_m + tl.arange(0, BLOCK_SIZE_M)
+        offsets_m = tl.max_contiguous(offsets_m, BLOCK_SIZE_M)
+        mask_m = offsets_m < n_elements
+        indices = tl.load(indices_ptr + offsets_m, mask=mask_m, other=0)
+
+        for block_n in tl.range(0, grid_n):
+            start_n = block_n * BLOCK_SIZE_N
+
+            offsets_n = start_n + tl.arange(0, BLOCK_SIZE_N)
+            offsets_n = tl.max_contiguous(offsets_n, BLOCK_SIZE_N)
+            mask_n = offsets_n < embedding_dim
+            block_mask = mask_m[:, None] & mask_n[None, :]
+
+            embedding_offsets = indices[:, None] * embedding_dim + offsets_n[None, :]
+            embeddings = tl.load(
+                embeddings_ptr + embedding_offsets,
+                mask=block_mask,
+                other=0.0,
+            )
+
+            output_offsets = offsets_m[:, None] * embedding_dim + offsets_n[None, :]
+            tl.store(output_ptr + output_offsets, embeddings, mask=block_mask)
 
 
 @triton.jit
 def embedding_backward_kernel(
+    grad_output_ptr,
+    grad_weight_ptr,
+    indices_ptr,
+    n_elements,
+    embedding_dim: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+
+    grid_m = tl.cdiv(n_elements, BLOCK_SIZE_M)
+    grid_n = tl.cdiv(embedding_dim, BLOCK_SIZE_N)
+
+    for block_m in tl.range(pid, grid_m, num_progs):
+        start_m = block_m * BLOCK_SIZE_M
+
+        offsets_m = start_m + tl.arange(0, BLOCK_SIZE_M)
+        offsets_m = tl.max_contiguous(offsets_m, BLOCK_SIZE_M)
+        mask_m = offsets_m < n_elements
+        indices = tl.load(indices_ptr + offsets_m, mask=mask_m, other=0)
+
+        for block_n in tl.range(0, grid_n):
+            start_n = block_n * BLOCK_SIZE_N
+            offsets_n = start_n + tl.arange(0, BLOCK_SIZE_N)
+            offsets_n = tl.max_contiguous(offsets_n, BLOCK_SIZE_N)
+            mask_n = offsets_n < embedding_dim
+            block_mask = mask_m[:, None] & mask_n[None, :]
+
+            grad_output_offsets = offsets_m[:, None] * embedding_dim + offsets_n[None, :]
+            grad_output = tl.load(
+                grad_output_ptr + grad_output_offsets,
+                mask=block_mask,
+                other=0.0,
+            )
+
+            grad_weight_offsets = indices[:, None] * embedding_dim + offsets_n[None, :]
+            tl.atomic_add(
+                grad_weight_ptr + grad_weight_offsets,
+                grad_output,
+                mask=block_mask,
+            )
+
+
+@triton.jit
+def embedding_backward_kernel_2d(
     grad_output_ptr,
     grad_weight_ptr,
     indices_ptr,
@@ -81,13 +189,13 @@ def embedding_backward_kernel(
         start_n = block_n * BLOCK_SIZE_N
 
         offsets_m = start_m + tl.arange(0, BLOCK_SIZE_M)
+        offsets_m = tl.max_contiguous(offsets_m, BLOCK_SIZE_M)
         mask_m = offsets_m < n_elements
-
         indices = tl.load(indices_ptr + offsets_m, mask=mask_m, other=0)
 
         offsets_n = start_n + tl.arange(0, BLOCK_SIZE_N)
+        offsets_n = tl.max_contiguous(offsets_n, BLOCK_SIZE_N)
         mask_n = offsets_n < embedding_dim
-
         block_mask = mask_m[:, None] & mask_n[None, :]
 
         grad_output_offsets = offsets_m[:, None] * embedding_dim + offsets_n[None, :]
@@ -105,30 +213,143 @@ def embedding_backward_kernel(
         )
 
 
-def get_optimal_block_size(total_elements, dtype_size, BLOCK_SIZE_N: tl.constexpr):
-    # 1. Set Memory Multiplier
-    # 3.0 are empirical values based on Atlas 800I A2 UB (192KB)
-    # embedding_offsets, embedding_offsets : BLOCK_SIZE_N * BLOCK_SIZE_M (total 2 * BLOCK_SIZE_N * BLOCK_SIZE_M)
-    # Reserve a unit of space for the remaining one-dimensional ub to occupy.
-    # A conservative estimate of the total space occupation is 3 * BLOCK_SIZE_N * BLOCK_SIZE_M
-    multiplier = 3.0
+def _max_block_m_for_ub(
+    block_size_n: int,
+    dtype_size: int,
+    multiplier: float = _UB_MULTIPLIER,
+    safety_margin: float = _UB_SAFETY,
+) -> int:
+    usable_bits = int(_ASCEND_UB_CAPACITY_BITS * safety_margin)
+    bits_per_m = max(1, int(multiplier * block_size_n * dtype_size * 8))
+    return max(1, min(usable_bits // bits_per_m, 128))
 
-    # 2. Call calculation function
-    # Treat input as 1D (total_elements,), only tiling on dim 0
+
+def _clamp_forward_block_m(block_m: int, block_n: int, dtype_size: int) -> int:
+    compile_max_m = _FORWARD_COMPILED_MAX_M.get(block_n)
+    if compile_max_m is None:
+        compile_max_m = max(
+            16,
+            int(_ASCEND_UB_CAPACITY_BITS * 0.99 / (82.5 * block_n * max(dtype_size, 1) / 2)),
+        )
+    ub_max_m = _max_block_m_for_ub(block_n, dtype_size)
+    return max(1, min(block_m, compile_max_m, ub_max_m))
+
+
+def _largest_wide_forward_block_n(embedding_dim: int, dtype_size: int) -> int:
+    for block_n in _FORWARD_WIDE_BLOCK_N_CANDIDATES:
+        if block_n > embedding_dim:
+            continue
+        if _clamp_forward_block_m(4, block_n, dtype_size) >= 4:
+            return block_n
+    return _FORWARD_MAX_BLOCK_N
+
+
+def _select_forward_tile_sizes(
+    n_elements: int,
+    embedding_dim: int,
+    dtype_size: int,
+) -> tuple[int, int]:
+    if embedding_dim >= _WIDE_EMBEDDING_THRESHOLD:
+        block_n = _largest_wide_forward_block_n(embedding_dim, dtype_size)
+        max_m = _clamp_forward_block_m(128, block_n, dtype_size)
+        block_m = min(6, max_m)
+        return max(1, block_m), block_n
+
+    best_key = None
+    best_m = 64
+    best_n = triton.next_power_of_2(min(128, embedding_dim))
+
+    for block_n in (_FORWARD_MAX_BLOCK_N, 256, 128, 64):
+        if block_n > embedding_dim:
+            continue
+        block_n = triton.next_power_of_2(block_n)
+        max_m = _max_block_m_for_ub(block_n, dtype_size)
+        if max_m < 16:
+            continue
+
+        block_m = min(max_m, triton.next_power_of_2(min(128, n_elements)))
+        while block_m > max_m and block_m > 1:
+            block_m //= 2
+        block_m = _clamp_forward_block_m(block_m, block_n, dtype_size)
+        if block_m < 1:
+            continue
+
+        grid_m = triton.cdiv(n_elements, block_m)
+        grid_n = triton.cdiv(embedding_dim, block_n)
+        n_bias = block_n if embedding_dim >= 1024 else 0
+        key = (-(block_m * block_n), -n_bias, grid_m * grid_n)
+        if best_key is None or key < best_key:
+            best_key = key
+            best_m, best_n = block_m, block_n
+
+    return best_m, best_n
+
+
+def _pick_forward_schedule(
+    n_elements: int,
+    embedding_dim: int,
+    block_n: int,
+) -> tuple[bool, int]:
+    if embedding_dim < _WIDE_EMBEDDING_THRESHOLD:
+        return False, 2 if n_elements >= 2048 else 1
+
+    grid_n = triton.cdiv(embedding_dim, block_n)
+    if grid_n == 1:
+        if n_elements >= 8192:
+            return False, 8
+        if n_elements >= 4096:
+            return False, 6
+        if n_elements >= 2048:
+            return False, 1
+        return False, 2
+
+    if n_elements <= 1024:
+        return True, 3
+    if n_elements <= 2048:
+        return False, 1
+    return False, 2
+
+
+@lru_cache(maxsize=256)
+def _get_optimal_block_m(n_elements: int, dtype_size: int, block_size_n: int) -> int:
     tile_shapes = compute_default_tiling_strategy(
-        safety_margin=0.9,
+        safety_margin=_UB_SAFETY,
         dtype_size=dtype_size,
-        memory_multiplier=multiplier,
-        shapes=((total_elements, BLOCK_SIZE_N),),
+        memory_multiplier=_UB_MULTIPLIER,
+        shapes=((n_elements, block_size_n),),
         tiling_dims=(0,),
     )
+    block_m = tile_shapes[0][0] if tile_shapes else triton.next_power_of_2(min(128, n_elements))
+    return min(block_m, _max_block_m_for_ub(block_size_n, dtype_size))
 
-    # 3. Parse result
-    if tile_shapes and len(tile_shapes) > 0:
-        block_size = tile_shapes[0][0]
-        return block_size
+
+@lru_cache(maxsize=256)
+def _select_backward_tile_sizes(
+    n_elements: int,
+    embedding_dim: int,
+    dtype_size: int,
+) -> tuple[int, int]:
+    if embedding_dim >= _WIDE_EMBEDDING_THRESHOLD:
+        block_n = min(_FORWARD_MAX_BLOCK_N, triton.next_power_of_2(embedding_dim))
+        max_m = _max_block_m_for_ub(block_n, dtype_size)
+        return _clamp_forward_block_m(max_m, block_n, dtype_size), block_n
+
+    if n_elements >= 4096 and embedding_dim >= 256:
+        block_n = 256
     else:
-        return triton.next_power_of_2(min(128, total_elements))
+        block_n = triton.next_power_of_2(min(128, embedding_dim))
+    return _get_optimal_block_m(n_elements, dtype_size, block_n), block_n
+
+
+@lru_cache(maxsize=256)
+def _get_forward_launch_config(n_elements: int, embedding_dim: int, dtype_size: int):
+    block_m, block_n = _select_forward_tile_sizes(n_elements, embedding_dim, dtype_size)
+    use_mouter, core_mult = _pick_forward_schedule(n_elements, embedding_dim, block_n)
+    return block_m, block_n, use_mouter, core_mult
+
+
+def _launch_grid(num_cores: int, total_blocks: int, core_multiplier: int = 1) -> int:
+    return max(1, min(num_cores * core_multiplier, total_blocks))
 
 
 def embedding_forward(embeddings, indices):
@@ -137,58 +358,81 @@ def embedding_forward(embeddings, indices):
 
     n_elements = indices.numel()
     embedding_dim = embeddings.shape[1]
+    if n_elements == 0:
+        return torch.empty(*ori_shape, embedding_dim, device=indices.device, dtype=embeddings.dtype)
+
     output = torch.empty(
-        indices.shape[0],
-        embeddings.shape[1],
+        n_elements,
+        embedding_dim,
         device=indices.device,
         dtype=embeddings.dtype,
     )
 
-    # Due to the involvement of two-dimensional partitioning,
-    # the sizes of block_m and block_n in the ub space will influence each other.
-    # Considering that embedding_dim is usually relatively smaller in most cases,
-    # a value is first assigned to block_n, and then the largest possible block_m is used.
-    BLOCK_SIZE_N = triton.next_power_of_2(min(128, embedding_dim))
-    BLOCK_SIZE_M = get_optimal_block_size(n_elements, embeddings.element_size(), BLOCK_SIZE_N)
+    block_m, block_n, use_mouter, core_mult = _get_forward_launch_config(
+        n_elements, embedding_dim, embeddings.element_size()
+    )
     num_cores = get_npu_core_count()
-    total_blocks = triton.cdiv(n_elements, BLOCK_SIZE_M) * triton.cdiv(embedding_dim, BLOCK_SIZE_N)
-    grid = min(num_cores, total_blocks)
 
-    embedding_forward_kernel[(grid,)](
+    if use_mouter:
+        total_blocks = triton.cdiv(n_elements, block_m)
+        kernel = embedding_forward_kernel_mouter
+    else:
+        total_blocks = triton.cdiv(n_elements, block_m) * triton.cdiv(embedding_dim, block_n)
+        kernel = embedding_forward_kernel
+
+    kernel[_launch_grid(num_cores, total_blocks, core_mult),](
         embeddings,
         indices,
         output,
         n_elements,
         embedding_dim=embedding_dim,
-        BLOCK_SIZE_M=BLOCK_SIZE_M,
-        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_M=block_m,
+        BLOCK_SIZE_N=block_n,
     )
 
     return output.view(*ori_shape, -1)
 
 
 def embedding_backward(embeddings, indices, grad_output):
+    indices = indices.contiguous().view(-1)
     grad_output = grad_output.contiguous().view(-1, embeddings.shape[1])
 
     grad_weight = torch.zeros_like(embeddings)
 
     n_elements = indices.numel()
     embedding_dim = embeddings.shape[1]
-    BLOCK_SIZE_N = triton.next_power_of_2(min(128, embedding_dim))
-    BLOCK_SIZE_M = get_optimal_block_size(n_elements, embeddings.element_size(), BLOCK_SIZE_N)
-    num_cores = get_npu_core_count()
-    total_blocks = triton.cdiv(n_elements, BLOCK_SIZE_M) * triton.cdiv(embedding_dim, BLOCK_SIZE_N)
-    grid = min(num_cores, total_blocks)
+    if n_elements == 0:
+        return grad_weight
 
-    embedding_backward_kernel[(grid,)](
-        grad_output,
-        grad_weight,
-        indices,
-        n_elements,
-        embedding_dim=embedding_dim,
-        BLOCK_SIZE_M=BLOCK_SIZE_M,
-        BLOCK_SIZE_N=BLOCK_SIZE_N,
-    )
+    block_m, block_n = _select_backward_tile_sizes(n_elements, embedding_dim, embeddings.element_size())
+    num_cores = get_npu_core_count()
+    use_2d = embedding_dim >= _WIDE_EMBEDDING_THRESHOLD or n_elements >= 4096
+
+    if use_2d:
+        total_blocks = triton.cdiv(n_elements, block_m) * triton.cdiv(embedding_dim, block_n)
+        core_mult = 1 if 4096 <= n_elements < 8192 else (2 if n_elements >= 2048 else 1)
+        grid = _launch_grid(num_cores, total_blocks, core_mult)
+        embedding_backward_kernel_2d[(grid,)](
+            grad_output,
+            grad_weight,
+            indices,
+            n_elements,
+            embedding_dim=embedding_dim,
+            BLOCK_SIZE_M=block_m,
+            BLOCK_SIZE_N=block_n,
+        )
+    else:
+        total_blocks = triton.cdiv(n_elements, block_m)
+        grid = _launch_grid(num_cores, total_blocks)
+        embedding_backward_kernel[(grid,)](
+            grad_output,
+            grad_weight,
+            indices,
+            n_elements,
+            embedding_dim=embedding_dim,
+            BLOCK_SIZE_M=block_m,
+            BLOCK_SIZE_N=block_n,
+        )
 
     return grad_weight
 
@@ -206,5 +450,4 @@ class LigerEmbeddingFunction(torch.autograd.Function):
     def backward(ctx, grad_output: torch.Tensor):
         indices, embeddings = ctx.saved_tensors
         grad_weight = embedding_backward(embeddings, indices, grad_output)
-
         return grad_weight, None


### PR DESCRIPTION
## Summary

Optimize the Ascend NPU Triton embedding kernel for wide-embedding LLM workloads (e.g., Qwen3.5 on Ascend A3 X86). This PR replaces the fixed tiling strategy with hardware-aware, shape-adaptive scheduling.

## Details

- **Hardware-aware tiling**: Model Ascend UB capacity (192KB), compile-time `BLOCK_M` limits on Ascend910 bf16, and tuned memory multiplier (3.2) / safety margin (0.85).
- **Dual forward kernels**: Introduce `embedding_forward_kernel_mouter` (M-outer, N-inner) alongside the existing 2D kernel; auto-select based on `embedding_dim` and token count.
- **Dual backward kernels**: Split into M-outer (`embedding_backward_kernel`) and 2D-flat (`embedding_backward_kernel_2d`) paths to reduce atomic contention for different workload shapes.
- **Adaptive tile selection**: For wide embeddings (dim ≥ 2048), use large `BLOCK_N` (up to 4096) with small `BLOCK_M`; for narrow embeddings, search over candidate tile sizes with a cost heuristic.
- **Launch tuning**: Add `core_multiplier` to grid sizing and cache tile configs via `@lru_cache`.
- **Compiler hints**: Apply `tl.max_contiguous` on offset arrays for better memory access patterns.
- **Correctness fixes**: Handle empty inputs, fix output buffer sizing for multi-dimensional indices, and ensure contiguous indices in backward.

## Testing Done

ut:
<img width="1099" height="389" alt="embedding" src="https://github.com/user-attachments/assets/46a413c1-89a8-4495-92ba-1367c77a9336" />

forward:
<img width="1312" height="362" alt="forward" src="https://github.com/user-attachments/assets/aae48724-8bb0-4cfc-811e-fa365d558ddf" />

backward:
<img width="1339" height="357" alt="backward" src="https://github.com/user-attachments/assets/eed319cd-4a69-47b6-9f0c-4aa8277ba285" />

full:
<img width="1306" height="368" alt="full" src="https://github.com/user-attachments/assets/e77f36b5-d964-4fb5-a073-1b72ff84f461" />

- Hardware Type: <BLANK>
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
