### PR TITLE
[NPU] Bump Ascend NPU deps to torch/torch_npu 2.7.1 and triton-ascend 3.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ y = orpo_loss(lm_head.weight, x, target)
 pip3 install torch torchvision --index-url https://download.pytorch.org/whl/rocm7.2
 ```
 
+#### Ascend NPU
+
+- `torch == 2.7.1`
+- `torch_npu == 2.7.1`
+- `triton-ascend == 3.2.1` Install from the Ascend PyPI mirror (not on default PyPI).
+
+```bash
+pip install -e ".[dev]" --extra-index-url https://triton-ascend.osinfra.cn/pypi/simple
+```
+
 ### Optional Dependencies
 
 - `transformers >= 4.x`: Required if you plan to use the transformers models patching APIs. The specific model you are working will dictate the minimum version of transformers.

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,8 @@ def get_default_dependencies():
         return [
             "torch>=2.6.0",
         ]
-    # TODO: Currently, triton-ascend is not compatible with torch 2.7.1. We will upgrade it later.
-    # TODO: triton-ascend v3.2.1 is expected to release soon with some incompatible API changes.
-    # Until we adapt to those changes, pin triton-ascend to v3.2.0.
     elif platform == "npu":
-        return ["torch==2.6.0", "torch_npu==2.6.0", "triton-ascend==3.2.0"]
+        return ["torch==2.7.1", "torch_npu==2.7.1", "triton-ascend==3.2.1"]
 
 
 def get_optional_dependencies():


### PR DESCRIPTION
## Summary

- Bump NPU default dependencies in `setup.py` from `torch==2.6.0` / `torch_npu==2.6.0` / `triton-ascend==3.2.0` to `torch==2.7.1` / `torch_npu==2.7.1` / `triton-ascend==3.2.1`.
- Remove outdated TODO comments that blocked the 2.7.1 / 3.2.1 upgrade.
- Add an **Ascend NPU** subsection at the end of the Installation section in `README.md`, documenting the source install command with `--extra-index-url` (required because `triton-ascend` is not on the default PyPI index).

## Motivation

Align Liger-Kernel with the current Ascend NPU stack (torch 2.7.1 + triton-ascend 3.2.1) while keeping the existing `pip install -e ".[dev]"` workflow. The extra index URL must be passed on the same pip invocation so dependency resolution can find `triton-ascend`.

On an Ascend NPU machine, run:

 ```bash
 pip install -e ".[dev]" --extra-index-url https://triton-ascend.osinfra.cn/pypi/simple
```

## Testing Done

All test cases have been fully verified in:

- https://github.com/linkedin/Liger-Kernel/pull/1259


Hardware Type: All NPUs.
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
