### PR TITLE
remove incorrect import for qwen3_5 monkey patch with cross_entropy=True

### DIFF
--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -3107,8 +3107,6 @@ def apply_liger_kernel_to_qwen3_5(
     if cross_entropy:
         from transformers.loss.loss_utils import nn
 
-        from liger_kernel.transformers.cross_entropy import liger_cross_entropy
-
         nn.functional.cross_entropy = liger_cross_entropy
 
     if fused_linear_cross_entropy:


### PR DESCRIPTION
## Summary
The function `apply_liger_kernel_to_qwen3_5` would crash when called with `cross_entropy=True` because it contains an incorrect import. Moreover, function `liger_cross_entropy` is already imported in line 15, so I just removed the extra incorrect import.

