### PR TITLE
perf(ce): hardware exp2 (ex2.approx) for softmax

### DIFF
--- a/src/liger_kernel/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cross_entropy.py
@@ -22,6 +22,9 @@ if compare_version("triton", operator.ge, "3.0.0") and not is_npu_available():
 else:
     from triton.language.math import tanh
 
+# log2(e): lets us emit the hardware ex2.approx instruction via e^x = 2^(x * LOG2_E)
+LOG2_E = 1.4426950408889634
+
 
 @triton.jit
 def liger_cross_entropy_kernel(
@@ -170,7 +173,7 @@ def liger_cross_entropy_kernel(
             else:
                 scaled_x_sum += tl.sum(tl.where(X_offsets < n_cols, -eps * X_block, 0.0))
         m_new = tl.maximum(m, block_max)
-        d = d * tl.exp2((m - m_new) * 1.4426950408889634) + tl.sum(tl.exp2((X_block - m_new) * 1.4426950408889634))
+        d = d * tl.exp2((m - m_new) * LOG2_E) + tl.sum(tl.exp2((X_block - m_new) * LOG2_E))
         m = m_new
 
     # log (sum(e^(X_i))) = log (sum(e ^ (max(X) * e ^ (X_i - max(X)))))
@@ -207,7 +210,7 @@ def liger_cross_entropy_kernel(
 
             if not HAS_WEIGHT:
                 # softmax(x_i)
-                X_block = tl.exp2((X_block - m) * 1.4426950408889634) / d
+                X_block = tl.exp2((X_block - m) * LOG2_E) / d
                 # derivative of z-loss: 2 * lse_square_scale * lse * softmax(x_i)
                 X_block += 2 * lse_square_scale * lse * X_block
                 # smoothing term
@@ -219,7 +222,7 @@ def liger_cross_entropy_kernel(
                     X_block = X_block / n_non_ignore
             else:
                 weight_block = tl.load(weight_ptr + X_offsets, mask=X_offsets < n_cols)
-                softmax_X = tl.exp2((X_block - m) * 1.4426950408889634) / d
+                softmax_X = tl.exp2((X_block - m) * LOG2_E) / d
                 # derivative of original_loss
                 dloss_ori = (1 - label_smoothing) * softmax_X
                 # specially handle dx_y

--- a/src/liger_kernel/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cross_entropy.py
@@ -170,7 +170,7 @@ def liger_cross_entropy_kernel(
             else:
                 scaled_x_sum += tl.sum(tl.where(X_offsets < n_cols, -eps * X_block, 0.0))
         m_new = tl.maximum(m, block_max)
-        d = d * tl.exp(m - m_new) + tl.sum(tl.exp(X_block - m_new))
+        d = d * tl.exp2((m - m_new) * 1.4426950408889634) + tl.sum(tl.exp2((X_block - m_new) * 1.4426950408889634))
         m = m_new
 
     # log (sum(e^(X_i))) = log (sum(e ^ (max(X) * e ^ (X_i - max(X)))))
@@ -207,7 +207,7 @@ def liger_cross_entropy_kernel(
 
             if not HAS_WEIGHT:
                 # softmax(x_i)
-                X_block = tl.exp(X_block - m) / d
+                X_block = tl.exp2((X_block - m) * 1.4426950408889634) / d
                 # derivative of z-loss: 2 * lse_square_scale * lse * softmax(x_i)
                 X_block += 2 * lse_square_scale * lse * X_block
                 # smoothing term
@@ -219,7 +219,7 @@ def liger_cross_entropy_kernel(
                     X_block = X_block / n_non_ignore
             else:
                 weight_block = tl.load(weight_ptr + X_offsets, mask=X_offsets < n_cols)
-                softmax_X = tl.exp(X_block - m) / d
+                softmax_X = tl.exp2((X_block - m) * 1.4426950408889634) / d
                 # derivative of original_loss
                 dloss_ori = (1 - label_smoothing) * softmax_X
                 # specially handle dx_y


### PR DESCRIPTION
## PR1: CE `exp2` — B200 + H100 benchmarks

Optimization measured against the **frozen original baseline** (`v0_base`, == upstream HEAD). Correctness: full CE suite (177 cases, bf16+fp32, weight/softcap/smoothing/z_loss/ignore_index combos) passes.

### What & why
Replace `tl.exp` with the hardware `ex2.approx` instruction via `e^x = 2^(x·log₂e)`, in both the online-softmax accumulation and the gradient pass.
- **Why:** NVIDIA GPUs have no native `e^x` — `tl.exp` lowers to a multi-instruction accurate sequence, while `tl.exp2` emits a single `ex2.approx.f32`. This is the most frequent FP op in the kernel (once per vocab element × 2 passes), so it cuts total issued instructions.
- **Accuracy:** `ex2.approx` has ~2.4e-7 relative error — within the suite's fp32 `rtol=1e-6` and bf16 `rtol=5e-2`, and softmax normalization further cancels the (correlated) error. Helps every dtype.

### Headline shape (BT=8192, V=128256, full fwd+bwd)

| GPU | dtype | baseline | this PR | latency | throughput |
|---|---|--:|--:|--:|--:|
| H100 | bf16 | 2.583 ms | 2.225 ms | **-13.9%** | +16.1% |
| H100 | fp32 | 4.489 ms | 4.475 ms | **-0.3%** | +0.3% |
| B200 | bf16 | 1.847 ms | 1.687 ms | **-8.6%** | +9.5% |
| B200 | fp32 | 2.085 ms | 1.887 ms | **-9.5%** | +10.5% |

### Across context length (V=128256, BT 1024–65536)

| GPU | dtype | min | avg | max |
|---|---|--:|--:|--:|
| H100 | bf16 | -10% | -13% | -15% |
| H100 | fp32 | -0% | -0% | -1% |
| B200 | bf16 | -4% | -8% | -10% |
| B200 | fp32 | -5% | -8% | -10% |

### Figures
_Latency vs context length and vs vocab, baseline vs this PR, on H100 and B200._
<!-- Drag these PNGs from optimization/pr_figs/ into the PR editor; GitHub uploads them inline (repo-relative paths don't render in PR bodies). Then delete this list. -->
<img width="1650" height="566" alt="pr1_bf16_bt" src="https://github.com/user-attachments/assets/5433baa7-58f3-40cf-a86e-1f704542fc98" />
<img width="1650" height="566" alt="pr1_bf16_vocab" src="https://github.com/user-attachments/assets/1c5eeec2-5e08-4069-8306-d0eb3f62a050" />
<img width="1650" height="566" alt="pr1_fp32_bt" src="https://github.com/user-attachments/assets/78f9ef67-dc90-4112-b3b5-349dc00e72a3" />
<img width="1650" height="566" alt="pr1_fp32_vocab" src="https://github.com/user-attachments/assets/bd23a639-a8f3-49ca-9514-68122ba5acf8" />
