### PR TITLE
perf(ce): dtype-aware num_warps (Blackwell-gated)

### DIFF
--- a/src/liger_kernel/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cross_entropy.py
@@ -8,6 +8,7 @@ import triton.language as tl
 
 from liger_kernel.ops.utils import compare_version
 from liger_kernel.ops.utils import element_mul_kernel
+from liger_kernel.ops.utils import get_gpu_arch
 from liger_kernel.ops.utils import is_hip
 from liger_kernel.utils import infer_device
 from liger_kernel.utils import is_npu_available
@@ -375,6 +376,15 @@ def cross_entropy_forward(
     if target.stride(-1) != 1:
         target = target.contiguous()
 
+    # num_warps is dtype- and arch-dependent (measured on CE, full fwd+bwd):
+    #   Blackwell (B200, sm_100+) bf16/fp16 -> 8 (instruction-issue-bound); fp32 -> 32
+    #   Hopper (H100, sm_90) and earlier    -> 32 for all dtypes (bandwidth-bound)
+    #   AMD (ROCm)                          -> 16
+    if is_hip():
+        ce_num_warps = 16
+    else:
+        ce_num_warps = 8 if (_input.element_size() == 2 and get_gpu_arch() == "blackwell") else 32
+
     # Here we use a trick to store X_ptr gradient in X_ptr so we can save memory
     liger_cross_entropy_kernel[(n_rows,)](
         X_ptr=_input,
@@ -409,9 +419,7 @@ def cross_entropy_forward(
         HAS_WEIGHT=True if weight is not None else False,
         HAS_SOFTCAPPING=True if softcap is not None else False,
         HAS_GRADIENTS=_input.requires_grad,
-        # TODO: 32 seems to give the best performance
-        # Performance is quite sensitive to num_warps
-        num_warps=32 if not is_hip() else 16,
+        num_warps=ce_num_warps,
     )
 
     if reduction == "none":

--- a/src/liger_kernel/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cross_entropy.py
@@ -8,9 +8,9 @@ import triton.language as tl
 
 from liger_kernel.ops.utils import compare_version
 from liger_kernel.ops.utils import element_mul_kernel
-from liger_kernel.ops.utils import get_gpu_arch
 from liger_kernel.ops.utils import is_hip
 from liger_kernel.utils import infer_device
+from liger_kernel.utils import infer_device_arch
 from liger_kernel.utils import is_npu_available
 
 if compare_version("triton", operator.ge, "3.0.0") and not is_npu_available():
@@ -380,10 +380,14 @@ def cross_entropy_forward(
     #   Blackwell (B200, sm_100+) bf16/fp16 -> 8 (instruction-issue-bound); fp32 -> 32
     #   Hopper (H100, sm_90) and earlier    -> 32 for all dtypes (bandwidth-bound)
     #   AMD (ROCm)                          -> 16
+    # infer_device_arch() reports Blackwell parts as "blackwell" (sm_100),
+    # "blackwell_ultra" (sm_103), or "blackwell_consumer" (sm_120), so gate on the
+    # "blackwell" prefix to cover the whole generation (sm_100+).
     if is_hip():
         ce_num_warps = 16
     else:
-        ce_num_warps = 8 if (_input.element_size() == 2 and get_gpu_arch() == "blackwell") else 32
+        is_blackwell = infer_device_arch().startswith("blackwell")
+        ce_num_warps = 8 if (_input.element_size() == 2 and is_blackwell) else 32
 
     # Here we use a trick to store X_ptr gradient in X_ptr so we can save memory
     liger_cross_entropy_kernel[(n_rows,)](

--- a/src/liger_kernel/ops/utils.py
+++ b/src/liger_kernel/ops/utils.py
@@ -29,27 +29,6 @@ def is_hip() -> bool:
     return torch.version.hip is not None
 
 
-def get_gpu_arch() -> str:
-    """Coarse NVIDIA GPU architecture family for the active CUDA device.
-
-    Returns one of "blackwell" (sm_100+), "hopper" (sm_90), "ampere" (sm_80/86/89),
-    or "" when not on an NVIDIA CUDA device — i.e. CPU/XPU/NPU, or AMD (HIP). Note
-    ``infer_device()`` reports both NVIDIA and AMD as "cuda", so AMD is excluded here
-    via ``is_hip()`` and callers branch on it separately. Use this to pick arch-tuned
-    scheduling parameters such as ``num_warps``.
-    """
-    if is_hip() or infer_device() != "cuda":
-        return ""
-    major = torch.cuda.get_device_capability()[0]
-    if major >= 10:
-        return "blackwell"
-    if major == 9:
-        return "hopper"
-    if major == 8:
-        return "ampere"
-    return ""
-
-
 def ensure_contiguous(fn):
     @functools.wraps(fn)
     def wrapper(ctx, *args, **kwargs):

--- a/src/liger_kernel/ops/utils.py
+++ b/src/liger_kernel/ops/utils.py
@@ -29,6 +29,27 @@ def is_hip() -> bool:
     return torch.version.hip is not None
 
 
+def get_gpu_arch() -> str:
+    """Coarse NVIDIA GPU architecture family for the active CUDA device.
+
+    Returns one of "blackwell" (sm_100+), "hopper" (sm_90), "ampere" (sm_80/86/89),
+    or "" when not on an NVIDIA CUDA device — i.e. CPU/XPU/NPU, or AMD (HIP). Note
+    ``infer_device()`` reports both NVIDIA and AMD as "cuda", so AMD is excluded here
+    via ``is_hip()`` and callers branch on it separately. Use this to pick arch-tuned
+    scheduling parameters such as ``num_warps``.
+    """
+    if is_hip() or infer_device() != "cuda":
+        return ""
+    major = torch.cuda.get_device_capability()[0]
+    if major >= 10:
+        return "blackwell"
+    if major == 9:
+        return "hopper"
+    if major == 8:
+        return "ampere"
+    return ""
+
+
 def ensure_contiguous(fn):
     @functools.wraps(fn)
     def wrapper(ctx, *args, **kwargs):


### PR DESCRIPTION
## CE `num_warps`: dtype- & arch-aware (Blackwell-gated)

Rebased onto current `main` (post-#1266). All numbers below use **#1266 (`v1_exp2`) as the
baseline**, so they isolate *this* PR's contribution and exclude #1266's exp2 gains. Measured on
**B200**, which is what this gate targets. Correctness: full CE suite (bf16+fp32, with
weight/softcap/label_smoothing/z_loss/ignore_index combos) passes.

### What & why
Replace the hardcoded `num_warps=32` in CE forward with a dtype- and arch-aware choice:
- **Blackwell (sm_100+) bf16/fp16 → 8**; everything else (Hopper & earlier, all fp32) → **32**; AMD → **16**.
- Adds a small reusable helper `get_gpu_arch()` in `ops/utils.py` that returns
  `"blackwell"` / `"hopper"` / `"ampere"` / `""`. It uses `infer_device()` as the CUDA guard and
  excludes AMD via `is_hip()` (since `infer_device()` reports AMD as `"cuda"` too). The gate reads
  `get_gpu_arch() == "blackwell"`.
- **Why 8 on Blackwell bf16:** CE there is *instruction-issue-bound* (ncu: ALU is the top pipe; the
  dominant stall is "Not Selected" from a surplus of warps) — fewer warps cut issue contention.
  Hopper/earlier and fp32 are *bandwidth-bound* and keep 32 to hide memory latency.
- **Scoped to exactly bf16/fp16** (`element_size() == 2`) on sm_100+; fp8 (1 B) and fp32 keep 32
  warps (unmeasured → safe default). `num_warps` is purely a scheduling parameter → no correctness impact.

### Headline (BT=8192, V=128256, full fwd+bwd; baseline = #1266)

| dtype | baseline (#1266) | this PR | latency | throughput |
|---|--:|--:|--:|--:|
| bf16 | 1.686 ms | 1.438 ms | **−14.7%** | +17.2% |
| fp32 | 1.892 ms | 1.892 ms | +0.0% (unchanged) | +0.0% |

Only bf16/fp16 fires the gate; fp32 keeps 32 warps and is flat — shown to confirm no regression.

### bf16 across context length (V=128256; baseline = #1266)

| BT | baseline | this PR | latency |
|--:|--:|--:|--:|
| 1024 | 0.405 ms | 0.391 ms | −3.4% |
| 2048 | 0.583 ms | 0.542 ms | −7.0% |
| 4096 | 0.950 ms | 0.839 ms | −11.6% |
| 8192 | 1.686 ms | 1.438 ms | −14.7% |
| 16384 | 3.184 ms | 2.694 ms | −15.4% |
| 32768 | 6.092 ms | 5.101 ms | −16.3% |
| 65536 | 11.958 ms | 9.924 ms | −17.0% |

Gain grows with batch size (−3% → −17%; avg −12% over the sweep).

### bf16 across vocab (BT=8192; baseline = #1266)
−17.1% @ V=32k → −8.6% @ V=262k (avg −13.0%) — larger relative win at smaller vocab.

### Figures
<img width="818" height="566" alt="pr2_bf16_bt" src="https://github.com/user-attachments/assets/fda19ba4-aab2-4dbc-98de-8fc0ad060f7b" />

<img width="818" height="566" alt="pr2_bf16_vocab" src="https://github.com/user-attachments/assets/537b6af0-689c-4be0-97cd-f8b8c4953a08" />

<img width="818" height="566" alt="pr2_fp32_bt" src="https://github.com/user-attachments/assets/600c4e4f-c8b5-4791-a595-8bc5ea73419a" />
<img width="818" height="566" alt="pr2_fp32_vocab" src="https://github.com/user-attachments/assets/fc541ce2-1f62-44c4-9417-b0d039953299" />

