### PR TITLE
perf(flce): fuse grad_weight accumulation via addmm_ (cuBLAS beta=1) + memory cleanups

### DIFF
--- a/src/liger_kernel/ops/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_cross_entropy.py
@@ -57,7 +57,7 @@ def fused_linear_cross_entropy_forward(
     chunk_size = triton.next_power_of_2(triton.cdiv(BT, inc_factor))  # (BT + inc_factor - 1) // inc_factor
     num_chunks = triton.cdiv(BT, chunk_size)  # (BT + chunk_size - 1) // chunk_size
 
-    grad_input = torch.zeros_like(_input, device=device)
+    grad_input = torch.empty_like(_input, device=device)  # fully overwritten per-chunk below
 
     # we use fp32 for loss and gradients accumulator
     if input_requires_grad:
@@ -101,7 +101,12 @@ def fused_linear_cross_entropy_forward(
         # when doing matmul, use the original precision
         logits_chunk = _input_chunk @ weight.t()  # chunk_size x V
         if bias is not None:
-            logits_chunk = logits_chunk + bias
+            # in-place add avoids a second chunk_size x V temp; fall back to out-of-place when
+            # dtypes differ (autocast promotes bf16 matmul + fp32 bias -> keep that behavior)
+            if logits_chunk.dtype == bias.dtype:
+                logits_chunk += bias
+            else:
+                logits_chunk = logits_chunk + bias
 
         target_chunk = target[start_idx:end_idx]  # chunk_size,
 
@@ -209,7 +214,17 @@ def fused_linear_cross_entropy_forward(
             grad_input[start_idx:end_idx] = grad_logits_chunk @ weight
 
         if grad_weight is not None and input_requires_grad:
-            grad_weight += torch.mm(grad_logits_chunk.t(), _input_chunk).float()
+            # Fuse matmul + accumulate via cuBLAS (beta=1): one GEMM, no fp32 temp, no separate
+            # add. The old `+= mm(...).float()` materialized a V*H fp32 copy and ran a separate
+            # elementwise add every chunk (~28% of the forward by nsys: direct_copy 12% + add 16%).
+            # addmm_ needs ALL THREE operands the same dtype. Under autocast the matmul output
+            # (grad_logits_chunk) is bf16 while _input_chunk stays fp32, and the fp32-accumulator
+            # path makes grad_weight fp32 -- those mixed-dtype cases fall back to the autocast-safe
+            # mm+upcast (which is what passed before); the pure same-dtype case gets the fused GEMM.
+            if grad_weight.dtype == grad_logits_chunk.dtype == _input_chunk.dtype:
+                grad_weight.addmm_(grad_logits_chunk.t(), _input_chunk)
+            else:
+                grad_weight += torch.mm(grad_logits_chunk.t(), _input_chunk).float()
 
         if bias is not None and input_requires_grad:
             torch.add(


### PR DESCRIPTION
## perf(flce): fuse grad_weight accumulation via `addmm_` (cuBLAS β=1) — B200 + H100

Measured against the **frozen upstream baseline** (`v0_base`, == HEAD). Correctness: the full FLCE suite (`test_fused_linear_cross_entropy.py`, 137 cases) plus a torch-reference gate (42/42 — 3 shapes incl. a **multi-chunk** BT=16384 shape × 7 feature toggles × bf16+fp32, so the cross-chunk grad_weight accumulation is covered) pass.

### What & why
In the per-chunk backward, the weight gradient `grad_weight += grad_logits_chunkᵀ @ _input_chunk` was computed as `grad_weight += torch.mm(...).float()` — a GEMM, then a **V×H fp32 temporary** (the `.float()` copy), then a **separate elementwise add**, every chunk. Replace it with `grad_weight.addmm_(grad_logits_chunkᵀ, _input_chunk)`: cuBLAS folds the accumulate into the GEMM epilogue (β=1) — **one GEMM, no fp32 temp, no separate add kernel**.
- **Why:** the `.float()` materialized a V×H fp32 buffer (2.1 GB at V=128256, H=4096) and the `+=` was a second full-tensor memory pass — by nsys ~28% of the forward (`direct_copy` 12% + `add` 16%). Removing both cuts latency **and** peak memory.
- **Correctness:** gated to the pure same-dtype case (`grad_weight == grad_logits_chunk == _input_chunk`). Autocast (bf16 matmul + fp32 input) and the fp32-accumulator path (`accum_dtype=fp32`) keep the original `mm + upcast`. bf16 tensor cores already accumulate the MMA in fp32 internally, so the fused path is numerically equivalent to the old one (same bf16 running accumulator).

**Also includes two small memory cleanups in the same loop:**
- `grad_input`: `torch.zeros_like` → `torch.empty_like` — it is fully overwritten per chunk, so the zero-fill was wasted work.
- bias add: `logits_chunk += bias` in place when dtypes match (out-of-place fallback under autocast) — avoids a second `chunk×V` temporary for models with an lm_head bias; no-op otherwise.

### Headline shape (BT=8192, V=128256, full fwd+bwd)

| GPU | dtype | baseline | this PR | latency | throughput | peak mem (base → PR) |
|---|---|--:|--:|--:|--:|--:|
| H100 | bf16 | 160.882 ms | 63.204 ms | **-60.7%** | +154.5% | 6.64 → 3.55 GB (**-46%**) |
| H100 | fp32 | 596.720 ms | 563.251 ms | **-5.6%** | +5.9% | 9.01 → 7.04 GB (**-22%**) |
| B200 | bf16 | 124.027 ms | 31.484 ms | **-74.6%** | +293.9% | 6.64 → 3.55 GB (**-46%**) |
| B200 | fp32 | 472.132 ms | 476.846 ms | **+1.0%** | -1.0% | 9.01 → 7.04 GB (**-22%**) |

### Across context length (V=128256, BT 1024–65536)

| GPU | dtype | latency min/avg/max | peak-mem min/avg/max |
|---|---|--:|--:|
| H100 | bf16 | -25% / -52% / -62% | -31% / -44% / -49% |
| H100 | fp32 | -1% / -9% / -24% | -8% / -19% / -24% |
| B200 | bf16 | -36% / -66% / -79% | -31% / -44% / -49% |
| B200 | fp32 | +3% / -4% / -16% | -8% / -19% / -24% |

### Figures
_Latency and peak memory vs context length and vs vocab, baseline vs this PR, on H100 and B200._
<!-- Drag these PNGs from optimization/pr_flce_figs/ into the PR editor; GitHub uploads them inline (repo-relative paths don't render in PR bodies). Then delete this list. -->
<img width="1650" height="566" alt="flce_addmm_bf16_bt" src="https://github.com/user-attachments/assets/459537b4-81b4-4fa2-b0fa-966b5ad62ba1" />
<img width="1650" height="566" alt="flce_addmm_bf16_vocab" src="https://github.com/user-attachments/assets/18ab0cd3-cd0a-43bd-9f75-1b4c4a81a3cd" />

<img width="1650" height="566" alt="flce_addmm_fp32_bt" src="https://github.com/user-attachments/assets/4810e7d9-3e6f-48cb-8bf3-05b495f6c0c7" />
<img width="1650" height="566" alt="flce_addmm_fp32_vocab" src="https://github.com/user-attachments/assets/bc65118d-67cd-4923-a8f8-77b61af48b17" />
<img width="1650" height="566" alt="flce_addmm_mem_bf16_bt" src="https://github.com/user-attachments/assets/222e59fd-66b2-4a8f-b46f-125578a4fca1" />

<img width="1650" height="566" alt="flce_addmm_mem_bf16_vocab" src="https://github.com/user-attachments/assets/58ecff49-43d7-4741-bbac-172f945d1d11" />
<img width="1650" height="566" alt="flce_addmm_mem_fp32_bt" src="https://github.com/user-attachments/assets/89823376-c736-41c1-8fd7-9a05395ecb24" />
<img width="1650" height="566" alt="flce_addmm_mem_fp32_vocab" src="https://github.com/user-attachments/assets/36ea2ef9-3669-4777-95b9-c7c82e8d7699" />