### PR TITLE
perf(swiglu): architecture-aware column tiling for Blackwell (B200)

### DIFF
--- a/src/liger_kernel/ops/swiglu.py
+++ b/src/liger_kernel/ops/swiglu.py
@@ -11,7 +11,6 @@ from liger_kernel.utils import infer_device_arch
 # occupancy-starved on Blackwell for wide rows. Splitting each row into fixed
 # 1024-wide column tiles over a 2D grid raises occupancy so HBM saturates
 # (~1.63x backward at n_cols=14336, bit-exact). Tile size 1024 chosen by sweep.
-# See optimization/swiglu/report.md for the full diagnosis and numbers.
 _SWIGLU_TILE = 1024
 
 # Only tile when the original one-row block is register-heavy: next_pow2(n_cols)
@@ -19,20 +18,15 @@ _SWIGLU_TILE = 1024
 _SWIGLU_TILE_MIN_BLOCK = 16384
 
 
-def _is_blackwell():
-    """True only on NVIDIA Blackwell-family GPUs; tiling regresses on H100/A100."""
-    return infer_device_arch().startswith("blackwell")
-
-
 def _should_tile(n_cols):
     """Use the Blackwell column-tiled path only for wide-enough rows."""
-    return _is_blackwell() and triton.next_power_of_2(n_cols) >= _SWIGLU_TILE_MIN_BLOCK
+    return infer_device_arch().startswith("blackwell") and triton.next_power_of_2(n_cols) >= _SWIGLU_TILE_MIN_BLOCK
 
 
-def swiglu_tile_settings(n_cols):
+def _swiglu_tile_settings(n_cols):
     """Pick the column-tile BLOCK_SIZE and num_warps for the Blackwell 2D-grid path."""
     BLOCK_SIZE = min(_SWIGLU_TILE, triton.next_power_of_2(n_cols))
-    num_warps = 8 if BLOCK_SIZE >= 2048 else 4
+    num_warps = 4
     return BLOCK_SIZE, num_warps
 
 
@@ -154,7 +148,7 @@ def swiglu_forward(a, b, gate_multiplier: float = 1.0):
 
     if _should_tile(n_cols):
         # Blackwell (B200), wide rows: column-tiled 2D grid for higher SM occupancy.
-        BLOCK_SIZE, num_warps = swiglu_tile_settings(n_cols)
+        BLOCK_SIZE, num_warps = _swiglu_tile_settings(n_cols)
         grid = (n_rows, triton.cdiv(n_cols, BLOCK_SIZE))
         _swiglu_forward_kernel_tiled[grid](
             a,
@@ -191,7 +185,7 @@ def swiglu_backward(a, b, dc, gate_multiplier: float = 1.0):
 
     if _should_tile(n_cols):
         # Blackwell (B200), wide rows: column-tiled 2D grid for higher SM occupancy.
-        BLOCK_SIZE, num_warps = swiglu_tile_settings(n_cols)
+        BLOCK_SIZE, num_warps = _swiglu_tile_settings(n_cols)
         grid = (n_rows, triton.cdiv(n_cols, BLOCK_SIZE))
         _swiglu_backward_kernel_tiled[grid](
             dc,

--- a/src/liger_kernel/ops/swiglu.py
+++ b/src/liger_kernel/ops/swiglu.py
@@ -4,6 +4,7 @@ import triton.language as tl
 
 from liger_kernel.ops.utils import calculate_settings
 from liger_kernel.ops.utils import ensure_contiguous
+from liger_kernel.utils import infer_device_arch
 
 # Blackwell (B200) column-tiling parameters. The original one-row layout
 # (BLOCK_SIZE = next_pow2(n_cols)) is H100-tuned and leaves the backward kernel
@@ -19,13 +20,8 @@ _SWIGLU_TILE_MIN_BLOCK = 16384
 
 
 def _is_blackwell():
-    """True only on NVIDIA Blackwell (SM 10.x); tiling regresses on H100/A100."""
-    if not torch.cuda.is_available():
-        return False
-    try:
-        return torch.cuda.get_device_capability()[0] == 10
-    except Exception:
-        return False
+    """True only on NVIDIA Blackwell-family GPUs; tiling regresses on H100/A100."""
+    return infer_device_arch().startswith("blackwell")
 
 
 def _should_tile(n_cols):

--- a/src/liger_kernel/ops/swiglu.py
+++ b/src/liger_kernel/ops/swiglu.py
@@ -5,6 +5,40 @@ import triton.language as tl
 from liger_kernel.ops.utils import calculate_settings
 from liger_kernel.ops.utils import ensure_contiguous
 
+# Blackwell (B200) column-tiling parameters. The original one-row layout
+# (BLOCK_SIZE = next_pow2(n_cols)) is H100-tuned and leaves the backward kernel
+# occupancy-starved on Blackwell for wide rows. Splitting each row into fixed
+# 1024-wide column tiles over a 2D grid raises occupancy so HBM saturates
+# (~1.63x backward at n_cols=14336, bit-exact). Tile size 1024 chosen by sweep.
+# See optimization/swiglu/report.md for the full diagnosis and numbers.
+_SWIGLU_TILE = 1024
+
+# Only tile when the original one-row block is register-heavy: next_pow2(n_cols)
+# >= this. Narrower rows gain nothing and keep the original one-row layout.
+_SWIGLU_TILE_MIN_BLOCK = 16384
+
+
+def _is_blackwell():
+    """True only on NVIDIA Blackwell (SM 10.x); tiling regresses on H100/A100."""
+    if not torch.cuda.is_available():
+        return False
+    try:
+        return torch.cuda.get_device_capability()[0] == 10
+    except Exception:
+        return False
+
+
+def _should_tile(n_cols):
+    """Use the Blackwell column-tiled path only for wide-enough rows."""
+    return _is_blackwell() and triton.next_power_of_2(n_cols) >= _SWIGLU_TILE_MIN_BLOCK
+
+
+def swiglu_tile_settings(n_cols):
+    """Pick the column-tile BLOCK_SIZE and num_warps for the Blackwell 2D-grid path."""
+    BLOCK_SIZE = min(_SWIGLU_TILE, triton.next_power_of_2(n_cols))
+    num_warps = 8 if BLOCK_SIZE >= 2048 else 4
+    return BLOCK_SIZE, num_warps
+
 
 @triton.jit
 def silu(x):
@@ -62,6 +96,57 @@ def _swiglu_backward_kernel(
     tl.store(b_ptr + col_offsets, db_row, mask=mask)
 
 
+@triton.jit
+def _swiglu_forward_kernel_tiled(a_ptr, b_ptr, c_ptr, stride, gate_multiplier, n_cols, BLOCK_SIZE: tl.constexpr):
+    # Blackwell path: 2D grid -- axis 0 selects the row, axis 1 the column tile.
+    program_id = tl.program_id(0).to(tl.int64)
+    col_tile = tl.program_id(1)
+
+    # locate start index (row base; column offset added below)
+    a_ptr += program_id * stride
+    b_ptr += program_id * stride
+    c_ptr += program_id * stride
+
+    col_offsets = col_tile * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = col_offsets < n_cols
+
+    # sigmoid requires type float32
+    a_row = tl.load(a_ptr + col_offsets, mask=mask, other=0).to(tl.float32) * gate_multiplier
+    b_row = tl.load(b_ptr + col_offsets, mask=mask, other=0)
+    c_row = silu(a_row).cast(b_row.dtype) * b_row
+    tl.store(c_ptr + col_offsets, c_row, mask=mask)
+
+
+@triton.jit
+def _swiglu_backward_kernel_tiled(dc_ptr, a_ptr, b_ptr, stride, gate_multiplier, n_cols, BLOCK_SIZE: tl.constexpr):
+    # Blackwell path: 2D grid -- axis 0 selects the row, axis 1 the column tile.
+    program_id = tl.program_id(0).to(tl.int64)
+    col_tile = tl.program_id(1)
+
+    # locate start index (row base; column offset added below)
+    dc_ptr += program_id * stride
+    a_ptr += program_id * stride
+    b_ptr += program_id * stride
+
+    col_offsets = col_tile * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = col_offsets < n_cols
+
+    dc_row = tl.load(dc_ptr + col_offsets, mask=mask, other=0)
+    # sigmoid requires type float32
+    a_row = tl.load(a_ptr + col_offsets, mask=mask, other=0).to(tl.float32) * gate_multiplier
+    b_row = tl.load(b_ptr + col_offsets, mask=mask, other=0)
+
+    # recomputation to save memory. a_row already holds a * gate_multiplier.
+    sig_a = tl.sigmoid(a_row)
+    silu_a = a_row * sig_a
+    db_row = dc_row * silu_a
+    # chain rule pulls an extra factor of gate_multiplier through the pre-activation scaling
+    da_row = dc_row * (silu_a * (1 - sig_a) + sig_a) * b_row * gate_multiplier
+
+    tl.store(a_ptr + col_offsets, da_row, mask=mask)
+    tl.store(b_ptr + col_offsets, db_row, mask=mask)
+
+
 def swiglu_forward(a, b, gate_multiplier: float = 1.0):
     ori_shape = a.shape
 
@@ -70,6 +155,22 @@ def swiglu_forward(a, b, gate_multiplier: float = 1.0):
     b = b.view(-1, n_cols)
     c = torch.empty_like(a)
     n_rows = a.shape[0]
+
+    if _should_tile(n_cols):
+        # Blackwell (B200), wide rows: column-tiled 2D grid for higher SM occupancy.
+        BLOCK_SIZE, num_warps = swiglu_tile_settings(n_cols)
+        grid = (n_rows, triton.cdiv(n_cols, BLOCK_SIZE))
+        _swiglu_forward_kernel_tiled[grid](
+            a,
+            b,
+            c,
+            c.stride(-2),
+            float(gate_multiplier),
+            n_cols,
+            BLOCK_SIZE=BLOCK_SIZE,
+            num_warps=num_warps,
+        )
+        return a, b, c.view(*ori_shape)
 
     BLOCK_SIZE, num_warps = calculate_settings(n_cols)
 
@@ -91,6 +192,22 @@ def swiglu_backward(a, b, dc, gate_multiplier: float = 1.0):
     n_cols = ori_shape[-1]
     dc = dc.view(-1, n_cols)
     n_rows = dc.shape[0]
+
+    if _should_tile(n_cols):
+        # Blackwell (B200), wide rows: column-tiled 2D grid for higher SM occupancy.
+        BLOCK_SIZE, num_warps = swiglu_tile_settings(n_cols)
+        grid = (n_rows, triton.cdiv(n_cols, BLOCK_SIZE))
+        _swiglu_backward_kernel_tiled[grid](
+            dc,
+            a,
+            b,
+            dc.stride(-2),
+            float(gate_multiplier),
+            n_cols,
+            BLOCK_SIZE=BLOCK_SIZE,
+            num_warps=num_warps,
+        )
+        return a.view(*ori_shape), b.view(*ori_shape)
 
     BLOCK_SIZE, num_warps = calculate_settings(n_cols)
 

--- a/test/transformers/test_swiglu.py
+++ b/test/transformers/test_swiglu.py
@@ -715,12 +715,12 @@ def test_swiglu_blackwell_tiled_matches_original(monkeypatch, n_rows, n_cols, ga
         return c.detach(), a_.grad.detach(), b_.grad.detach()
 
     # Original one-row kernel (gate forced off).
-    monkeypatch.setattr(swiglu_ops, "_is_blackwell", lambda: False)
+    monkeypatch.setattr(swiglu_ops, "infer_device_arch", lambda: "hopper")
     assert not swiglu_ops._should_tile(n_cols)
     c_ref, da_ref, db_ref = run()
 
     # Forced Blackwell tiled kernel (gate forced on).
-    monkeypatch.setattr(swiglu_ops, "_is_blackwell", lambda: True)
+    monkeypatch.setattr(swiglu_ops, "infer_device_arch", lambda: "blackwell")
     assert swiglu_ops._should_tile(n_cols)
     c_tiled, da_tiled, db_tiled = run()
 

--- a/test/transformers/test_swiglu.py
+++ b/test/transformers/test_swiglu.py
@@ -13,6 +13,8 @@ from transformers.models.mixtral.configuration_mixtral import MixtralConfig
 from transformers.models.phi3.configuration_phi3 import Phi3Config
 from transformers.models.phi3.modeling_phi3 import Phi3MLP
 
+import liger_kernel.ops.swiglu as swiglu_ops
+
 from liger_kernel.ops import LigerSiLUMulFunction
 from liger_kernel.transformers.functional import liger_swiglu
 from liger_kernel.transformers.swiglu import LigerBlockSparseTop2MLP
@@ -670,3 +672,59 @@ def test_dtensor_liger_silumul(world_size, bsz, seq_len, hidden_size, dtype, ato
             nprocs=world_size,
             join=True,
         )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Blackwell tiled SwiGLU path is CUDA-only")
+@pytest.mark.parametrize(
+    "n_rows, n_cols",
+    [
+        (4, 11009),  # wide + NOT a multiple of the 1024 tile -> exercises the column mask
+        (3, 14337),  # ragged final tile, odd row count
+        (4, 16384),  # exactly tile-aligned (16 full tiles)
+    ],
+)
+@pytest.mark.parametrize("gate_multiplier", [1.0, 1.3])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.float32,
+        pytest.param(
+            torch.bfloat16,
+            marks=pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this GPU"),
+        ),
+    ],
+)
+def test_swiglu_blackwell_tiled_matches_original(monkeypatch, n_rows, n_cols, gate_multiplier, dtype):
+    """The Blackwell column-tiled path must be bit-for-bit identical to the one-row kernel.
+
+    The dispatch normally only fires on SM 10.x, so CI never reaches it. The tiled kernels
+    use no Blackwell-only instructions, so we force the gate on and compare against the
+    original kernel on any CUDA GPU. Widths land on a ragged final tile (n_cols % 1024 != 0)
+    to cover the column mask.
+    """
+    torch.manual_seed(0)
+    a = torch.randn(n_rows, n_cols, device=device, dtype=dtype)
+    b = torch.randn(n_rows, n_cols, device=device, dtype=dtype)
+    dc = torch.randn(n_rows, n_cols, device=device, dtype=dtype)
+
+    def run():
+        a_ = a.clone().detach().requires_grad_(True)
+        b_ = b.clone().detach().requires_grad_(True)
+        c = LigerSiLUMulFunction.apply(a_, b_, gate_multiplier)
+        c.backward(dc)
+        return c.detach(), a_.grad.detach(), b_.grad.detach()
+
+    # Original one-row kernel (gate forced off).
+    monkeypatch.setattr(swiglu_ops, "_is_blackwell", lambda: False)
+    assert not swiglu_ops._should_tile(n_cols)
+    c_ref, da_ref, db_ref = run()
+
+    # Forced Blackwell tiled kernel (gate forced on).
+    monkeypatch.setattr(swiglu_ops, "_is_blackwell", lambda: True)
+    assert swiglu_ops._should_tile(n_cols)
+    c_tiled, da_tiled, db_tiled = run()
+
+    # Launch-geometry change only -> require exact equality (the PR's headline claim).
+    torch.testing.assert_close(c_tiled, c_ref, rtol=0, atol=0)
+    torch.testing.assert_close(da_tiled, da_ref, rtol=0, atol=0)
+    torch.testing.assert_close(db_tiled, db_ref, rtol=0, atol=0)


### PR DESCRIPTION
## Summary

The SwiGLU (`SiLUMul`) Triton kernels launch one program per row with
`BLOCK_SIZE = next_pow2(n_cols)` — tuned for H100, but it leaves the **backward** kernel
occupancy-starved on B200. This PR adds a column-tiled 2D-grid path selected **only on
Blackwell (SM 10.x) for wide rows**, giving **1.63× backward / 1.41× full step** at the
Llama-3 8B shape, **bit-for-bit identical numerics** (zero tolerance change). Hopper /
Ampere and narrow rows keep the original kernels unchanged → **no regression off
Blackwell** (H100 cross-validated at 1.00×).

## Details

### What & why

Decouple `BLOCK_SIZE` from `n_cols`: split each row into fixed **1024-wide** column tiles
over a 2D grid `(n_rows, cdiv(n_cols, BLOCK_SIZE))`, instead of one program covering the
whole row (`BLOCK_SIZE = next_pow2(n_cols)`, e.g. 16384 for Llama-3 8B's 14336).

- **Why it's faster:** the one-row block spans the full hidden dim → 70 regs/thread → only
  1 block/SM → the backward kernel is latency-bound (22.7% occupancy, 42% DRAM). Smaller
  tiles drop to 32 regs/thread → 8 blocks/SM, so the memory-bound kernel saturates HBM.
  Access stays coalesced; a column mask handles non-divisible `n_cols`.
- **Bit-exact:** only launch geometry changes — outputs match the original kernel exactly.
- **Tile = 1024:** a per-shape sweep over {512…8192} found 1024 best-or-tied for backward
  on every shape (2048 ties; 8192 regresses).
- **Width gate (`next_pow2(n_cols) >= 16384`):** narrow rows aren't register-heavy, so
  tiling only adds overhead (~2–3% regression). They — plus all of H100/A100, which
  already run ~90% of the memory roofline — dispatch to the **exact original one-row
  kernels**, byte-for-byte upstream.
- **Bonus:** lifts the original `MAX_FUSED_SIZE = 65536` one-row cap on `n_cols`.

### NCU diagnosis (8192 × 14336, bf16, B200 — backward kernel)

| metric | original (one-row) | optimized (tiled) |
|---|---:|---:|
| achieved occupancy | 22.7% | **83.9%** |
| registers / thread | 70 → 1 block/SM | **32 → 8 blocks/SM** |
| DRAM throughput | 42% | **83%** |
| warps issued / scheduler | 0.39 (idle ~61%) | **0.82** |
| backward SOL efficiency | 50.0% | **81.5%** |

### Results — Llama-3 8B (isolated SiLUMul, n_cols=14336, bf16, B200)

Headline at T=8192, then across context length (win grows with T as more rows expose the
occupancy gap):

| pass | baseline | this PR | latency | throughput |
|---|---:|---:|---:|---:|
| forward | 0.1141 ms | 0.1106 ms | −3.1% | **+3.2%** |
| backward | 0.2937 ms | 0.1802 ms | **−38.6%** | **+63.0%** |
| full | 0.4020 ms | 0.2855 ms | **−29.0%** | **+40.8%** |

| T | backward | full | backward SOL (orig → opt) |
|---:|---:|---:|---|
| 1024 | 1.52× | 1.34× | 42.1% → 63.8% |
| 2048 | 1.56× | 1.39× | 45.9% → 71.8% |
| 4096 | 1.61× | 1.41× | 48.4% → 77.9% |
| 8192 | 1.63× | 1.41× | 50.0% → 81.5% |


### Results — across model shapes (isolated SiLUMul, T = 1024…8192, B200)

Same model set as the existing SwiGLU benchmarks. Only `n_cols` (= `intermediate_size`)
and dtype affect the activation kernel; ranges span T=1024→8192.

| config | dtype | n_cols | tiled? | backward | forward | full |
|---|---|---:|:--:|---:|---:|---:|
| llama-8B | bf16 | 14336 | ✅ | **1.51–1.63×** | 1.03–1.10× | 1.34–1.40× |
| qwen2.5-7B | bf16 | 18944 | ✅ | 1.15–1.21× | **1.48–1.49×** | 1.28–1.34× |
| llama-7B | bf16 | 11008 | ✅ | 1.20–1.24× | 0.98–1.00× | 1.12–1.15× |
| llama-7B | fp16 | 11008 | ✅ | 1.19–1.24× | 0.94–1.00× | 1.11–1.15× |
| llama-7B | fp32 | 11008 | ✅ | 1.03–1.05× | 0.96–1.01× | 1.01–1.04× |
| small | bf16 | 4096 | ➖ fallback | 1.00× | 1.00× | 1.00× |

- Biggest backward wins on the **widest bf16 rows** (14336). **qwen2.5-7B (18944)** gets a
  smaller backward win but a large **forward** win (its original forward is itself
  under-occupied at that width).
- **fp32** is near-flat (already close to roofline) but never regresses on the tiled path.
- **small (4096)** is below the width gate → falls back → exactly 1.00× at every T.

### H100 cross-validation (no regression off Blackwell)

Re-run on a real **H100** (self-contained `bench_swiglu_h100.py`, n_cols=14336, bf16).
With the arch dispatch, the H100 path executes the **identical original kernel**:

| T | backward speedup | full speedup |
|---:|---:|---:|
| 1024 | 1.000× | 1.000× |
| 2048 | 1.001× | 1.000× |
| 4096 | 1.000× | 1.000× |
| 8192 | 1.000× | 1.000× |

(An earlier unconditional-tiling version regressed H100 by 1–3% because the one-row
backward there is already at ~90% SOL; dispatching to the original kernels removes that
entirely.)


## Testing Done

- Bit-exact correctness vs the original one-row kernel: forward `0.00e+00`,
  backward (da, db) `0.00e+00` max abs diff — on both the tiled path (n_cols=14336) and
  the fallback path (n_cols=4096), across T = 1024–8192.
- Validated the dispatch: tiled on B200 (SM 10.0) for wide rows, original one-row path on
  H100 (SM 9.0) and for narrow rows on B200; all bit-exact on their respective GPUs.
- Multi-model sweep (6 configs × T∈{1024,2048,4096,8192}): backward avg 1.21×, max 1.63×,
  min 1.00× (the min is the width-gated small shape, i.e. no regression).

- Hardware Type: NVIDIA B200 (SM 10.0) + NVIDIA H100 80GB HBM3 (SM 9.0)
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
