### PR TITLE
Avoid torch.compile graph break in SAPO loss

### DIFF
--- a/src/liger_kernel/chunked_loss/grpo_loss.py
+++ b/src/liger_kernel/chunked_loss/grpo_loss.py
@@ -163,17 +163,16 @@ class LigerFusedLinearGRPOFunction(LigerFusedLinearPPOBase):
             # Uses sigmoid-based soft gating instead of hard clipping
             # Reference: https://huggingface.co/papers/2511.20347
             # TRL implementation: https://github.com/huggingface/trl/blob/1bd2a52ec2d8344050af736d60cdc735181ae4b8/trl/trainer/grpo_trainer.py#L2037-L2046
-            per_token_loss = torch.empty_like(coef_1)
-            # Expand advantages to match coef_1 shape for masking
             advantages_expanded = advantages.unsqueeze(1).expand_as(coef_1)
             positive_advantages_mask = advantages_expanded > 0
 
-            # Apply different temperatures based on advantage sign
-            per_token_loss[positive_advantages_mask] = sapo_loss_fn(
-                coef_1[positive_advantages_mask], sapo_temperature_pos
-            )
-            per_token_loss[~positive_advantages_mask] = sapo_loss_fn(
-                coef_1[~positive_advantages_mask], sapo_temperature_neg
+            # torch.where over both branches rather than boolean-mask assignment:
+            # mask indexing lowers to aten.nonzero, which graph-breaks under
+            # torch.compile. sapo_loss_fn is elementwise so this is identical.
+            per_token_loss = torch.where(
+                positive_advantages_mask,
+                sapo_loss_fn(coef_1, sapo_temperature_pos),
+                sapo_loss_fn(coef_1, sapo_temperature_neg),
             )
             per_token_loss = -per_token_loss * advantages_expanded
         elif loss_type == "vespo":


### PR DESCRIPTION
The SAPO branch of the GRPO loss assigned per-token loss values using boolean-mask indexing (`per_token_loss[mask] = sapo_loss_fn(coef_1[mask], ...)`). That kind of indexing lowers to `aten.nonzero`, whose output shape is data-dependent, so Inductor cannot trace it and torch.compile inserts a graph break. With recent torch versions this shows up as a noisy backend compiler warning when running the SAPO correctness test.

Since `sapo_loss_fn` is elementwise, we can evaluate both temperature branches over the full tensor and pick by the advantage sign with `torch.where`. The result is numerically identical and compiles cleanly with no graph break.

The existing SAPO correctness test passes and the warning is gone.
