### PR TITLE
Make LOG2_E a tl.constexpr so the CE kernel compiles on newer Triton

### DIFF
--- a/src/liger_kernel/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cross_entropy.py
@@ -23,7 +23,7 @@ else:
     from triton.language.math import tanh
 
 # log2(e): lets us emit the hardware ex2.approx instruction via e^x = 2^(x * LOG2_E)
-LOG2_E = 1.4426950408889634
+LOG2_E = tl.constexpr(1.4426950408889634)
 
 
 @triton.jit


### PR DESCRIPTION
Follow up to https://github.com/linkedin/Liger-Kernel/pull/1266  the cross entropy kernel reads the module level `LOG2_E` constant from inside the `@triton.jit` kernel. Newer Triton no longer allows accessing a plain (non-constexpr) global from within a kernel, so the kernel fails to compile with a NameError and the cross entropy correctness tests error out.

Wrapping the constant in `tl.constexpr` is what the Triton error itself suggests, and it keeps the value identical. The cross entropy tests pass again with this change.
