### PR TITLE
Add -m flag for modal runs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -117,7 +117,7 @@ jobs:
           
       - name: Run benchmarks on GPU
         run: |
-          modal run dev.modal.benchmarks
+          modal run -m dev.modal.benchmarks
         
        # Step 5: Checkout gh-pages branch in a subfolderAdd commentMore actions
       - name: Checkout gh-pages

--- a/.github/workflows/nvi-ci.yml
+++ b/.github/workflows/nvi-ci.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Run tests
       run: |
-        modal run dev.modal.tests::liger_correctness_tests
+        modal run -m dev.modal.tests::liger_correctness_tests
 
   nvi-convergence-tests:
     if: github.event_name == 'merge_group'
@@ -66,7 +66,7 @@ jobs:
 
     - name: Run tests
       run: |
-        modal run dev.modal.tests::liger_convergence_tests
+        modal run -m dev.modal.tests::liger_convergence_tests
 
   nvi-correctness-tests-with-transformers-4-52-0:
     if: github.event_name == 'merge_group'
@@ -91,7 +91,7 @@ jobs:
 
     - name: Run tests
       run: |
-        modal run dev.modal.tests::liger_oldest_v4_correctness_tests
+        modal run -m dev.modal.tests::liger_oldest_v4_correctness_tests
 
 
   nvi-convergence-tests-with-transformers-4-52-0:
@@ -117,4 +117,4 @@ jobs:
 
     - name: Run tests
       run: |
-        modal run dev.modal.tests::liger_oldest_v4_convergence_tests
+        modal run -m dev.modal.tests::liger_oldest_v4_convergence_tests


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Add -m flag for modal runs. Otherwise modal runs fail with 
```
Run modal run dev.modal.tests::liger_oldest_v4_correctness_tests
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ Python module paths must be specified with the -m flag. Use `modal run -m    │
│ dev.modal.tests` instead.                                                    │
╰──────────────────────────────────────────────────────────────────────────────╯
```

Also, updated secrets with a temporary modal secrets to test things out. 

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
