### PR TITLE
[CuteDSL] Add CuTe DSL cross-entropy kernel and CuteDSL integration scaffolding (B200)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,9 @@ def get_optional_dependencies():
     cutile_tileiras_deps = [
         "cuda-tile[tileiras]",
     ]
+    cutedsl_deps = [
+        "nvidia-cutlass-dsl",
+    ]
     dev_deps = [
         "transformers>=4.52.0",
         "matplotlib>=3.7.2",
@@ -54,6 +57,7 @@ def get_optional_dependencies():
     return {
         "cutile": cutile_deps,
         "cutile-tileiras": cutile_tileiras_deps,
+        "cutedsl": cutedsl_deps,
         "dev": dev_deps,
     }
 

--- a/src/liger_kernel/ops/cutedsl/__init__.py
+++ b/src/liger_kernel/ops/cutedsl/__init__.py
@@ -1,0 +1,20 @@
+"""
+CuTe DSL backend for Liger-Kernel.
+
+CuTe DSL is the optional, CUDA-only Python DSL shipped with NVIDIA CUTLASS
+(``import cutlass.cute``), targeting Hopper (SM90) and Blackwell (SM100/SM110).
+It is opt-in only — users select it explicitly via ``LIGER_KERNEL_IMPL=cutedsl``.
+It is not auto-applied on any device (note the empty ``default_devices`` on the
+registration below).
+"""
+
+from liger_kernel.ops.backends.registry import ImplInfo
+from liger_kernel.ops.backends.registry import register_impl
+
+register_impl(
+    ImplInfo(
+        name="cutedsl",
+        devices=("cuda",),
+        module_path=f"{__name__}.ops",  # liger_kernel.ops.cutedsl.ops
+    )
+)

--- a/src/liger_kernel/ops/cutedsl/ops/__init__.py
+++ b/src/liger_kernel/ops/cutedsl/ops/__init__.py
@@ -1,0 +1,22 @@
+"""
+CuTe DSL-specific operator implementations.
+"""
+
+try:
+    import cutlass.cute as cute  # noqa: F401
+except ImportError as exc:
+    raise ImportError(
+        "cutedsl backend requires the NVIDIA CUTLASS Python DSL (CuTe DSL). "
+        "Install it with `pip install nvidia-cutlass-dsl`, or when installing "
+        "Liger-Kernel use `pip install 'liger-kernel[cutedsl]'`."
+    ) from exc
+
+from liger_kernel.ops.cutedsl.ops.cross_entropy import LigerCrossEntropyFunction
+from liger_kernel.ops.cutedsl.ops.cross_entropy import cross_entropy_backward
+from liger_kernel.ops.cutedsl.ops.cross_entropy import cross_entropy_forward
+
+__all__ = [
+    "LigerCrossEntropyFunction",
+    "cross_entropy_backward",
+    "cross_entropy_forward",
+]

--- a/src/liger_kernel/ops/cutedsl/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cutedsl/ops/cross_entropy.py
@@ -1,0 +1,903 @@
+import inspect
+
+from typing import Optional
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils
+import torch
+
+from cutlass import Float32
+from cutlass import Int32
+from cutlass import const_expr
+from cutlass._mlir.dialects import nvvm
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cutlass_dsl import T
+from cutlass.cutlass_dsl import dsl_user_op
+
+from liger_kernel.ops.cutedsl.ops.utils import to_cute_tensor
+
+# log2(e) and ln(2): the online-softmax math is done in base-2 (hardware ex2.approx)
+# then converted, exactly mirroring the Triton kernel for numerical parity.
+LOG2_E = 1.4426950408889634
+NEG_LOG2_E = -1.4426950408889634  # for FMA-folding exp2 args: exp2(x*LOG2_E + (-m*LOG2_E))
+LN2 = 0.6931471805599453
+
+
+# Pick the nvvm.fmax calling convention from the installed binding itself rather
+# than from a CUDA/torch/cutlass version (which can disagree with the wheel): the
+# CUDA 12.9-era binding takes the result type as its first positional arg
+# (res, a, b, ...); newer bindings infer it (a, b, ...).
+# NOTE: single `except Exception` (not a tuple of types) on purpose — this module is
+# AST-preprocessed by cute.compile, whose import scanner crashes on a tuple-form
+# `except (A, B):` handler at module scope.
+try:
+    _FMAX_NEEDS_RESULT_TYPE = next(iter(inspect.signature(nvvm.fmax).parameters)) == "res"
+except Exception:
+    _FMAX_NEEDS_RESULT_TYPE = False  # assume the newer binding (matches FA4)
+
+
+@dsl_user_op
+def fmax(a, b, c=None, *, loc=None, ip=None) -> Float32:
+    """Hardware fp32 max via the NVVM ``fmax`` intrinsic.
+
+    Adapted from FlashAttention-4 (flash_attn/cute/utils.py), which calls
+    ``nvvm.fmax`` directly since cutlass.cute exposes no high-level scalar fmax.
+    FA4 targets the newer binding (result type inferred); we also support the
+    older CUDA 12.9 binding, which needs the result type as the first argument.
+    """
+    av = Float32(a).ir_value(loc=loc, ip=ip)
+    bv = Float32(b).ir_value(loc=loc, ip=ip)
+    cv = Float32(c).ir_value(loc=loc, ip=ip) if c is not None else None
+    if _FMAX_NEEDS_RESULT_TYPE:
+        return Float32(nvvm.fmax(T.f32(), av, bv, c=cv, loc=loc, ip=ip))
+    return Float32(nvvm.fmax(av, bv, c=cv, loc=loc, ip=ip))
+
+
+# A very negative fp32 sentinel used as -inf for the running max (avoids relying
+# on a float("-inf") literal surviving the DSL trace).
+NEG_INF_F32 = -1.0e38
+
+
+# cp.async pipeline depth: prefetch this many row tiles gmem->smem (cache_mode=GLOBAL bypasses
+# L1) while computing the current one. A "tile" = one 128-bit vector per thread = THREADS*16
+# bytes, dtype-independent. 4 measured best on B200 (fp32 -5% vs 3; bf16 flat). 5 crushes
+# occupancy at 32 warps (80 KB smem/CTA) and regresses fp32-large, so 4 is the sweet spot.
+_NUM_STAGES = 4
+
+# Compiled-kernel cache keyed on (dtypes, has_grad, feature flags, num_warps) — everything the
+# kernel bakes. V/BT are dynamic so one compile serves all shapes. REQUIRED: without it the
+# @cute.jit host fn recompiles on every call (~30 ms that dwarfs the kernel).
+_compile_cache = {}
+
+# Per-call host overhead is constant (~25 us): it doesn't scale with BT/V, so it dominates small
+# shapes and vanishes at scale. Cache the CUstream wrapper keyed on torch's raw stream handle so
+# we don't reconstruct the cuda.CUstream object every launch (general — no shape dependence).
+_stream_cache = {}
+
+
+def _cute_stream():
+    raw = torch.cuda.current_stream().cuda_stream
+    s = _stream_cache.get(raw)
+    if s is None:
+        s = cuda.CUstream(raw)
+        _stream_cache[raw] = s
+    return s
+
+
+# =============================================================================
+# Device-side helpers
+# =============================================================================
+@cute.jit
+def _warp_online_combine(m: Float32, d: Float32):
+    """Full-warp online-softmax reduction via butterfly shuffle.
+
+    After this every lane holds the row's final (max, normalizer). Combine rule:
+        m' = max(m1, m2);  d' = d1*2^((m1-m')*log2e) + d2*2^((m2-m')*log2e)
+    """
+    for i in cutlass.range_constexpr(5):  # log2(32) = 5 butterfly steps
+        offset = 1 << i
+        m_o = cute.arch.shuffle_sync_bfly(m, offset=offset)
+        d_o = cute.arch.shuffle_sync_bfly(d, offset=offset)
+        m_new = fmax(m, m_o)
+        d = d * cute.math.exp2((m - m_new) * LOG2_E, fastmath=True) + d_o * cute.math.exp2(
+            (m_o - m_new) * LOG2_E, fastmath=True
+        )
+        m = m_new
+    return m, d
+
+
+@cute.jit
+def _warp_argmax_combine(am: Float32, acol: Float32):
+    """Full-warp argmax reduction via butterfly shuffle.
+
+    Reduces (max logit value, smallest column achieving it) — the smallest-index
+    tie-break matches Triton's argmax. ``acol`` is the column carried as fp32 (exact
+    for V < 2^24). After this every lane holds the warp's (max, argmax-col).
+    """
+    for i in cutlass.range_constexpr(5):  # log2(32) = 5 butterfly steps
+        offset = 1 << i
+        om = cute.arch.shuffle_sync_bfly(am, offset=offset)
+        oc = cute.arch.shuffle_sync_bfly(acol, offset=offset)
+        # strictly-greater wins; exact tie keeps the smaller column. (Both compares use
+        # the pre-update `am`, and the two conditions are mutually exclusive.)
+        if om > am:
+            acol = oc
+        if om == am:
+            if oc < acol:
+                acol = oc
+        am = fmax(am, om)
+    return am, acol
+
+
+@cute.jit
+def _advance(idx, n: cutlass.Constexpr):
+    """Circular increment of a ring index. For a power-of-2 ring (NUM_STAGES=4) this is a
+    single AND mask (`(idx+1) & (n-1)`) instead of the ISETP+SEL+IADD a compare-select emits
+    — one fewer ALU instruction per call, and the steady-state loop calls it twice per tile.
+    Falls back to the branchless compare-select for non-power-of-2 n (resolved at trace time)."""
+    if const_expr(n & (n - 1) == 0):
+        return (idx + 1) & (n - 1)
+    return idx + 1 if idx < n - 1 else 0
+
+
+# =============================================================================
+# Device kernel
+# =============================================================================
+@cute.kernel
+def _ce_fwd_kernel(
+    mX: cute.Tensor,  # (BT, V) logits in/out (gradient written in-place)
+    mY: cute.Tensor,  # (BT,) int64 targets
+    mLoss: cute.Tensor,  # (BT,) per-row loss (input dtype, matches Triton)
+    mZLoss: cute.Tensor,  # (BT,) per-row z_loss out; written only if RETURN_Z_LOSS
+    mTokenAcc: cute.Tensor,  # (BT,) fp32 per-row accuracy out; written only if RETURN_TOKEN_ACCURACY
+    mPredTok: cute.Tensor,  # (BT,) int64 per-row argmax out; written only if RETURN_PREDICTED_TOKENS
+    mWeight: cute.Tensor,  # (V,) fp32 class weights; read only if HAS_WEIGHT
+    inv_n_loss: Float32,  # main-loss/grad normalizer: 1/sum_non_ignore_weight (mean+weight), 1/n (mean), else 1.0
+    inv_n_z: Float32,  # z_loss normalizer: 1/n_non_ignore (mean), else 1.0 (z_loss is never weight-scaled)
+    lse_sq_scale: Float32,  # lse_square_scale (z_loss coefficient); unused if not HAS_ZLOSS
+    softcap: Float32,  # logit soft-cap threshold; unused if not HAS_SOFTCAP
+    label_smoothing: Float32,  # smoothing amount; unused if not HAS_SMOOTHING
+    weight_sum: Float32,  # sum of the full weight vector; used only by weighted smoothing
+    ignore_index: Int32,
+    HAS_GRAD: cutlass.Constexpr,
+    HAS_ZLOSS: cutlass.Constexpr,  # lse_square_scale != 0 or return_z_loss
+    RETURN_Z_LOSS: cutlass.Constexpr,  # write per-row z_loss to mZLoss
+    HAS_SOFTCAP: cutlass.Constexpr,  # apply softcap*tanh(x/softcap) to logits
+    RETURN_TOKEN_ACCURACY: cutlass.Constexpr,  # write per-row (argmax == y) to mTokenAcc
+    RETURN_PREDICTED_TOKENS: cutlass.Constexpr,  # write per-row argmax column to mPredTok
+    HAS_WEIGHT: cutlass.Constexpr,  # scale loss/grad by per-class weight
+    HAS_SMOOTHING: cutlass.Constexpr,  # label_smoothing != 0
+    NUM_WARPS: cutlass.Constexpr,  # warps/CTA cooperating on one row (8 for 2-byte, 32 for fp32)
+):
+    THREADS = const_expr(32 * NUM_WARPS)
+    tid, _, _ = cute.arch.thread_idx()  # 0..THREADS-1
+    lane = tid % 32
+    warp = tid // 32
+    row, _, _ = cute.arch.block_idx()
+
+    # token_accuracy and predicted_tokens both reduce to the row's argmax column.
+    NEED_ARGMAX = const_expr(RETURN_TOKEN_ACCURACY or RETURN_PREDICTED_TOKENS)
+
+    # Cross-warp reduction scratch (one (m, d)[, argmax][, scaled_x_sum] per warp), carved from
+    # one smem pool sized for NUM_WARPS; the cp.async tile buffer comes from the same pool below.
+    # NUM_WARPS is compile-time, so the smem footprint shrinks for the 8-warp bf16 kernel and
+    # grows only for the 32-warp fp32 kernel — keeping occupancy high where it matters.
+    _smem = cutlass.utils.SmemAllocator()
+    sm_m = _smem.allocate_tensor(Float32, cute.make_layout(NUM_WARPS), byte_alignment=4)
+    sm_d = _smem.allocate_tensor(Float32, cute.make_layout(NUM_WARPS), byte_alignment=4)
+    sm_argm = _smem.allocate_tensor(Float32, cute.make_layout(NUM_WARPS), byte_alignment=4)
+    sm_argcol = _smem.allocate_tensor(Float32, cute.make_layout(NUM_WARPS), byte_alignment=4)
+    sm_sxs = _smem.allocate_tensor(Float32, cute.make_layout(NUM_WARPS), byte_alignment=4)
+
+    gX = mX[row, None]  # 1D (V,) view of this row; grad written in-place here
+    V = gX.shape[0]
+    # cp.async's 128-bit atom needs a 16-byte-aligned gmem source, but the dynamic
+    # row slice drops the static alignment to element size. Rebuild the row pointer
+    # with an explicit 16-byte alignment — valid because each row starts 16-aligned
+    # (V*sizeof is a multiple of 16 given V % VEC == 0).
+    gX = cute.make_tensor(
+        cute.make_ptr(mX.element_type, gX.iterator.toint(), cute.AddressSpace.gmem, assumed_align=16),
+        cute.make_layout((V,)),
+    )
+
+    y = mY[row]
+    is_ignored = y == ignore_index
+    # Clamp the target index for ignored rows so the gX[y] load can't go OOB
+    # (ignore_index is typically negative). `y * 0` keeps y's dtype.
+    y_safe = y
+    if is_ignored:
+        y_safe = y * 0
+
+    ori_xy = gX[y_safe].to(Float32)  # logit at the target, for the loss
+    if const_expr(HAS_SOFTCAP):
+        # cap the target logit too — the loss uses the capped value, like Triton.
+        ori_xy = softcap * cute.math.tanh(ori_xy / softcap)
+
+    # per-row class weight (stays 1.0 when unweighted, so it can multiply unconditionally).
+    w_eff = Float32(1.0)
+    if const_expr(HAS_WEIGHT):
+        w_eff = mWeight[y_safe].to(Float32)
+    # label-smoothing per-class mass eps = label_smoothing / V (matches Triton).
+    eps = Float32(0.0)
+    if const_expr(HAS_SMOOTHING):
+        eps = label_smoothing / Float32(V)
+
+    # 128-bit vectorization + cp.async pipeline. gXv: (VEC, V//VEC). 256 threads
+    # cooperate; each loads its 128-bit vector per tile. Tail predicated -> V % VEC.
+    VEC = const_expr(128 // gX.element_type.width)
+    gXv = cute.tiled_divide(gX, (VEC,))
+    num_vec = V // VEC
+    num_tiles = (num_vec + THREADS - 1) // THREADS
+    x_frag = cute.make_rmem_tensor((VEC,), gX.element_type)
+
+    # Weighted label smoothing is the only path that needs per-column weights (the smoothing
+    # loss/grad use weight_block); load them as a plain vectorized gmem read (the (V,) weight
+    # vector is shared by every row, so it stays L2-resident — no cp.async pipeline needed).
+    NEED_WBLOCK = const_expr(HAS_WEIGHT and HAS_SMOOTHING)
+    if const_expr(NEED_WBLOCK):
+        gW = cute.make_tensor(
+            cute.make_ptr(mWeight.element_type, mWeight.iterator.toint(), cute.AddressSpace.gmem, assumed_align=16),
+            cute.make_layout((V,)),
+        )
+        gWv = cute.tiled_divide(gW, (VEC,))
+        w_frag = cute.make_rmem_tensor((VEC,), Float32)
+
+    # cp.async (L1-bypassing) atom + multi-stage smem tile view (VEC, 256, NUM_STAGES).
+    cp_atom = cute.make_copy_atom(
+        cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL), gX.element_type, num_bits_per_copy=128
+    )
+    sTiles = _smem.allocate_tensor(gX.element_type, cute.make_layout((THREADS * VEC, _NUM_STAGES)), byte_alignment=16)
+    sTilesV = cute.tiled_divide(sTiles, (VEC,))  # (VEC, THREADS, NUM_STAGES)
+
+    # --- pass 1: [Online softmax] first pass — find the running max m and normalizer d
+    # (Algorithm 3, https://arxiv.org/pdf/1805.02867): 2 loads + 1 store vs 3+1 for safe
+    # softmax. cp.async-pipelined; each thread keeps its own (m, d) then we reduce across the CTA.
+    m = Float32(NEG_INF_F32)
+    d = Float32(0.0)
+    # per-thread argmax: max raw logit seen + smallest column achieving it (V = sentinel).
+    t_am = Float32(NEG_INF_F32)
+    t_acol = Float32(V)
+    # per-thread label-smoothing partial: sum of (-eps * x_capped [* weight]) over its cols.
+    t_sxs = Float32(0.0)
+    # prologue: prefetch the first NUM_STAGES-1 tiles
+    for s in cutlass.range_constexpr(_NUM_STAGES - 1):
+        p_vidx = s * THREADS + tid
+        if p_vidx < num_vec:
+            cute.copy(cp_atom, gXv[None, p_vidx], sTilesV[None, tid, s])
+        cute.arch.cp_async_commit_group()
+    # steady state: rotating stage indices (no % modulo) + incremental vidx (ALU win).
+    read_stage = Int32(0)
+    write_stage = Int32(_NUM_STAGES - 1)
+    r_vidx = Int32(tid)
+    w_vidx = Int32((_NUM_STAGES - 1) * THREADS + tid)
+    for _t in cutlass.range(0, num_tiles):
+        if w_vidx < num_vec:
+            cute.copy(cp_atom, gXv[None, w_vidx], sTilesV[None, tid, write_stage])
+        cute.arch.cp_async_commit_group()
+        cute.arch.cp_async_wait_group(_NUM_STAGES - 1)
+        if r_vidx < num_vec:
+            cute.autovec_copy(sTilesV[None, tid, read_stage], x_frag)  # smem -> reg
+            if const_expr(NEED_ARGMAX):
+                # argmax on the RAW logits: softcap is monotonic, so argmax(softcap(x)) ==
+                # argmax(x) and the column is identical. Smaller j (and earlier, smaller-
+                # column tiles) win ties via the strict `>`.
+                base = r_vidx * VEC
+                for j in cutlass.range_constexpr(VEC):
+                    xj = x_frag[j].to(Float32)
+                    if xj > t_am:
+                        t_am = xj
+                        t_acol = Float32(base + j)
+            x_ssa = x_frag.load().to(Float32)  # (VEC,) fp32 TensorSSA
+            if const_expr(HAS_SOFTCAP):
+                x_ssa = softcap * cute.math.tanh(x_ssa / softcap)  # cap before max/sum
+            if const_expr(HAS_SMOOTHING):
+                # scaled_x_sum partial: sum of -eps * x_capped, * weight_block when weighted.
+                neg_eps = Float32(0.0) - eps
+                if const_expr(NEED_WBLOCK):
+                    cute.autovec_copy(gWv[None, r_vidx], w_frag)
+                    w_ssa = w_frag.load()
+                    t_sxs = t_sxs + (x_ssa * w_ssa * neg_eps).reduce(cute.ReductionOp.ADD, Float32(0.0), 0)
+                else:
+                    t_sxs = t_sxs + (x_ssa * neg_eps).reduce(cute.ReductionOp.ADD, Float32(0.0), 0)
+            local_max = x_ssa.reduce(cute.ReductionOp.MAX, Float32(NEG_INF_F32), 0)
+            m_new = fmax(m, local_max)
+            # FMA-fold: exp2((x - m_new)*LOG2_E) == exp2(x*LOG2_E + (-m_new*LOG2_E)).
+            # Hoisting the per-tile scalar neg_m2 lets the per-element arg compile to one
+            # FFMA instead of FADD+FMUL — fewer issued instructions on the issue-bound P1.
+            neg_m2 = m_new * NEG_LOG2_E
+            x_exp = cute.math.exp2(x_ssa * LOG2_E + neg_m2, fastmath=True)
+            local_sum = x_exp.reduce(cute.ReductionOp.ADD, Float32(0.0), 0)
+            d = d * cute.math.exp2((m - m_new) * LOG2_E, fastmath=True) + local_sum
+            m = m_new
+        read_stage = _advance(read_stage, _NUM_STAGES)
+        write_stage = _advance(write_stage, _NUM_STAGES)
+        r_vidx = r_vidx + THREADS
+        w_vidx = w_vidx + THREADS
+    cute.arch.cp_async_wait_group(0)  # drain remaining prefetches
+
+    # warp-level reduce (collective: all 32 lanes) -> each lane has the warp's (m, d)
+    m, d = _warp_online_combine(m, d)
+    if const_expr(NEED_ARGMAX):
+        t_am, t_acol = _warp_argmax_combine(t_am, t_acol)
+    if const_expr(HAS_SMOOTHING):
+        # plain warp sum-reduce of the scaled_x_sum partial (butterfly add).
+        for _i in cutlass.range_constexpr(5):
+            t_sxs = t_sxs + cute.arch.shuffle_sync_bfly(t_sxs, offset=1 << _i)
+    # cross-warp: each warp's lane 0 publishes its (m, d)[, argmax][, scaled_x_sum]; then combine.
+    if lane == 0:
+        sm_m[warp] = m
+        sm_d[warp] = d
+        if const_expr(NEED_ARGMAX):
+            sm_argm[warp] = t_am
+            sm_argcol[warp] = t_acol
+        if const_expr(HAS_SMOOTHING):
+            sm_sxs[warp] = t_sxs
+    cute.arch.barrier()
+    m = Float32(NEG_INF_F32)
+    d = Float32(0.0)
+    if const_expr(NEED_ARGMAX):
+        g_am = Float32(NEG_INF_F32)
+        g_acol = Float32(V)
+    if const_expr(HAS_SMOOTHING):
+        g_sxs = Float32(0.0)
+    for w in cutlass.range_constexpr(NUM_WARPS):
+        mw = sm_m[w]
+        dw = sm_d[w]
+        m_new = fmax(m, mw)
+        d = d * cute.math.exp2((m - m_new) * LOG2_E, fastmath=True) + dw * cute.math.exp2(
+            (mw - m_new) * LOG2_E, fastmath=True
+        )
+        m = m_new
+        if const_expr(NEED_ARGMAX):
+            aw = sm_argm[w]
+            cw = sm_argcol[w]
+            if aw > g_am:
+                g_acol = cw
+            if aw == g_am:
+                if cw < g_acol:
+                    g_acol = cw
+            g_am = fmax(g_am, aw)
+        if const_expr(HAS_SMOOTHING):
+            g_sxs = g_sxs + sm_sxs[w]
+
+    # lse = m + ln(d) = m + log2(d)*ln2
+    lse = m + cute.math.log2(d, fastmath=True) * LN2
+
+    # main loss = weight_y * (lse - x_y) (weight_y == 1 when unweighted), then normalize by
+    # inv_n_loss (1/sum_non_ignore_weight when weighted+mean, else 1/n or 1.0). The label-
+    # smoothing mix is spliced in here under HAS_SMOOTHING.
+    # loss = log(softmax(X_y)) = (X_y - m) - log d = X_y - lse, weighted by weight_y (== 1
+    # when unweighted). sum(e^(X-m)) >= 1 (the max term is e^0 = 1) so this can't overflow.
+    main = (lse - ori_xy) * w_eff
+    if const_expr(HAS_SMOOTHING):
+        # Label smoothing regularizes H(q, p) -> H(q', p), with eps = label_smoothing / V:
+        #   H(q', p) = (1 - ls) * H(q, p) + ls * H(u, p)
+        #            = (1 - ls) * H(q, p) + (sum(-eps * x_i) + ls * (m + log d))
+        # g_sxs is the reduced sum(-eps * x_capped [* weight_block]); inv_n_loss normalizes
+        # the whole. Refer to H(q', p) in section 7 of https://arxiv.org/pdf/1512.00567 and the
+        # full derivation in https://github.com/linkedin/Liger-Kernel/pull/198#issuecomment-2333753087
+        if const_expr(HAS_WEIGHT):
+            smooth_loss = g_sxs + eps * lse * weight_sum
+        else:
+            smooth_loss = g_sxs + label_smoothing * lse
+        main = main * (Float32(1.0) - label_smoothing) + smooth_loss
+    loss = main * inv_n_loss
+    # An auxiliary z_loss = lse_square_scale * lse^2 (PaLM, page 14:
+    # https://www.jmlr.org/papers/v24/22-1144.html), normalized by inv_n_z (always
+    # /n_non_ignore for mean, never weight-scaled — matches Triton) and added to the per-row loss.
+    zl = Float32(0.0)
+    if const_expr(HAS_ZLOSS):
+        zl = lse_sq_scale * lse * lse * inv_n_z
+        loss = loss + zl
+    if is_ignored:
+        loss = Float32(0.0)
+        zl = Float32(0.0)
+    if tid == 0:
+        mLoss[row] = loss.to(mLoss.element_type)
+        if const_expr(RETURN_Z_LOSS):
+            mZLoss[row] = zl.to(mZLoss.element_type)
+
+    # token_accuracy / predicted_tokens: ignored rows get 0.0 / -1 (matches Triton).
+    # The ignored sentinel is folded in at fp32 (col_out) before the single int cast — the
+    # DSL forbids reassigning an int-typed var inside a dynamic `if`, but fp32 is fine
+    # (same pattern as `loss = Float32(0.0)` above).
+    if const_expr(NEED_ARGMAX):
+        argcol = Int32(g_acol)  # global argmax column (g_acol is an integer-valued fp32)
+        if tid == 0:
+            if const_expr(RETURN_TOKEN_ACCURACY):
+                acc = Float32(0.0)
+                if Int32(y) == argcol:
+                    acc = Float32(1.0)
+                if is_ignored:
+                    acc = Float32(0.0)
+                mTokenAcc[row] = acc.to(mTokenAcc.element_type)
+            if const_expr(RETURN_PREDICTED_TOKENS):
+                col_out = g_acol
+                if is_ignored:
+                    col_out = Float32(-1.0)
+                mPredTok[row] = Int32(col_out).to(mPredTok.element_type)
+
+    # --- pass 2: [Online softmax] second pass — gradient, written in-place over the logits.
+    # For 'mean' reduction (normalized by N = number of non-ignored elements):
+    #   dx_i = softmax(x_i) / N,                                      i != y
+    #   dx_y = (softmax(x_y) - 1) / N
+    # With label smoothing (eps = label_smoothing / V):
+    #   dx_i = (softmax(x_i) - eps) / N ;   dx_y = dx_i - (1 - ls) / N
+    # With z_loss: every softmax(x_i) picks up a (1 + 2*lse_square_scale*lse) factor.
+    # For 'sum'/'none' there is no /N. (Weighted variants scale by weight_y / sum_w; see below.)
+    if const_expr(HAS_GRAD):
+        # per-element grad = softmax_i * (coef / d). coef folds the dloss_ori coefficient and the
+        # dz_loss coefficient 2*s*lse*inv_n_z. The two use DIFFERENT normalizers when weighted
+        # (sum_w vs n), so they can't share one scale; the additive smoothing term (not
+        # proportional to softmax) is applied per element below. is_ignored zeros the whole row.
+        # dloss_ori coefficient: the weighted branch scales softmax by (1-ls)*weight_y; the
+        # unweighted branch uses the equivalent simplified form (coefficient 1, with smoothing
+        # handled by the additive -eps term applied per element below). Both match Triton.
+        if const_expr(HAS_WEIGHT):
+            coef = (Float32(1.0) - label_smoothing) * w_eff * inv_n_loss
+        else:
+            coef = inv_n_loss
+        if const_expr(HAS_ZLOSS):
+            coef = coef + (Float32(2.0) * lse_sq_scale * lse) * inv_n_z
+        if is_ignored:
+            coef = Float32(0.0)
+        recip = coef / d
+        # smoothing additive-term coefficient (eps * inv_n_loss), zeroed on ignored rows so an
+        # ignored row's gradient stays entirely 0 — coef above only zeros the softmax part, but
+        # the additive smoothing term must vanish too (Triton zeros ignored rows wholesale).
+        if const_expr(HAS_SMOOTHING):
+            eps_g = eps * inv_n_loss
+            if is_ignored:
+                eps_g = Float32(0.0)
+        g_frag = cute.make_rmem_tensor((VEC,), gX.element_type)
+        # P2's max `m` is loop-invariant, so hoist the FMA-fold scalar once:
+        # exp2((x - m)*LOG2_E) == exp2(x*LOG2_E + neg_m2_p2). Per-element arg becomes one FFMA.
+        neg_m2_p2 = m * NEG_LOG2_E
+        # prologue (smem tile buffer free to reuse: the cross-warp barrier above
+        # synced pass 1's drains before any pass-2 prefetch overwrites it)
+        for s in cutlass.range_constexpr(_NUM_STAGES - 1):
+            p_vidx = s * THREADS + tid
+            if p_vidx < num_vec:
+                cute.copy(cp_atom, gXv[None, p_vidx], sTilesV[None, tid, s])
+            cute.arch.cp_async_commit_group()
+        read_stage = Int32(0)
+        write_stage = Int32(_NUM_STAGES - 1)
+        r_vidx = Int32(tid)
+        w_vidx = Int32((_NUM_STAGES - 1) * THREADS + tid)
+        for _t in cutlass.range(0, num_tiles):
+            if w_vidx < num_vec:
+                cute.copy(cp_atom, gXv[None, w_vidx], sTilesV[None, tid, write_stage])
+            cute.arch.cp_async_commit_group()
+            cute.arch.cp_async_wait_group(_NUM_STAGES - 1)
+            if r_vidx < num_vec:
+                cute.autovec_copy(sTilesV[None, tid, read_stage], x_frag)  # smem -> reg
+                x_ssa = x_frag.load().to(Float32)
+                if const_expr(HAS_SOFTCAP):
+                    t_ssa = cute.math.tanh(x_ssa / softcap)
+                    x_ssa = softcap * t_ssa  # capped logits feed the softmax
+                g_ssa = cute.math.exp2(x_ssa * LOG2_E + neg_m2_p2, fastmath=True) * recip
+                if const_expr(HAS_SMOOTHING):
+                    # additive smoothing term (not proportional to softmax), via the ignore-gated
+                    # eps_g. Unweighted: -eps_g. Weighted: (softmax*weight_sum - weight_block)*eps_g.
+                    if const_expr(NEED_WBLOCK):
+                        cute.autovec_copy(gWv[None, r_vidx], w_frag)
+                        w_ssa = w_frag.load()
+                        softmax_ssa = cute.math.exp2(x_ssa * LOG2_E + neg_m2_p2, fastmath=True) / d
+                        g_ssa = g_ssa + (softmax_ssa * weight_sum - w_ssa) * eps_g
+                    else:
+                        g_ssa = g_ssa + (Float32(0.0) - eps_g)
+                if const_expr(HAS_SOFTCAP):
+                    # chain rule applies to the FULL gradient incl. smoothing:
+                    # d(softcap*tanh(x/softcap))/dx = 1 - tanh^2(x/softcap).
+                    g_ssa = g_ssa * (1.0 - t_ssa * t_ssa)
+                g_frag.store(g_ssa.to(gX.element_type))
+                cute.autovec_copy(g_frag, gXv[None, r_vidx])  # 128-bit store to gmem
+            read_stage = _advance(read_stage, _NUM_STAGES)
+            write_stage = _advance(write_stage, _NUM_STAGES)
+            r_vidx = r_vidx + THREADS
+            w_vidx = w_vidx + THREADS
+        cute.arch.cp_async_wait_group(0)  # drain remaining prefetches
+        cute.arch.barrier()  # all grad writes visible before the target correction
+        # -(1 - ls) * weight_y / N_loss correction at the (non-ignored) target index, one thread.
+        do_correction = y != ignore_index
+        if tid == 0:
+            if do_correction:
+                dxy = (Float32(0.0) - (Float32(1.0) - label_smoothing)) * w_eff * inv_n_loss
+                if const_expr(HAS_SOFTCAP):
+                    # same chain factor at y: t_y = tanh(x_y/softcap) = ori_xy_capped/softcap.
+                    t_y = ori_xy / softcap
+                    dxy = dxy * (1.0 - t_y * t_y)
+                corr = gX[y].to(Float32) + dxy
+                gX[y] = corr.to(gX.element_type)
+
+
+# =============================================================================
+# Host launch
+# =============================================================================
+@cute.jit
+def _ce_fwd_host(
+    mX: cute.Tensor,
+    mY: cute.Tensor,
+    mLoss: cute.Tensor,
+    mZLoss: cute.Tensor,
+    mTokenAcc: cute.Tensor,
+    mPredTok: cute.Tensor,
+    mWeight: cute.Tensor,
+    inv_n_loss: Float32,
+    inv_n_z: Float32,
+    lse_sq_scale: Float32,
+    softcap: Float32,
+    label_smoothing: Float32,
+    weight_sum: Float32,
+    ignore_index: Int32,
+    HAS_GRAD: cutlass.Constexpr,
+    HAS_ZLOSS: cutlass.Constexpr,
+    RETURN_Z_LOSS: cutlass.Constexpr,
+    HAS_SOFTCAP: cutlass.Constexpr,
+    RETURN_TOKEN_ACCURACY: cutlass.Constexpr,
+    RETURN_PREDICTED_TOKENS: cutlass.Constexpr,
+    HAS_WEIGHT: cutlass.Constexpr,
+    HAS_SMOOTHING: cutlass.Constexpr,
+    NUM_WARPS: cutlass.Constexpr,
+    stream: cuda.CUstream = None,
+):
+    BT = mX.shape[0]
+    threads = 32 * NUM_WARPS
+    # smem = the cp.async tile ring (threads * 16 bytes/thread * NUM_STAGES) + the 5 per-warp
+    # reduction arrays (fp32), 16-byte rounded. Sized from NUM_WARPS so the 8-warp bf16 kernel
+    # uses ~1/4 the smem of the 32-warp fp32 kernel and keeps more CTAs resident per SM.
+    smem_bytes = threads * 16 * _NUM_STAGES + ((5 * NUM_WARPS * 4 + 15) // 16) * 16
+    _ce_fwd_kernel(
+        mX,
+        mY,
+        mLoss,
+        mZLoss,
+        mTokenAcc,
+        mPredTok,
+        mWeight,
+        inv_n_loss,
+        inv_n_z,
+        lse_sq_scale,
+        softcap,
+        label_smoothing,
+        weight_sum,
+        ignore_index,
+        HAS_GRAD,
+        HAS_ZLOSS,
+        RETURN_Z_LOSS,
+        HAS_SOFTCAP,
+        RETURN_TOKEN_ACCURACY,
+        RETURN_PREDICTED_TOKENS,
+        HAS_WEIGHT,
+        HAS_SMOOTHING,
+        NUM_WARPS,
+    ).launch(
+        grid=[BT, 1, 1],
+        block=[threads, 1, 1],
+        smem=smem_bytes,
+        stream=stream,
+    )
+
+
+def _launch_ce_fwd(
+    x,
+    y,
+    loss,
+    inv_n_loss,
+    ignore_index,
+    has_grad,
+    lse_sq_scale=0.0,
+    z_loss_out=None,
+    return_z_loss=False,
+    softcap=None,
+    label_smoothing=0.0,
+    weight=None,
+    weight_sum=0.0,
+    return_token_accuracy=False,
+    return_predicted_tokens=False,
+    token_acc_out=None,
+    pred_tok_out=None,
+    inv_n_z=None,
+):
+    vec = 16 // x.element_size()  # 128-bit vectorization width: 8 bf16 / 4 fp32
+    assert x.shape[-1] % vec == 0, (
+        f"cutedsl CE needs V % {vec} == 0 for {x.dtype} (128-bit vectorized loads); "
+        f"got V={x.shape[-1]}. The 256-thread tail is predicated, so only V % VEC is required."
+    )
+    # inv_n_z defaults to inv_n_loss: on the core / no-class-weight path the main loss and the
+    # z_loss share one normalizer. Keeping inv_n_z a trailing keyword (not a 5th positional)
+    # leaves the 6-arg call other cutedsl ops use unchanged: (x, y, loss, inv_n, ignore_index,
+    # has_grad) — so this stays a drop-in for FLCE and any other caller.
+    if inv_n_z is None:
+        inv_n_z = inv_n_loss
+    # Compile ONCE per (dtype, has_grad, feature flags) and cache the compiled callable;
+    # invoke it each call. (Eager-calling the @cute.jit fn recompiled on every invocation
+    # -> ~30 ms fixed overhead.) Launch on torch's current CUDA stream so the in-place
+    # grad write is ordered w.r.t. the caller.
+    has_zloss = bool(lse_sq_scale != 0.0 or return_z_loss)
+    has_softcap = softcap is not None
+    has_weight = weight is not None
+    has_smoothing = bool(label_smoothing != 0.0)
+    softcap_val = float(softcap) if has_softcap else 0.0
+    x_ct = to_cute_tensor(x)
+    y_ct = to_cute_tensor(y, assumed_align=8)  # int64
+    loss_ct = to_cute_tensor(loss, assumed_align=2)  # bf16/fp16/fp32 scalar
+    stream = _cute_stream()
+    # Key on EVERY dtype the kernel bakes at compile time, not just x.dtype:
+    #   mX.element_type (x), mY.element_type (y), mLoss.element_type (loss, via
+    #   `loss.to(mLoss.element_type)`). Missing loss.dtype let two callers with the
+    #   same (x.dtype, has_grad) but different loss-buffer widths reuse each other's
+    #   kernel and write wrong-width values into the loss buffer — e.g. CE (loss =
+    #   input dtype) vs FLCE (loss = fp32) collided on bf16.
+    # When an optional output isn't requested, pass a same-shape dummy
+    # of any dtype (mZLoss reuses `loss`; mTokenAcc reuses `loss`; mPredTok reuses the
+    # int64 target `y`) — the kernel never touches it because its RETURN_* flag bakes
+    # False, and the compile key carries that flag so a real-output compile can't reuse it.
+    # Reuse the already-marshalled loss_ct/y_ct handles for the dummies (no extra from_dlpack
+    # on the common path — one fewer DLPack capsule per call).
+    z_ct = to_cute_tensor(z_loss_out, assumed_align=2) if return_z_loss else loss_ct
+    ta_ct = to_cute_tensor(token_acc_out, assumed_align=4) if return_token_accuracy else loss_ct
+    pt_ct = to_cute_tensor(pred_tok_out, assumed_align=8) if return_predicted_tokens else y_ct
+    # weight is a fp32 (V,) vector when present (caller upcasts); dummy reuses int64 `y`.
+    w_ct = to_cute_tensor(weight, assumed_align=4) if has_weight else y_ct
+    # warps/CTA: mirror Triton's Blackwell CE convention — 2-byte dtypes (bf16/fp16) are
+    # instruction-issue-bound -> 8 warps; fp32 is bandwidth-bound -> 32 warps. Baked into the
+    # kernel, so it's part of the compile key.
+    num_warps = 8 if x.element_size() == 2 else 32
+    key = (
+        x.dtype,
+        y.dtype,
+        loss.dtype,
+        has_grad,
+        has_zloss,
+        bool(return_z_loss),
+        has_softcap,
+        bool(return_token_accuracy),
+        bool(return_predicted_tokens),
+        has_weight,
+        has_smoothing,
+        num_warps,
+    )
+    if key not in _compile_cache:
+        _compile_cache[key] = cute.compile(
+            _ce_fwd_host,
+            x_ct,
+            y_ct,
+            loss_ct,
+            z_ct,
+            ta_ct,
+            pt_ct,
+            w_ct,
+            float(inv_n_loss),
+            float(inv_n_z),
+            float(lse_sq_scale),
+            float(softcap_val),
+            float(label_smoothing),
+            float(weight_sum),
+            int(ignore_index),
+            has_grad,
+            has_zloss,
+            bool(return_z_loss),
+            has_softcap,
+            bool(return_token_accuracy),
+            bool(return_predicted_tokens),
+            has_weight,
+            has_smoothing,
+            num_warps,
+            stream,
+        )
+    # The constexpr flags are baked at compile; pass runtime tensors/scalars/stream only.
+    _compile_cache[key](
+        x_ct,
+        y_ct,
+        loss_ct,
+        z_ct,
+        ta_ct,
+        pt_ct,
+        w_ct,
+        float(inv_n_loss),
+        float(inv_n_z),
+        float(lse_sq_scale),
+        float(softcap_val),
+        float(label_smoothing),
+        float(weight_sum),
+        int(ignore_index),
+        stream,
+    )
+
+
+# =============================================================================
+# Public host API (matches liger_kernel.ops.cross_entropy)
+# =============================================================================
+def cross_entropy_forward(
+    _input,
+    target,
+    weight,
+    ignore_index,
+    lse_square_scale,
+    label_smoothing,
+    reduction,
+    softcap,
+    return_z_loss,
+    return_token_accuracy=False,
+    return_predicted_tokens=False,
+):
+    """CuTe DSL CE forward. Returns (loss, z_loss, token_accuracy, predicted_tokens, _input)."""
+    assert reduction in ("mean", "sum", "none"), f"Unsupported reduction: {reduction}"
+
+    BT, V = _input.shape
+    _vec = 16 // _input.element_size()  # 128-bit vectorization width (8 bf16 / 4 fp32)
+    assert V % _vec == 0, f"cutedsl CE needs V % {_vec} == 0 for {_input.dtype} (128-bit vectorized loads); got V={V}."
+    if _input.stride(-1) != 1:
+        _input = _input.contiguous()
+    if target.stride(-1) != 1:
+        target = target.contiguous()
+
+    target_mask = target != ignore_index
+    # Batch the count + bounds checks into ONE D2H sync (was three: sum().item(), max(), min()).
+    # Each .item() is a ~15-20 us host stall independent of BT/V, so collapsing 3->1 cuts a
+    # constant per-call cost that hurts small shapes most — fully general, no shape branching.
+    _mt = target * target_mask
+    _stats = torch.stack((target_mask.sum(), _mt.max(), _mt.min())).tolist()
+    n_non_ignore = int(_stats[0])
+    assert _stats[1] < V, f"Target out of bounds. Expected < {V}"
+    assert _stats[2] >= 0, "Target out of bounds. Expected >= 0"
+
+    # Class weight: sum_non_ignore_weight (the mean denominator for the weighted loss/grad)
+    # replaces n_non_ignore; weight_sum (the full-vector sum) is used by weighted smoothing.
+    # The kernel reads weight as fp32, so upcast here (exact parity for fp32 weights).
+    sum_non_ignore_weight = float(n_non_ignore)
+    weight_sum = 0.0
+    if weight is not None:
+        assert weight.shape[0] == V, f"weight must be a Tensor of size V={V}. Got: {tuple(weight.shape)}"
+        assert torch.is_floating_point(weight), f"weight must be floating point. Got: {weight.dtype}"
+        weight = weight.to(torch.float32)
+        if weight.stride(-1) != 1:
+            weight = weight.contiguous()
+        sum_non_ignore_weight = torch.gather(weight, 0, target.masked_select(target_mask)).sum().item()
+        weight_sum = weight.sum().item()
+
+    loss_1d = torch.zeros(BT, dtype=_input.dtype, device=_input.device)
+    # z_loss buffer: input dtype, zero-init so ignored rows stay 0 (matches Triton).
+    z_loss_1d = torch.zeros(BT, dtype=_input.dtype, device=_input.device) if return_z_loss else None
+    # token_accuracy is fp32 (1.0/0.0 per row); predicted_tokens is int64 (argmax column,
+    # -1 for ignored rows). Zero/-1 init so ignored rows are correct even though the kernel
+    # also writes them. Matches Triton's buffer dtypes/fills.
+    token_accuracy_1d = torch.zeros(BT, dtype=torch.float32, device=_input.device) if return_token_accuracy else None
+    predicted_tokens_1d = (
+        torch.full((BT,), -1, dtype=torch.int64, device=_input.device) if return_predicted_tokens else None
+    )
+
+    # Normalizers (mean -> 1/N applied per-row in-kernel; sum/none -> 1.0; 1.0 when all
+    # rows are ignored). The main loss/grad use sum_non_ignore_weight when weighted, else
+    # n_non_ignore; z_loss is never weight-scaled so it always uses n_non_ignore.
+    if reduction == "mean" and n_non_ignore > 0:
+        if weight is not None and sum_non_ignore_weight > 0:
+            inv_n_loss = 1.0 / sum_non_ignore_weight
+        else:
+            inv_n_loss = 1.0 / n_non_ignore
+        inv_n_z = 1.0 / n_non_ignore
+    else:
+        inv_n_loss = 1.0
+        inv_n_z = 1.0
+    has_grad = bool(_input.requires_grad)
+
+    _launch_ce_fwd(
+        _input,
+        target,
+        loss_1d,
+        inv_n_loss,
+        ignore_index,
+        has_grad,
+        lse_square_scale,
+        z_loss_1d,
+        return_z_loss,
+        softcap,
+        label_smoothing=label_smoothing,
+        weight=weight,
+        weight_sum=weight_sum,
+        return_token_accuracy=return_token_accuracy,
+        return_predicted_tokens=return_predicted_tokens,
+        token_acc_out=token_accuracy_1d,
+        pred_tok_out=predicted_tokens_1d,
+        inv_n_z=inv_n_z,
+    )
+
+    if reduction == "none":
+        loss = loss_1d
+        z_loss = z_loss_1d if return_z_loss else None
+        token_accuracy = token_accuracy_1d if return_token_accuracy else None
+    else:
+        loss = torch.sum(loss_1d)
+        z_loss = torch.sum(z_loss_1d) if return_z_loss else None
+        # accuracy reduces to the mean over non-ignored tokens (matches Triton).
+        token_accuracy = torch.sum(token_accuracy_1d) / n_non_ignore if return_token_accuracy else None
+    # predicted_tokens is always the per-row vector, regardless of reduction (matches Triton).
+    predicted_tokens = predicted_tokens_1d if return_predicted_tokens else None
+    return loss, z_loss, token_accuracy, predicted_tokens, _input
+
+
+def cross_entropy_backward(_input, grad_output):
+    """Scale the saved in-place gradient by grad_output (chain rule from upstream)."""
+    # CE is usually the last layer -> grad_output == 1.0; skip the mul.
+    if torch.equal(grad_output, torch.tensor(1.0, device=grad_output.device)):
+        return _input
+    # reduction="none": per-row upstream grad.
+    if grad_output.ndim > 0:
+        return _input * grad_output.unsqueeze(dim=1)
+    # reduction in {mean, sum}: scalar upstream grad. Fresh tensor (not in-place)
+    # to avoid the autograd anomalies the Triton path uses a kernel to dodge.
+    return _input * grad_output
+
+
+class LigerCrossEntropyFunction(torch.autograd.Function):
+    """
+    CuTe DSL autograd wrapper for Cross Entropy loss.
+
+    Signature-compatible with ``liger_kernel.ops.cross_entropy.LigerCrossEntropyFunction``.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        _input: torch.Tensor,
+        target: torch.Tensor,
+        weight: Optional[torch.FloatTensor],
+        ignore_index: int = -100,
+        lse_square_scale: float = 0.0,
+        label_smoothing: float = 0.0,
+        reduction: str = "mean",
+        softcap: Optional[float] = None,
+        return_z_loss: bool = False,
+        return_token_accuracy: bool = False,
+        return_predicted_tokens: bool = False,
+    ):
+        input_requires_grad = _input.requires_grad
+
+        loss, z_loss, token_accuracy, predicted_tokens, _input = cross_entropy_forward(
+            _input,
+            target,
+            weight,
+            ignore_index,
+            lse_square_scale,
+            label_smoothing,
+            reduction,
+            softcap,
+            return_z_loss,
+            return_token_accuracy,
+            return_predicted_tokens,
+        )
+        if input_requires_grad:
+            ctx.save_for_backward(_input.detach())
+        ctx.return_z_loss = return_z_loss
+        ctx.return_token_accuracy = return_token_accuracy
+        ctx.return_predicted_tokens = return_predicted_tokens
+
+        return loss, z_loss, token_accuracy, predicted_tokens
+
+    @staticmethod
+    def backward(ctx, grad_output, grad_output2, grad_output3, grad_output4):
+        if ctx.return_z_loss:
+            del grad_output2  # z_loss is only for logging
+        if ctx.return_token_accuracy:
+            del grad_output3  # token_accuracy is only for metrics
+        if ctx.return_predicted_tokens:
+            del grad_output4  # predicted_tokens is only for metrics
+
+        (_input,) = ctx.saved_tensors
+        _input = cross_entropy_backward(_input, grad_output)
+        return (
+            _input,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )

--- a/src/liger_kernel/ops/cutedsl/ops/utils.py
+++ b/src/liger_kernel/ops/cutedsl/ops/utils.py
@@ -1,0 +1,27 @@
+"""
+Shared helpers for the CuTe DSL backend ops.
+"""
+
+from cutlass.cute.runtime import from_dlpack
+
+
+def _next_power_of_2(n: int) -> int:
+    """Return the smallest power of 2 greater than or equal to n."""
+    n -= 1
+    n |= n >> 1
+    n |= n >> 2
+    n |= n >> 4
+    n |= n >> 8
+    n |= n >> 16
+    n |= n >> 32
+    n += 1
+    return n
+
+
+def to_cute_tensor(t, leading_dim=None, assumed_align=16):
+    """torch.Tensor -> cute.Tensor via DLPack, with a dynamic (runtime) layout."""
+    if t is None:
+        return None
+    ct = from_dlpack(t.detach(), assumed_align=assumed_align)
+    ld = (t.ndim - 1) if leading_dim is None else leading_dim
+    return ct.mark_layout_dynamic(leading_dim=ld)

--- a/test/transformers/test_cutedsl_cross_entropy.py
+++ b/test/transformers/test_cutedsl_cross_entropy.py
@@ -13,7 +13,11 @@ import torch.nn.functional as F
 # suite's main-correctness bar (test_cross_entropy.py: fp32=(1e-8,1e-6), bf16=(1e-8,5e-2)),
 # loosened only where measured kernel-vs-kernel divergence requires it — this suite stresses
 # the kernels harder than Triton's does (fp16, extreme peaked logits, aux metrics):
-#   * bf16 -> Triton's exact bar; verified 0 failures (rtol dominates even under logit=50 rows).
+#   * bf16 -> Triton's rtol bar (5e-2), but rtol alone does NOT dominate on the extreme
+#     peaked-softmax rows (logit=50) in the accuracy test: those produce near-zero grad
+#     entries where bf16's ~2-digit mantissa lands a few ULPs from Triton (~8.7e-6 abs), and
+#     rtol*|ref| collapses toward zero there. A 5e-5 atol floor covers it with ~5.7x headroom
+#     and is still 100x tighter than the original 5e-3.
 #   * fp32 -> loss is bit-identical; grad matches (1e-8,1e-6) except the extreme peaked-softmax
 #     rows (logit=50) in the accuracy test, where base-2 ex2.approx divergence reaches ~1.1e-6
 #     abs at sum/none scale. A 1e-5 atol floor covers that with ~10x headroom (still 10x tighter
@@ -23,7 +27,7 @@ import torch.nn.functional as F
 #     covers it and is still 2x tighter than Triton's fp16 reference.
 _TOL = {
     torch.float32: (1e-5, 1e-5),
-    torch.bfloat16: (1e-8, 5e-2),
+    torch.bfloat16: (5e-5, 5e-2),
     torch.float16: (5e-3, 5e-2),
 }
 _DTYPES = [torch.bfloat16, torch.float16, torch.float32]

--- a/test/transformers/test_cutedsl_cross_entropy.py
+++ b/test/transformers/test_cutedsl_cross_entropy.py
@@ -1,0 +1,667 @@
+import os
+import subprocess
+import sys
+import textwrap
+
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+# Per-dtype (atol, rtol). bf16/fp16 are generous — the fp32-accumulated result is
+# cast to the low-precision output, so the cast dominates the error. fp32 is tight.
+_TOL = {
+    torch.float32: (1e-4, 1e-3),
+    torch.bfloat16: (5e-3, 5e-2),
+    torch.float16: (5e-3, 5e-2),
+}
+_DTYPES = [torch.bfloat16, torch.float16, torch.float32]
+_DTYPE_IDS = ["bf16", "fp16", "fp32"]
+
+cuda_required = pytest.mark.skipif(not torch.cuda.is_available(), reason="cutedsl CE requires CUDA")
+
+
+def set_seed(seed: int = 42):
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+# =============================================================================
+# Imports (skip — don't fail — when the optional backend isn't installed)
+# =============================================================================
+def _cutedsl_ce():
+    """cutedsl ``LigerCrossEntropyFunction``, or skip if CUTLASS isn't installed."""
+    try:
+        from liger_kernel.ops.cutedsl.ops.cross_entropy import LigerCrossEntropyFunction
+    except ImportError as exc:
+        pytest.skip(f"cutedsl backend not importable (cutlass.cute missing?): {exc}")
+    return LigerCrossEntropyFunction
+
+
+def _cutedsl_ce_module():
+    """The cutedsl CE *module* — white-box access to ``_compile_cache`` (for the warp-count test)."""
+    try:
+        import liger_kernel.ops.cutedsl.ops.cross_entropy as mod
+    except ImportError as exc:
+        pytest.skip(f"cutedsl backend not importable: {exc}")
+    return mod
+
+
+def _triton_ce():
+    """Triton reference ``LigerCrossEntropyFunction`` (the parity oracle)."""
+    from liger_kernel.ops.cross_entropy import LigerCrossEntropyFunction
+
+    return LigerCrossEntropyFunction
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+def _apply(
+    fn,
+    _input,
+    target,
+    *,
+    weight=None,
+    ignore_index=-100,
+    lse_square_scale=0.0,
+    label_smoothing=0.0,
+    reduction="mean",
+    softcap=None,
+    return_z_loss=False,
+    return_token_accuracy=False,
+    return_predicted_tokens=False,
+):
+    """Positional ``apply`` matching BOTH the Triton and cutedsl CE signatures."""
+    return fn.apply(
+        _input,
+        target,
+        weight,
+        ignore_index,
+        lse_square_scale,
+        label_smoothing,
+        reduction,
+        softcap,
+        return_z_loss,
+        return_token_accuracy,
+        return_predicted_tokens,
+    )
+
+
+def _run_or_skip(thunk):
+    """Run ``thunk``; if the cutedsl branch is still a stub, SKIP instead of fail."""
+    try:
+        return thunk()
+    except NotImplementedError as exc:
+        pytest.skip(f"cutedsl CE branch not implemented yet: {exc}")
+
+
+def _run(
+    fn,
+    base_logits,
+    target,
+    dtype,
+    *,
+    reduction="mean",
+    ignore_index=-100,
+    lse_square_scale=0.0,
+    softcap=None,
+    return_z_loss=False,
+    weight=None,
+    label_smoothing=0.0,
+    return_token_accuracy=False,
+    return_predicted_tokens=False,
+    requires_grad=True,
+    grad_vec=None,
+    grad_scale=None,
+):
+    """One CE fwd (+bwd); returns ``(loss, z_loss, grad, token_accuracy, predicted_tokens)``,
+    each detached fp32 (predicted_tokens int64) or None.
+
+    Backward protocol (drives the three branches in ``cross_entropy_backward``):
+      * reduction in {mean, sum}, default      -> ``grad_output == 1.0`` fast path.
+      * reduction in {mean, sum}, ``grad_scale`` -> scalar ``grad_output != 1`` (not-last-layer).
+      * reduction == 'none'                     -> per-row vector ``grad_output``.
+    """
+    _input = base_logits.clone().detach().to(dtype).requires_grad_(requires_grad)
+    loss, z_loss, token_acc, pred = _apply(
+        fn,
+        _input,
+        target,
+        weight=weight,
+        ignore_index=ignore_index,
+        lse_square_scale=lse_square_scale,
+        label_smoothing=label_smoothing,
+        reduction=reduction,
+        softcap=softcap,
+        return_z_loss=return_z_loss,
+        return_token_accuracy=return_token_accuracy,
+        return_predicted_tokens=return_predicted_tokens,
+    )
+    grad = None
+    if requires_grad:
+        if reduction == "none":
+            go = torch.ones_like(loss) if grad_vec is None else grad_vec.to(loss.dtype)
+            loss.backward(gradient=go)
+        elif grad_scale is not None:
+            (loss * grad_scale).backward()
+        else:
+            loss.backward()
+        grad = _input.grad.detach().float()
+    return (
+        loss.detach().float(),
+        None if z_loss is None else z_loss.detach().float(),
+        grad,
+        None if token_acc is None else token_acc.detach().float(),
+        None if pred is None else pred.detach(),
+    )
+
+
+def _assert_close(out, ref, atol, rtol, what):
+    if out is None and ref is None:
+        return
+    assert out is not None and ref is not None, (
+        f"{what}: one side is None (out={out is not None}, ref={ref is not None})"
+    )
+    if not torch.allclose(out, ref, atol=atol, rtol=rtol):
+        diff = (out - ref).abs()
+        raise AssertionError(
+            f"{what} mismatch vs Triton: max|diff|={diff.max().item():.3e} "
+            f"mean|diff|={diff.mean().item():.3e} (atol={atol}, rtol={rtol})"
+        )
+
+
+def _assert_ce_parity(base_logits, target, dtype, *, check_grad=True, **opts):
+    """Run cutedsl + Triton with identical inputs/opts and compare loss[/z_loss][/grad]."""
+    atol, rtol = _TOL[dtype]
+    ref = _run(_triton_ce(), base_logits, target, dtype, **opts)
+    out = _run_or_skip(lambda: _run(_cutedsl_ce(), base_logits, target, dtype, **opts))
+    _assert_close(out[0], ref[0], atol, rtol, "loss")
+    if opts.get("return_z_loss"):
+        _assert_close(out[1], ref[1], atol, rtol, "z_loss")
+    if check_grad and opts.get("requires_grad", True):
+        _assert_close(out[2], ref[2], atol, rtol, "grad")
+    if opts.get("return_token_accuracy"):
+        _assert_close(out[3], ref[3], atol, rtol, "token_accuracy")
+    if opts.get("return_predicted_tokens"):
+        assert torch.equal(out[4], ref[4]), "predicted_tokens mismatch vs Triton (exact int match expected)"
+
+
+# =============================================================================
+# A. Parity vs Triton — implemented branches (auto-skip while a feature is a stub)
+# =============================================================================
+@cuda_required
+@pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
+@pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+@pytest.mark.parametrize("BT, V", [(4, 4096), (1024, 4096)], ids=["bt4", "bt1024"])
+def test_ce_core_matches_triton(BT, V, reduction, dtype):
+    """dtype x reduction x BT core matrix. BT=4 stresses the per-row-CTA small-BT path."""
+    set_seed()
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    _assert_ce_parity(base, target, dtype, reduction=reduction)
+
+
+@cuda_required
+@pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+def test_ce_core_matches_torch_reference(reduction):
+    """Independent anchor: cutedsl fp32 loss vs torch.nn.functional.cross_entropy."""
+    set_seed()
+    BT, V = 256, 4096
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    out = _run_or_skip(
+        lambda: _run(_cutedsl_ce(), base, target, torch.float32, reduction=reduction, requires_grad=False)
+    )
+    out_loss = out[0]
+    ref = F.cross_entropy(base, target, reduction=reduction).detach().float()
+    _assert_close(out_loss, ref, 1e-3, 1e-3, f"loss vs torch ({reduction})")
+
+
+@cuda_required
+@pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
+@pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+def test_ce_ignore_index_matches_triton(reduction, dtype):
+    """~1/3 of rows ignored — exercises the per-row ignore mask + n_non_ignore scaling."""
+    set_seed()
+    BT, V, ignore_index = 512, 4096, -100
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    target[torch.randperm(BT, device="cuda")[: BT // 3]] = ignore_index
+    _assert_ce_parity(base, target, dtype, reduction=reduction, ignore_index=ignore_index)
+
+
+@cuda_required
+@pytest.mark.parametrize("reduction", ["mean", "sum"])
+def test_ce_all_ignored_matches_triton(reduction):
+    """Every row ignored: n_non_ignore == 0 -> inv_n = 1.0, loss & grad must be exactly 0."""
+    set_seed()
+    BT, V, ignore_index = 64, 4096, -100
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.full((BT,), ignore_index, device="cuda", dtype=torch.long)
+    out = _run_or_skip(
+        lambda: _run(_cutedsl_ce(), base, target, torch.float32, reduction=reduction, ignore_index=ignore_index)
+    )
+    ref = _run(_triton_ce(), base, target, torch.float32, reduction=reduction, ignore_index=ignore_index)
+    _assert_close(out[0], ref[0], 1e-5, 1e-4, "loss(all-ignored)")
+    assert torch.equal(out[0], torch.zeros_like(out[0])), "all-ignored loss must be exactly 0"
+    assert out[2] is not None and out[2].abs().max().item() == 0.0, "all-ignored grad must be exactly 0"
+
+
+@cuda_required
+@pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
+@pytest.mark.parametrize("return_z_loss", [True, False], ids=["zret", "znoret"])
+@pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+def test_ce_z_loss_matches_triton(reduction, return_z_loss, dtype):
+    """lse_square_scale != 0 routes to the streaming kernel; compares loss AND z_loss."""
+    set_seed()
+    BT, V = 512, 4096
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    _assert_ce_parity(base, target, dtype, reduction=reduction, lse_square_scale=1e-4, return_z_loss=return_z_loss)
+
+
+@cuda_required
+@pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
+@pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+def test_ce_softcap_matches_triton(reduction, dtype):
+    """softcap = 30.0 -> softcap*tanh(x/softcap) applied to logits (streaming path)."""
+    set_seed()
+    BT, V = 512, 4096
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    _assert_ce_parity(base, target, dtype, reduction=reduction, softcap=30.0)
+
+
+@cuda_required
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "fp32"])
+def test_ce_combined_features_matches_triton(dtype):
+    """ignore_index + z_loss + softcap together (the 'all-on' combo)."""
+    set_seed()
+    BT, V, ignore_index = 512, 4096, -100
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    target[torch.randperm(BT, device="cuda")[: BT // 4]] = ignore_index
+    _assert_ce_parity(
+        base,
+        target,
+        dtype,
+        reduction="mean",
+        ignore_index=ignore_index,
+        lse_square_scale=1e-4,
+        softcap=30.0,
+        return_z_loss=True,
+    )
+
+
+@cuda_required
+@pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
+def test_ce_forward_only_matches_triton(dtype):
+    """requires_grad=False -> the has_grad=False compile path (no in-place grad write)."""
+    set_seed()
+    BT, V = 256, 4096
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    _assert_ce_parity(base, target, dtype, reduction="mean", requires_grad=False, check_grad=False)
+
+
+@cuda_required
+@pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
+@pytest.mark.parametrize("reduction", ["mean", "sum"])
+def test_ce_not_last_layer_grad_matches_triton(reduction, dtype):
+    """grad_output != 1.0 (scalar): exercises the `_input * grad_output` backward branch."""
+    set_seed()
+    BT, V = 256, 4096
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    _assert_ce_parity(base, target, dtype, reduction=reduction, grad_scale=2.0)
+
+
+@cuda_required
+@pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
+def test_ce_reduction_none_perrow_grad_matches_triton(dtype):
+    """reduction='none' with a per-row grad_output vector: the ndim>0 backward branch."""
+    set_seed()
+    BT, V = 256, 4096
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    grad_vec = torch.rand(BT, device="cuda", dtype=torch.float32)  # SAME vector fed to both backends
+    _assert_ce_parity(base, target, dtype, reduction="none", grad_vec=grad_vec)
+
+
+@cuda_required
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "fp32"])
+def test_ce_noncontiguous_input_matches_triton(dtype):
+    """Non-contiguous logits -> the host-side `.contiguous()` branch. Forward-only loss parity."""
+    set_seed()
+    BT, V = 128, 4096
+    base = torch.randn(V, BT, device="cuda", dtype=torch.float32).t()  # (BT, V), stride(-1)=BT != 1
+    assert not base.is_contiguous()
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    _assert_ce_parity(base, target, dtype, reduction="mean", requires_grad=False, check_grad=False)
+
+
+# =============================================================================
+# B. Warp-count selection (white-box on the compile cache): the streaming kernel bakes
+#    num_warps per dtype, mirroring the Triton CE Blackwell convention — 8 warps for 2-byte
+#    dtypes (instruction-issue-bound), 32 for fp32 (bandwidth-bound). num_warps is the last
+#    element of the compile-cache key.
+# =============================================================================
+@cuda_required
+@pytest.mark.parametrize(
+    "dtype, expected_warps",
+    [(torch.bfloat16, 8), (torch.float16, 8), (torch.float32, 32)],
+    ids=["bf16", "fp16", "fp32"],
+)
+def test_num_warps_matches_dtype_convention(dtype, expected_warps):
+    mod = _cutedsl_ce_module()
+    base = torch.randn(64, 4096, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, 4096, (64,), device="cuda", dtype=torch.long)
+    mod._compile_cache.clear()
+    _run_or_skip(lambda: _run(_cutedsl_ce(), base, target, dtype, reduction="mean", requires_grad=False))
+    warps = {k[-1] for k in mod._compile_cache}
+    assert warps == {expected_warps}, f"expected num_warps={expected_warps} for {dtype}, got cache keys {warps}"
+
+
+# =============================================================================
+# C. Parity vs Triton — class weight, label_smoothing, and the argmax aux outputs.
+#    (Each was a NotImplementedError scope guard until the feature landed; now a real
+#    parity gate. If a feature is ever re-stubbed, its test auto-skips, not fails.)
+# =============================================================================
+def _basic_inputs(BT=64, V=4096):
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32, requires_grad=True)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    return base, target
+
+
+def _rand_weight(V):
+    """Strictly-positive fp32 class-weight vector (cutedsl upcasts weight to fp32 internally)."""
+    return torch.rand(V, device="cuda", dtype=torch.float32) + 0.5
+
+
+def _scatter_ignored(target, frac, ignore_index=-100):
+    BT = target.shape[0]
+    target[torch.randperm(BT, device=target.device)[: int(BT * frac)]] = ignore_index
+
+
+@cuda_required
+@pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
+@pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+def test_ce_class_weight_matches_triton(reduction, dtype):
+    """Per-class weight: mean denominator becomes sum_non_ignore_weight; grad scales by weight_y."""
+    set_seed()
+    BT, V = 512, 4096
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    _scatter_ignored(target, 0.25)
+    _assert_ce_parity(base, target, dtype, reduction=reduction, weight=_rand_weight(V))
+
+
+@cuda_required
+@pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
+@pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+@pytest.mark.parametrize("label_smoothing", [0.1, 0.3], ids=["ls0.1", "ls0.3"])
+def test_ce_label_smoothing_matches_triton(label_smoothing, reduction, dtype):
+    """label_smoothing (no weight): the scaled_x_sum fwd reduction + additive -eps grad term."""
+    set_seed()
+    BT, V = 512, 4096
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    _scatter_ignored(target, 0.25)
+    _assert_ce_parity(base, target, dtype, reduction=reduction, label_smoothing=label_smoothing)
+
+
+@cuda_required
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "fp32"])
+@pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+def test_ce_weight_and_label_smoothing_matches_triton(reduction, dtype):
+    """The coupled path: weighted scaled_x_sum + weighted dloss_smooth (per-column weight stream)."""
+    set_seed()
+    BT, V = 512, 4096
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    _scatter_ignored(target, 0.25)
+    _assert_ce_parity(base, target, dtype, reduction=reduction, weight=_rand_weight(V), label_smoothing=0.1)
+
+
+@cuda_required
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "fp32"])
+def test_ce_all_features_matches_triton(dtype):
+    """Everything at once: weight + label_smoothing + z_loss + softcap + ignore_index (loss+grad+z)."""
+    set_seed()
+    BT, V = 512, 4096
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    _scatter_ignored(target, 0.25)
+    _assert_ce_parity(
+        base,
+        target,
+        dtype,
+        reduction="mean",
+        weight=_rand_weight(V),
+        label_smoothing=0.1,
+        lse_square_scale=1e-4,
+        softcap=30.0,
+        return_z_loss=True,
+    )
+
+
+@cuda_required
+@pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
+@pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+def test_ce_token_accuracy_matches_triton(reduction, dtype):
+    """token_accuracy = per-row (argmax == target), reduced to the non-ignored mean for mean/sum.
+
+    Force ~half the rows to predict correctly (boost the target logit) so the acc==1.0 path
+    is exercised, not just the trivial all-zero case random targets would give.
+    """
+    set_seed()
+    BT, V = 256, 4096
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    for i in range(BT // 2):
+        base[i, target[i]] = 50.0
+    _scatter_ignored(target, 0.125)
+    _assert_ce_parity(base, target, dtype, reduction=reduction, return_token_accuracy=True)
+
+
+@cuda_required
+@pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
+def test_ce_predicted_tokens_matches_triton(dtype):
+    """predicted_tokens = per-row argmax column (int64), -1 for ignored rows. Exact int parity."""
+    set_seed()
+    BT, V = 256, 4096
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    _scatter_ignored(target, 0.125)
+    # predicted_tokens is independent of reduction; forward-only is enough.
+    _assert_ce_parity(
+        base, target, dtype, reduction="none", requires_grad=False, check_grad=False, return_predicted_tokens=True
+    )
+
+
+# =============================================================================
+# D. Input validation — host-side asserts.
+# =============================================================================
+@cuda_required
+def test_vocab_not_multiple_of_vec_raises():
+    """fp32 needs V % 4 == 0 (128-bit vectorized loads); 4094 % 4 == 2 must be rejected."""
+    base, target = _basic_inputs(BT=8, V=4094)
+    with pytest.raises(AssertionError):
+        _apply(_cutedsl_ce(), base, target)
+
+
+@cuda_required
+def test_target_out_of_bounds_raises():
+    """A non-ignored target >= V must be rejected."""
+    base, target = _basic_inputs(BT=8, V=4096)
+    target[0] = base.shape[1]  # == V, out of [0, V)
+    with pytest.raises(AssertionError):
+        _apply(_cutedsl_ce(), base, target)
+
+
+@cuda_required
+def test_target_negative_non_ignore_raises():
+    """A negative target that isn't ignore_index must be rejected (min >= 0 check)."""
+    base, target = _basic_inputs(BT=8, V=4096)
+    target[0] = -5  # negative but != ignore_index(-100)
+    with pytest.raises(AssertionError):
+        _apply(_cutedsl_ce(), base, target)
+
+
+# =============================================================================
+# E. Dispatch / swap wiring — the only thing the registry layer adds over the
+#    parity tests above: does LIGER_KERNEL_IMPL=cutedsl actually rewire the public
+#    LigerCrossEntropyFunction to the cutedsl implementation? (Triton is the default
+#    impl, so it needs no such check.) Subprocess because the swap happens at import.
+# =============================================================================
+@cuda_required
+@pytest.mark.skipif(
+    os.environ.get("LIGER_KERNEL_IMPL", "").strip().lower() != "cutedsl",
+    reason="cutedsl selection test requires LIGER_KERNEL_IMPL=cutedsl",
+)
+def test_liger_kernel_impl_cutedsl_selects_cutedsl_ce():
+    repo_root = Path(__file__).resolve().parents[2]
+    pythonpath = os.pathsep.join([str(repo_root / "src"), str(repo_root), os.environ.get("PYTHONPATH", "")])
+    env = {**os.environ, "LIGER_KERNEL_IMPL": "cutedsl", "PYTHONPATH": pythonpath}
+    script = textwrap.dedent(
+        """
+        from liger_kernel.transformers.cross_entropy import LigerCrossEntropyFunction
+
+        prefix = "liger_kernel.ops.cutedsl."
+        mod = LigerCrossEntropyFunction.__module__
+        if not mod.startswith(prefix):
+            raise AssertionError(f"Expected cutedsl LigerCrossEntropyFunction from {prefix}, got {mod}")
+        """
+    )
+    subprocess.run([sys.executable, "-c", script], check=True, env=env, cwd=repo_root)
+
+
+# =============================================================================
+# F. Coverage parity with the Triton suite — production vocab/shape, scalar-grad
+#    combined with other params, and the functional/structured-output wrapper.
+#    The Triton suite parametrizes every correctness test at V=32000 (+ odd shapes);
+#    the cutedsl kernel's tiling is V-dependent, so these close the gaps a V=4096-only
+#    matrix leaves — most importantly the tail-predication path.
+# =============================================================================
+# (name, feature-kwargs) — each exercises a distinct loss/grad path at production vocab.
+_BIG_FEATURES = [
+    ("core", {}),
+    ("weight_ignore", {"weight_": True, "ignore": True}),
+    ("smoothing_ignore", {"label_smoothing": 0.1, "ignore": True}),
+    (
+        "all",
+        {
+            "weight_": True,
+            "label_smoothing": 0.1,
+            "lse_square_scale": 1e-4,
+            "softcap": 30.0,
+            "ignore": True,
+            "return_z_loss": True,
+        },
+    ),
+]
+
+
+@cuda_required
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "fp32"])
+@pytest.mark.parametrize("BT, V", [(1269, 32000), (256, 32000)], ids=["1269x32000", "256x32000"])
+@pytest.mark.parametrize("name, feats", _BIG_FEATURES, ids=[f[0] for f in _BIG_FEATURES])
+def test_ce_production_vocab_matches_triton(name, feats, BT, V, dtype):
+    """V=32000 (llama vocab) + the odd (3,423,32000)->1269 flat shape.
+
+    This is the only V here that leaves a PARTIAL last tile (num_vec % 256 != 0), so it is
+    what actually exercises the tail-predication path — V=4096/36864 divide the 256-thread
+    tile grid evenly and never predicate a thread off. Also production scale (many tiles).
+    """
+    set_seed()
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    if feats.get("ignore"):
+        _scatter_ignored(target, 0.25)
+    opts = {k: v for k, v in feats.items() if k in ("label_smoothing", "lse_square_scale", "softcap", "return_z_loss")}
+    if feats.get("weight_"):
+        opts["weight"] = _rand_weight(V)
+    _assert_ce_parity(base, target, dtype, reduction="mean", **opts)
+
+
+@cuda_required
+@pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
+@pytest.mark.parametrize("reduction", ["mean", "sum"])
+def test_ce_not_last_layer_with_other_params_matches_triton(reduction, dtype):
+    """Scalar grad_output != 1 combined with z_loss + softcap + label_smoothing + ignore_index
+    (Triton's not_last_layer_with_other_params): backward scaling must compose with every
+    forward feature term, not just plain CE (which test_ce_not_last_layer_grad covers)."""
+    set_seed()
+    BT, V = 512, 4096
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+    _scatter_ignored(target, 0.25)
+    _assert_ce_parity(
+        base,
+        target,
+        dtype,
+        reduction=reduction,
+        grad_scale=2.0,
+        lse_square_scale=1e-4,
+        softcap=30.0,
+        label_smoothing=0.1,
+        return_z_loss=True,
+    )
+
+
+@cuda_required
+@pytest.mark.parametrize("return_z_loss", [True, False], ids=["z1", "z0"])
+@pytest.mark.parametrize("return_token_accuracy", [True, False], ids=["acc1", "acc0"])
+@pytest.mark.parametrize("return_predicted_tokens", [True, False], ids=["pred1", "pred0"])
+def test_ce_functional_structured_output_matches_triton(
+    return_z_loss, return_token_accuracy, return_predicted_tokens, monkeypatch
+):
+    """End-to-end through ``liger_cross_entropy(...)``: the cutedsl Function must drive the
+    bare-loss path and the ``CrossEntropyOutput`` dataclass identically to Triton across all 8
+    (z_loss, token_accuracy, predicted_tokens) flag combinations (None where a flag is off).
+    Monkeypatches the wrapper's Function so the real backend-agnostic wrapper code runs.
+    """
+    import liger_kernel.transformers.functional as fmod
+
+    set_seed()
+    BT, V = 256, 4096
+    base = torch.randn(BT, V, device="cuda", dtype=torch.float32)
+    target = torch.randint(0, V, (BT,), device="cuda", dtype=torch.long)
+
+    def via_wrapper(fn):
+        monkeypatch.setattr(fmod, "LigerCrossEntropyFunction", fn)
+        return fmod.liger_cross_entropy(
+            base.clone(),
+            target,
+            reduction="mean",
+            lse_square_scale=1e-4,  # make z_loss non-trivial when requested
+            return_z_loss=return_z_loss,
+            return_token_accuracy=return_token_accuracy,
+            return_predicted_tokens=return_predicted_tokens,
+        )
+
+    out_c = _run_or_skip(lambda: via_wrapper(_cutedsl_ce()))
+    out_t = via_wrapper(_triton_ce())
+
+    if not (return_z_loss or return_token_accuracy or return_predicted_tokens):
+        # bare-loss path: liger_cross_entropy returns the loss tensor itself, not the dataclass.
+        assert not hasattr(out_c, "loss"), "expected a bare loss tensor when no flags are set"
+        _assert_close(out_c.detach().float(), out_t.detach().float(), 1e-4, 1e-3, "loss (bare)")
+        return
+
+    _assert_close(out_c.loss.detach().float(), out_t.loss.detach().float(), 1e-4, 1e-3, "loss")
+    for field, flag in (
+        ("z_loss", return_z_loss),
+        ("token_accuracy", return_token_accuracy),
+        ("predicted_tokens", return_predicted_tokens),
+    ):
+        c, t = getattr(out_c, field), getattr(out_t, field)
+        if not flag:
+            assert c is None and t is None, f"{field} must be None when its flag is off"
+        elif field == "predicted_tokens":
+            assert torch.equal(c, t), "predicted_tokens mismatch vs Triton"
+        else:
+            _assert_close(c.detach().float(), t.detach().float(), 1e-4, 1e-3, field)

--- a/test/transformers/test_cutedsl_cross_entropy.py
+++ b/test/transformers/test_cutedsl_cross_entropy.py
@@ -9,11 +9,21 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-# Per-dtype (atol, rtol). bf16/fp16 are generous — the fp32-accumulated result is
-# cast to the low-precision output, so the cast dominates the error. fp32 is tight.
+# Per-dtype (atol, rtol) for the cutedsl-vs-Triton parity checks. Anchored to the Triton CE
+# suite's main-correctness bar (test_cross_entropy.py: fp32=(1e-8,1e-6), bf16=(1e-8,5e-2)),
+# loosened only where measured kernel-vs-kernel divergence requires it — this suite stresses
+# the kernels harder than Triton's does (fp16, extreme peaked logits, aux metrics):
+#   * bf16 -> Triton's exact bar; verified 0 failures (rtol dominates even under logit=50 rows).
+#   * fp32 -> loss is bit-identical; grad matches (1e-8,1e-6) except the extreme peaked-softmax
+#     rows (logit=50) in the accuracy test, where base-2 ex2.approx divergence reaches ~1.1e-6
+#     abs at sum/none scale. A 1e-5 atol floor covers that with ~10x headroom (still 10x tighter
+#     than the original 1e-4).
+#   * fp16 -> Triton has no tight fp16 bar (its only fp16 reference uses 1e-2). fp16's ~3-digit
+#     mantissa rounds near-zero grad entries a few ULPs apart (~7.6e-6 abs); the 5e-3 atol floor
+#     covers it and is still 2x tighter than Triton's fp16 reference.
 _TOL = {
-    torch.float32: (1e-4, 1e-3),
-    torch.bfloat16: (5e-3, 5e-2),
+    torch.float32: (1e-5, 1e-5),
+    torch.bfloat16: (1e-8, 5e-2),
     torch.float16: (5e-3, 5e-2),
 }
 _DTYPES = [torch.bfloat16, torch.float16, torch.float32]


### PR DESCRIPTION
## Summary

Adds an optional **CuTe DSL** (`nvidia-cutlass-dsl`) backend implementing Liger cross-entropy
(forward + backward) as a single fused kernel, signature-compatible with the Triton
`LigerCrossEntropyFunction`. Feature parity: z-loss, softcap, label smoothing, class weights,
`ignore_index`, token-accuracy, predicted-tokens, reductions `mean`/`sum`/`none`, across
bf16/fp16/fp32.

The fused-linear-CE (FLCE) variant will follow in a later PR.

### Kernel design / optimizations (B200)
- Online-softmax forward pass with a **cp.async multi-stage smem pipeline** (128-bit vectorized).
- **FMA-folded `exp2` arguments** — `(x - m)·log2e` → `fma(x, log2e, -m·log2e)` with the scalar
  hoisted, cutting one issue slot per element on the instruction-bound pass.
- **Power-of-2 ring-buffer stage advance** (`(i+1) & (n-1)`) — one fewer ALU op per tile.
- **Reduced per-call host overhead** (constant ~25–40 µs, dominates small shapes): cached
  `CUstream`, batched the 3 target-validation D2H syncs into 1, and reused DLPack handles for
  unused optional outputs.

### Correctness
`test/transformers/test_cutedsl_cross_entropy.py` — **158 passed, 1 skipped**, full parity vs the
Triton kernel across dtype × reduction × features × grad (and vs `torch` where applicable).

## Benchmarks — CuTe DSL vs Triton (NVIDIA B200)

Median of 40 iters, warmup 20. **speedup = Triton ÷ CuteDSL** (>1.00 → CuteDSL faster).
Reference config: BT=8192, V=128256. `full` = fwd+bwd.

### bf16

**full (fwd+bwd) — vocab sweep (BT=8192)**
| vocab | cutedsl (ms) | triton (ms) | speedup |
|------:|-------------:|------------:|--------:|
| 32000 | 0.4024 | 0.4519 | 1.123× |
| 50304 | 0.5616 | 0.6703 | 1.194× |
| 102400 | 0.9643 | 1.1170 | 1.158× |
| 128256 | 1.1595 | 1.1855 | 1.022× |
| 152064 | 1.3336 | 1.4445 | 1.083× |
| 201088 | 1.7063 | 1.9767 | 1.158× |
| 262144 | 2.2164 | 2.3127 | 1.043× |

**full — BT sweep (V=128256)**
| BT | cutedsl (ms) | triton (ms) | speedup |
|---:|-------------:|------------:|--------:|
| 1024 | 0.3364 | 0.3348 | 0.995× |
| 2048 | 0.4554 | 0.4570 | 1.003× |
| 4096 | 0.6902 | 0.7008 | 1.015× |
| 8192 | 1.1565 | 1.1825 | 1.023× |
| 16384 | 2.0945 | 2.1952 | 1.048× |
| 32768 | 4.0096 | 4.1110 | 1.025× |
| 65536 | 7.7274 | 7.9275 | 1.026× |

### fp32

**full (fwd+bwd) — vocab sweep (BT=8192)**
| vocab | cutedsl (ms) | triton (ms) | speedup |
|------:|-------------:|------------:|--------:|
| 32000 | 0.7084 | 0.6213 | 0.877× |
| 50304 | 0.9226 | 0.9231 | 1.001× |
| 102400 | 1.4332 | 1.6221 | 1.132× |
| 128256 | 1.8311 | 1.7849 | 0.975× |
| 152064 | 2.2882 | 2.2613 | 0.988× |
| 201088 | 3.0892 | 3.1684 | 1.026× |
| 262144 | 3.9836 | 3.9752 | 0.998× |

**full — BT sweep (V=128256)**
| BT | cutedsl (ms) | triton (ms) | speedup |
|---:|-------------:|------------:|--------:|
| 1024 | 0.3967 | 0.3883 | 0.979× |
| 2048 | 0.5990 | 0.5944 | 0.992× |
| 4096 | 1.0071 | 0.9909 | 0.984× |
| 8192 | 1.8288 | 1.7867 | 0.977× |
| 16384 | 3.5309 | 3.4171 | 0.968× |
| 32768 | 6.8136 | 6.5726 | 0.965× |
| 65536 | 13.6012 | 13.0380 | 0.959× |

### Notes
- CuteDSL wins/ties Triton across bf16 (both modes) and fp32 inference; the remaining gap is
  **fp32 `full`** (~0.96–0.98×, a steady-state per-element gap, not launch overhead) plus the
  small-vocab V=32k fp32 corner — targeted for a follow-up.
- Requires `pip install 'liger-kernel[cutedsl]'` (adds `nvidia-cutlass-dsl`). NVIDIA GPUs only.
