### PR TITLE
fix: align _input_chunk dtype in FLCE grad_weight addmm under AMP

### DIFF
--- a/src/liger_kernel/ops/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_cross_entropy.py
@@ -212,16 +212,24 @@ def fused_linear_cross_entropy_forward(
             grad_input[start_idx:end_idx] = grad_logits_chunk @ weight
 
         if grad_weight is not None and input_requires_grad:
+            grad_logits_t = grad_logits_chunk.t()
             if (
                 _ADDMM_SUPPORTS_OUT_DTYPE
                 and grad_weight.device.type == "cuda"
                 and grad_weight.dtype == torch.float32
-                and grad_logits_chunk.t().dtype in (torch.float16, torch.bfloat16)
+                and grad_logits_t.dtype in (torch.float16, torch.bfloat16)
             ):
+                # Unlike torch.mm, torch.addmm's out_dtype path does not participate in
+                # autocast operand casting, so under AMP (fp32 params, no bias) _input_chunk
+                # can stay fp32 while grad_logits is the autocast dtype. addmm requires mat1
+                # and mat2 to share a dtype, so align _input_chunk before accumulating.
+                input_chunk = _input_chunk
+                if input_chunk.dtype != grad_logits_t.dtype:
+                    input_chunk = input_chunk.to(grad_logits_t.dtype)
                 torch.addmm(
                     grad_weight,
-                    grad_logits_chunk.t(),
-                    _input_chunk,
+                    grad_logits_t,
+                    input_chunk,
                     out_dtype=torch.float32,
                     out=grad_weight,
                 )


### PR DESCRIPTION
## Summary

PR #1239 replaced `grad_weight += torch.mm(...).float()` with `torch.addmm(..., out_dtype=torch.float32, out=grad_weight)` in the FLCE backward, guarded only on `grad_logits_chunk.dtype`.

Unlike `torch.mm`, the `addmm` `out_dtype=`/`out=` overload does **not** participate in autocast operand casting. So under AMP (fp32 master params, `bias=False`), `grad_logits` is the autocast dtype (bf16/fp16) while `_input_chunk` stays fp32. `addmm` requires `mat1` and `mat2` to share a dtype, raising:

```
RuntimeError: mat1 and mat2 must have the same dtype, but got BFloat16 and Float
```

`bias=True` sidesteps the bug because `logits + bias` promotes `grad_logits` to fp32. As-is this regresses AMP training of `bias=False` LM heads (the common LLM case) on `torch>=2.8.0`.

## Details

Align `_input_chunk` to the `grad_logits` dtype inside the `addmm` fast path — a no-op in the intended bf16-native case, exactly what autocast previously did to `torch.mm`. This preserves #1239's memory optimization and is numerically unchanged on the non-AMP path.

Scope: 1 file, +11/-3, branched directly on top of current `main` (which already includes #1239).

## Testing Done

- `test_amp`: the 8 `bias=False` cases that crashed after #1239 now pass — 16/16 green.
- `test_fused_linear_cross_entropy.py`: 137/137 pass.
- Numerically verified vs a pure-torch reference (loss / grad_input / grad_weight / grad_bias) across {bf16, fp16, no-AMP} x {bias, nobias}; the non-AMP `mm().float()` path is bit-for-bit unchanged.

- Hardware Type: B200
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
