### PR TITLE
Add THD support for RoPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ loss.backward()
 | RMSNorm                         | `liger_kernel.transformers.LigerRMSNorm`                    |
 | Modulated RMSNorm               | `liger_kernel.transformers.LigerModulatedRMSNorm`           |
 | LayerNorm                       | `liger_kernel.transformers.LigerLayerNorm`                  |
-| RoPE                            | `liger_kernel.transformers.liger_rotary_pos_emb`            |
+| RoPE                            | `liger_kernel.transformers.liger_rotary_pos_emb`, `liger_kernel.transformers.liger_rotary_pos_emb_thd` |
 | SwiGLU                          | `liger_kernel.transformers.LigerSwiGLUMLP`                  |
 | GeGLU                           | `liger_kernel.transformers.LigerGEGLUMLP`                   |
 | CrossEntropy                    | `liger_kernel.transformers.LigerCrossEntropyLoss`           |

--- a/docs/Low-Level-APIs.md
+++ b/docs/Low-Level-APIs.md
@@ -5,7 +5,7 @@
 | RMSNorm                         | `liger_kernel.transformers.LigerRMSNorm`                    |
 | Modulated RMSNorm               | `liger_kernel.transformers.LigerModulatedRMSNorm`           |
 | LayerNorm                       | `liger_kernel.transformers.LigerLayerNorm`                  |
-| RoPE                            | `liger_kernel.transformers.liger_rotary_pos_emb`            |
+| RoPE                            | `liger_kernel.transformers.liger_rotary_pos_emb`, `liger_kernel.transformers.liger_rotary_pos_emb_thd` |
 | SwiGLU                          | `liger_kernel.transformers.LigerSwiGLUMLP`                  |
 | GeGLU                           | `liger_kernel.transformers.LigerGEGLUMLP`                   |
 | CrossEntropy                    | `liger_kernel.transformers.LigerCrossEntropyLoss`           |
@@ -57,6 +57,7 @@ Functional API: `liger_kernel.transformers.functional.liger_modulated_rms_norm`
 RoPE (Rotary Position Embedding) enhances the positional encoding used in transformer models.
 
 The implementation allows for effective handling of positional information without incurring significant computational overhead.
+For packed THD inputs, use `liger_kernel.transformers.liger_rotary_pos_emb_thd` with query/key tensors shaped `(total_tokens, num_heads, head_dim)` and `cos`/`sin` tensors shaped `(total_tokens, head_dim)`.
 
 !!! Example "Try it out"
     You can experiment as shown in this example [here](https://colab.research.google.com/drive/1llnAdo0hc9FpxYRRnjih0l066NCp7Ylu?usp=sharing).

--- a/src/liger_kernel/ops/__init__.py
+++ b/src/liger_kernel/ops/__init__.py
@@ -84,8 +84,11 @@ from liger_kernel.ops.rms_norm import LigerRMSNormFunction  # noqa: F401
 from liger_kernel.ops.rms_norm import rms_norm_backward  # noqa: F401
 from liger_kernel.ops.rms_norm import rms_norm_forward  # noqa: F401
 from liger_kernel.ops.rope import LigerRopeFunction  # noqa: F401
+from liger_kernel.ops.rope import LigerRopeTHDFunction  # noqa: F401
 from liger_kernel.ops.rope import rope_backward  # noqa: F401
+from liger_kernel.ops.rope import rope_backward_thd  # noqa: F401
 from liger_kernel.ops.rope import rope_forward  # noqa: F401
+from liger_kernel.ops.rope import rope_forward_thd  # noqa: F401
 from liger_kernel.ops.softmax import LigerSoftmaxFunction  # noqa: F401
 from liger_kernel.ops.sparsemax import LigerSparsemaxFunction  # noqa: F401
 from liger_kernel.ops.swiglu import LigerSiLUMulFunction  # noqa: F401

--- a/src/liger_kernel/ops/rope.py
+++ b/src/liger_kernel/ops/rope.py
@@ -201,6 +201,78 @@ def rope_backward(dq, dk, cos, sin):
     return dq.transpose(1, 2), dk.transpose(1, 2)
 
 
+def rope_forward_thd(q, k, cos, sin):
+    total_tokens, n_q_head, head_dim = q.shape
+    n_kv_head = k.shape[1]
+    pad_hd = triton.next_power_of_2(head_dim)
+    pad_n_q_head = triton.next_power_of_2(n_q_head)
+    pad_n_kv_head = triton.next_power_of_2(n_kv_head)
+    BLOCK_SIZE = max(pad_n_q_head, pad_n_kv_head)
+
+    q = q.contiguous()
+    k = k.contiguous()
+    cos = cos.contiguous()
+    sin = sin.contiguous()
+
+    _triton_rope[(total_tokens,)](
+        q,
+        q.stride(0),
+        k,
+        k.stride(0),
+        cos,
+        cos.stride(-2),
+        sin,
+        sin.stride(-2),
+        total_tokens,
+        1,
+        1,
+        n_q_head,
+        n_kv_head,
+        head_dim,
+        pad_n_q_head,
+        pad_n_kv_head,
+        pad_hd,
+        BLOCK_SIZE=BLOCK_SIZE,
+        BACKWARD_PASS=False,
+    )
+    return q, k, cos, sin
+
+
+def rope_backward_thd(dq, dk, cos, sin):
+    total_tokens, n_q_head, head_dim = dq.shape
+    n_kv_head = dk.shape[1]
+    pad_hd = triton.next_power_of_2(head_dim)
+    pad_n_q_head = triton.next_power_of_2(n_q_head)
+    pad_n_kv_head = triton.next_power_of_2(n_kv_head)
+    BLOCK_SIZE = max(pad_n_q_head, pad_n_kv_head)
+
+    dq = dq.contiguous()
+    dk = dk.contiguous()
+
+    _triton_rope[(total_tokens,)](
+        dq,
+        dq.stride(0),
+        dk,
+        dk.stride(0),
+        cos,
+        cos.stride(-2),
+        sin,
+        sin.stride(-2),
+        total_tokens,
+        1,
+        1,
+        n_q_head,
+        n_kv_head,
+        head_dim,
+        pad_n_q_head,
+        pad_n_kv_head,
+        pad_hd,
+        BLOCK_SIZE=BLOCK_SIZE,
+        BACKWARD_PASS=True,
+    )
+    return dq, dk
+
+
 class LigerRopeFunction(torch.autograd.Function):
     """
     Triton implementation of the Rotary Positional Embedding (RoPE) operation. Please note that
@@ -237,3 +309,35 @@ class LigerRopeFunction(torch.autograd.Function):
         cos, sin = ctx.saved_tensors
         dq, dk = rope_backward(dq, dk, cos, sin)
         return dq, dk, None, None, None, None
+
+
+class LigerRopeTHDFunction(torch.autograd.Function):
+    """
+    Triton implementation of RoPE for THD packed inputs.
+
+    The input tensors are expected to be laid out as (total_tokens, num_heads, head_dim).
+    Position information is assumed to have already been reflected in the per-token cos/sin rows.
+    """
+
+    @staticmethod
+    def forward(ctx, q, k, cos, sin):
+        """
+        q size: (total_tokens, n_q_head, head_dim)
+        k size: (total_tokens, n_kv_head, head_dim)
+        cos size: (total_tokens, head_dim)
+        sin size: (total_tokens, head_dim)
+        """
+        q, k, cos, sin = rope_forward_thd(q, k, cos, sin)
+        ctx.save_for_backward(cos, sin)
+        return q, k
+
+    def backward(ctx, dq, dk):
+        """
+        dq size: (total_tokens, n_q_head, head_dim)
+        dk size: (total_tokens, n_kv_head, head_dim)
+        cos size: (total_tokens, head_dim)
+        sin size: (total_tokens, head_dim)
+        """
+        cos, sin = ctx.saved_tensors
+        dq, dk = rope_backward_thd(dq, dk, cos, sin)
+        return dq, dk, None, None

--- a/src/liger_kernel/transformers/functional.py
+++ b/src/liger_kernel/transformers/functional.py
@@ -25,6 +25,7 @@ from liger_kernel.ops import LigerQwen2VLMRopeFunction
 from liger_kernel.ops import LigerReLUSquaredFunction
 from liger_kernel.ops import LigerRMSNormFunction
 from liger_kernel.ops import LigerRopeFunction
+from liger_kernel.ops import LigerRopeTHDFunction
 from liger_kernel.ops import LigerSiLUMulFunction
 from liger_kernel.ops import LigerSoftmaxFunction
 from liger_kernel.ops import LigerSparsemaxFunction
@@ -319,6 +320,10 @@ def liger_fused_add_rms_norm(X, R, W, eps, offset: float = 0.0, casting_mode: st
 
 def liger_rope(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     return LigerRopeFunction.apply(q, k, cos, sin, position_ids, unsqueeze_dim)
+
+
+def liger_rope_thd(q, k, cos, sin):
+    return LigerRopeTHDFunction.apply(q, k, cos, sin)
 
 
 def liger_swiglu(a, b):

--- a/src/liger_kernel/transformers/rope.py
+++ b/src/liger_kernel/transformers/rope.py
@@ -3,6 +3,7 @@ from typing import Tuple
 import torch
 
 from liger_kernel.ops import LigerRopeFunction
+from liger_kernel.ops import LigerRopeTHDFunction
 
 
 def liger_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
@@ -22,6 +23,23 @@ def liger_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     """
 
     return LigerRopeFunction.apply(q, k, cos, sin, position_ids, unsqueeze_dim)
+
+
+def liger_rotary_pos_emb_thd(q, k, cos, sin):
+    """
+    Applies Rotary Positional Embedding (RoPE) operation to THD packed query and key states.
+
+    Args:
+        q (torch.Tensor): The query tensor of shape (total_tokens, n_q_head, head_dim).
+        k (torch.Tensor): The key tensor of shape (total_tokens, n_kv_head, head_dim).
+        cos (torch.Tensor): The cosine tensor of shape (total_tokens, head_dim).
+        sin (torch.Tensor): The sine tensor of shape (total_tokens, head_dim).
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: The query and key tensors after applying the RoPE operation.
+    """
+
+    return LigerRopeTHDFunction.apply(q, k, cos, sin)
 
 
 def liger_rotary_pos_emb_vision(

--- a/test/transformers/test_rope.py
+++ b/test/transformers/test_rope.py
@@ -7,8 +7,11 @@ from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding
 from transformers.models.llama.modeling_llama import apply_rotary_pos_emb
 
 from liger_kernel.ops import LigerRopeFunction
+from liger_kernel.ops import LigerRopeTHDFunction
 from liger_kernel.transformers.functional import liger_rope
+from liger_kernel.transformers.functional import liger_rope_thd
 from liger_kernel.transformers.rope import liger_rotary_pos_emb
+from liger_kernel.transformers.rope import liger_rotary_pos_emb_thd
 from liger_kernel.utils import infer_device
 from liger_kernel.utils import transformers_version_dispatch
 
@@ -99,6 +102,165 @@ def test_correctness(
 
     assert torch.allclose(q1_grad, q2_grad, atol=atol, rtol=rtol)
     assert torch.allclose(k1_grad, k2_grad, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize(
+    "total_tokens, num_q_heads, num_kv_heads, head_dim",
+    [
+        (128, 32, 32, 64),
+        (128, 32, 8, 64),
+        (423, 73, 155, 92),
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype, atol, rtol",
+    [
+        (torch.float32, 1e-5, 1e-5),
+        pytest.param(
+            torch.bfloat16,
+            1e-1,
+            1e-5,
+            marks=pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this GPU"),
+        ),
+    ],
+)
+def test_thd_correctness(
+    total_tokens,
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+    dtype,
+    atol,
+    rtol,
+):
+    _q = torch.randn((total_tokens, num_q_heads, head_dim), device=device, dtype=dtype)
+    _k = torch.randn((total_tokens, num_kv_heads, head_dim), device=device, dtype=dtype)
+
+    rotary_emb = transformers_version_dispatch(
+        "4.48.0",
+        LlamaRotaryEmbedding,
+        LlamaRotaryEmbedding,
+        before_kwargs={"dim": head_dim, "device": device},
+        after_kwargs={"config": LlamaConfig(num_kv_heads=num_kv_heads, head_dim=head_dim), "device": device},
+    )
+
+    pos_ids = torch.arange(total_tokens, device=device, dtype=torch.long).unsqueeze(0)
+    _cos, _sin = rotary_emb(_k.transpose(0, 1).unsqueeze(0), pos_ids)
+    _cos = _cos.squeeze(0)
+    _sin = _sin.squeeze(0)
+
+    q1 = _q.clone().requires_grad_(True)
+    k1 = _k.clone().requires_grad_(True)
+    q2 = _q.clone().requires_grad_(True)
+    k2 = _k.clone().requires_grad_(True)
+
+    ref_q, ref_k = apply_rotary_pos_emb(
+        q1.transpose(0, 1).unsqueeze(0),
+        k1.transpose(0, 1).unsqueeze(0),
+        _cos.unsqueeze(0),
+        _sin.unsqueeze(0),
+    )
+    ref_q = ref_q.squeeze(0).transpose(0, 1)
+    ref_k = ref_k.squeeze(0).transpose(0, 1)
+    tt_q, tt_k = liger_rotary_pos_emb_thd(q2, k2, _cos, _sin)
+
+    assert torch.allclose(ref_q, tt_q, atol=atol, rtol=rtol)
+    assert torch.allclose(ref_k, tt_k, atol=atol, rtol=rtol)
+
+    dq, dk = torch.randn_like(ref_q), torch.randn_like(ref_k)
+
+    q1_grad, k1_grad = torch.autograd.grad((ref_q, ref_k), (q1, k1), (dq, dk), allow_unused=True)
+    q2_grad, k2_grad = torch.autograd.grad((tt_q, tt_k), (q2, k2), (dq.clone(), dk.clone()), allow_unused=True)
+
+    assert torch.allclose(q1_grad, q2_grad, atol=atol, rtol=rtol)
+    assert torch.allclose(k1_grad, k2_grad, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize(
+    "total_tokens, num_q_heads, num_kv_heads, head_dim",
+    [
+        (7, 2, 2, 8),
+        (7, 1, 2, 8),
+        (11, 41, 41, 64),
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype, atol, rtol",
+    [
+        (torch.float32, 1e-5, 1e-5),
+        (torch.bfloat16, 1e-1, 1e-5),
+    ],
+)
+def test_thd_functional_correctness(
+    total_tokens,
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+    dtype,
+    atol,
+    rtol,
+):
+    _q = torch.randn((total_tokens, num_q_heads, head_dim), device=device, dtype=dtype)
+    _k = torch.randn((total_tokens, num_kv_heads, head_dim), device=device, dtype=dtype)
+
+    rotary_emb = transformers_version_dispatch(
+        "4.48.0",
+        LlamaRotaryEmbedding,
+        LlamaRotaryEmbedding,
+        before_kwargs={"dim": head_dim, "device": device},
+        after_kwargs={"config": LlamaConfig(num_kv_heads=num_kv_heads, head_dim=head_dim), "device": device},
+    )
+
+    pos_ids = torch.arange(total_tokens, device=device, dtype=torch.long).unsqueeze(0)
+    _cos, _sin = rotary_emb(_k.transpose(0, 1).unsqueeze(0), pos_ids)
+    _cos = _cos.squeeze(0)
+    _sin = _sin.squeeze(0)
+
+    q1 = _q.clone().requires_grad_(True)
+    q2 = _q.clone().requires_grad_(True)
+    q3 = _q.clone().requires_grad_(True)
+
+    k1 = _k.clone().requires_grad_(True)
+    k2 = _k.clone().requires_grad_(True)
+    k3 = _k.clone().requires_grad_(True)
+
+    functional_q, functional_k = liger_rope_thd(q=q1, k=k1, cos=_cos, sin=_sin)
+    class_q, class_k = LigerRopeTHDFunction.apply(q2, k2, _cos, _sin)
+    wrapper_q, wrapper_k = liger_rotary_pos_emb_thd(q3, k3, _cos, _sin)
+
+    assert torch.allclose(functional_q, class_q, atol=atol, rtol=rtol)
+    assert torch.allclose(functional_k, class_k, atol=atol, rtol=rtol)
+    assert torch.allclose(functional_q, wrapper_q, atol=atol, rtol=rtol)
+    assert torch.allclose(functional_k, wrapper_k, atol=atol, rtol=rtol)
+
+    dq, dk = torch.randn_like(functional_q), torch.randn_like(functional_k)
+    dq1, dk1 = dq.clone(), dk.clone()
+    dq2, dk2 = dq.clone(), dk.clone()
+    dq3, dk3 = dq.clone(), dk.clone()
+
+    q1_grad, k1_grad = torch.autograd.grad(
+        (functional_q, functional_k),
+        (q1, k1),
+        (dq1, dk1),
+        allow_unused=True,
+    )
+    q2_grad, k2_grad = torch.autograd.grad(
+        (class_q, class_k),
+        (q2, k2),
+        (dq2, dk2),
+        allow_unused=True,
+    )
+    q3_grad, k3_grad = torch.autograd.grad(
+        (wrapper_q, wrapper_k),
+        (q3, k3),
+        (dq3, dk3),
+        allow_unused=True,
+    )
+
+    assert torch.allclose(q1_grad, q2_grad, atol=atol, rtol=rtol)
+    assert torch.allclose(k1_grad, k2_grad, atol=atol, rtol=rtol)
+    assert torch.allclose(q1_grad, q3_grad, atol=atol, rtol=rtol)
+    assert torch.allclose(k1_grad, k3_grad, atol=atol, rtol=rtol)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Add THD packed-input support for RoPE. This introduces a THD RoPE autograd wrapper and public functional/transformers APIs for query/key tensors shaped `(total_tokens, num_heads, head_dim)` with `cos`/`sin` shaped `(total_tokens, head_dim)`.

## Details
The THD path reuses the existing Triton RoPE kernel with a packed-token layout wrapper, keeping the existing batch-major RoPE API unchanged. Documentation and RoPE unit tests were updated to cover the new public THD API.

This is an initial RoPE-only step toward THD / packed-sequence training support requested in #1281. It does not close the issue, since broader packed-layout support across kernels remains future work.

## Testing Done
- Hardware Type:  NVIDIA GB200
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
Additional targeted testing:
- `python -m pytest test/transformers/test_rope.py`