### PR TITLE
Add Native Sparse Attention (NSA) Triton kernels and module

### DIFF
--- a/benchmark/scripts/benchmark_native_sparse_attention.py
+++ b/benchmark/scripts/benchmark_native_sparse_attention.py
@@ -1,0 +1,156 @@
+"""Benchmark for Native Sparse Attention (arXiv 2502.11089).
+
+This measures the pure-PyTorch NSA reference (provider ``liger``) against dense
+full causal attention (provider ``torch``) as sequence length grows. PR-1 ships
+the reference implementation only, so this establishes the benchmark harness and
+a baseline; the Triton kernel added in follow-up work is measured against these
+same numbers to demonstrate the sparse-attention speed/memory win.
+"""
+
+import math
+
+import torch
+import torch.nn as nn
+
+from benchmark_model_configs import MODEL_REGISTRY
+from benchmark_model_configs import build_model_config_sweep
+from benchmark_model_configs import build_token_length_sweep
+from benchmark_model_configs import get_benchmark_model_config
+from utils import SingleBenchmarkRunInput
+from utils import build_memory_bench_fn
+from utils import build_speed_bench_fn
+from utils import parse_benchmark_script_args
+from utils import run_benchmarks
+
+from liger_kernel.transformers.native_sparse_attention import LigerNativeSparseAttention
+from liger_kernel.utils import infer_device
+
+device = infer_device()
+
+
+class DenseCausalAttention(nn.Module):
+    """Standard dense causal GQA attention — the O(S^2) baseline NSA replaces."""
+
+    def __init__(self, hidden_size, num_heads, num_kv_heads, head_dim, bias=False):
+        super().__init__()
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        self.scale = 1.0 / math.sqrt(head_dim)
+        self.q_proj = nn.Linear(hidden_size, num_heads * head_dim, bias=bias)
+        self.k_proj = nn.Linear(hidden_size, num_kv_heads * head_dim, bias=bias)
+        self.v_proj = nn.Linear(hidden_size, num_kv_heads * head_dim, bias=bias)
+        self.o_proj = nn.Linear(num_heads * head_dim, hidden_size, bias=bias)
+
+    def forward(self, x):
+        b, s, _ = x.shape
+        q = self.q_proj(x).view(b, s, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.k_proj(x).view(b, s, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.v_proj(x).view(b, s, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        group = self.num_heads // self.num_kv_heads
+        k = k.repeat_interleave(group, dim=1)
+        v = v.repeat_interleave(group, dim=1)
+        scores = torch.matmul(q, k.transpose(-1, -2)).float() * self.scale
+        causal = torch.arange(s, device=x.device).view(s, 1) >= torch.arange(s, device=x.device).view(1, s)
+        scores = scores.masked_fill(~causal, float("-inf"))
+        out = torch.matmul(torch.softmax(scores, dim=-1).to(v.dtype), v)
+        out = out.transpose(1, 2).contiguous().view(b, s, self.num_heads * self.head_dim)
+        return self.o_proj(out)
+
+
+def setup_native_sparse_attention(input: SingleBenchmarkRunInput):
+    """Create input tensor and attention layer from benchmark config."""
+    cfg = input.extra_benchmark_config
+    if isinstance(input.x, str):
+        model_cfg = MODEL_REGISTRY[input.x]
+        seq_len = cfg["seq_len"]
+        hidden_size = model_cfg.hidden_size
+        dtype = model_cfg.dtype
+    else:
+        seq_len = input.x
+        hidden_size = cfg["hidden_size"]
+        dtype = cfg["dtype"]
+
+    head_dim = cfg["head_dim"]
+    batch = cfg["batch"]
+    num_heads = max(1, hidden_size // head_dim)
+    num_kv_heads = max(1, num_heads // cfg["gqa_group"])
+
+    x = torch.randn(batch, seq_len, hidden_size, device=device, dtype=dtype, requires_grad=True)
+
+    if input.kernel_provider == "liger":
+        layer = LigerNativeSparseAttention(
+            hidden_size=hidden_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            compress_block_size=cfg["compress_block_size"],
+            compress_stride=cfg["compress_stride"],
+            selection_block_size=cfg["selection_block_size"],
+            num_selected_blocks=cfg["num_selected_blocks"],
+            sliding_window_size=cfg["sliding_window_size"],
+        ).to(device)
+    elif input.kernel_provider == "torch":
+        layer = DenseCausalAttention(hidden_size, num_heads, num_kv_heads, head_dim).to(device)
+    else:
+        raise ValueError(f"Invalid provider: {input.kernel_provider} for native_sparse_attention")
+    return x, layer.to(dtype)
+
+
+_NSA_EXTRA = {
+    "head_dim": 64,
+    "gqa_group": 4,
+    "batch": 1,
+    "compress_block_size": 32,
+    "compress_stride": 16,
+    "selection_block_size": 64,
+    "num_selected_blocks": 16,
+    "sliding_window_size": 512,
+}
+
+
+if __name__ == "__main__":
+    args = parse_benchmark_script_args()
+
+    if args.sweep_mode == "model_config":
+        common_configs = build_model_config_sweep(
+            kernel_name="native_sparse_attention",
+            setup_fn=setup_native_sparse_attention,
+            model_keys=["hidden_size", "dtype"],
+            extra_configs=dict(_NSA_EXTRA),
+            probe_dim="T",
+            probe_provider="torch",
+            bt=args.bt,
+            overwrite=args.overwrite,
+        )
+    else:
+        model = get_benchmark_model_config(args.model)
+        common_configs = build_token_length_sweep(
+            kernel_name="native_sparse_attention",
+            probe_x=1024,
+            model=model,
+            setup_fn=setup_native_sparse_attention,
+            model_keys=["hidden_size", "dtype"],
+            extra_configs=dict(_NSA_EXTRA),
+            scale_dim="T",
+            x_label="Sequence length",
+            probe_provider="torch",
+            overwrite=args.overwrite,
+        )
+
+    common_configs["kernel_providers"] = ["torch", "liger"]
+
+    run_benchmarks(
+        bench_test_fn=build_speed_bench_fn(setup_native_sparse_attention),
+        kernel_operation_modes=["forward", "backward", "full"],
+        metric_name="speed",
+        metric_unit="ms",
+        **common_configs,
+    )
+    run_benchmarks(
+        bench_test_fn=build_memory_bench_fn(setup_native_sparse_attention),
+        kernel_operation_modes=["full"],
+        metric_name="memory",
+        metric_unit="MB",
+        **common_configs,
+    )

--- a/src/liger_kernel/ops/__init__.py
+++ b/src/liger_kernel/ops/__init__.py
@@ -73,6 +73,12 @@ from liger_kernel.ops.modulated_rms_norm import LigerModulatedRMSNormFunction  #
 from liger_kernel.ops.modulated_rms_norm import modulated_rms_norm_backward  # noqa: F401
 from liger_kernel.ops.modulated_rms_norm import modulated_rms_norm_forward  # noqa: F401
 from liger_kernel.ops.multi_token_attention import LigerMultiTokenAttentionFunction  # noqa: F401
+from liger_kernel.ops.nsa_compressed_attention import LigerNSACompressedAttentionFunction  # noqa: F401
+from liger_kernel.ops.nsa_compressed_attention import nsa_compressed_attention  # noqa: F401
+from liger_kernel.ops.nsa_selected_attention import LigerNSASelectedAttentionFunction  # noqa: F401
+from liger_kernel.ops.nsa_selected_attention import nsa_selected_attention  # noqa: F401
+from liger_kernel.ops.nsa_sliding_attention import LigerNSASlidingAttentionFunction  # noqa: F401
+from liger_kernel.ops.nsa_sliding_attention import nsa_sliding_attention  # noqa: F401
 from liger_kernel.ops.poly_norm import LigerPolyNormFunction  # noqa: F401
 from liger_kernel.ops.poly_norm import poly_norm_backward  # noqa: F401
 from liger_kernel.ops.poly_norm import poly_norm_forward  # noqa: F401

--- a/src/liger_kernel/ops/nsa_compressed_attention.py
+++ b/src/liger_kernel/ops/nsa_compressed_attention.py
@@ -1,0 +1,420 @@
+"""
+Native Sparse Attention (arXiv 2502.11089) — compressed (coarse) branch, Triton.
+
+Each query attends over the *compressed* key/value stream produced by the learnable
+compression MLP phi (paper Eq. 7-8): ``k_cmp/v_cmp`` have one vector per length-``l``
+strided block, so this axis is ``Sc = floor((S - l) / d) + 1`` long — far shorter
+than ``S``. A compressed block ``j`` spans original positions
+``[j*stride, j*stride + block_size - 1]`` and is visible to query ``t`` only once it
+lies fully in the past (``j*stride + block_size - 1 <= t``).
+
+FlashAttention-2 online-softmax forward + recompute-from-LSE backward, mirroring
+``nsa_sliding_attention.py``. The compression MLP itself stays in PyTorch (small,
+not the bottleneck); only this attention is kernelised. The selection-scoring
+matrix ``p_cmp`` is recomputed in torch from the (cheap, ``[S, Sc]``) score matmul.
+
+Kernel structure informed by the public NSA references
+XunhaoLai/native-sparse-attention-triton (Apache-2.0) and
+fla-org/native-sparse-attention (MIT); no code copied verbatim.
+"""
+
+import operator
+
+import torch
+import triton
+import triton.language as tl
+
+from liger_kernel.ops.utils import compare_version
+from liger_kernel.ops.utils import ensure_contiguous
+from liger_kernel.ops.utils import is_hip
+from liger_kernel.utils import is_npu_available
+
+if compare_version("triton", operator.ge, "3.0.0") and not is_npu_available():
+    try:
+        from triton.language.extra.libdevice import exp2
+        from triton.language.extra.libdevice import log2
+    except ModuleNotFoundError:
+        from triton.language.extra.cuda.libdevice import exp2
+        from triton.language.extra.cuda.libdevice import log2
+else:
+    from triton.language.math import exp2
+    from triton.language.math import log2
+
+LOG2E: tl.constexpr = 1.4426950408889634
+
+
+def _num_warps(block: int) -> int:
+    # Portable warp count: cap on HIP (warp=64) so block-threads stay <= 1024.
+    if block >= 128:
+        return 8 if not is_hip() else 4
+    return 4
+
+
+@triton.jit
+def _compressed_fwd_kernel(
+    Q,
+    K,
+    V,
+    Out,
+    LSE,
+    seq_len,
+    num_cmp,  # Sc: number of compressed blocks
+    block_size,
+    stride,
+    qk_scale,  # scale * log2(e)
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_bh = tl.program_id(0).to(tl.int64)
+    pid_m = tl.program_id(1)
+
+    row = pid_bh * seq_len * HEAD_DIM
+    cmp_row = pid_bh * num_cmp * HEAD_DIM
+    lse_row = pid_bh * seq_len
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    d_mask = offs_d < HEAD_DIM
+
+    q = tl.load(
+        Q + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :],
+        mask=(offs_m[:, None] < seq_len) & d_mask[None, :],
+        other=0.0,
+    )
+
+    m_i = tl.full([BLOCK_M], float("-inf"), tl.float32)
+    l_i = tl.zeros([BLOCK_M], tl.float32)
+    acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], tl.float32)
+
+    # Only compressed blocks whose last covered position <= max query in the tile
+    # can be visible; block j needs j*stride + block_size - 1 <= offs_m.
+    m_last = pid_m * BLOCK_M + BLOCK_M - 1
+    hi = (m_last - (block_size - 1)) // stride + 1  # exclusive upper compressed-block bound
+    hi = tl.minimum(tl.maximum(hi, 0), num_cmp)
+
+    for start_n in range(0, hi, BLOCK_N):
+        offs_n = start_n + tl.arange(0, BLOCK_N)
+        k_ptrs = K + cmp_row + offs_n[:, None] * HEAD_DIM + offs_d[None, :]
+        k = tl.load(k_ptrs, mask=(offs_n[:, None] < num_cmp) & d_mask[None, :], other=0.0)
+        qk = tl.dot(q, tl.trans(k), input_precision="ieee") * qk_scale
+
+        key_last = offs_n[None, :] * stride + (block_size - 1)
+        valid = (key_last <= offs_m[:, None]) & (offs_n[None, :] < num_cmp)
+        qk = tl.where(valid, qk, float("-inf"))
+
+        m_new = tl.maximum(m_i, tl.max(qk, 1))
+        # Rows with no visible block in this chunk keep m_new = -inf; a safe 0 in the
+        # exponentials makes alpha=p=0 (no-op) and avoids NaN (see sliding kernel).
+        m_new_safe = tl.where(m_new == float("-inf"), 0.0, m_new)
+        alpha = exp2(m_i - m_new_safe)
+        p = exp2(qk - m_new_safe[:, None])
+        l_i = l_i * alpha + tl.sum(p, 1)
+
+        v_ptrs = V + cmp_row + offs_n[:, None] * HEAD_DIM + offs_d[None, :]
+        v = tl.load(v_ptrs, mask=(offs_n[:, None] < num_cmp) & d_mask[None, :], other=0.0)
+        acc = acc * alpha[:, None] + tl.dot(p.to(v.dtype), v, input_precision="ieee")
+        m_i = m_new
+
+    l_safe = tl.where(l_i == 0.0, 1.0, l_i)
+    acc = acc / l_safe[:, None]
+    lse = m_i + log2(l_safe)
+
+    o_ptrs = Out + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :]
+    tl.store(o_ptrs, acc.to(Out.dtype.element_ty), mask=(offs_m[:, None] < seq_len) & d_mask[None, :])
+    tl.store(LSE + lse_row + offs_m, lse, mask=offs_m < seq_len)
+
+
+@triton.jit
+def _compressed_bwd_preprocess(
+    Out,
+    DO,
+    DELTA,
+    seq_len,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    pid_bh = tl.program_id(0).to(tl.int64)
+    pid_m = tl.program_id(1)
+    row = pid_bh * seq_len * HEAD_DIM
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    d_mask = offs_d < HEAD_DIM
+    mask = (offs_m[:, None] < seq_len) & d_mask[None, :]
+    o = tl.load(Out + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=mask, other=0.0).to(tl.float32)
+    do = tl.load(DO + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=mask, other=0.0).to(tl.float32)
+    delta = tl.sum(o * do, axis=1)
+    tl.store(DELTA + pid_bh * seq_len + offs_m, delta, mask=offs_m < seq_len)
+
+
+@triton.jit
+def _compressed_bwd_dq_kernel(
+    Q,
+    K,
+    V,
+    DO,
+    LSE,
+    DELTA,
+    DQ,
+    seq_len,
+    num_cmp,
+    block_size,
+    stride,
+    scale,
+    qk_scale,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_bh = tl.program_id(0).to(tl.int64)
+    pid_m = tl.program_id(1)
+    row = pid_bh * seq_len * HEAD_DIM
+    cmp_row = pid_bh * num_cmp * HEAD_DIM
+    lse_row = pid_bh * seq_len
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    d_mask = offs_d < HEAD_DIM
+    m_mask = (offs_m[:, None] < seq_len) & d_mask[None, :]
+
+    q = tl.load(Q + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=m_mask, other=0.0)
+    do = tl.load(DO + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=m_mask, other=0.0)
+    lse = tl.load(LSE + lse_row + offs_m, mask=offs_m < seq_len, other=0.0)
+    delta = tl.load(DELTA + lse_row + offs_m, mask=offs_m < seq_len, other=0.0)
+
+    dq = tl.zeros([BLOCK_M, BLOCK_DMODEL], tl.float32)
+
+    m_last = pid_m * BLOCK_M + BLOCK_M - 1
+    hi = (m_last - (block_size - 1)) // stride + 1
+    hi = tl.minimum(tl.maximum(hi, 0), num_cmp)
+
+    for start_n in range(0, hi, BLOCK_N):
+        offs_n = start_n + tl.arange(0, BLOCK_N)
+        n_mask = (offs_n[:, None] < num_cmp) & d_mask[None, :]
+        k = tl.load(K + cmp_row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], mask=n_mask, other=0.0)
+        v = tl.load(V + cmp_row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], mask=n_mask, other=0.0)
+
+        qk = tl.dot(q, tl.trans(k), input_precision="ieee") * qk_scale
+        key_last = offs_n[None, :] * stride + (block_size - 1)
+        valid = (key_last <= offs_m[:, None]) & (offs_n[None, :] < num_cmp)
+        p = tl.where(valid, exp2(qk - lse[:, None]), 0.0)
+
+        dp = tl.dot(do, tl.trans(v), input_precision="ieee")
+        ds = p * (dp - delta[:, None])
+        dq += tl.dot(ds.to(k.dtype), k, input_precision="ieee")
+
+    dq = dq * scale
+    tl.store(DQ + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], dq.to(DQ.dtype.element_ty), mask=m_mask)
+
+
+@triton.jit
+def _compressed_bwd_dkdv_kernel(
+    Q,
+    K,
+    V,
+    DO,
+    LSE,
+    DELTA,
+    DK,
+    DV,
+    seq_len,
+    num_cmp,
+    block_size,
+    stride,
+    scale,
+    qk_scale,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_bh = tl.program_id(0).to(tl.int64)
+    pid_n = tl.program_id(1)
+    row = pid_bh * seq_len * HEAD_DIM
+    cmp_row = pid_bh * num_cmp * HEAD_DIM
+    lse_row = pid_bh * seq_len
+
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)  # compressed-key rows owned here
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    d_mask = offs_d < HEAD_DIM
+    n_mask = (offs_n[:, None] < num_cmp) & d_mask[None, :]
+
+    k = tl.load(K + cmp_row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], mask=n_mask, other=0.0)
+    v = tl.load(V + cmp_row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], mask=n_mask, other=0.0)
+
+    dk = tl.zeros([BLOCK_N, BLOCK_DMODEL], tl.float32)
+    dv = tl.zeros([BLOCK_N, BLOCK_DMODEL], tl.float32)
+
+    # Earliest query that can see the first key in this tile: n_start*stride + block_size - 1.
+    n_start = pid_n * BLOCK_N
+    first_q = n_start * stride + (block_size - 1)
+    lo = (first_q // BLOCK_M) * BLOCK_M
+
+    for start_m in range(lo, seq_len, BLOCK_M):
+        offs_m = start_m + tl.arange(0, BLOCK_M)
+        m_mask = (offs_m[:, None] < seq_len) & d_mask[None, :]
+        q = tl.load(Q + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=m_mask, other=0.0)
+        do = tl.load(DO + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=m_mask, other=0.0)
+        lse = tl.load(LSE + lse_row + offs_m, mask=offs_m < seq_len, other=0.0)
+        delta = tl.load(DELTA + lse_row + offs_m, mask=offs_m < seq_len, other=0.0)
+
+        qk = tl.dot(q, tl.trans(k), input_precision="ieee") * qk_scale
+        key_last = offs_n[None, :] * stride + (block_size - 1)
+        valid = (key_last <= offs_m[:, None]) & (offs_n[None, :] < num_cmp) & (offs_m[:, None] < seq_len)
+        p = tl.where(valid, exp2(qk - lse[:, None]), 0.0)
+
+        dp = tl.dot(do, tl.trans(v), input_precision="ieee")
+        ds = p * (dp - delta[:, None])
+
+        dv += tl.dot(tl.trans(p).to(do.dtype), do, input_precision="ieee")
+        dk += tl.dot(tl.trans(ds).to(q.dtype), q, input_precision="ieee")
+
+    dk = dk * scale
+    tl.store(DK + cmp_row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], dk.to(DK.dtype.element_ty), mask=n_mask)
+    tl.store(DV + cmp_row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], dv.to(DV.dtype.element_ty), mask=n_mask)
+
+
+def _shape_bh(x):
+    b, h, s, d = x.shape
+    return x.reshape(b * h, s, d), (b, h, s, d)
+
+
+def compressed_attention_forward(q, k_cmp, v_cmp, block_size, stride, scale):
+    q2, shape = _shape_bh(q)
+    k2, _ = _shape_bh(k_cmp)
+    v2, _ = _shape_bh(v_cmp)
+    bh, seq_len, head_dim = q2.shape
+    num_cmp = k2.shape[1]
+    block_dmodel = triton.next_power_of_2(head_dim)
+    BLOCK_M = 64
+    BLOCK_N = 32
+
+    o = torch.empty_like(q2)
+    lse = torch.empty((bh, seq_len), device=q.device, dtype=torch.float32)
+    grid = (bh, triton.cdiv(seq_len, BLOCK_M))
+    _compressed_fwd_kernel[grid](
+        q2,
+        k2,
+        v2,
+        o,
+        lse,
+        seq_len,
+        num_cmp,
+        block_size,
+        stride,
+        scale * LOG2E,
+        HEAD_DIM=head_dim,
+        BLOCK_DMODEL=block_dmodel,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=_num_warps(block_dmodel),
+        num_stages=2,
+    )
+    return o.view(shape), lse
+
+
+def compressed_attention_backward(do, q, k_cmp, v_cmp, o, lse, block_size, stride, scale):
+    q2, shape = _shape_bh(q)
+    k2, cmp_shape = _shape_bh(k_cmp)
+    v2, _ = _shape_bh(v_cmp)
+    o2, _ = _shape_bh(o)
+    do2, _ = _shape_bh(do)
+    bh, seq_len, head_dim = q2.shape
+    num_cmp = k2.shape[1]
+    block_dmodel = triton.next_power_of_2(head_dim)
+    BLOCK_M = 64
+    BLOCK_N = 32
+
+    delta = torch.empty((bh, seq_len), device=q.device, dtype=torch.float32)
+    _compressed_bwd_preprocess[(bh, triton.cdiv(seq_len, BLOCK_M))](
+        o2, do2, delta, seq_len, HEAD_DIM=head_dim, BLOCK_DMODEL=block_dmodel, BLOCK_M=BLOCK_M, num_warps=4
+    )
+
+    dq = torch.empty_like(q2)
+    dk = torch.empty_like(k2)
+    dv = torch.empty_like(v2)
+
+    _compressed_bwd_dq_kernel[(bh, triton.cdiv(seq_len, BLOCK_M))](
+        q2,
+        k2,
+        v2,
+        do2,
+        lse,
+        delta,
+        dq,
+        seq_len,
+        num_cmp,
+        block_size,
+        stride,
+        scale,
+        scale * LOG2E,
+        HEAD_DIM=head_dim,
+        BLOCK_DMODEL=block_dmodel,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=_num_warps(block_dmodel),
+        num_stages=2,
+    )
+    _compressed_bwd_dkdv_kernel[(bh, triton.cdiv(num_cmp, BLOCK_N))](
+        q2,
+        k2,
+        v2,
+        do2,
+        lse,
+        delta,
+        dk,
+        dv,
+        seq_len,
+        num_cmp,
+        block_size,
+        stride,
+        scale,
+        scale * LOG2E,
+        HEAD_DIM=head_dim,
+        BLOCK_DMODEL=block_dmodel,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=_num_warps(block_dmodel),
+        num_stages=2,
+    )
+    return dq.view(shape), dk.view(cmp_shape), dv.view(cmp_shape)
+
+
+class LigerNSACompressedAttentionFunction(torch.autograd.Function):
+    """Compressed (coarse) attention (MHA; expand compressed KV for GQA before calling)."""
+
+    @staticmethod
+    @ensure_contiguous
+    def forward(ctx, q, k_cmp, v_cmp, block_size, stride, scale):
+        o, lse = compressed_attention_forward(q, k_cmp, v_cmp, block_size, stride, scale)
+        ctx.save_for_backward(q, k_cmp, v_cmp, o, lse)
+        ctx.block_size = block_size
+        ctx.stride = stride
+        ctx.scale = scale
+        return o
+
+    @staticmethod
+    @ensure_contiguous
+    def backward(ctx, do):
+        q, k_cmp, v_cmp, o, lse = ctx.saved_tensors
+        dq, dk, dv = compressed_attention_backward(do, q, k_cmp, v_cmp, o, lse, ctx.block_size, ctx.stride, ctx.scale)
+        return dq, dk, dv, None, None, None
+
+
+def nsa_compressed_attention(q, k_cmp, v_cmp, block_size, stride, scale):
+    """Compressed branch with GQA support.
+
+    q: ``[B, Hq, S, D]``; k_cmp, v_cmp: ``[B, Hkv, Sc, D]`` (Hkv divides Hq). Returns
+    ``[B, Hq, S, D]``. Compressed KV heads are expanded to query heads (autograd
+    reduces the duplicated grads). Returns only the branch output; the selection
+    score matrix ``p_cmp`` is recomputed in torch from the cheap ``[S, Sc]`` matmul.
+    """
+    num_q_heads, num_kv_heads = q.shape[1], k_cmp.shape[1]
+    if num_kv_heads != num_q_heads:
+        group = num_q_heads // num_kv_heads
+        k_cmp = k_cmp.repeat_interleave(group, dim=1)
+        v_cmp = v_cmp.repeat_interleave(group, dim=1)
+    return LigerNSACompressedAttentionFunction.apply(q, k_cmp, v_cmp, block_size, stride, scale)

--- a/src/liger_kernel/ops/nsa_selected_attention.py
+++ b/src/liger_kernel/ops/nsa_selected_attention.py
@@ -1,0 +1,440 @@
+"""
+Native Sparse Attention (arXiv 2502.11089) — selected block-sparse branch, Triton.
+
+This is *the* NSA kernel: exact causal attention restricted to the top-n selection
+blocks chosen per query (paper Eq. 11-12). The block choice is discrete and shared
+by every query head in a GQA group, which is precisely what lets the backward stay
+atomic-free — the selection is a fixed boolean ``block_mask`` (no gradient), so
+dK/dV can be computed KV-block-parallel with a single deterministic write.
+
+FlashAttention-2 (arXiv 2307.08691) online-softmax forward + recompute-from-LSE
+backward, mirroring ``nsa_sliding_attention.py``. Each key chunk is loaded only
+when at least one query in the tile selects its block, giving the O(S*n*l') work
+that beats the dense O(S^2) baseline.
+
+Kernel structure informed by the public NSA references
+XunhaoLai/native-sparse-attention-triton (Apache-2.0) and
+fla-org/native-sparse-attention (MIT); no code copied verbatim.
+"""
+
+import operator
+
+import torch
+import triton
+import triton.language as tl
+
+from liger_kernel.ops.utils import compare_version
+from liger_kernel.ops.utils import ensure_contiguous
+from liger_kernel.ops.utils import is_hip
+from liger_kernel.utils import is_npu_available
+
+if compare_version("triton", operator.ge, "3.0.0") and not is_npu_available():
+    try:
+        from triton.language.extra.libdevice import exp2
+        from triton.language.extra.libdevice import log2
+    except ModuleNotFoundError:
+        from triton.language.extra.cuda.libdevice import exp2
+        from triton.language.extra.cuda.libdevice import log2
+else:
+    from triton.language.math import exp2
+    from triton.language.math import log2
+
+LOG2E: tl.constexpr = 1.4426950408889634
+
+
+def _num_warps(block: int) -> int:
+    # Portable warp count: cap on HIP (warp=64) so block-threads stay <= 1024.
+    if block >= 128:
+        return 8 if not is_hip() else 4
+    return 4
+
+
+def _pick_block_n(selection_block_size: int) -> int:
+    """Largest kernel key-block in {64,32,16} that divides the selection block.
+
+    A key chunk of ``BLOCK_N`` positions must lie entirely inside one selection
+    block so its selection bit is well defined; requiring ``BLOCK_N | l'`` (and
+    ``BLOCK_N >= 16`` for a portable ``tl.dot``) guarantees that.
+    """
+    for cand in (64, 32, 16):
+        if selection_block_size % cand == 0:
+            return cand
+    raise ValueError(
+        f"selection_block_size ({selection_block_size}) must be a multiple of 16, 32, or 64 "
+        "for the selected-attention kernel."
+    )
+
+
+@triton.jit
+def _selected_fwd_kernel(
+    Q,
+    K,
+    V,
+    Out,
+    LSE,
+    BM,  # block_mask [BH, seq_len, num_blocks], int8 (1 = selected)
+    seq_len,
+    num_blocks,
+    qk_scale,  # scale * log2(e)
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    SEL_BLOCK: tl.constexpr,
+):
+    pid_bh = tl.program_id(0).to(tl.int64)
+    pid_m = tl.program_id(1)
+
+    row = pid_bh * seq_len * HEAD_DIM
+    lse_row = pid_bh * seq_len
+    bm_row = pid_bh * seq_len * num_blocks
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    d_mask = offs_d < HEAD_DIM
+
+    q = tl.load(
+        Q + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :],
+        mask=(offs_m[:, None] < seq_len) & d_mask[None, :],
+        other=0.0,
+    )
+
+    m_i = tl.full([BLOCK_M], float("-inf"), tl.float32)
+    l_i = tl.zeros([BLOCK_M], tl.float32)
+    acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], tl.float32)
+
+    hi = tl.minimum(pid_m * BLOCK_M + BLOCK_M, seq_len)  # causal: no key beyond last query in tile
+    for start_n in range(0, hi, BLOCK_N):
+        j = start_n // SEL_BLOCK  # the (single) selection block this chunk lies in
+        sel = tl.load(BM + bm_row + offs_m * num_blocks + j, mask=offs_m < seq_len, other=0)
+        # Skip the whole chunk unless some query in the tile selects this block.
+        if tl.sum(sel.to(tl.int32)) > 0:
+            offs_n = start_n + tl.arange(0, BLOCK_N)
+            k_ptrs = K + row + offs_n[:, None] * HEAD_DIM + offs_d[None, :]
+            k = tl.load(k_ptrs, mask=(offs_n[:, None] < seq_len) & d_mask[None, :], other=0.0)
+            qk = tl.dot(q, tl.trans(k), input_precision="ieee") * qk_scale
+
+            valid = (sel[:, None] != 0) & (offs_n[None, :] <= offs_m[:, None]) & (offs_n[None, :] < seq_len)
+            qk = tl.where(valid, qk, float("-inf"))
+
+            m_new = tl.maximum(m_i, tl.max(qk, 1))
+            # Rows selecting no key in this chunk keep m_new = -inf; a safe 0 in the
+            # exponentials makes alpha=p=0 (no-op) and avoids NaN (see sliding kernel).
+            m_new_safe = tl.where(m_new == float("-inf"), 0.0, m_new)
+            alpha = exp2(m_i - m_new_safe)
+            p = exp2(qk - m_new_safe[:, None])
+            l_i = l_i * alpha + tl.sum(p, 1)
+
+            v_ptrs = V + row + offs_n[:, None] * HEAD_DIM + offs_d[None, :]
+            v = tl.load(v_ptrs, mask=(offs_n[:, None] < seq_len) & d_mask[None, :], other=0.0)
+            acc = acc * alpha[:, None] + tl.dot(p.to(v.dtype), v, input_precision="ieee")
+            m_i = m_new
+
+    l_safe = tl.where(l_i == 0.0, 1.0, l_i)
+    acc = acc / l_safe[:, None]
+    lse = m_i + log2(l_safe)
+
+    o_ptrs = Out + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :]
+    tl.store(o_ptrs, acc.to(Out.dtype.element_ty), mask=(offs_m[:, None] < seq_len) & d_mask[None, :])
+    tl.store(LSE + lse_row + offs_m, lse, mask=offs_m < seq_len)
+
+
+@triton.jit
+def _selected_bwd_preprocess(
+    Out,
+    DO,
+    DELTA,
+    seq_len,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    pid_bh = tl.program_id(0).to(tl.int64)
+    pid_m = tl.program_id(1)
+    row = pid_bh * seq_len * HEAD_DIM
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    d_mask = offs_d < HEAD_DIM
+    mask = (offs_m[:, None] < seq_len) & d_mask[None, :]
+    o = tl.load(Out + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=mask, other=0.0).to(tl.float32)
+    do = tl.load(DO + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=mask, other=0.0).to(tl.float32)
+    delta = tl.sum(o * do, axis=1)
+    tl.store(DELTA + pid_bh * seq_len + offs_m, delta, mask=offs_m < seq_len)
+
+
+@triton.jit
+def _selected_bwd_dq_kernel(
+    Q,
+    K,
+    V,
+    DO,
+    LSE,
+    DELTA,
+    DQ,
+    BM,
+    seq_len,
+    num_blocks,
+    scale,
+    qk_scale,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    SEL_BLOCK: tl.constexpr,
+):
+    pid_bh = tl.program_id(0).to(tl.int64)
+    pid_m = tl.program_id(1)
+    row = pid_bh * seq_len * HEAD_DIM
+    lse_row = pid_bh * seq_len
+    bm_row = pid_bh * seq_len * num_blocks
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    d_mask = offs_d < HEAD_DIM
+    m_mask = (offs_m[:, None] < seq_len) & d_mask[None, :]
+
+    q = tl.load(Q + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=m_mask, other=0.0)
+    do = tl.load(DO + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=m_mask, other=0.0)
+    lse = tl.load(LSE + lse_row + offs_m, mask=offs_m < seq_len, other=0.0)
+    delta = tl.load(DELTA + lse_row + offs_m, mask=offs_m < seq_len, other=0.0)
+
+    dq = tl.zeros([BLOCK_M, BLOCK_DMODEL], tl.float32)
+
+    hi = tl.minimum(pid_m * BLOCK_M + BLOCK_M, seq_len)
+    for start_n in range(0, hi, BLOCK_N):
+        j = start_n // SEL_BLOCK
+        sel = tl.load(BM + bm_row + offs_m * num_blocks + j, mask=offs_m < seq_len, other=0)
+        if tl.sum(sel.to(tl.int32)) > 0:
+            offs_n = start_n + tl.arange(0, BLOCK_N)
+            n_mask = (offs_n[:, None] < seq_len) & d_mask[None, :]
+            k = tl.load(K + row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], mask=n_mask, other=0.0)
+            v = tl.load(V + row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], mask=n_mask, other=0.0)
+
+            qk = tl.dot(q, tl.trans(k), input_precision="ieee") * qk_scale
+            valid = (sel[:, None] != 0) & (offs_n[None, :] <= offs_m[:, None]) & (offs_n[None, :] < seq_len)
+            p = tl.where(valid, exp2(qk - lse[:, None]), 0.0)
+
+            dp = tl.dot(do, tl.trans(v), input_precision="ieee")
+            ds = p * (dp - delta[:, None])
+            dq += tl.dot(ds.to(k.dtype), k, input_precision="ieee")
+
+    dq = dq * scale
+    tl.store(DQ + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], dq.to(DQ.dtype.element_ty), mask=m_mask)
+
+
+@triton.jit
+def _selected_bwd_dkdv_kernel(
+    Q,
+    K,
+    V,
+    DO,
+    LSE,
+    DELTA,
+    DK,
+    DV,
+    BM,
+    seq_len,
+    num_blocks,
+    scale,
+    qk_scale,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    SEL_BLOCK: tl.constexpr,
+):
+    pid_bh = tl.program_id(0).to(tl.int64)
+    pid_n = tl.program_id(1)
+    row = pid_bh * seq_len * HEAD_DIM
+    lse_row = pid_bh * seq_len
+    bm_row = pid_bh * seq_len * num_blocks
+
+    n_start = pid_n * BLOCK_N
+    j = n_start // SEL_BLOCK  # selection block owned by this key tile (BLOCK_N | SEL_BLOCK)
+    offs_n = n_start + tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    d_mask = offs_d < HEAD_DIM
+    n_mask = (offs_n[:, None] < seq_len) & d_mask[None, :]
+
+    k = tl.load(K + row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], mask=n_mask, other=0.0)
+    v = tl.load(V + row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], mask=n_mask, other=0.0)
+
+    dk = tl.zeros([BLOCK_N, BLOCK_DMODEL], tl.float32)
+    dv = tl.zeros([BLOCK_N, BLOCK_DMODEL], tl.float32)
+
+    lo = (n_start // BLOCK_M) * BLOCK_M  # causal: only queries at or after this key tile
+    for start_m in range(lo, seq_len, BLOCK_M):
+        offs_m = start_m + tl.arange(0, BLOCK_M)
+        sel = tl.load(BM + bm_row + offs_m * num_blocks + j, mask=offs_m < seq_len, other=0)
+        if tl.sum(sel.to(tl.int32)) > 0:
+            m_mask = (offs_m[:, None] < seq_len) & d_mask[None, :]
+            q = tl.load(Q + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=m_mask, other=0.0)
+            do = tl.load(DO + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=m_mask, other=0.0)
+            lse = tl.load(LSE + lse_row + offs_m, mask=offs_m < seq_len, other=0.0)
+            delta = tl.load(DELTA + lse_row + offs_m, mask=offs_m < seq_len, other=0.0)
+
+            qk = tl.dot(q, tl.trans(k), input_precision="ieee") * qk_scale
+            valid = (sel[:, None] != 0) & (offs_n[None, :] <= offs_m[:, None])
+            valid = valid & (offs_n[None, :] < seq_len) & (offs_m[:, None] < seq_len)
+            p = tl.where(valid, exp2(qk - lse[:, None]), 0.0)
+
+            dp = tl.dot(do, tl.trans(v), input_precision="ieee")
+            ds = p * (dp - delta[:, None])
+
+            dv += tl.dot(tl.trans(p).to(do.dtype), do, input_precision="ieee")
+            dk += tl.dot(tl.trans(ds).to(q.dtype), q, input_precision="ieee")
+
+    dk = dk * scale
+    tl.store(DK + row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], dk.to(DK.dtype.element_ty), mask=n_mask)
+    tl.store(DV + row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], dv.to(DV.dtype.element_ty), mask=n_mask)
+
+
+def _shape_bh(x):
+    b, h, s, d = x.shape
+    return x.reshape(b * h, s, d), (b, h, s, d)
+
+
+def selected_attention_forward(q, k, v, block_mask, selection_block_size, scale):
+    q2, shape = _shape_bh(q)
+    k2, _ = _shape_bh(k)
+    v2, _ = _shape_bh(v)
+    b, h, seq_len, num_blocks = block_mask.shape
+    bm2 = block_mask.reshape(b * h, seq_len, num_blocks)
+
+    bh, _, head_dim = q2.shape
+    block_dmodel = triton.next_power_of_2(head_dim)
+    BLOCK_M = 64
+    BLOCK_N = _pick_block_n(selection_block_size)
+
+    o = torch.empty_like(q2)
+    lse = torch.empty((bh, seq_len), device=q.device, dtype=torch.float32)
+    grid = (bh, triton.cdiv(seq_len, BLOCK_M))
+    _selected_fwd_kernel[grid](
+        q2,
+        k2,
+        v2,
+        o,
+        lse,
+        bm2,
+        seq_len,
+        num_blocks,
+        scale * LOG2E,
+        HEAD_DIM=head_dim,
+        BLOCK_DMODEL=block_dmodel,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        SEL_BLOCK=selection_block_size,
+        num_warps=_num_warps(block_dmodel),
+        num_stages=2,
+    )
+    return o.view(shape), lse
+
+
+def selected_attention_backward(do, q, k, v, o, lse, block_mask, selection_block_size, scale):
+    q2, shape = _shape_bh(q)
+    k2, _ = _shape_bh(k)
+    v2, _ = _shape_bh(v)
+    o2, _ = _shape_bh(o)
+    do2, _ = _shape_bh(do)
+    b, h, seq_len, num_blocks = block_mask.shape
+    bm2 = block_mask.reshape(b * h, seq_len, num_blocks)
+
+    bh, _, head_dim = q2.shape
+    block_dmodel = triton.next_power_of_2(head_dim)
+    BLOCK_M = 64
+    BLOCK_N = _pick_block_n(selection_block_size)
+
+    delta = torch.empty((bh, seq_len), device=q.device, dtype=torch.float32)
+    _selected_bwd_preprocess[(bh, triton.cdiv(seq_len, BLOCK_M))](
+        o2, do2, delta, seq_len, HEAD_DIM=head_dim, BLOCK_DMODEL=block_dmodel, BLOCK_M=BLOCK_M, num_warps=4
+    )
+
+    dq = torch.empty_like(q2)
+    dk = torch.empty_like(k2)
+    dv = torch.empty_like(v2)
+
+    _selected_bwd_dq_kernel[(bh, triton.cdiv(seq_len, BLOCK_M))](
+        q2,
+        k2,
+        v2,
+        do2,
+        lse,
+        delta,
+        dq,
+        bm2,
+        seq_len,
+        num_blocks,
+        scale,
+        scale * LOG2E,
+        HEAD_DIM=head_dim,
+        BLOCK_DMODEL=block_dmodel,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        SEL_BLOCK=selection_block_size,
+        num_warps=_num_warps(block_dmodel),
+        num_stages=2,
+    )
+    _selected_bwd_dkdv_kernel[(bh, triton.cdiv(seq_len, BLOCK_N))](
+        q2,
+        k2,
+        v2,
+        do2,
+        lse,
+        delta,
+        dk,
+        dv,
+        bm2,
+        seq_len,
+        num_blocks,
+        scale,
+        scale * LOG2E,
+        HEAD_DIM=head_dim,
+        BLOCK_DMODEL=block_dmodel,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        SEL_BLOCK=selection_block_size,
+        num_warps=_num_warps(block_dmodel),
+        num_stages=2,
+    )
+    return dq.view(shape), dk.view(shape), dv.view(shape)
+
+
+class LigerNSASelectedAttentionFunction(torch.autograd.Function):
+    """Selected block-sparse attention (MHA; expand KV + mask for GQA before calling)."""
+
+    @staticmethod
+    @ensure_contiguous
+    def forward(ctx, q, k, v, block_mask, selection_block_size, scale):
+        o, lse = selected_attention_forward(q, k, v, block_mask, selection_block_size, scale)
+        ctx.save_for_backward(q, k, v, o, lse, block_mask)
+        ctx.selection_block_size = selection_block_size
+        ctx.scale = scale
+        return o
+
+    @staticmethod
+    @ensure_contiguous
+    def backward(ctx, do):
+        q, k, v, o, lse, block_mask = ctx.saved_tensors
+        dq, dk, dv = selected_attention_backward(do, q, k, v, o, lse, block_mask, ctx.selection_block_size, ctx.scale)
+        return dq, dk, dv, None, None, None
+
+
+def nsa_selected_attention(q, k, v, selected, selection_block_size, scale):
+    """Selected block-sparse branch with GQA support.
+
+    q: ``[B, Hq, S, D]``; k, v: ``[B, Hkv, S, D]`` (Hkv divides Hq); ``selected``:
+    ``[B, Hkv, S, num_blocks]`` boolean block mask (already causal & forced-block
+    aware, from :func:`select_blocks`). Returns ``[B, Hq, S, D]``.
+
+    KV heads and the group-shared block mask are expanded to query heads so the
+    kernel runs one head per program (autograd reduces the duplicated grads). The
+    group-centric KV-reuse optimisation is a documented fast-follow.
+    """
+    num_q_heads, num_kv_heads = q.shape[1], k.shape[1]
+    if num_kv_heads != num_q_heads:
+        group = num_q_heads // num_kv_heads
+        k = k.repeat_interleave(group, dim=1)
+        v = v.repeat_interleave(group, dim=1)
+        selected = selected.repeat_interleave(group, dim=1)
+    block_mask = selected.to(torch.int8).contiguous()
+    return LigerNSASelectedAttentionFunction.apply(q, k, v, block_mask, selection_block_size, scale)

--- a/src/liger_kernel/ops/nsa_sliding_attention.py
+++ b/src/liger_kernel/ops/nsa_sliding_attention.py
@@ -1,0 +1,392 @@
+"""
+Native Sparse Attention (arXiv 2502.11089) — sliding-window branch, Triton.
+
+Causal sliding-window attention: each query attends to the ``window_size`` most
+recent keys (inclusive of itself). FlashAttention-2 style: online softmax in the
+forward, recompute-from-LSE in the backward. The attended key range is a
+contiguous band, so each dK/dV output tile is written by exactly one program —
+no ``tl.atomic_add``, fully deterministic, and multi-backend safe.
+
+Algorithm: FlashAttention-2 (arXiv 2307.08691). Kernel structure informed by the
+public NSA references XunhaoLai/native-sparse-attention-triton (Apache-2.0) and
+fla-org/native-sparse-attention (MIT); no code copied verbatim.
+"""
+
+import operator
+
+import torch
+import triton
+import triton.language as tl
+
+from liger_kernel.ops.utils import compare_version
+from liger_kernel.ops.utils import ensure_contiguous
+from liger_kernel.ops.utils import is_hip
+from liger_kernel.utils import is_npu_available
+
+if compare_version("triton", operator.ge, "3.0.0") and not is_npu_available():
+    try:
+        from triton.language.extra.libdevice import exp2
+        from triton.language.extra.libdevice import log2
+    except ModuleNotFoundError:
+        from triton.language.extra.cuda.libdevice import exp2
+        from triton.language.extra.cuda.libdevice import log2
+else:
+    from triton.language.math import exp2
+    from triton.language.math import log2
+
+LOG2E: tl.constexpr = 1.4426950408889634
+
+
+def _num_warps(block: int) -> int:
+    # Portable warp count: cap on HIP (warp=64) so block-threads stay <= 1024.
+    if block >= 128:
+        return 8 if not is_hip() else 4
+    return 4
+
+
+@triton.jit
+def _sliding_fwd_kernel(
+    Q,
+    K,
+    V,
+    Out,
+    LSE,
+    seq_len,
+    window,
+    qk_scale,  # scale * log2(e)
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_bh = tl.program_id(0).to(tl.int64)
+    pid_m = tl.program_id(1)
+
+    row = pid_bh * seq_len * HEAD_DIM
+    lse_row = pid_bh * seq_len
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    d_mask = offs_d < HEAD_DIM
+
+    q_ptrs = Q + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :]
+    q = tl.load(q_ptrs, mask=(offs_m[:, None] < seq_len) & d_mask[None, :], other=0.0)
+
+    m_i = tl.full([BLOCK_M], float("-inf"), tl.float32)
+    l_i = tl.zeros([BLOCK_M], tl.float32)
+    acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], tl.float32)
+
+    m_start = pid_m * BLOCK_M
+    lo = m_start - window + 1
+    lo = tl.maximum(lo, 0)
+    lo = (lo // BLOCK_N) * BLOCK_N
+    hi = tl.minimum(m_start + BLOCK_M, seq_len)
+
+    for start_n in range(lo, hi, BLOCK_N):
+        offs_n = start_n + tl.arange(0, BLOCK_N)
+        k_ptrs = K + row + offs_n[:, None] * HEAD_DIM + offs_d[None, :]
+        k = tl.load(k_ptrs, mask=(offs_n[:, None] < seq_len) & d_mask[None, :], other=0.0)
+        qk = tl.dot(q, tl.trans(k), input_precision="ieee") * qk_scale  # [BLOCK_M, BLOCK_N] fp32
+
+        valid = (offs_n[None, :] <= offs_m[:, None]) & (offs_n[None, :] > offs_m[:, None] - window)
+        valid = valid & (offs_n[None, :] < seq_len)
+        qk = tl.where(valid, qk, float("-inf"))
+
+        m_new = tl.maximum(m_i, tl.max(qk, 1))
+        # Rows whose entire key block is masked keep m_new = -inf; using a safe 0
+        # in the exponentials makes alpha=p=0 for them (no-op) and avoids NaN. A later
+        # in-band block (every real query has its diagonal in-band) resets via alpha.
+        m_new_safe = tl.where(m_new == float("-inf"), 0.0, m_new)
+        alpha = exp2(m_i - m_new_safe)
+        p = exp2(qk - m_new_safe[:, None])
+        l_i = l_i * alpha + tl.sum(p, 1)
+
+        v_ptrs = V + row + offs_n[:, None] * HEAD_DIM + offs_d[None, :]
+        v = tl.load(v_ptrs, mask=(offs_n[:, None] < seq_len) & d_mask[None, :], other=0.0)
+        acc = acc * alpha[:, None] + tl.dot(p.to(v.dtype), v, input_precision="ieee")
+        m_i = m_new
+
+    l_safe = tl.where(l_i == 0.0, 1.0, l_i)
+    acc = acc / l_safe[:, None]
+    lse = m_i + log2(l_safe)
+
+    o_ptrs = Out + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :]
+    tl.store(o_ptrs, acc.to(Out.dtype.element_ty), mask=(offs_m[:, None] < seq_len) & d_mask[None, :])
+    tl.store(LSE + lse_row + offs_m, lse, mask=offs_m < seq_len)
+
+
+@triton.jit
+def _sliding_bwd_preprocess(
+    Out,
+    DO,
+    DELTA,
+    seq_len,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    pid_bh = tl.program_id(0).to(tl.int64)
+    pid_m = tl.program_id(1)
+    row = pid_bh * seq_len * HEAD_DIM
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    d_mask = offs_d < HEAD_DIM
+    mask = (offs_m[:, None] < seq_len) & d_mask[None, :]
+    o = tl.load(Out + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=mask, other=0.0).to(tl.float32)
+    do = tl.load(DO + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=mask, other=0.0).to(tl.float32)
+    delta = tl.sum(o * do, axis=1)
+    tl.store(DELTA + pid_bh * seq_len + offs_m, delta, mask=offs_m < seq_len)
+
+
+@triton.jit
+def _sliding_bwd_dq_kernel(
+    Q,
+    K,
+    V,
+    DO,
+    LSE,
+    DELTA,
+    DQ,
+    seq_len,
+    window,
+    scale,
+    qk_scale,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_bh = tl.program_id(0).to(tl.int64)
+    pid_m = tl.program_id(1)
+    row = pid_bh * seq_len * HEAD_DIM
+    lse_row = pid_bh * seq_len
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    d_mask = offs_d < HEAD_DIM
+    m_mask = (offs_m[:, None] < seq_len) & d_mask[None, :]
+
+    q = tl.load(Q + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=m_mask, other=0.0)
+    do = tl.load(DO + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=m_mask, other=0.0)
+    lse = tl.load(LSE + lse_row + offs_m, mask=offs_m < seq_len, other=0.0)
+    delta = tl.load(DELTA + lse_row + offs_m, mask=offs_m < seq_len, other=0.0)
+
+    dq = tl.zeros([BLOCK_M, BLOCK_DMODEL], tl.float32)
+
+    m_start = pid_m * BLOCK_M
+    lo = tl.maximum(m_start - window + 1, 0)
+    lo = (lo // BLOCK_N) * BLOCK_N
+    hi = tl.minimum(m_start + BLOCK_M, seq_len)
+
+    for start_n in range(lo, hi, BLOCK_N):
+        offs_n = start_n + tl.arange(0, BLOCK_N)
+        n_mask = (offs_n[:, None] < seq_len) & d_mask[None, :]
+        k = tl.load(K + row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], mask=n_mask, other=0.0)
+        v = tl.load(V + row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], mask=n_mask, other=0.0)
+
+        qk = tl.dot(q, tl.trans(k), input_precision="ieee") * qk_scale
+        valid = (offs_n[None, :] <= offs_m[:, None]) & (offs_n[None, :] > offs_m[:, None] - window)
+        valid = valid & (offs_n[None, :] < seq_len)
+        p = tl.where(valid, exp2(qk - lse[:, None]), 0.0)
+
+        dp = tl.dot(do, tl.trans(v), input_precision="ieee")  # [BLOCK_M, BLOCK_N]
+        ds = p * (dp - delta[:, None])
+        dq += tl.dot(ds.to(k.dtype), k, input_precision="ieee")
+
+    dq = dq * scale
+    tl.store(DQ + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], dq.to(DQ.dtype.element_ty), mask=m_mask)
+
+
+@triton.jit
+def _sliding_bwd_dkdv_kernel(
+    Q,
+    K,
+    V,
+    DO,
+    LSE,
+    DELTA,
+    DK,
+    DV,
+    seq_len,
+    window,
+    scale,
+    qk_scale,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_bh = tl.program_id(0).to(tl.int64)
+    pid_n = tl.program_id(1)
+    row = pid_bh * seq_len * HEAD_DIM
+    lse_row = pid_bh * seq_len
+
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)  # key rows owned by this program
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    d_mask = offs_d < HEAD_DIM
+    n_mask = (offs_n[:, None] < seq_len) & d_mask[None, :]
+
+    k = tl.load(K + row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], mask=n_mask, other=0.0)
+    v = tl.load(V + row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], mask=n_mask, other=0.0)
+
+    dk = tl.zeros([BLOCK_N, BLOCK_DMODEL], tl.float32)
+    dv = tl.zeros([BLOCK_N, BLOCK_DMODEL], tl.float32)
+
+    # Queries touching key p: t in [p, p+window). For this key block, t in [n_start, n_end-1+window).
+    n_start = pid_n * BLOCK_N
+    lo = (n_start // BLOCK_M) * BLOCK_M
+    hi = tl.minimum(n_start + BLOCK_N - 1 + window, seq_len)
+
+    for start_m in range(lo, hi, BLOCK_M):
+        offs_m = start_m + tl.arange(0, BLOCK_M)
+        m_mask = (offs_m[:, None] < seq_len) & d_mask[None, :]
+        q = tl.load(Q + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=m_mask, other=0.0)
+        do = tl.load(DO + row + offs_m[:, None] * HEAD_DIM + offs_d[None, :], mask=m_mask, other=0.0)
+        lse = tl.load(LSE + lse_row + offs_m, mask=offs_m < seq_len, other=0.0)
+        delta = tl.load(DELTA + lse_row + offs_m, mask=offs_m < seq_len, other=0.0)
+
+        qk = tl.dot(q, tl.trans(k), input_precision="ieee") * qk_scale  # [BLOCK_M, BLOCK_N]
+        valid = (offs_n[None, :] <= offs_m[:, None]) & (offs_n[None, :] > offs_m[:, None] - window)
+        valid = valid & (offs_n[None, :] < seq_len) & (offs_m[:, None] < seq_len)
+        p = tl.where(valid, exp2(qk - lse[:, None]), 0.0)  # [BLOCK_M, BLOCK_N]
+
+        dp = tl.dot(do, tl.trans(v), input_precision="ieee")  # [BLOCK_M, BLOCK_N]
+        ds = p * (dp - delta[:, None])  # [BLOCK_M, BLOCK_N]
+
+        dv += tl.dot(tl.trans(p).to(do.dtype), do, input_precision="ieee")  # [BLOCK_N, D]
+        dk += tl.dot(tl.trans(ds).to(q.dtype), q, input_precision="ieee")  # [BLOCK_N, D]
+
+    dk = dk * scale
+    tl.store(DK + row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], dk.to(DK.dtype.element_ty), mask=n_mask)
+    tl.store(DV + row + offs_n[:, None] * HEAD_DIM + offs_d[None, :], dv.to(DV.dtype.element_ty), mask=n_mask)
+
+
+def _shape_bh(x):
+    b, h, s, d = x.shape
+    return x.reshape(b * h, s, d), (b, h, s, d)
+
+
+def sliding_attention_forward(q, k, v, window, scale):
+    q2, shape = _shape_bh(q)
+    k2, _ = _shape_bh(k)
+    v2, _ = _shape_bh(v)
+    bh, seq_len, head_dim = q2.shape
+    block_dmodel = triton.next_power_of_2(head_dim)
+    BLOCK_M = 64
+    BLOCK_N = 64
+    o = torch.empty_like(q2)
+    lse = torch.empty((bh, seq_len), device=q.device, dtype=torch.float32)
+    grid = (bh, triton.cdiv(seq_len, BLOCK_M))
+    _sliding_fwd_kernel[grid](
+        q2,
+        k2,
+        v2,
+        o,
+        lse,
+        seq_len,
+        window,
+        scale * LOG2E,
+        HEAD_DIM=head_dim,
+        BLOCK_DMODEL=block_dmodel,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=_num_warps(block_dmodel),
+        num_stages=2,
+    )
+    return o.view(shape), lse
+
+
+def sliding_attention_backward(do, q, k, v, o, lse, window, scale):
+    q2, shape = _shape_bh(q)
+    k2, _ = _shape_bh(k)
+    v2, _ = _shape_bh(v)
+    o2, _ = _shape_bh(o)
+    do2, _ = _shape_bh(do)
+    bh, seq_len, head_dim = q2.shape
+    block_dmodel = triton.next_power_of_2(head_dim)
+    BLOCK_M = 64
+    BLOCK_N = 64
+
+    delta = torch.empty((bh, seq_len), device=q.device, dtype=torch.float32)
+    _sliding_bwd_preprocess[(bh, triton.cdiv(seq_len, BLOCK_M))](
+        o2, do2, delta, seq_len, HEAD_DIM=head_dim, BLOCK_DMODEL=block_dmodel, BLOCK_M=BLOCK_M, num_warps=4
+    )
+
+    dq = torch.empty_like(q2)
+    dk = torch.empty_like(k2)
+    dv = torch.empty_like(v2)
+
+    _sliding_bwd_dq_kernel[(bh, triton.cdiv(seq_len, BLOCK_M))](
+        q2,
+        k2,
+        v2,
+        do2,
+        lse,
+        delta,
+        dq,
+        seq_len,
+        window,
+        scale,
+        scale * LOG2E,
+        HEAD_DIM=head_dim,
+        BLOCK_DMODEL=block_dmodel,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=_num_warps(block_dmodel),
+        num_stages=2,
+    )
+    _sliding_bwd_dkdv_kernel[(bh, triton.cdiv(seq_len, BLOCK_N))](
+        q2,
+        k2,
+        v2,
+        do2,
+        lse,
+        delta,
+        dk,
+        dv,
+        seq_len,
+        window,
+        scale,
+        scale * LOG2E,
+        HEAD_DIM=head_dim,
+        BLOCK_DMODEL=block_dmodel,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=_num_warps(block_dmodel),
+        num_stages=2,
+    )
+    return dq.view(shape), dk.view(shape), dv.view(shape)
+
+
+class LigerNSASlidingAttentionFunction(torch.autograd.Function):
+    """Causal sliding-window attention (MHA; expand KV for GQA before calling)."""
+
+    @staticmethod
+    @ensure_contiguous
+    def forward(ctx, q, k, v, window_size, scale):
+        o, lse = sliding_attention_forward(q, k, v, window_size, scale)
+        ctx.save_for_backward(q, k, v, o, lse)
+        ctx.window_size = window_size
+        ctx.scale = scale
+        return o
+
+    @staticmethod
+    @ensure_contiguous
+    def backward(ctx, do):
+        q, k, v, o, lse = ctx.saved_tensors
+        dq, dk, dv = sliding_attention_backward(do, q, k, v, o, lse, ctx.window_size, ctx.scale)
+        return dq, dk, dv, None, None
+
+
+def nsa_sliding_attention(q, k, v, window_size, scale):
+    """Sliding-window branch with GQA support.
+
+    q: [B, Hq, S, D]; k, v: [B, Hkv, S, D] (Hkv divides Hq). Returns [B, Hq, S, D].
+    KV heads are expanded to query heads (autograd reduces the duplicated grads).
+    """
+    num_q_heads, num_kv_heads = q.shape[1], k.shape[1]
+    if num_kv_heads != num_q_heads:
+        group = num_q_heads // num_kv_heads
+        k = k.repeat_interleave(group, dim=1)
+        v = v.repeat_interleave(group, dim=1)
+    return LigerNSASlidingAttentionFunction.apply(q, k, v, window_size, scale)

--- a/src/liger_kernel/transformers/__init__.py
+++ b/src/liger_kernel/transformers/__init__.py
@@ -17,6 +17,7 @@ from liger_kernel.transformers.llama4_rope import liger_llama4_vision_rotary_pos
 from liger_kernel.transformers.mhc import LigerMHC  # noqa: F401
 from liger_kernel.transformers.modulated_rms_norm import LigerModulatedRMSNorm  # noqa: F401
 from liger_kernel.transformers.multi_token_attention import LigerMultiTokenAttention  # noqa: F401
+from liger_kernel.transformers.native_sparse_attention import LigerNativeSparseAttention  # noqa: F401
 from liger_kernel.transformers.poly_norm import LigerPolyNorm  # noqa: F401
 from liger_kernel.transformers.relu_squared import LigerReLUSquared  # noqa: F401
 from liger_kernel.transformers.rms_norm import LigerRMSNorm  # noqa: F401
@@ -198,6 +199,7 @@ __all__ = [
     "LigerKLDIVLoss",
     "LigerMHC",
     "LigerMultiTokenAttention",
+    "LigerNativeSparseAttention",
     "LigerSoftmax",
     "LigerSparsemax",
 ]

--- a/src/liger_kernel/transformers/functional.py
+++ b/src/liger_kernel/transformers/functional.py
@@ -1,3 +1,5 @@
+import math
+
 from dataclasses import dataclass
 from typing import Optional
 
@@ -29,6 +31,8 @@ from liger_kernel.ops import LigerSiLUMulFunction
 from liger_kernel.ops import LigerSoftmaxFunction
 from liger_kernel.ops import LigerSparsemaxFunction
 from liger_kernel.ops import LigerTVDLossFunction
+from liger_kernel.transformers.native_sparse_attention import native_sparse_attention
+from liger_kernel.transformers.native_sparse_attention import native_sparse_attention_kernel
 
 
 @dataclass
@@ -262,6 +266,80 @@ def liger_fused_neighborhood_attention(
         Output tensor of shape [batch_size, num_heads, seq_len, head_dim]
     """
     return LigerFusedNeighborhoodAttentionFunction.apply(query, key, value, kernel_size, dilation, scale)
+
+
+def liger_native_sparse_attention(
+    q,
+    k,
+    v,
+    gate,
+    k_cmp,
+    v_cmp,
+    *,
+    num_kv_heads: int,
+    compress_block_size: int = 32,
+    compress_stride: int = 16,
+    selection_block_size: int = 64,
+    num_selected_blocks: int = 16,
+    init_blocks: int = 1,
+    local_blocks: int = 2,
+    window_size: int = 512,
+    scale: float = None,
+    use_kernel: bool = None,
+):
+    """
+    Liger Native Sparse Attention (three gated branches: compression, selection, sliding window).
+
+    paper: https://arxiv.org/abs/2502.11089
+
+    Args:
+        q: Query tensor of shape [batch_size, num_query_heads, seq_len, head_dim]
+        k: Key tensor of shape [batch_size, num_kv_heads, seq_len, head_dim]
+        v: Value tensor of shape [batch_size, num_kv_heads, seq_len, head_dim]
+        gate: Per-head branch gates of shape [batch_size, num_query_heads, seq_len, 3] in [0, 1]
+        k_cmp: Compressed keys of shape [batch_size, num_kv_heads, num_compressed_blocks, head_dim]
+        v_cmp: Compressed values of shape [batch_size, num_kv_heads, num_compressed_blocks, head_dim]
+        num_kv_heads: Number of key/value heads (GQA); must divide num_query_heads.
+        compress_block_size: Compression block length l (default: 32)
+        compress_stride: Compression sliding stride d (default: 16)
+        selection_block_size: Selection block size l' (default: 64)
+        num_selected_blocks: Number of selected blocks n incl. forced (default: 16)
+        init_blocks: Leading blocks always selected (default: 1)
+        local_blocks: Trailing local blocks always selected (default: 2)
+        window_size: Sliding window size w (default: 512)
+        scale: Scaling factor for attention scores (default: 1 / sqrt(head_dim))
+        use_kernel: True forces the Triton kernels, False the pure-torch reference,
+            None (default) auto-selects — kernels on a non-CPU device, torch on CPU.
+
+    Returns:
+        Output tensor of shape [batch_size, num_query_heads, seq_len, head_dim]
+    """
+    if scale is None:
+        scale = 1.0 / math.sqrt(q.shape[-1])
+    if use_kernel is None:
+        use_kernel = (
+            q.device.type != "cpu"
+            and q.dtype in (torch.float16, torch.bfloat16, torch.float32)
+            and selection_block_size % 16 == 0
+        )
+    combine = native_sparse_attention_kernel if use_kernel else native_sparse_attention
+    return combine(
+        q,
+        k,
+        v,
+        gate,
+        k_cmp,
+        v_cmp,
+        num_kv_heads=num_kv_heads,
+        compress_block_size=compress_block_size,
+        compress_stride=compress_stride,
+        selection_block_size=selection_block_size,
+        num_selected_blocks=num_selected_blocks,
+        init_blocks=init_blocks,
+        local_blocks=local_blocks,
+        window_size=window_size,
+        scale=scale,
+    )
 
 
 def liger_tvd(

--- a/src/liger_kernel/transformers/native_sparse_attention.py
+++ b/src/liger_kernel/transformers/native_sparse_attention.py
@@ -1,0 +1,599 @@
+"""
+Native Sparse Attention (NSA).
+
+Reference: Yuan et al., "Native Sparse Attention: Hardware-Aligned and Natively
+Trainable Sparse Attention", https://arxiv.org/abs/2502.11089
+
+This module provides a pure-PyTorch, fully-differentiable reference implementation
+of NSA. It is the exactness oracle that the Triton kernels (added in follow-up
+work) are validated against; every branch is exposed as a standalone function so
+each can later be swapped for a fused kernel independently.
+
+The structure (compression -> compressed-attention scoring -> top-n block
+selection -> selected block-sparse attention -> sliding window -> gated combine)
+follows the paper and is informed by the public reference implementations
+XunhaoLai/native-sparse-attention-triton (Apache-2.0) and
+lucidrains/native-sparse-attention-pytorch (MIT). No code is copied verbatim.
+
+Scope: the trainable, parallel (training / prefill) path over dense
+``[batch, heads, seq_len, head_dim]`` tensors. NSA is defined for grouped-query
+attention (GQA); all query heads in a KV group share one block selection, which
+is what makes the sparse-attention kernel hardware-aligned. The autoregressive
+decode path and variable-length (``cu_seqlens``) inputs are out of scope here.
+"""
+
+import math
+
+import torch
+import torch.nn as nn
+
+
+def _accum_dtype(dtype: torch.dtype) -> torch.dtype:
+    """Score/softmax accumulation dtype: fp32 for low-precision inputs, fp64 kept as-is."""
+    return dtype if dtype == torch.float64 else torch.float32
+
+
+def _expand_kv_heads(x: torch.Tensor, num_query_heads: int) -> torch.Tensor:
+    """Repeat each KV head to cover its query-head group (GQA).
+
+    x: ``[batch, num_kv_heads, seq_len, dim]`` -> ``[batch, num_query_heads, seq_len, dim]``.
+    Query head ``h`` uses KV head ``h // group`` where ``group = num_query_heads // num_kv_heads``.
+    """
+    num_kv_heads = x.shape[1]
+    if num_kv_heads == num_query_heads:
+        return x
+    group = num_query_heads // num_kv_heads
+    return x.repeat_interleave(group, dim=1)
+
+
+def _masked_softmax(scores: torch.Tensor, keep_mask: torch.Tensor) -> torch.Tensor:
+    """Row-softmax over ``keep_mask==True`` entries; fully-masked rows return all-zero.
+
+    Uses a large finite fill (not ``-inf``) so no row ever produces ``NaN`` in the
+    forward or backward pass, then explicitly zeros rows that had no valid key. For
+    a row with at least one valid key the result is bit-identical to masking with
+    ``-inf`` (the fill underflows to exactly ``0`` after the internal max-subtraction).
+    ``scores`` is expected to already be ``float32``.
+    """
+    keep_mask = keep_mask.expand_as(scores)
+    scores = scores.masked_fill(~keep_mask, torch.finfo(scores.dtype).min)
+    weights = torch.softmax(scores, dim=-1)
+    any_valid = keep_mask.any(dim=-1, keepdim=True)
+    return torch.where(any_valid, weights, torch.zeros_like(weights))
+
+
+def compress_kv(
+    x: torch.Tensor,
+    intra_block_pe: torch.Tensor,
+    mlp: nn.Module,
+    block_size: int,
+    stride: int,
+) -> torch.Tensor:
+    """Compress consecutive blocks of keys/values into block-level representations.
+
+    Implements ``phi(k_{id+1:id+l})`` (paper Eq. 7): each length-``block_size`` window
+    (stride ``stride``) gets a learnable intra-block positional encoding added, is
+    flattened, and is passed through the learnable MLP ``phi`` to a single vector.
+
+    x: ``[batch, heads, seq_len, dim]`` -> ``[batch, heads, num_blocks, dim]`` with
+    ``num_blocks = floor((seq_len - block_size) / stride) + 1`` (0 when ``seq_len < block_size``).
+    """
+    batch, heads, seq_len, dim = x.shape
+    if seq_len < block_size:
+        return x.new_zeros((batch, heads, 0, dim))
+    # windows: [batch, heads, num_blocks, dim, block_size] -> [..., block_size, dim]
+    windows = x.unfold(dimension=2, size=block_size, step=stride).transpose(-1, -2)
+    windows = windows + intra_block_pe  # broadcast [block_size, dim]
+    num_blocks = windows.shape[2]
+    flat = windows.reshape(batch, heads, num_blocks, block_size * dim)
+    return mlp(flat)
+
+
+def compressed_scores(
+    q: torch.Tensor,
+    k_cmp: torch.Tensor,
+    scale: float,
+    block_size: int,
+    stride: int,
+) -> torch.Tensor:
+    """Softmax scores of full queries over compressed keys (paper Eq. 8).
+
+    Returns ``p_cmp`` ``[batch, num_query_heads, seq_len, num_blocks]`` (all-zero
+    rows for queries with no visible block). A compressed block ``j`` spans original
+    positions ``[j*stride, j*stride + block_size - 1]`` and is visible to query ``t``
+    only when it lies fully in the past (``j*stride + block_size - 1 <= t``). Split
+    out from :func:`compressed_attention` so the Triton path can reuse the score
+    matrix (needed for selection routing) without recomputing the softmax.
+    """
+    batch, num_q_heads, seq_len, _ = q.shape
+    num_blocks = k_cmp.shape[2]
+    if num_blocks == 0:
+        return q.new_zeros((batch, num_q_heads, seq_len, 0))
+
+    k_cmp = _expand_kv_heads(k_cmp, num_q_heads)
+
+    # Upcast operands *before* the matmul so a low-precision (e.g. fp16) product
+    # cannot saturate to inf prior to the accumulation cast.
+    acc = _accum_dtype(q.dtype)
+    scores = torch.matmul(q.to(acc), k_cmp.to(acc).transpose(-1, -2)) * scale
+
+    # Causal mask over compressed blocks: block j visible to query t iff its last
+    # covered original position is <= t.
+    device = q.device
+    query_pos = torch.arange(seq_len, device=device).view(seq_len, 1)
+    block_last = torch.arange(num_blocks, device=device).view(1, num_blocks) * stride + (block_size - 1)
+    visible = (block_last <= query_pos).view(1, 1, seq_len, num_blocks)  # [1, 1, seq_len, num_blocks]
+
+    # Early queries (no compressed block visible yet) get an all-zero score row.
+    return _masked_softmax(scores, visible)
+
+
+def compressed_attention(
+    q: torch.Tensor,
+    k_cmp: torch.Tensor,
+    v_cmp: torch.Tensor,
+    scale: float,
+    block_size: int,
+    stride: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Attention of full queries over compressed KV (paper Eq. 8).
+
+    Returns ``(out_cmp, p_cmp)`` where ``out_cmp`` is the compression-branch output
+    ``[batch, num_query_heads, seq_len, dim]`` and ``p_cmp`` is the softmax score
+    matrix ``[batch, num_query_heads, seq_len, num_blocks]`` reused to score
+    selection blocks.
+    """
+    batch, num_q_heads, seq_len, _ = q.shape
+    num_blocks = k_cmp.shape[2]
+    if num_blocks == 0:
+        out = q.new_zeros((batch, num_q_heads, seq_len, v_cmp.shape[-1]))
+        p_cmp = q.new_zeros((batch, num_q_heads, seq_len, 0))
+        return out, p_cmp
+
+    p_cmp = compressed_scores(q, k_cmp, scale, block_size, stride)
+    v_cmp = _expand_kv_heads(v_cmp, num_q_heads)
+    out = torch.matmul(p_cmp.to(v_cmp.dtype), v_cmp)
+    return out, p_cmp
+
+
+def selection_block_scores(
+    p_cmp: torch.Tensor,
+    num_kv_heads: int,
+    compress_block_size: int,
+    compress_stride: int,
+    selection_block_size: int,
+    num_selection_blocks: int,
+) -> torch.Tensor:
+    """Derive per-selection-block importance from compression scores.
+
+    Implements paper Eq. 9 (mapping compression scores to selection blocks when
+    block sizes differ) followed by Eq. 10 (summing importance across the query
+    heads in each GQA group so the whole group selects the same blocks).
+
+    p_cmp: ``[batch, num_query_heads, seq_len, num_cmp_blocks]``
+    returns: ``[batch, num_kv_heads, seq_len, num_selection_blocks]``.
+    """
+    batch, num_q_heads, seq_len, num_cmp = p_cmp.shape
+    lp = selection_block_size // compress_stride  # l' / d
+    lc = compress_block_size // compress_stride  # l / d
+
+    p_slc = p_cmp.new_zeros((batch, num_q_heads, seq_len, num_selection_blocks))
+    if num_cmp > 0:
+        base = torch.arange(num_selection_blocks, device=p_cmp.device) * lp  # [num_selection_blocks]
+        for m in range(lp):
+            for n in range(lc):
+                idx = base + m + n
+                valid = idx < num_cmp
+                gathered = p_cmp[..., idx.clamp(max=num_cmp - 1)]
+                p_slc = p_slc + gathered * valid.to(p_slc.dtype)
+
+    # GQA group reduction (Eq. 10): sum over the query heads sharing each KV head.
+    group = num_q_heads // num_kv_heads
+    p_slc = p_slc.view(batch, num_kv_heads, group, seq_len, num_selection_blocks).sum(dim=2)
+    return p_slc
+
+
+def select_blocks(
+    p_slc: torch.Tensor,
+    selection_block_size: int,
+    topk: int,
+    init_blocks: int,
+    local_blocks: int,
+) -> torch.Tensor:
+    """Top-n block selection with forced initial + local blocks (paper Eq. 11-12).
+
+    p_slc: ``[batch, num_kv_heads, seq_len, num_selection_blocks]`` importance scores.
+    Returns a boolean mask of the same shape marking selected blocks. Future blocks
+    (start position > query position) are never selected; ``init_blocks`` leading
+    blocks and ``local_blocks`` blocks ending at the query's own block are always
+    forced in. Selection is discrete and carries no gradient (hard routing).
+    """
+    batch, num_kv_heads, seq_len, num_blocks = p_slc.shape
+    device = p_slc.device
+
+    block_ids = torch.arange(num_blocks, device=device)
+    query_block = torch.arange(seq_len, device=device) // selection_block_size  # [seq_len]
+
+    # Causal: a block is eligible for query t iff it starts at or before t.
+    causal = block_ids.view(1, num_blocks) <= query_block.view(seq_len, 1)  # [seq_len, num_blocks]
+
+    forced_init = block_ids.view(1, num_blocks) < init_blocks  # [1, num_blocks]
+    local_lo = (query_block - (local_blocks - 1)).clamp(min=0).view(seq_len, 1)
+    local = (block_ids.view(1, num_blocks) >= local_lo) & (
+        block_ids.view(1, num_blocks) <= query_block.view(seq_len, 1)
+    )
+    forced = (forced_init | local) & causal  # [seq_len, num_blocks]
+    forced = forced.view(1, 1, seq_len, num_blocks).expand(batch, num_kv_heads, seq_len, num_blocks)
+
+    # Rank the remaining eligible blocks by importance, forced blocks always win.
+    neg_inf = torch.finfo(p_slc.dtype).min
+    scores = p_slc.masked_fill(~causal.view(1, 1, seq_len, num_blocks), neg_inf)
+    scores = scores.masked_fill(forced, torch.finfo(p_slc.dtype).max)
+
+    k = min(topk, num_blocks)
+    topk_idx = scores.topk(k, dim=-1).indices  # [batch, num_kv_heads, seq_len, k]
+    selected = torch.zeros_like(p_slc, dtype=torch.bool)
+    selected.scatter_(-1, topk_idx, True)
+    # Drop any non-causal blocks that were pulled in by topk padding.
+    selected = selected & causal.view(1, 1, seq_len, num_blocks)
+    return selected
+
+
+def selected_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    selected: torch.Tensor,
+    selection_block_size: int,
+    scale: float,
+) -> torch.Tensor:
+    """Exact causal attention restricted to the selected KV blocks.
+
+    q: ``[batch, num_query_heads, seq_len, dim]``; k/v: full-length
+    ``[batch, num_kv_heads, seq_len, dim]``; selected: block mask from
+    :func:`select_blocks`. Reference builds an explicit key-position mask; the
+    Triton kernel gathers only the selected blocks.
+    """
+    batch, num_q_heads, seq_len, _ = q.shape
+    num_kv_heads = k.shape[1]
+    device = q.device
+
+    # Map each key position to its selection block, then to the per-query mask.
+    key_block = torch.arange(seq_len, device=device) // selection_block_size  # [seq_len]
+    # selected: [batch, num_kv_heads, seq_len(query), num_blocks] -> gather per key pos
+    key_mask = selected[..., key_block]  # [batch, num_kv_heads, seq_len(query), seq_len(key)]
+
+    causal = torch.arange(seq_len, device=device).view(seq_len, 1) >= torch.arange(seq_len, device=device).view(
+        1, seq_len
+    )
+    key_mask = key_mask & causal.view(1, 1, seq_len, seq_len)
+    key_mask = _expand_mask_kv_heads(key_mask, num_q_heads, num_kv_heads)
+
+    return _masked_attention(q, _expand_kv_heads(k, num_q_heads), _expand_kv_heads(v, num_q_heads), key_mask, scale)
+
+
+def sliding_window_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    window_size: int,
+    scale: float,
+) -> torch.Tensor:
+    """Exact causal attention over the last ``window_size`` tokens."""
+    batch, num_q_heads, seq_len, _ = q.shape
+    device = q.device
+    query_pos = torch.arange(seq_len, device=device).view(seq_len, 1)
+    key_pos = torch.arange(seq_len, device=device).view(1, seq_len)
+    mask = (key_pos <= query_pos) & (key_pos > query_pos - window_size)  # [seq_len, seq_len]
+    mask = mask.view(1, 1, seq_len, seq_len)
+    return _masked_attention(q, _expand_kv_heads(k, num_q_heads), _expand_kv_heads(v, num_q_heads), mask, scale)
+
+
+def _expand_mask_kv_heads(mask: torch.Tensor, num_query_heads: int, num_kv_heads: int) -> torch.Tensor:
+    if num_kv_heads == num_query_heads:
+        return mask
+    group = num_query_heads // num_kv_heads
+    return mask.repeat_interleave(group, dim=1)
+
+
+def _masked_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    mask: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Softmax attention with a boolean keep-mask; masked-out rows return zero."""
+    acc = _accum_dtype(q.dtype)
+    scores = torch.matmul(q.to(acc), k.to(acc).transpose(-1, -2)) * scale
+    weights = _masked_softmax(scores, mask)
+    return torch.matmul(weights.to(v.dtype), v)
+
+
+def native_sparse_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    k_cmp: torch.Tensor,
+    v_cmp: torch.Tensor,
+    *,
+    num_kv_heads: int,
+    compress_block_size: int,
+    compress_stride: int,
+    selection_block_size: int,
+    num_selected_blocks: int,
+    init_blocks: int,
+    local_blocks: int,
+    window_size: int,
+    scale: float,
+) -> torch.Tensor:
+    """Combine the three NSA branches with per-head gates (paper Eq. 5).
+
+    q: ``[batch, num_query_heads, seq_len, dim]``; k/v: ``[batch, num_kv_heads, seq_len, dim]``;
+    gate: ``[batch, num_query_heads, seq_len, 3]`` in ``[0, 1]`` (compression, selection, sliding);
+    k_cmp/v_cmp: precomputed compressed KV from :func:`compress_kv`.
+    Returns ``[batch, num_query_heads, seq_len, dim]``.
+    """
+    seq_len = q.shape[2]
+
+    out_cmp, p_cmp = compressed_attention(q, k_cmp, v_cmp, scale, compress_block_size, compress_stride)
+
+    num_selection_blocks = math.ceil(seq_len / selection_block_size)
+    p_slc = selection_block_scores(
+        p_cmp,
+        num_kv_heads,
+        compress_block_size,
+        compress_stride,
+        selection_block_size,
+        num_selection_blocks,
+    )
+    # Block selection is discrete (hard top-n), exactly as in the NSA paper, so no
+    # gradient flows through the choice itself. This is by design, not a limitation:
+    # the block scorer (q, k_cmp, and the compression MLP phi) is still trained,
+    # because those same tensors feed the differentiable compression branch above.
+    selected = select_blocks(
+        p_slc.detach(),
+        selection_block_size,
+        num_selected_blocks,
+        init_blocks,
+        local_blocks,
+    )
+    out_slc = selected_attention(q, k, v, selected, selection_block_size, scale)
+    out_win = sliding_window_attention(q, k, v, window_size, scale)
+
+    g_cmp, g_slc, g_win = gate[..., 0:1], gate[..., 1:2], gate[..., 2:3]
+    return g_cmp * out_cmp + g_slc * out_slc + g_win * out_win
+
+
+def native_sparse_attention_kernel(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    k_cmp: torch.Tensor,
+    v_cmp: torch.Tensor,
+    *,
+    num_kv_heads: int,
+    compress_block_size: int,
+    compress_stride: int,
+    selection_block_size: int,
+    num_selected_blocks: int,
+    init_blocks: int,
+    local_blocks: int,
+    window_size: int,
+    scale: float,
+) -> torch.Tensor:
+    """Triton-kernel-backed NSA combine; numerically matches :func:`native_sparse_attention`.
+
+    The three attention branches run as fused FlashAttention-2 kernels (compressed,
+    selected block-sparse, sliding window); compression ``phi``, the selection scoring
+    and top-n routing, and the gate blend stay in PyTorch (small, and the routing is
+    non-differentiable by design). Same signature and result as the pure-torch combine,
+    which is its correctness oracle. Requires CUDA/ROCm/XPU + Triton.
+    """
+    # Deferred so the pure-torch reference above stays importable without Triton.
+    from liger_kernel.ops.nsa_compressed_attention import nsa_compressed_attention
+    from liger_kernel.ops.nsa_selected_attention import nsa_selected_attention
+    from liger_kernel.ops.nsa_sliding_attention import nsa_sliding_attention
+
+    batch, num_q_heads, seq_len, dim = q.shape
+
+    num_cmp_blocks = k_cmp.shape[2]
+    if num_cmp_blocks > 0:
+        out_cmp = nsa_compressed_attention(q, k_cmp, v_cmp, compress_block_size, compress_stride, scale)
+        p_cmp = compressed_scores(q, k_cmp, scale, compress_block_size, compress_stride)
+    else:
+        out_cmp = torch.zeros_like(q)
+        p_cmp = q.new_zeros((batch, num_q_heads, seq_len, 0))
+
+    num_selection_blocks = math.ceil(seq_len / selection_block_size)
+    p_slc = selection_block_scores(
+        p_cmp,
+        num_kv_heads,
+        compress_block_size,
+        compress_stride,
+        selection_block_size,
+        num_selection_blocks,
+    )
+    selected = select_blocks(
+        p_slc.detach(),
+        selection_block_size,
+        num_selected_blocks,
+        init_blocks,
+        local_blocks,
+    )
+    out_slc = nsa_selected_attention(q, k, v, selected, selection_block_size, scale)
+    out_win = nsa_sliding_attention(q, k, v, window_size, scale)
+
+    g_cmp, g_slc, g_win = gate[..., 0:1], gate[..., 1:2], gate[..., 2:3]
+    return g_cmp * out_cmp + g_slc * out_slc + g_win * out_win
+
+
+class LigerNativeSparseAttention(nn.Module):
+    """Native Sparse Attention (arXiv 2502.11089).
+
+    Applies grouped-query NSA to ``[batch, seq_len, hidden_size]`` inputs: coarse
+    compressed attention, fine top-n block selection, and a sliding window,
+    blended by learned per-head gates.
+
+    On CUDA/ROCm/XPU the three attention branches run as fused FlashAttention-2
+    Triton kernels (:func:`native_sparse_attention_kernel`); on CPU, or when
+    ``use_kernel=False``, it falls back to the pure-PyTorch reference
+    (:func:`native_sparse_attention`) that also serves as the kernels' correctness
+    oracle. Both paths are fully differentiable and numerically equivalent.
+
+    Args:
+        hidden_size: model dimension.
+        num_heads: number of query heads.
+        num_kv_heads: number of key/value heads (GQA); must divide ``num_heads``.
+        head_dim: per-head dimension; defaults to ``hidden_size // num_heads``.
+        compress_block_size: compression block length ``l`` (paper default 32).
+        compress_stride: compression sliding stride ``d`` (paper default 16).
+        selection_block_size: selection block size ``l'`` (paper default 64).
+        num_selected_blocks: number of selected blocks ``n`` incl. forced (paper default 16).
+        init_blocks: leading blocks always selected (paper default 1).
+        local_blocks: trailing local blocks always selected (paper default 2).
+        sliding_window_size: sliding window ``w`` (paper default 512).
+        compress_mlp_hidden_dim: hidden width of the compression MLP ``phi``; defaults
+            to ``4 * head_dim``. ``phi`` maps a flattened ``block_size * head_dim`` window
+            through one hidden layer (GELU) down to ``head_dim`` (paper Eq. 7).
+        bias: whether the q/k/v/o projections use a bias.
+        scale: attention scale; defaults to ``1 / sqrt(head_dim)``.
+        use_kernel: ``True`` forces the Triton kernels, ``False`` forces the
+            pure-torch reference, ``None`` (default) auto-selects — kernels on a
+            non-CPU device, torch on CPU.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int = None,
+        compress_block_size: int = 32,
+        compress_stride: int = 16,
+        selection_block_size: int = 64,
+        num_selected_blocks: int = 16,
+        init_blocks: int = 1,
+        local_blocks: int = 2,
+        sliding_window_size: int = 512,
+        compress_mlp_hidden_dim: int = None,
+        bias: bool = False,
+        scale: float = None,
+        use_kernel: bool = None,
+    ):
+        super().__init__()
+        if num_heads % num_kv_heads != 0:
+            raise ValueError(f"num_heads ({num_heads}) must be divisible by num_kv_heads ({num_kv_heads}).")
+        if compress_block_size % compress_stride != 0:
+            raise ValueError(
+                f"compress_block_size ({compress_block_size}) must be divisible by compress_stride ({compress_stride})."
+            )
+        if selection_block_size % compress_stride != 0:
+            raise ValueError(
+                f"selection_block_size ({selection_block_size}) must be divisible by "
+                f"compress_stride ({compress_stride})."
+            )
+        if num_selected_blocks < init_blocks + local_blocks:
+            raise ValueError(
+                f"num_selected_blocks ({num_selected_blocks}) must be >= "
+                f"init_blocks + local_blocks ({init_blocks + local_blocks})."
+            )
+
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim if head_dim is not None else hidden_size // num_heads
+        self.compress_block_size = compress_block_size
+        self.compress_stride = compress_stride
+        self.selection_block_size = selection_block_size
+        self.num_selected_blocks = num_selected_blocks
+        self.init_blocks = init_blocks
+        self.local_blocks = local_blocks
+        self.sliding_window_size = sliding_window_size
+        self.scale = scale if scale is not None else 1.0 / math.sqrt(self.head_dim)
+        self.use_kernel = use_kernel
+
+        q_out = num_heads * self.head_dim
+        kv_out = num_kv_heads * self.head_dim
+        self.q_proj = nn.Linear(hidden_size, q_out, bias=bias)
+        self.k_proj = nn.Linear(hidden_size, kv_out, bias=bias)
+        self.v_proj = nn.Linear(hidden_size, kv_out, bias=bias)
+        self.o_proj = nn.Linear(q_out, hidden_size, bias=bias)
+
+        # Per-head, per-branch gates (compression, selection, sliding).
+        self.gate_proj = nn.Linear(hidden_size, num_heads * 3, bias=bias)
+
+        # Learnable KV compression phi (paper Eq. 7): intra-block positional encoding
+        # added to each window, then a 2-layer MLP over the flattened block.
+        self.compress_mlp_hidden_dim = (
+            compress_mlp_hidden_dim if compress_mlp_hidden_dim is not None else 4 * self.head_dim
+        )
+        self.k_intra_block_pe = nn.Parameter(torch.zeros(compress_block_size, self.head_dim))
+        self.v_intra_block_pe = nn.Parameter(torch.zeros(compress_block_size, self.head_dim))
+        self.k_compress = self._build_compress_mlp(bias)
+        self.v_compress = self._build_compress_mlp(bias)
+
+    def _build_compress_mlp(self, bias: bool) -> nn.Module:
+        in_dim = self.compress_block_size * self.head_dim
+        return nn.Sequential(
+            nn.Linear(in_dim, self.compress_mlp_hidden_dim, bias=bias),
+            nn.GELU(),
+            nn.Linear(self.compress_mlp_hidden_dim, self.head_dim, bias=bias),
+        )
+
+    def forward(self, hidden_states: torch.Tensor, attention_mask: torch.Tensor = None) -> torch.Tensor:
+        if attention_mask is not None:
+            raise NotImplementedError("LigerNativeSparseAttention does not support attention_mask yet.")
+
+        batch, seq_len, _ = hidden_states.shape
+        q = self.q_proj(hidden_states).view(batch, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.k_proj(hidden_states).view(batch, seq_len, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.v_proj(hidden_states).view(batch, seq_len, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        gate = torch.sigmoid(self.gate_proj(hidden_states)).view(batch, seq_len, self.num_heads, 3).transpose(1, 2)
+
+        k_cmp = compress_kv(k, self.k_intra_block_pe, self.k_compress, self.compress_block_size, self.compress_stride)
+        v_cmp = compress_kv(v, self.v_intra_block_pe, self.v_compress, self.compress_block_size, self.compress_stride)
+
+        if self.use_kernel is None:
+            # Auto: use the Triton kernels on an accelerator when the config is
+            # kernel-compatible (Triton has no fp64; selection blocks tile in 16/32/64).
+            use_kernel = (
+                hidden_states.device.type != "cpu"
+                and hidden_states.dtype in (torch.float16, torch.bfloat16, torch.float32)
+                and self.selection_block_size % 16 == 0
+            )
+        else:
+            use_kernel = self.use_kernel
+        combine = native_sparse_attention_kernel if use_kernel else native_sparse_attention
+        out = combine(
+            q,
+            k,
+            v,
+            gate,
+            k_cmp,
+            v_cmp,
+            num_kv_heads=self.num_kv_heads,
+            compress_block_size=self.compress_block_size,
+            compress_stride=self.compress_stride,
+            selection_block_size=self.selection_block_size,
+            num_selected_blocks=self.num_selected_blocks,
+            init_blocks=self.init_blocks,
+            local_blocks=self.local_blocks,
+            window_size=self.sliding_window_size,
+            scale=self.scale,
+        )
+
+        out = out.transpose(1, 2).contiguous().view(batch, seq_len, self.num_heads * self.head_dim)
+        return self.o_proj(out)
+
+    def extra_repr(self) -> str:
+        return (
+            f"hidden_size={self.hidden_size}, num_heads={self.num_heads}, num_kv_heads={self.num_kv_heads}, "
+            f"head_dim={self.head_dim}, compress_block_size={self.compress_block_size}, "
+            f"compress_stride={self.compress_stride}, selection_block_size={self.selection_block_size}, "
+            f"num_selected_blocks={self.num_selected_blocks}, init_blocks={self.init_blocks}, "
+            f"local_blocks={self.local_blocks}, sliding_window_size={self.sliding_window_size}, "
+            f"compress_mlp_hidden_dim={self.compress_mlp_hidden_dim}, scale={self.scale}"
+        )

--- a/test/transformers/test_native_sparse_attention.py
+++ b/test/transformers/test_native_sparse_attention.py
@@ -1,0 +1,541 @@
+"""Tests for the pure-PyTorch Native Sparse Attention reference (arXiv 2502.11089).
+
+The vectorized implementation in ``liger_kernel.transformers.native_sparse_attention``
+is validated against an independent, deliberately-naive per-token oracle defined
+here (``_naive_nsa``), plus degenerate-case milestones where individual branches
+must reduce to ordinary causal attention.
+"""
+
+import math
+
+import pytest
+import torch
+
+from test.utils import assert_verbose_allclose
+from test.utils import set_seed
+from test.utils import supports_bfloat16
+
+from liger_kernel.transformers.native_sparse_attention import LigerNativeSparseAttention
+from liger_kernel.transformers.native_sparse_attention import native_sparse_attention
+from liger_kernel.transformers.native_sparse_attention import select_blocks
+from liger_kernel.transformers.native_sparse_attention import selected_attention
+from liger_kernel.transformers.native_sparse_attention import sliding_window_attention
+from liger_kernel.utils import infer_device
+
+device = infer_device()
+set_seed()
+
+
+# ---------------------------------------------------------------------------
+# Independent naive oracle (explicit per-token loops)
+# ---------------------------------------------------------------------------
+def _naive_nsa(
+    q,
+    k,
+    v,
+    gate,
+    k_cmp,
+    v_cmp,
+    *,
+    num_kv_heads,
+    compress_block_size,
+    compress_stride,
+    selection_block_size,
+    num_selected_blocks,
+    init_blocks,
+    local_blocks,
+    window_size,
+    scale,
+):
+    batch, num_q_heads, seq_len, dim = q.shape
+    group = num_q_heads // num_kv_heads
+    num_cmp = k_cmp.shape[2]
+    num_sel = math.ceil(seq_len / selection_block_size)
+    lp = selection_block_size // compress_stride
+    lc = compress_block_size // compress_stride
+
+    cdt = torch.float64 if q.dtype == torch.float64 else torch.float32
+    qf, kf, vf = q.to(cdt), k.to(cdt), v.to(cdt)
+    kcf, vcf = k_cmp.to(cdt), v_cmp.to(cdt)
+
+    # Stage 1: compression scores p_cmp and compression-branch output.
+    p_cmp = qf.new_zeros((batch, num_q_heads, seq_len, num_cmp))
+    out_cmp = qf.new_zeros((batch, num_q_heads, seq_len, dim))
+    for b in range(batch):
+        for hq in range(num_q_heads):
+            hkv = hq // group
+            for t in range(seq_len):
+                visible = [j for j in range(num_cmp) if j * compress_stride + compress_block_size - 1 <= t]
+                if not visible:
+                    continue
+                logits = torch.stack([qf[b, hq, t] @ kcf[b, hkv, j] for j in visible]) * scale
+                w = torch.softmax(logits, dim=0)
+                for wi, j in enumerate(visible):
+                    p_cmp[b, hq, t, j] = w[wi]
+                out_cmp[b, hq, t] = sum(w[wi] * vcf[b, hkv, j] for wi, j in enumerate(visible))
+
+    # Stage 2: selection block scores (Eq. 9 + GQA group sum Eq. 10).
+    p_slc = qf.new_zeros((batch, num_kv_heads, seq_len, num_sel))
+    for b in range(batch):
+        for hkv in range(num_kv_heads):
+            for t in range(seq_len):
+                for jj in range(num_sel):
+                    acc = 0.0
+                    for m in range(lp):
+                        for n in range(lc):
+                            idx = lp * jj + m + n
+                            if idx < num_cmp:
+                                acc = acc + sum(p_cmp[b, hkv * group + g, t, idx] for g in range(group))
+                    p_slc[b, hkv, t, jj] = acc
+
+    # Stage 3: block selection (forced init + local, then top-n by importance).
+    selected = torch.zeros((batch, num_kv_heads, seq_len, num_sel), dtype=torch.bool)
+    for b in range(batch):
+        for hkv in range(num_kv_heads):
+            for t in range(seq_len):
+                qblock = t // selection_block_size
+                causal = [jj for jj in range(num_sel) if jj <= qblock]
+                row = p_slc[b, hkv, t].clone()
+                for jj in range(num_sel):
+                    if jj > qblock:
+                        row[jj] = float("-inf")
+                    elif jj < init_blocks or (qblock - (local_blocks - 1) <= jj <= qblock):
+                        row[jj] = float("inf")
+                kk = min(num_selected_blocks, num_sel)
+                top = torch.topk(row, kk).indices.tolist()
+                for jj in top:
+                    if jj in causal:
+                        selected[b, hkv, t, jj] = True
+
+    # Stage 4 + 5: selected and sliding attention.
+    out_slc = qf.new_zeros((batch, num_q_heads, seq_len, dim))
+    out_win = qf.new_zeros((batch, num_q_heads, seq_len, dim))
+    for b in range(batch):
+        for hq in range(num_q_heads):
+            hkv = hq // group
+            for t in range(seq_len):
+                sel_keys = [p for p in range(t + 1) if selected[b, hkv, t, p // selection_block_size]]
+                out_slc[b, hq, t] = _attend(qf[b, hq, t], kf[b, hkv], vf[b, hkv], sel_keys, scale)
+                win_keys = [p for p in range(t + 1) if p > t - window_size]
+                out_win[b, hq, t] = _attend(qf[b, hq, t], kf[b, hkv], vf[b, hkv], win_keys, scale)
+
+    g = gate.to(cdt)
+    out = g[..., 0:1] * out_cmp + g[..., 1:2] * out_slc + g[..., 2:3] * out_win
+    return out.to(q.dtype)
+
+
+def _attend(qt, k, v, key_positions, scale):
+    if not key_positions:
+        return torch.zeros_like(qt)
+    idx = torch.tensor(key_positions, device=qt.device)
+    logits = (k[idx] @ qt) * scale
+    w = torch.softmax(logits, dim=0)
+    return (w.unsqueeze(-1) * v[idx]).sum(dim=0)
+
+
+def _full_causal_attention(q, k, v, scale, num_kv_heads):
+    batch, num_q_heads, seq_len, _ = q.shape
+    group = num_q_heads // num_kv_heads
+    k = k.repeat_interleave(group, dim=1)
+    v = v.repeat_interleave(group, dim=1)
+    scores = torch.matmul(q, k.transpose(-1, -2)).float() * scale
+    causal = torch.arange(seq_len, device=q.device).view(seq_len, 1) >= torch.arange(seq_len, device=q.device).view(
+        1, seq_len
+    )
+    scores = scores.masked_fill(~causal, float("-inf"))
+    return torch.matmul(torch.softmax(scores, dim=-1).to(v.dtype), v)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / config
+# ---------------------------------------------------------------------------
+# (batch, seq_len, num_q_heads, num_kv_heads, head_dim, l, d, l', n, init, local, window)
+_CONFIG = dict(
+    compress_block_size=4,
+    compress_stride=2,
+    selection_block_size=8,
+    num_selected_blocks=4,
+    init_blocks=1,
+    local_blocks=2,
+    window_size=6,
+)
+
+# The module exposes the window as `sliding_window_size`; the core function uses
+# `window_size`. Derive the module kwargs from the single source of truth above.
+_MODULE_CONFIG = {k: v for k, v in _CONFIG.items() if k != "window_size"}
+_MODULE_CONFIG["sliding_window_size"] = _CONFIG["window_size"]
+
+
+def _make_inputs(batch, num_q_heads, num_kv_heads, seq_len, dim, dtype, requires_grad=True):
+    cfg = _CONFIG
+    num_cmp = max(0, (seq_len - cfg["compress_block_size"]) // cfg["compress_stride"] + 1)
+    q = torch.randn(batch, num_q_heads, seq_len, dim, device=device, dtype=dtype)
+    k = torch.randn(batch, num_kv_heads, seq_len, dim, device=device, dtype=dtype)
+    v = torch.randn(batch, num_kv_heads, seq_len, dim, device=device, dtype=dtype)
+    k_cmp = torch.randn(batch, num_kv_heads, num_cmp, dim, device=device, dtype=dtype)
+    v_cmp = torch.randn(batch, num_kv_heads, num_cmp, dim, device=device, dtype=dtype)
+    gate = torch.rand(batch, num_q_heads, seq_len, 3, device=device, dtype=dtype)
+    tensors = [q, k, v, gate, k_cmp, v_cmp]
+    if requires_grad:
+        for t in tensors:
+            t.requires_grad_(True)
+    return tensors
+
+
+def _core(q, k, v, gate, k_cmp, v_cmp, num_kv_heads):
+    return native_sparse_attention(
+        q, k, v, gate, k_cmp, v_cmp, num_kv_heads=num_kv_heads, scale=1.0 / math.sqrt(q.shape[-1]), **_CONFIG
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("num_kv_heads", [1, 2, 4])
+@pytest.mark.parametrize("seq_len", [16, 24, 30])
+@pytest.mark.parametrize(
+    "dtype, atol, rtol",
+    [
+        (torch.float64, 1e-10, 1e-10),
+        (torch.float32, 1e-5, 1e-5),
+        (torch.float16, 5e-2, 5e-2),
+        pytest.param(
+            torch.bfloat16,
+            5e-2,
+            5e-2,
+            marks=pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this device"),
+        ),
+    ],
+)
+def test_core_matches_naive_oracle(num_kv_heads, seq_len, dtype, atol, rtol):
+    """Vectorized `native_sparse_attention` == independent per-token oracle (fwd + bwd)."""
+    set_seed(0)
+    batch, num_q_heads, dim = 2, 4, 16
+    q, k, v, gate, k_cmp, v_cmp = _make_inputs(batch, num_q_heads, num_kv_heads, seq_len, dim, dtype)
+    ref_inputs = [t.detach().clone().requires_grad_(True) for t in (q, k, v, gate, k_cmp, v_cmp)]
+
+    out = _core(q, k, v, gate, k_cmp, v_cmp, num_kv_heads)
+    ref = _naive_nsa(*ref_inputs, num_kv_heads=num_kv_heads, scale=1.0 / math.sqrt(dim), **_CONFIG)
+    assert_verbose_allclose(out, ref, atol=atol, rtol=rtol)
+
+    grad = torch.randn_like(out)
+    out.backward(grad)
+    ref.backward(grad)
+    for a, b in zip((q, k, v, gate, k_cmp, v_cmp), ref_inputs):
+        assert_verbose_allclose(a.grad, b.grad, atol=atol * 10, rtol=rtol * 10)
+
+
+def test_sliding_branch_reduces_to_full_causal():
+    """window_size >= seq_len => sliding branch is exactly full causal attention."""
+    set_seed(1)
+    batch, num_q_heads, num_kv_heads, seq_len, dim = 2, 4, 2, 12, 16
+    q, k, v, _, _, _ = _make_inputs(batch, num_q_heads, num_kv_heads, seq_len, dim, torch.float32, requires_grad=False)
+    scale = 1.0 / math.sqrt(dim)
+    out = sliding_window_attention(q, k, v, window_size=seq_len, scale=scale)
+    ref = _full_causal_attention(q, k, v, scale, num_kv_heads)
+    assert_verbose_allclose(out, ref, atol=1e-5, rtol=1e-5)
+
+
+def test_selected_branch_reduces_to_full_causal_when_all_selected():
+    """All blocks selected => selected branch is exactly full causal attention."""
+    set_seed(2)
+    batch, num_q_heads, num_kv_heads, seq_len, dim = 2, 4, 2, 16, 16
+    q, k, v, _, _, _ = _make_inputs(batch, num_q_heads, num_kv_heads, seq_len, dim, torch.float32, requires_grad=False)
+    num_sel = math.ceil(seq_len / _CONFIG["selection_block_size"])
+    selected = torch.ones(batch, num_kv_heads, seq_len, num_sel, dtype=torch.bool, device=device)
+    scale = 1.0 / math.sqrt(dim)
+    out = selected_attention(q, k, v, selected, _CONFIG["selection_block_size"], scale)
+    ref = _full_causal_attention(q, k, v, scale, num_kv_heads)
+    assert_verbose_allclose(out, ref, atol=1e-5, rtol=1e-5)
+
+
+def test_module_forward_backward():
+    set_seed(3)
+    batch, seq_len, hidden = 2, 24, 64
+    model = LigerNativeSparseAttention(
+        hidden_size=hidden, num_heads=4, num_kv_heads=2, head_dim=16, **_MODULE_CONFIG
+    ).to(device)
+    x = torch.randn(batch, seq_len, hidden, device=device, requires_grad=True)
+    out = model(x)
+    assert out.shape == (batch, seq_len, hidden)
+    assert torch.isfinite(out).all()
+    out.sum().backward()
+    assert x.grad is not None and torch.isfinite(x.grad).all()
+    for name, p in model.named_parameters():
+        assert p.grad is not None, f"no grad for {name}"
+        assert torch.isfinite(p.grad).all(), f"non-finite grad for {name}"
+
+
+def test_module_determinism():
+    set_seed(4)
+    model = LigerNativeSparseAttention(hidden_size=64, num_heads=4, num_kv_heads=2, head_dim=16, **_MODULE_CONFIG).to(
+        device
+    )
+    x = torch.randn(2, 20, 64, device=device)
+    a = model(x)
+    b = model(x)
+    assert torch.equal(a, b)
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        (dict(num_heads=4, num_kv_heads=3), "divisible by num_kv_heads"),
+        (dict(num_heads=4, num_kv_heads=2, compress_block_size=5, compress_stride=2), "compress_block_size"),
+        (dict(num_heads=4, num_kv_heads=2, selection_block_size=7, compress_stride=2), "selection_block_size"),
+        (
+            dict(num_heads=4, num_kv_heads=2, num_selected_blocks=2, init_blocks=1, local_blocks=2),
+            "num_selected_blocks",
+        ),
+    ],
+)
+def test_validation_errors(kwargs, match):
+    base = dict(hidden_size=64, head_dim=16)
+    base.update(kwargs)
+    with pytest.raises(ValueError, match=match):
+        LigerNativeSparseAttention(**base)
+
+
+def test_short_sequence_no_compression():
+    """seq_len < compress_block_size: compression/selection empty, sliding still works."""
+    set_seed(5)
+    model = LigerNativeSparseAttention(hidden_size=64, num_heads=4, num_kv_heads=2, head_dim=16, **_MODULE_CONFIG).to(
+        device
+    )
+    x = torch.randn(1, 3, 64, device=device, requires_grad=True)  # 3 < compress_block_size (4)
+    out = model(x)
+    assert out.shape == (1, 3, 64)
+    assert torch.isfinite(out).all()
+    out.sum().backward()
+    assert torch.isfinite(x.grad).all()
+
+
+def test_select_blocks_exact():
+    """Hand-computed selection mask, independent of the naive oracle's topk convention."""
+    # 1 batch, 1 kv head, 4 query positions, 4 selection blocks (block size 2 => positions 0..7).
+    # Importance favors block 3 for the last query; forced = init block 0 + local (current) block.
+    p_slc = torch.tensor([[[[9.0, 1.0, 2.0, 3.0]]]]).repeat(1, 1, 8, 1)  # [1,1,8,4]
+    selected = select_blocks(p_slc, selection_block_size=2, topk=2, init_blocks=1, local_blocks=1)
+    # query t=0 -> query block 0: only block 0 causal -> {0}
+    assert selected[0, 0, 0].tolist() == [True, False, False, False]
+    # query t=3 -> query block 1: causal blocks {0,1}; forced init {0} + local {1}; topk=2 -> {0,1}
+    assert selected[0, 0, 3].tolist() == [True, True, False, False]
+    # query t=7 -> query block 3: causal {0,1,2,3}; forced init {0}+local {3}; topk=2 fills highest
+    # non-forced by importance among remaining {1,2}: block 2 (2.0) > block 1 (1.0) is NOT added
+    # because topk=2 is already full with forced {0,3}. So exactly {0,3}.
+    assert selected[0, 0, 7].tolist() == [True, False, False, True]
+    # No future blocks ever selected.
+    for t in range(8):
+        qb = t // 2
+        for j in range(4):
+            if j > qb:
+                assert not selected[0, 0, t, j]
+
+
+def test_no_future_leakage():
+    """Perturbing a future token must not change outputs at earlier positions (causality)."""
+    set_seed(6)
+    model = LigerNativeSparseAttention(hidden_size=64, num_heads=4, num_kv_heads=2, head_dim=16, **_MODULE_CONFIG).to(
+        device
+    )
+    x = torch.randn(1, 20, 64, device=device)
+    out_a = model(x)
+    x2 = x.clone()
+    x2[:, 15:, :] += torch.randn_like(x2[:, 15:, :])  # change only positions >= 15
+    out_b = model(x2)
+    assert_verbose_allclose(out_a[:, :15], out_b[:, :15], atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.parametrize("batch, num_q_heads, num_kv_heads", [(1, 1, 1), (1, 4, 1), (3, 4, 4)])
+def test_core_edge_shapes(batch, num_q_heads, num_kv_heads):
+    """Single-head, batch=1, and full-MHA (group=1) all match the oracle."""
+    set_seed(7)
+    seq_len, dim = 20, 16
+    q, k, v, gate, k_cmp, v_cmp = _make_inputs(batch, num_q_heads, num_kv_heads, seq_len, dim, torch.float32)
+    ref_inputs = [t.detach().clone().requires_grad_(True) for t in (q, k, v, gate, k_cmp, v_cmp)]
+    out = _core(q, k, v, gate, k_cmp, v_cmp, num_kv_heads)
+    ref = _naive_nsa(*ref_inputs, num_kv_heads=num_kv_heads, scale=1.0 / math.sqrt(dim), **_CONFIG)
+    assert_verbose_allclose(out, ref, atol=1e-5, rtol=1e-5)
+
+
+def test_core_no_forced_blocks():
+    """init_blocks=0, local_blocks=0 exercises the pure top-k selection regime."""
+    set_seed(8)
+    dim = 16
+    alt = dict(_CONFIG, init_blocks=0, local_blocks=0)
+    q, k, v, gate, k_cmp, v_cmp = _make_inputs(2, 4, 2, 24, dim, torch.float32)
+    ref_inputs = [t.detach().clone().requires_grad_(True) for t in (q, k, v, gate, k_cmp, v_cmp)]
+    out = native_sparse_attention(q, k, v, gate, k_cmp, v_cmp, num_kv_heads=2, scale=1.0 / math.sqrt(dim), **alt)
+    ref = _naive_nsa(*ref_inputs, num_kv_heads=2, scale=1.0 / math.sqrt(dim), **alt)
+    assert_verbose_allclose(out, ref, atol=1e-5, rtol=1e-5)
+
+
+def test_fp16_no_overflow():
+    """Large head_dim + large activations in fp16 must not saturate to inf pre-softmax."""
+    q = torch.randn(1, 2, 8, 128, device=device, dtype=torch.float16) * 30.0
+    k = torch.randn(1, 2, 8, 128, device=device, dtype=torch.float16) * 30.0
+    v = torch.randn(1, 2, 8, 128, device=device, dtype=torch.float16)
+    out = sliding_window_attention(q, k, v, window_size=4, scale=1.0 / math.sqrt(128))
+    assert torch.isfinite(out.float()).all()
+
+
+def test_compression_mlp_is_trained():
+    """The compression scorer (phi MLP + intra-block PE) must receive gradient even
+    though block selection is non-differentiable (grad flows via the compression branch)."""
+    set_seed(9)
+    model = LigerNativeSparseAttention(hidden_size=64, num_heads=4, num_kv_heads=2, head_dim=16, **_MODULE_CONFIG).to(
+        device
+    )
+    x = torch.randn(2, 24, 64, device=device)
+    model(x).sum().backward()
+    for name in ["k_compress.0.weight", "k_compress.2.weight", "v_compress.0.weight", "k_intra_block_pe"]:
+        p = dict(model.named_parameters())[name]
+        assert p.grad is not None and p.grad.abs().sum() > 0, f"{name} received no gradient"
+
+
+# ---------------------------------------------------------------------------
+# Triton kernel path (validated against the pure-torch reference above)
+# ---------------------------------------------------------------------------
+_needs_accel = pytest.mark.skipif(device == "cpu", reason="Triton NSA kernels require an accelerator")
+
+# Kernel-valid config: selection blocks tile in 16/32/64, head_dim padded to a pow2.
+_KERNEL_CONFIG = dict(
+    compress_block_size=32,
+    compress_stride=16,
+    selection_block_size=64,
+    num_selected_blocks=6,
+    init_blocks=1,
+    local_blocks=2,
+    window_size=48,
+)
+
+
+@_needs_accel
+@pytest.mark.parametrize(
+    "dtype, atol, rtol",
+    [
+        (torch.float32, 1e-3, 1e-3),
+        pytest.param(
+            torch.bfloat16,
+            8e-2,
+            8e-2,
+            marks=pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this device"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("num_kv_heads", [1, 2, 4])
+@pytest.mark.parametrize("seq_len", [64, 130])
+def test_kernel_branches_match_reference(dtype, atol, rtol, num_kv_heads, seq_len):
+    """Each Triton branch kernel == its pure-torch oracle branch (fwd + bwd)."""
+    from liger_kernel.ops.nsa_compressed_attention import nsa_compressed_attention
+    from liger_kernel.ops.nsa_selected_attention import nsa_selected_attention
+    from liger_kernel.ops.nsa_sliding_attention import nsa_sliding_attention
+    from liger_kernel.transformers.native_sparse_attention import compressed_attention
+    from liger_kernel.transformers.native_sparse_attention import selection_block_scores
+
+    set_seed(20)
+    batch, num_q_heads, dim = 2, 4, 32
+    cfg = _KERNEL_CONFIG
+    scale = 1.0 / math.sqrt(dim)
+    num_cmp = max(0, (seq_len - cfg["compress_block_size"]) // cfg["compress_stride"] + 1)
+    num_sel = math.ceil(seq_len / cfg["selection_block_size"])
+
+    def mk(shape):
+        return torch.randn(*shape, device=device, dtype=dtype)
+
+    q = mk((batch, num_q_heads, seq_len, dim))
+    k = mk((batch, num_kv_heads, seq_len, dim))
+    v = mk((batch, num_kv_heads, seq_len, dim))
+    k_cmp = mk((batch, num_kv_heads, num_cmp, dim))
+    v_cmp = mk((batch, num_kv_heads, num_cmp, dim))
+
+    # selection mask from the (torch) scorer so kernel & oracle see the same routing
+    p_cmp = compressed_attention(q, k_cmp, v_cmp, scale, cfg["compress_block_size"], cfg["compress_stride"])[1]
+    p_slc = selection_block_scores(
+        p_cmp, num_kv_heads, cfg["compress_block_size"], cfg["compress_stride"], cfg["selection_block_size"], num_sel
+    )
+    selected = select_blocks(
+        p_slc, cfg["selection_block_size"], cfg["num_selected_blocks"], cfg["init_blocks"], cfg["local_blocks"]
+    )
+
+    from liger_kernel.transformers.native_sparse_attention import selected_attention as sel_ref
+    from liger_kernel.transformers.native_sparse_attention import sliding_window_attention as win_ref
+
+    cases = [
+        (
+            lambda a, b, c: nsa_compressed_attention(
+                a, b, c, cfg["compress_block_size"], cfg["compress_stride"], scale
+            ),
+            lambda a, b, c: compressed_attention(a, b, c, scale, cfg["compress_block_size"], cfg["compress_stride"])[0],
+            (q, k_cmp, v_cmp),
+        ),
+        (
+            lambda a, b, c: nsa_selected_attention(a, b, c, selected, cfg["selection_block_size"], scale),
+            lambda a, b, c: sel_ref(a, b, c, selected, cfg["selection_block_size"], scale),
+            (q, k, v),
+        ),
+        (
+            lambda a, b, c: nsa_sliding_attention(a, b, c, cfg["window_size"], scale),
+            lambda a, b, c: win_ref(a, b, c, cfg["window_size"], scale),
+            (q, k, v),
+        ),
+    ]
+    for kern_fn, ref_fn, inputs in cases:
+        ka = [t.detach().clone().requires_grad_(True) for t in inputs]
+        ra = [t.detach().clone().requires_grad_(True) for t in inputs]
+        ko = kern_fn(*ka)
+        ro = ref_fn(*ra)
+        assert_verbose_allclose(ko, ro, atol=atol, rtol=rtol)
+        g = torch.randn_like(ko)
+        ko.backward(g)
+        ro.backward(g)
+        for a, b in zip(ka, ra):
+            assert_verbose_allclose(a.grad, b.grad, atol=atol * 5, rtol=rtol * 5)
+
+
+@_needs_accel
+@pytest.mark.parametrize(
+    "dtype, otol, gtol",
+    [
+        (torch.float32, 2e-3, 5e-3),
+        pytest.param(
+            torch.bfloat16,
+            8e-2,
+            2e-1,
+            marks=pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this device"),
+        ),
+    ],
+)
+def test_kernel_module_matches_reference(dtype, otol, gtol):
+    """Full module: kernel path == torch reference path (fwd output + every param grad)."""
+    set_seed(21)
+    batch, seq_len, hidden = 2, 130, 128
+    model = (
+        LigerNativeSparseAttention(hidden_size=hidden, num_heads=4, num_kv_heads=2, head_dim=32, **_kernel_module_cfg())
+        .to(device)
+        .to(dtype)
+    )
+    x = torch.randn(batch, seq_len, hidden, device=device, dtype=dtype)
+    gout = torch.randn_like(x)
+
+    def run(use_kernel):
+        model.use_kernel = use_kernel
+        for p in model.parameters():
+            p.grad = None
+        xi = x.clone().requires_grad_(True)
+        out = model(xi)
+        out.backward(gout)
+        return out.detach(), xi.grad.detach(), {n: p.grad.detach().clone() for n, p in model.named_parameters()}
+
+    ok, gxk, gk = run(True)
+    ot, gxt, gt = run(False)
+    assert_verbose_allclose(ok, ot, atol=otol, rtol=otol)
+    assert_verbose_allclose(gxk, gxt, atol=gtol, rtol=gtol)
+    for name in gk:
+        assert_verbose_allclose(gk[name], gt[name], atol=gtol, rtol=gtol)
+
+
+def _kernel_module_cfg():
+    cfg = {k: v for k, v in _KERNEL_CONFIG.items() if k != "window_size"}
+    cfg["sliding_window_size"] = _KERNEL_CONFIG["window_size"]
+    return cfg


### PR DESCRIPTION
## Summary

Adds Native Sparse Attention (NSA, [arXiv:2502.11089](https://arxiv.org/abs/2502.11089)) as a
Triton-kernel-backed module. Closes #656.

NSA is a natively-trainable sparse attention mechanism built for grouped-query attention. Every
query attends through three gated branches:

- **compression** — coarse attention over learned block-level KV summaries,
- **selection** — fine attention over the top-`n` KV blocks chosen per query (the sparse core),
- **sliding window** — recent-token attention,

blended by learned per-head gates. All query heads in a KV group share one block selection, which
is what keeps the sparse kernel hardware-aligned.

This PR provides:

- `LigerNativeSparseAttention` (`nn.Module`) and a functional entry point `liger_native_sparse_attention`,
- three FlashAttention-2 Triton kernels (forward + backward) for the compression, selection, and
  sliding-window branches, in `ops/nsa_{compressed,selected,sliding}_attention.py`,
- a pure-PyTorch reference of the full mechanism used as the correctness oracle and as the CPU / fp64
  fallback,
- unit tests and a sequence-length benchmark against dense causal attention.

## Details

**What is kernelized, and what is not.** The three attention branches carry the O(S²) cost, so they
run as fused kernels. Compression φ (a small MLP over strided KV blocks), the selection scoring
(Eq. 9/10) and top-`n` routing (Eq. 11/12), and the gate blend stay in PyTorch — they are cheap and
the routing is non-differentiable by design (discrete block selection carries no gradient; the block
scorer is still trained through the differentiable compression branch). The module dispatches the
attention branches to the kernels on an accelerator and to the reference on CPU; both paths are
numerically equivalent and fully differentiable. `use_kernel=True/False/None` overrides or auto-selects.

**Backward.** Each kernel uses the standard FlashAttention-2 recompute-from-LSE backward, split into
a query-parallel dQ kernel and a KV-parallel dK/dV kernel. Because block selection is a fixed boolean
mask (no gradient), dK/dV can be accumulated with a single deterministic write per tile — there are no
`atomic_add` calls anywhere, so the backward is bit-for-bit reproducible.

**Portability.** The kernels follow the conventions already used across `ops/`: fp32 dot accumulators,
head dim padded to a power of two for the MMA, `exp2`/`log2` via the libdevice import ladder, int64
offset arithmetic, no bf16/fp16 atomics, and warp counts capped for HIP. fp32 dots use
`input_precision="ieee"` so the fp32 path matches the reference tightly rather than silently dropping
to TF32 (this does not affect the fp16/bf16 paths, which use native tensor cores).

**Scope.** This is the parallel training / prefill path over dense
`[batch, heads, seq_len, head_dim]` tensors, with `Dk == Dv`. Autoregressive decode and variable-length
(`cu_seqlens`) inputs are out of scope here. The reference implementations
[XunhaoLai/native-sparse-attention-triton](https://github.com/XunhaoLai/native-sparse-attention-triton)
(Apache-2.0) and [fla-org/native-sparse-attention](https://github.com/fla-org/native-sparse-attention)
(MIT) were consulted for the kernel structure; no code was copied.

Candidate follow-ups (kept out of this PR to keep it reviewable): group-centric KV reuse in the
selected kernel, a fused online top-k to avoid materializing the compression score matrix, a Triton
compression φ, and `Dk != Dv` support.

## Testing Done

67 unit tests in `test/transformers/test_native_sparse_attention.py`:

- The vectorized reference is checked against an independent, per-token naive oracle (forward and
  backward) across fp64/fp32/fp16/bf16, GQA groups 1/2/4, several sequence lengths, and edge shapes;
  plus degenerate-case milestones (a branch reduces to ordinary causal attention), exact hand-computed
  block selection, no-future-leakage (causality), and empty-compression short sequences.
- Each Triton branch kernel is checked against its reference branch (forward and backward), and the
  full module's kernel path is checked against its torch path on the output and on every parameter
  gradient. fp32 matches to ~1e-3 on gradients; fp16/bf16 within the usual low-precision tolerances.
  The backward is asserted bit-identical across repeated runs.

Benchmark (`benchmark/scripts/benchmark_native_sparse_attention.py`), bf16, hidden 1024, GQA-4,
`l=32, d=16, l'=64, n=16, w=512`, full forward+backward, vs dense causal attention:

| seq_len | dense (ms) | NSA (ms) | speedup | dense (MB) | NSA (MB) | mem ratio |
|--------:|-----------:|---------:|--------:|-----------:|---------:|----------:|
| 512     | 1.81       | 9.81     | 0.18×   | 107        | 55       | 1.97×     |
| 1024    | 9.47       | 7.95     | 1.19×   | 333        | 81       | 4.14×     |
| 2048    | 35.65      | 7.57     | 4.71×   | 1218       | 151      | 8.07×     |
| 4096    | 140.72     | 24.60    | 5.72×   | 4722       | 440      | 10.72×    |

Speed crosses over around 1k tokens and grows to ~5.7× at 4k; memory is lower at every length (up to
~10.7×), and dense runs out of memory past 4k on this device. The short-sequence slowdown is expected:
at small `S` the fixed routing overhead dominates and `w >= S` means the window branch is still full
attent (Plots attached.)

<img width="1000" height="600" alt="native_sparse_attention_memory_full_token_length" src="https://github.com/user-attachments/assets/cb0fe2c9-990c-48bd-a95e-a374d479cacd" />
ion. 

<img width="1000" height="600" alt="native_sparse_attention_speed_full_token_length" src="https://github.com/user-attachments/assets/613e03b5-5d99-4603-83e3-1e83fcde2d45" />

- Hardware Type: RTX 4060 Laptop GPU (8 GB), CUDA 12.6, Triton 3.x
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` — not applicable; this is a standalone attention module, not a
  drop-in replacement for a modeled layer's forward, so there is no convergence target to compare.
