### PR TITLE
Fix ZeroDivisionError in fused linear cross entropy when weight vocab dim is 0

### DIFF
--- a/src/liger_kernel/ops/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_cross_entropy.py
@@ -54,6 +54,12 @@ def fused_linear_cross_entropy_forward(
     # for ex: BT = 4096*4, V = 32000, H = 4096 ==> inc_factor = 8, chunk_size = 2048
     BT, H = _input.shape
     V = weight.shape[0]
+    assert V > 0, (
+        f"weight must have a non-empty vocab dimension, got weight.shape={tuple(weight.shape)}. "
+        "This usually means the weight tensor has not been materialized yet, e.g. when using "
+        "DeepSpeed ZeRO-3 and the parameter is accessed directly instead of through the module "
+        "forward (which triggers the all-gather). Gather the parameter before calling this function."
+    )
     BLOCK_SIZE = min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
 
     inc_factor = triton.cdiv(V, H)  # (V + H - 1) // H

--- a/test/transformers/test_fused_linear_cross_entropy.py
+++ b/test/transformers/test_fused_linear_cross_entropy.py
@@ -8,6 +8,7 @@ from test.utils import assert_verbose_allclose
 from test.utils import set_seed
 
 from liger_kernel.ops import LigerFusedLinearCrossEntropyFunction
+from liger_kernel.ops.fused_linear_cross_entropy import fused_linear_cross_entropy_forward
 from liger_kernel.transformers.functional import CrossEntropyOutput
 from liger_kernel.transformers.functional import liger_fused_linear_cross_entropy
 from liger_kernel.transformers.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyLoss
@@ -1022,3 +1023,22 @@ def test_correctness_with_predicted_tokens(B, T, H, V, reduction, dtype, bias, i
     # Verify backward still works
     result.loss.backward()
     assert _input.grad is not None
+
+
+def test_empty_weight_raises_clear_error():
+    """
+    Regression test for https://github.com/linkedin/Liger-Kernel/issues/767
+
+    When `weight` has a vocab dimension of 0 (e.g. accessing a DeepSpeed ZeRO-3
+    partitioned parameter directly, before it has been gathered), the chunking
+    math used to divide by `inc_factor = cdiv(V, H)`, which is 0 when V is 0.
+    This raised a cryptic `ZeroDivisionError` deep inside triton. We now raise a
+    clear, actionable error instead.
+    """
+    H = 16
+    weight = torch.randn(0, H)
+    _input = torch.randn(4, H, requires_grad=True)
+    target = torch.randint(0, 10, (4,))
+
+    with pytest.raises(AssertionError, match="non-empty vocab dimension"):
+        fused_linear_cross_entropy_forward(_input, weight, target)


### PR DESCRIPTION
Fixes #767

## Bug

`fused_linear_cross_entropy_forward` computes:

```python
V = weight.shape[0]
inc_factor = triton.cdiv(V, H)
chunk_size = triton.next_power_of_2(triton.cdiv(BT, inc_factor))
```

If `weight` has a vocab dimension of 0, `inc_factor` becomes 0 and the next `triton.cdiv` call divides by zero, raising a bare `ZeroDivisionError` from deep inside triton with no indication of what actually went wrong.

## Root cause

This happens when `weight` is not actually materialized yet when it reaches the kernel. In the reported case, the user was training under DeepSpeed ZeRO-3 with parameter offload, and `model.lm_head.weight` was an empty tensor at the point the Liger loss function accessed it directly (the raw parameter, not through the module forward that normally triggers the all-gather hook). Same class of bug would show up for any other reason `weight` ends up empty.

## Fix

Added an assertion right after `V` is computed that fails with a clear message pointing at the likely cause (unmaterialized weight, e.g. ZeRO-3 parameter accessed before it's gathered), instead of letting execution fall through to a cryptic ZeroDivisionError three calls deep in triton internals.

## Testing

Added `test_empty_weight_raises_clear_error` in `test/transformers/test_fused_linear_cross_entropy.py`. It calls `fused_linear_cross_entropy_forward` directly with a `weight` tensor of shape `(0, H)` and checks the new assertion fires with the expected message.

I confirmed this reproduces the exact bug from the issue: reverting just the source change and running the test gives:

```
src\liger_kernel\ops\fused_linear_cross_entropy.py:60: in fused_linear_cross_entropy_forward
    chunk_size = triton.next_power_of_2(triton.cdiv(BT, inc_factor))
...
ZeroDivisionError: integer division or modulo by zero
```

With the fix applied:

```
test/transformers/test_fused_linear_cross_entropy.py::test_empty_weight_raises_clear_error PASSED
```

Also ran `ruff check` and `ruff format --check` on both changed files, both clean. Full test file collection (138 tests) still succeeds with no import errors.

Note: my dev box doesn't have the CUDA toolkit/MSVC set up for compiling triton kernels, so I could not run the full GPU correctness/convergence suite. The new test and the guard itself run entirely on the host before any kernel is launched, so this was verified directly.