### PR TITLE
docs: sync README triton floor with setup.py and fix contributing install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ y = orpo_loss(lm_head.weight, x, target)
 #### CUDA
 
 - `torch >= 2.1.2`
-- `triton >= 2.3.0`
+- `triton >= 2.3.1`
 
 #### ROCm
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,7 +18,7 @@ cd Liger-Kernel
 ```
 2. **Install Dependencies and Editable Package**
 ```
-pip install . -e[dev]
+pip install -e ".[dev]"
 ```
 If encounter error `no matches found: .[dev]`, please use
 ```


### PR DESCRIPTION
## Summary

Two small documentation accuracy fixes:

1. **README CUDA requirements** said `triton >= 2.3.0`, but `setup.py` resolves `triton>=2.3.1` — issue #682 shows a user hitting exactly this confusion. Updated the README to `>= 2.3.1` so both sources agree.
2. **docs/contributing.md step 2** had `pip install . -e[dev]`, which isn't valid pip syntax (the guide even carries a workaround note for the error it causes). Replaced with `pip install -e ".[dev]"`, matching AGENTS.md and the README.

## Testing Done

Doc-only change. Verified `setup.py` line 17 (`triton>=2.3.1`) and that `pip install -e ".[dev]"` is the form AGENTS.md uses.

- Hardware Type: n/a (docs)
- [x] run `make test` to ensure correctness — n/a, docs only
- [x] run `make checkstyle` to ensure code style — n/a, docs only
- [x] run `make test-convergence` to ensure convergence — n/a, docs only

---

For transparency (per AGENTS.md's AI-assistant support): I used AI assistance to spot and draft this; I verified both lines against setup.py and issue #682 myself.
