### PR TITLE
feat: Add accum dtype support to fused linear JSD

### DIFF
--- a/src/liger_kernel/ops/fused_linear_jsd.py
+++ b/src/liger_kernel/ops/fused_linear_jsd.py
@@ -3,6 +3,8 @@ from typing import Optional
 import torch
 import triton
 
+from packaging.version import Version
+
 from liger_kernel.ops.jsd import _jsd_kernel
 from liger_kernel.ops.utils import amp_custom_bwd
 from liger_kernel.ops.utils import amp_custom_fwd
@@ -14,6 +16,8 @@ from liger_kernel.utils import infer_device
 # However, setting limit as 65536 as in LayerNorm tutorial is faster because of less register spilling
 # The optimal maximum block size depends on your hardware, your kernel, and your dtype
 MAX_FUSED_SIZE = 4096 if infer_device() == "xpu" else 65536 // 2
+_TORCH_VERSION = Version(torch.__version__.split("+")[0])
+_ADDMM_SUPPORTS_OUT_DTYPE = _TORCH_VERSION >= Version("2.8.0")
 
 
 def fused_linear_jsd_forward(
@@ -26,6 +30,7 @@ def fused_linear_jsd_forward(
     ignore_index,
     has_label,
     temperature,
+    accum_dtype=None,
 ):
     device = student_input.device
     dtype = student_input.dtype
@@ -45,7 +50,12 @@ def fused_linear_jsd_forward(
     chunk_size = triton.next_power_of_2(triton.cdiv(BT, inc_factor))  # (BT + inc_factor - 1) // inc_factor
     num_chunks = triton.cdiv(BT, chunk_size)  # (BT + chunk_size - 1) // chunk_size
 
-    grad_weight = torch.zeros_like(student_weight, device=device) if student_weight.requires_grad else None
+    if accum_dtype is None:
+        grad_weight = torch.zeros_like(student_weight, device=device) if student_weight.requires_grad else None
+    else:
+        grad_weight = (
+            torch.zeros_like(student_weight, dtype=accum_dtype, device=device) if student_weight.requires_grad else None
+        )
     grad_input = torch.zeros_like(student_input)
     # we use fp32 for loss accumulator
     loss_1d = torch.zeros((BT, V), dtype=torch.float32, device=device)
@@ -116,9 +126,34 @@ def fused_linear_jsd_forward(
         grad_input[start_idx:end_idx] = student_logits_chunk @ student_weight
 
         if grad_weight is not None:
-            grad_weight.add_(student_logits_chunk.t() @ student_input_chunk)
+            if accum_dtype is None:
+                grad_weight.add_(student_logits_chunk.t() @ student_input_chunk)
+            else:
+                grad_logits_t = student_logits_chunk.t()
+                if (
+                    _ADDMM_SUPPORTS_OUT_DTYPE
+                    and grad_weight.device.type == "cuda"
+                    and torch.cuda.get_device_capability(grad_weight.device)[0] >= 8
+                    and grad_weight.dtype == torch.float32
+                    and grad_logits_t.dtype in (torch.float16, torch.bfloat16)
+                ):
+                    input_chunk = student_input_chunk
+                    if input_chunk.dtype != grad_logits_t.dtype:
+                        input_chunk = input_chunk.to(grad_logits_t.dtype)
+                    torch.addmm(
+                        grad_weight,
+                        grad_logits_t,
+                        input_chunk,
+                        out_dtype=torch.float32,
+                        out=grad_weight,
+                    )
+                else:
+                    grad_weight.add_(torch.mm(grad_logits_t, student_input_chunk).float())
 
     loss = torch.sum(loss_1d)
+    grad_weight = (
+        grad_weight.to(student_weight.dtype) if grad_weight is not None and accum_dtype is not None else grad_weight
+    )
     return loss, grad_input, grad_weight
 
 
@@ -178,6 +213,7 @@ class LigerFusedLinearJSDFunction(torch.autograd.Function):
         jsd_beta: float = 0.5,
         ignore_index: int = -100,
         temperature: float = 1.0,
+        accum_dtype: Optional[torch.dtype] = None,
     ):
         """
         Args:
@@ -212,6 +248,7 @@ class LigerFusedLinearJSDFunction(torch.autograd.Function):
             ignore_index,
             has_label,
             temperature,
+            accum_dtype,
         )
         # downcast to dtype and store for backward
         ctx.save_for_backward(
@@ -225,4 +262,4 @@ class LigerFusedLinearJSDFunction(torch.autograd.Function):
     def backward(ctx, grad_output):
         (grad_input, grad_weight) = ctx.saved_tensors
         grad_input, grad_weight = fused_linear_jsd_backward(grad_output, grad_input, grad_weight)
-        return (grad_input, grad_weight, None, None, None, None, None, None)
+        return (grad_input, grad_weight, None, None, None, None, None, None, None)

--- a/src/liger_kernel/transformers/functional.py
+++ b/src/liger_kernel/transformers/functional.py
@@ -130,6 +130,7 @@ def liger_fused_linear_jsd(
     jsd_beta: float = 0.5,
     ignore_index: int = -100,
     temperature: float = 1.0,
+    accum_dtype=None,
 ):
     return LigerFusedLinearJSDFunction.apply(
         student_input,
@@ -140,6 +141,7 @@ def liger_fused_linear_jsd(
         jsd_beta,
         ignore_index,
         temperature,
+        accum_dtype,
     )
 
 

--- a/src/liger_kernel/transformers/fused_linear_jsd.py
+++ b/src/liger_kernel/transformers/fused_linear_jsd.py
@@ -15,6 +15,7 @@ class LigerFusedLinearJSD(torch.nn.Module):
         jsd_beta (float): coefficient beta of generalized JSD in the interval [0, 1]. It implements forward/reverse KL when beta equals 0 and 1 respectively. Default: `0.5`
         ignore_index (int): The index to ignore in the target. Default: `-100`
         temperature (float): temperature in softmax function to control the output probability distribution. Default: `1.0`
+        accum_dtype (torch.dtype): the dtype of intermediate result buffers for weight gradient accumulations. Default: `None`
 
     Shape:
         - student_input: :math:`(BT, H)`, where B is batch size, T is sequence length, H is hidden dimension.
@@ -68,12 +69,19 @@ class LigerFusedLinearJSD(torch.nn.Module):
     ```
     """
 
-    def __init__(self, jsd_beta=0.5, ignore_index=-100, temperature=1.0):
+    def __init__(
+        self,
+        jsd_beta=0.5,
+        ignore_index=-100,
+        temperature=1.0,
+        accum_dtype: Optional[torch.dtype] = None,
+    ):
         super().__init__()
         assert temperature != 0, "temperature cannot be 0."
         self.jsd_beta = jsd_beta
         self.temperature = temperature
         self.ignore_index = ignore_index
+        self.accum_dtype = accum_dtype
 
     def forward(
         self,
@@ -92,4 +100,5 @@ class LigerFusedLinearJSD(torch.nn.Module):
             self.jsd_beta,
             self.ignore_index,
             self.temperature,
+            self.accum_dtype,
         )

--- a/test/transformers/test_fused_linear_jsd.py
+++ b/test/transformers/test_fused_linear_jsd.py
@@ -254,7 +254,8 @@ def test_correctness_with_ignore_index(B, T, H, V, scalar, dtype, beta, ignore_i
     ],
 )
 @pytest.mark.parametrize("temperature, beta, ignore_index", [(1.0, 0.5, -100), (2.0, 0.1, 42)])
-def test_correctness_functional(B, T, H, V, scalar, dtype, beta, ignore_index, temperature, atol, rtol):
+@pytest.mark.parametrize("accum_dtype", [None, torch.float32])
+def test_correctness_functional(B, T, H, V, scalar, dtype, beta, ignore_index, temperature, accum_dtype, atol, rtol):
     # init the linear in all FusedLinearJSDs with the same weights
     _weight = torch.rand(V, H // 2, device=device, dtype=dtype)
     _weight1 = _weight.detach().clone().requires_grad_(True)
@@ -284,6 +285,7 @@ def test_correctness_functional(B, T, H, V, scalar, dtype, beta, ignore_index, t
         jsd_beta=beta,
         ignore_index=ignore_index,
         temperature=temperature,
+        accum_dtype=accum_dtype,
     )
     output2 = LigerFusedLinearJSDFunction.apply(
         _input2,
@@ -294,6 +296,7 @@ def test_correctness_functional(B, T, H, V, scalar, dtype, beta, ignore_index, t
         beta,
         ignore_index,
         temperature,
+        accum_dtype,
     )
 
     assert_verbose_allclose(output1, output2, atol=atol, rtol=rtol)


### PR DESCRIPTION
## Summary

Adds `accum_dtype` support to `LigerFusedLinearJSD`, matching the existing fused linear Cross Entropy accumulation pattern. When `accum_dtype` is provided, the fused JSD path accumulates the student weight gradient in the requested dtype, including the guarded CUDA `torch.addmm(..., out_dtype=torch.float32)` path where supported, then casts the accumulated gradient back to the original weight dtype before returning.

This preserves the existing default behavior when `accum_dtype=None` while allowing callers to opt into higher-precision weight-gradient accumulation for improved numerical stability.

## Testing Done

Validated the modified files with Python bytecode compilation and editor diagnostics:

```bash
python3 -m py_compile \
  fused_linear_jsd.py \
  fused_linear_jsd.py \
  functional.py \
  test_fused_linear_jsd.py
```

Added new unit tests via parameterization for the new functionality.

Will update the checkboxes below as the results come in, then bring out of draft.

- Hardware Type: 8x NVIDIA H100 80GB HBM3
- [x] run `make test` to ensure correctness (Unrelated failures)
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
