### PR TITLE
Add Megatron-Core integration for RoPE

### DIFF
--- a/benchmark/scripts/benchmark_megatron_rope.py
+++ b/benchmark/scripts/benchmark_megatron_rope.py
@@ -1,7 +1,7 @@
 """Benchmark Liger's Megatron-LM RoPE adapter.
 
 Compares three providers on Megatron's per-tensor RoPE call shape
-``[seq, batch, heads, head_dim]`` (sbhd), sweeping the sequence length:
+``[seq, batch, heads, head_dim]`` (SBHD), sweeping the sequence length:
 
   - **torch**: an eager-PyTorch re-implementation of Megatron's
     ``_apply_rotary_pos_emb_bshd`` (the raw reference).

--- a/benchmark/scripts/benchmark_megatron_rope.py
+++ b/benchmark/scripts/benchmark_megatron_rope.py
@@ -1,0 +1,167 @@
+"""Benchmark Liger's Megatron-LM RoPE adapter.
+
+Compares three providers on Megatron's per-tensor RoPE call shape
+``[seq, batch, heads, head_dim]`` (sbhd), sweeping the sequence length:
+
+  - **torch**: an eager-PyTorch re-implementation of Megatron's
+    ``_apply_rotary_pos_emb_bshd`` (the raw reference).
+  - **megatron**: Megatron-Core's own ``_apply_rotary_pos_emb_bshd`` — the
+    symbol Liger's ``apply_rotary_pos_emb`` patch routes around. Structurally
+    identical to ``torch``; included for explicit parity confirmation.
+  - **liger**: ``liger_apply_rotary_pos_emb_bshd`` — Liger's Triton RoPE in the
+    Megatron-shaped wrapper.
+
+Requires a Liger-supported accelerator (CUDA / ROCm). With megatron-core not
+installed, the ``megatron`` provider is silently dropped and the run proceeds
+with ``liger`` + ``torch``.
+
+Output goes to the shared ``benchmark/data/all_benchmark_data.csv`` — rows are
+tagged with ``kernel_name="megatron_rope"`` and the standard visualizer renders
+them via:
+
+    python benchmark/benchmarks_visualizer.py \\
+        --kernel-name megatron_rope --metric-name speed
+    python benchmark/benchmarks_visualizer.py \\
+        --kernel-name megatron_rope --metric-name memory
+"""
+
+import torch
+import triton
+
+from utils import QUANTILES
+from utils import SingleBenchmarkRunInput
+from utils import SingleBenchmarkRunOutput
+from utils import _test_memory
+from utils import parse_benchmark_script_args
+from utils import run_benchmarks
+
+from liger_kernel.megatron import liger_apply_rotary_pos_emb_bshd
+from liger_kernel.utils import infer_device
+
+device = infer_device()
+
+try:
+    from megatron.core.models.common.embeddings.rope_utils import _apply_rotary_pos_emb_bshd
+
+    _MEGATRON_AVAILABLE = True
+except ImportError:
+    _apply_rotary_pos_emb_bshd = None
+    _MEGATRON_AVAILABLE = False
+
+_B = 2
+_HEADS = 32
+_HEAD_DIM = 128
+
+
+def _torch_apply_rotary_pos_emb_bshd(t, freqs):
+    rot_dim = freqs.shape[-1]
+    t_rot, t_pass = t[..., :rot_dim], t[..., rot_dim:]
+    cos_ = torch.cos(freqs).to(t.dtype)
+    sin_ = torch.sin(freqs).to(t.dtype)
+    x1, x2 = torch.chunk(t_rot, 2, dim=-1)
+    rotated = (t_rot * cos_) + (torch.cat((-x2, x1), dim=-1) * sin_)
+    return torch.cat((rotated, t_pass), dim=-1)
+
+
+def _make_inputs(seq_len: int, requires_grad: bool = True):
+    t = torch.randn(seq_len, _B, _HEADS, _HEAD_DIM, device=device, dtype=torch.bfloat16, requires_grad=requires_grad)
+    half = _HEAD_DIM // 2
+    inv_freq = 1.0 / (10000.0 ** (torch.arange(0, half, device=device, dtype=torch.float32) / half))
+    theta = torch.outer(torch.arange(seq_len, device=device, dtype=torch.float32), inv_freq)
+    freqs = torch.cat((theta, theta), dim=-1).reshape(seq_len, 1, 1, _HEAD_DIM)
+    return t, freqs
+
+
+def _fn(provider):
+    if provider == "liger":
+        return liger_apply_rotary_pos_emb_bshd
+    if provider == "torch":
+        return _torch_apply_rotary_pos_emb_bshd
+    if provider == "megatron":
+        if not _MEGATRON_AVAILABLE:
+            raise RuntimeError("megatron-core not installed; cannot benchmark 'megatron' provider")
+        return _apply_rotary_pos_emb_bshd
+    raise ValueError(f"unknown provider: {provider!r}")
+
+
+def bench_speed_megatron_rope(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
+    seq_len = input.x
+    provider = input.kernel_provider
+    mode = input.kernel_operation_mode
+
+    fn = _fn(provider)
+    t, freqs = _make_inputs(seq_len)
+
+    def fwd():
+        return fn(t, freqs)
+
+    if mode == "forward":
+        ms_50, ms_20, ms_80 = triton.testing.do_bench(fwd, rep=100, quantiles=QUANTILES)
+    elif mode == "backward":
+
+        def _fwd_bwd():
+            if t.grad is not None:
+                t.grad = None
+            out = fwd()
+            out.sum().backward()
+
+        ms_50, ms_20, ms_80 = triton.testing.do_bench(_fwd_bwd, rep=100, quantiles=QUANTILES)
+    elif mode == "full":
+
+        def full():
+            y = fwd()
+            y.sum().backward()
+
+        ms_50, ms_20, ms_80 = triton.testing.do_bench(full, rep=100, quantiles=QUANTILES)
+    else:
+        raise ValueError(f"unknown mode: {mode!r}")
+
+    return SingleBenchmarkRunOutput(y_20=ms_20, y_50=ms_50, y_80=ms_80)
+
+
+def bench_memory_megatron_rope(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
+    seq_len = input.x
+    provider = input.kernel_provider
+
+    fn = _fn(provider)
+    t, freqs = _make_inputs(seq_len)
+
+    def full():
+        y = fn(t, freqs)
+        y.sum().backward()
+
+    mem_50, mem_20, mem_80 = _test_memory(full, quantiles=QUANTILES)
+    return SingleBenchmarkRunOutput(y_20=mem_20, y_50=mem_50, y_80=mem_80)
+
+
+if __name__ == "__main__":
+    args = parse_benchmark_script_args()
+
+    providers = ["liger", "torch"]
+    if _MEGATRON_AVAILABLE:
+        providers.append("megatron")
+
+    common_configs = {
+        "kernel_name": "megatron_rope",
+        "x_name": "S",
+        "x_label": "sequence length",
+        "x_values": [2**i for i in range(10, 15)],  # 1024 → 16384
+        "kernel_providers": providers,
+        "extra_benchmark_configs": [{"B": _B, "H": _HEADS, "head_dim": _HEAD_DIM}],
+        "overwrite": args.overwrite,
+    }
+
+    run_benchmarks(
+        bench_test_fn=bench_speed_megatron_rope,
+        kernel_operation_modes=["forward", "backward", "full"],
+        metric_name="speed",
+        metric_unit="ms",
+        **common_configs,
+    )
+    run_benchmarks(
+        bench_test_fn=bench_memory_megatron_rope,
+        kernel_operation_modes=["full"],
+        metric_name="memory",
+        metric_unit="MB",
+        **common_configs,
+    )

--- a/docs/High-Level-APIs.md
+++ b/docs/High-Level-APIs.md
@@ -98,17 +98,17 @@ You can also use the Patching APIs to use the kernels for a specific model archi
 
 Liger also exposes a patch for the [Megatron-LM](https://github.com/NVIDIA/Megatron-LM)
 training framework, replacing Megatron's native RMSNorm and both vocab-parallel
-cross-entropy paths (fused and unfused) with Liger's Triton kernels.
+cross-entropy paths (fused and unfused), and standard unfused RoPE with Liger's
+Triton kernels.
 
-| **Framework** | **API**                                                | **Supported Operations** |
-|---------------|--------------------------------------------------------|--------------------------|
-| Megatron-LM   | `liger_kernel.megatron.apply_liger_kernel_to_megatron` | RMSNorm, CrossEntropyLoss |
+| **Framework** | **API**                                                | **Supported Operations**       |
+|---------------|--------------------------------------------------------|--------------------------------|
+| Megatron-LM   | `liger_kernel.megatron.apply_liger_kernel_to_megatron` | RMSNorm, CrossEntropyLoss, RoPE |
 
-**Scope**: Initial release supports `tensor_model_parallel_size=1` only for
-cross-entropy. Vocab-parallel cross-entropy (TP>1) is follow-up work — with
-TP>1, each rank holds a sharded `[N, V/tp]` logits slice and cross-entropy
-requires cross-rank all-reduces that Liger's kernel does not perform. The
-patch raises a `RuntimeError` at patch time or call time if TP>1 is detected.
+**Scope**: Vocab-parallel cross-entropy supports all tensor-parallel sizes.
+RoPE uses Liger for the standard unfused `bshd` path; fused RoPE, packed `thd`
+sequences, interleaved rotation, multi-latent attention, YaRN scaling, and
+per-batch mRoPE frequencies fall back to Megatron's native implementation.
 
 **Usage**:
 
@@ -117,13 +117,15 @@ from liger_kernel.megatron import apply_liger_kernel_to_megatron
 
 # Call before Megatron's forward pass reaches compute_language_model_loss.
 # Defaults match Megatron's native CE behavior; no CE-specific config needed.
-apply_liger_kernel_to_megatron(rms_norm=True, cross_entropy=True)
+apply_liger_kernel_to_megatron(rms_norm=True, cross_entropy=True, rope=True)
 ```
 
 Both the fused (`config.cross_entropy_loss_fusion=True`,
 `cross_entropy_fusion_impl='native'`) and unfused
 (`config.cross_entropy_loss_fusion=False`) CE paths are patched in a single
 call, so Megatron picks up Liger regardless of which path your config selects.
+The RoPE patch similarly updates Megatron's dispatcher and all already-imported
+copies of it, while preserving native behavior for unsupported RoPE variants.
 
 For training setups that need explicit kernel configuration (custom
 `ignore_index`, `label_smoothing`, etc.), instantiate

--- a/docs/High-Level-APIs.md
+++ b/docs/High-Level-APIs.md
@@ -106,7 +106,7 @@ Triton kernels.
 | Megatron-LM   | `liger_kernel.megatron.apply_liger_kernel_to_megatron` | RMSNorm, CrossEntropyLoss, RoPE |
 
 **Scope**: Vocab-parallel cross-entropy supports all tensor-parallel sizes.
-RoPE uses Liger for the standard unfused `bshd` path; fused RoPE, packed `thd`
+RoPE uses Liger for the standard unfused non-packed path; fused RoPE, packed `thd`
 sequences, interleaved rotation, multi-latent attention, YaRN scaling, and
 per-batch mRoPE frequencies fall back to Megatron's native implementation.
 

--- a/examples/megatron/README.md
+++ b/examples/megatron/README.md
@@ -37,6 +37,28 @@ torchrun --nproc_per_node=2 \
     examples/megatron/run_mode2_hand_spec.py
 ```
 
+## Enabling more kernels
+
+`apply_liger_kernel_to_megatron()` takes one flag per kernel. Combine them in
+a single call before building the model:
+
+```python
+from liger_kernel.megatron import apply_liger_kernel_to_megatron
+
+apply_liger_kernel_to_megatron(
+    rms_norm=True,       # RMSNorm slots (default True)
+    cross_entropy=True,  # both fused + unfused vocab-parallel CE paths
+    rope=True,           # rotary positional embeddings (apply_rotary_pos_emb)
+)
+```
+
+`rope=True` reroutes Megatron's `apply_rotary_pos_emb` dispatcher — including
+the copy `megatron.core.transformer.attention` imported at load time — to
+Liger's Triton RoPE for the standard unfused `bshd` path. Fused (TE/Apex) RoPE,
+packed `thd` sequences, interleaved rotation, multi-latent attention and mRoPE
+transparently fall back to Megatron's native implementation, so enabling it is
+always safe.
+
 ## What you should see
 
 For both scripts:

--- a/examples/megatron/README.md
+++ b/examples/megatron/README.md
@@ -54,7 +54,7 @@ apply_liger_kernel_to_megatron(
 
 `rope=True` reroutes Megatron's `apply_rotary_pos_emb` dispatcher — including
 the copy `megatron.core.transformer.attention` imported at load time — to
-Liger's Triton RoPE for the standard unfused `bshd` path. Fused (TE/Apex) RoPE,
+Liger's Triton RoPE for the standard unfused non-packed path. Fused (TE/Apex) RoPE,
 packed `thd` sequences, interleaved rotation, multi-latent attention and mRoPE
 transparently fall back to Megatron's native implementation, so enabling it is
 always safe.

--- a/src/liger_kernel/megatron/__init__.py
+++ b/src/liger_kernel/megatron/__init__.py
@@ -5,10 +5,13 @@ Public API:
         LayerNormBuilder protocol.
     LigerMegatronCrossEntropy — drop-in for Megatron-LM's vocab-parallel
         cross-entropy (Megatron defaults). Supports all TP sizes.
+    liger_apply_rotary_pos_emb_bshd — Liger drop-in for Megatron-Core's
+        ``_apply_rotary_pos_emb_bshd`` (standard unfused ``bshd`` RoPE path).
     apply_liger_kernel_to_megatron — patches Megatron-Core so existing training
         scripts pick up Liger kernels with one line. Currently supports
-        RMSNorm (via BackendSpecProvider) plus both the fused and unfused
-        vocab-parallel cross-entropy paths.
+        RMSNorm (via BackendSpecProvider), both the fused and unfused
+        vocab-parallel cross-entropy paths, and RoPE (via the
+        ``apply_rotary_pos_emb`` dispatcher).
 
 The general-purpose ``LigerVocabParallelCrossEntropy`` Module lives under
 ``liger_kernel.transformers`` alongside the other nn.Module wrappers; the
@@ -20,9 +23,13 @@ the general-purpose (non-Megatron-default) variant.
 from liger_kernel.megatron.cross_entropy import LigerMegatronCrossEntropy
 from liger_kernel.megatron.monkey_patch import apply_liger_kernel_to_megatron
 from liger_kernel.megatron.rms_norm import LigerMegatronRMSNorm
+from liger_kernel.megatron.rope import LigerMegatronRopeFunction
+from liger_kernel.megatron.rope import liger_apply_rotary_pos_emb_bshd
 
 __all__ = [
     "LigerMegatronCrossEntropy",
     "LigerMegatronRMSNorm",
+    "LigerMegatronRopeFunction",
     "apply_liger_kernel_to_megatron",
+    "liger_apply_rotary_pos_emb_bshd",
 ]

--- a/src/liger_kernel/megatron/__init__.py
+++ b/src/liger_kernel/megatron/__init__.py
@@ -6,7 +6,8 @@ Public API:
     LigerMegatronCrossEntropy — drop-in for Megatron-LM's vocab-parallel
         cross-entropy (Megatron defaults). Supports all TP sizes.
     liger_apply_rotary_pos_emb_bshd — Liger drop-in for Megatron-Core's
-        ``_apply_rotary_pos_emb_bshd`` (standard unfused ``bshd`` RoPE path).
+        ``_apply_rotary_pos_emb_bshd`` (standard unfused non-packed RoPE path;
+        the function name mirrors Megatron's upstream helper).
     apply_liger_kernel_to_megatron — patches Megatron-Core so existing training
         scripts pick up Liger kernels with one line. Currently supports
         RMSNorm (via BackendSpecProvider), both the fused and unfused

--- a/src/liger_kernel/megatron/monkey_patch.py
+++ b/src/liger_kernel/megatron/monkey_patch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +13,7 @@ _PATCH_MARKER = "__liger_patched__"
 def apply_liger_kernel_to_megatron(
     rms_norm: bool = True,
     cross_entropy: bool = False,
+    rope: bool = False,
 ) -> None:
     """Patch Megatron-Core to use Liger Triton kernels.
 
@@ -38,6 +40,15 @@ def apply_liger_kernel_to_megatron(
             wrapper additionally honors a runtime ``label_smoothing``
             argument, matching native's
             ``(logits, target, label_smoothing=0.0, tp_group=None)``.
+        rope: When ``True`` replace
+            ``megatron.core.models.common.embeddings.rope_utils.apply_rotary_pos_emb``
+            (and every module that imported the symbol, e.g.
+            ``megatron.core.transformer.attention``) with Liger's Triton RoPE.
+            Default ``False`` so adopters opt in explicitly. Only the standard
+            unfused ``bshd`` path is routed through Liger; fused (TE/Apex) RoPE,
+            packed ``thd`` sequences, interleaved rotation, multi-latent
+            attention, ``mscale != 1`` and per-batch ``freqs`` transparently
+            fall back to Megatron's native implementation.
 
     Notes:
         Call this BEFORE building your model. Patching after instantiation
@@ -61,6 +72,8 @@ def apply_liger_kernel_to_megatron(
     if cross_entropy:
         _patch_fused_vocab_parallel_cross_entropy()
         _patch_vocab_parallel_cross_entropy()
+    if rope:
+        _patch_apply_rotary_pos_emb()
 
 
 def _patch_local_spec_provider_layer_norm() -> None:
@@ -259,4 +272,84 @@ def _patch_vocab_parallel_cross_entropy() -> None:
 
     logger.info(
         "Patched megatron.core.tensor_parallel.cross_entropy.vocab_parallel_cross_entropy with Liger cross-entropy."
+    )
+
+
+def _patch_apply_rotary_pos_emb() -> None:
+    """Replace ``rope_utils.apply_rotary_pos_emb`` with Liger's Triton RoPE.
+
+    Megatron's RoPE dispatcher lives in
+    ``megatron.core.models.common.embeddings.rope_utils`` but is imported by
+    value into consumer modules (``megatron.core.transformer.attention`` does
+    ``from ...rope_utils import apply_rotary_pos_emb`` at import time). Rebinding
+    only the definition module would therefore miss the copy attention already
+    holds. We rebind the symbol on *every* module whose ``apply_rotary_pos_emb``
+    still points at the original, so all live call sites pick up Liger.
+
+    Only the standard unfused ``bshd`` path is routed through Liger. Fused RoPE,
+    packed ``thd`` sequences, interleaved rotation, multi-latent attention,
+    ``mscale != 1`` and per-batch ``freqs`` delegate to the captured original so
+    numerics never silently change.
+    """
+    try:
+        import megatron.core.models.common.embeddings.rope_utils as rope_utils
+    except ImportError as exc:
+        raise ImportError(
+            "apply_liger_kernel_to_megatron(rope=True) requires megatron-core to be "
+            "installed. Expected symbol path: "
+            "megatron.core.models.common.embeddings.rope_utils.apply_rotary_pos_emb."
+        ) from exc
+
+    if not hasattr(rope_utils, "apply_rotary_pos_emb"):
+        raise ImportError(
+            "megatron.core.models.common.embeddings.rope_utils.apply_rotary_pos_emb not "
+            "found. The symbol path may have changed in your Megatron-LM version. Please file "
+            "an issue on https://github.com/linkedin/Liger-Kernel with your megatron-core version."
+        )
+
+    if getattr(rope_utils.apply_rotary_pos_emb, _PATCH_MARKER, False):
+        return  # already patched
+
+    original = rope_utils.apply_rotary_pos_emb
+
+    from liger_kernel.megatron.rope import liger_apply_rotary_pos_emb_bshd
+
+    def liger_apply_rotary_pos_emb(t, freqs, config, cu_seqlens=None, mscale=1.0, cp_group=None):
+        # Route only the standard unfused bshd path to Liger; everything else
+        # (fused TE/Apex RoPE, packed thd, interleaved, multi-latent attention,
+        # mscale scaling, per-batch/mRoPE freqs) falls back to native so we
+        # never change numerics for configs Liger's kernel does not cover.
+        unsupported = (
+            cu_seqlens is not None
+            or mscale != 1.0
+            or getattr(config, "apply_rope_fusion", False)
+            or getattr(config, "rotary_interleaved", False)
+            or getattr(config, "multi_latent_attention", False)
+            or freqs.shape[1] != 1
+            or freqs.shape[2] != 1
+        )
+        if unsupported:
+            return original(t, freqs, config, cu_seqlens=cu_seqlens, mscale=mscale, cp_group=cp_group)
+        return liger_apply_rotary_pos_emb_bshd(t, freqs)
+
+    setattr(liger_apply_rotary_pos_emb, _PATCH_MARKER, True)
+    setattr(liger_apply_rotary_pos_emb, "__wrapped__", original)
+
+    # Rebind on every module that imported the original symbol by value.
+    patched_modules = []
+    for name, module in list(sys.modules.items()):
+        if module is None:
+            continue
+        if getattr(module, "apply_rotary_pos_emb", None) is original:
+            module.apply_rotary_pos_emb = liger_apply_rotary_pos_emb
+            patched_modules.append(name)
+
+    # Guarantee the definition module is patched even if the scan missed it.
+    if rope_utils.apply_rotary_pos_emb is original:
+        rope_utils.apply_rotary_pos_emb = liger_apply_rotary_pos_emb
+        patched_modules.append(rope_utils.__name__)
+
+    logger.info(
+        "Patched apply_rotary_pos_emb with Liger RoPE on modules: %s.",
+        ", ".join(sorted(set(patched_modules))),
     )

--- a/src/liger_kernel/megatron/monkey_patch.py
+++ b/src/liger_kernel/megatron/monkey_patch.py
@@ -46,7 +46,7 @@ def apply_liger_kernel_to_megatron(
             (and every module that imported the symbol, e.g.
             ``megatron.core.transformer.attention``) with Liger's Triton RoPE.
             Default ``False`` so adopters opt in explicitly. Only the standard
-            unfused ``bshd`` path is routed through Liger; fused (TE/Apex) RoPE,
+            unfused non-packed path is routed through Liger; fused (TE/Apex) RoPE,
             packed ``thd`` sequences, interleaved rotation, multi-latent
             attention, ``mscale != 1`` and per-batch ``freqs`` transparently
             fall back to Megatron's native implementation.
@@ -287,7 +287,7 @@ def _patch_apply_rotary_pos_emb() -> None:
     holds. We rebind the symbol on *every* module whose ``apply_rotary_pos_emb``
     still points at the original, so all live call sites pick up Liger.
 
-    Only the standard unfused ``bshd`` path is routed through Liger. Fused RoPE,
+    Only the standard unfused non-packed path is routed through Liger. Fused RoPE,
     packed ``thd`` sequences, interleaved rotation, multi-latent attention,
     ``mscale != 1`` and per-batch ``freqs`` delegate to the captured original so
     numerics never silently change.
@@ -327,7 +327,7 @@ def _patch_apply_rotary_pos_emb() -> None:
         cp_group=None,
         mla_rotary_interleaved=False,
     ):
-        # Route only the standard unfused bshd path to Liger; everything else
+        # Route only the standard unfused non-packed path to Liger; everything else
         # (fused TE/Apex RoPE, packed thd, interleaved, multi-latent attention,
         # mscale scaling, per-batch/mRoPE freqs) falls back to native so we
         # never change numerics for configs Liger's kernel does not cover.

--- a/src/liger_kernel/megatron/monkey_patch.py
+++ b/src/liger_kernel/megatron/monkey_patch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 import sys
 
@@ -314,7 +315,18 @@ def _patch_apply_rotary_pos_emb() -> None:
 
     from liger_kernel.megatron.rope import liger_apply_rotary_pos_emb_bshd
 
-    def liger_apply_rotary_pos_emb(t, freqs, config, cu_seqlens=None, mscale=1.0, cp_group=None):
+    original_parameters = inspect.signature(original).parameters
+    original_accepts_mla_interleaving = "mla_rotary_interleaved" in original_parameters
+
+    def liger_apply_rotary_pos_emb(
+        t,
+        freqs,
+        config,
+        cu_seqlens=None,
+        mscale=1.0,
+        cp_group=None,
+        mla_rotary_interleaved=False,
+    ):
         # Route only the standard unfused bshd path to Liger; everything else
         # (fused TE/Apex RoPE, packed thd, interleaved, multi-latent attention,
         # mscale scaling, per-batch/mRoPE freqs) falls back to native so we
@@ -324,12 +336,20 @@ def _patch_apply_rotary_pos_emb() -> None:
             or mscale != 1.0
             or getattr(config, "apply_rope_fusion", False)
             or getattr(config, "rotary_interleaved", False)
+            or bool(mla_rotary_interleaved)
             or getattr(config, "multi_latent_attention", False)
             or freqs.shape[1] != 1
             or freqs.shape[2] != 1
         )
         if unsupported:
-            return original(t, freqs, config, cu_seqlens=cu_seqlens, mscale=mscale, cp_group=cp_group)
+            fallback_kwargs = {
+                "cu_seqlens": cu_seqlens,
+                "mscale": mscale,
+                "cp_group": cp_group,
+            }
+            if original_accepts_mla_interleaving:
+                fallback_kwargs["mla_rotary_interleaved"] = mla_rotary_interleaved
+            return original(t, freqs, config, **fallback_kwargs)
         return liger_apply_rotary_pos_emb_bshd(t, freqs)
 
     setattr(liger_apply_rotary_pos_emb, _PATCH_MARKER, True)

--- a/src/liger_kernel/megatron/rope.py
+++ b/src/liger_kernel/megatron/rope.py
@@ -13,13 +13,13 @@ extra work — one head out of typically dozens). The public entry point
 :func:`liger_apply_rotary_pos_emb_bshd` handles the layout / precision
 conversion between Megatron's convention and Liger's:
 
-  * Megatron ``t``     : ``[seq, batch, heads, head_dim]`` (sbhd)
+  * Megatron ``t``     : ``[seq, batch, heads, head_dim]`` (SBHD)
   * Megatron ``freqs`` : ``[seq, 1, 1, rot_dim]`` (already the doubled
     ``cat(freqs, freqs)`` produced by ``RotaryEmbedding``)
-  * Liger ``q``        : ``[batch, heads, seq, head_dim]`` (bshd)
+  * Liger ``q``        : ``[batch, heads, seq, head_dim]`` (BHSD)
   * Liger ``cos``/``sin`` : ``[1, seq, rot_dim]``
 
-Only the standard non-fused, non-interleaved, non-multi-latent ``bshd`` path
+Only the standard non-fused, non-interleaved, non-multi-latent, non-packed path
 is handled here. The monkey-patch delegates every other path (fused TE/Apex
 RoPE, packed ``thd`` sequences, interleaved rotation, multi-latent attention,
 ``mscale != 1``, per-batch ``freqs``) back to Megatron's native implementation
@@ -73,6 +73,10 @@ class LigerMegatronRopeFunction(torch.autograd.Function):
 def liger_apply_rotary_pos_emb_bshd(t: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
     """Liger drop-in for Megatron's ``_apply_rotary_pos_emb_bshd`` (standard path).
 
+    The ``bshd`` suffix mirrors Megatron's upstream helper name; the tensor
+    received here uses Megatron's ``[sequence, batch, heads, head_dim]`` (SBHD)
+    layout.
+
     Equivalent to Megatron-Core's
 
         t = (t * cos(freqs)) + (rotate_half(t) * sin(freqs))
@@ -100,7 +104,7 @@ def liger_apply_rotary_pos_emb_bshd(t: torch.Tensor, freqs: torch.Tensor) -> tor
     cos = torch.cos(freqs).to(t.dtype)[:, 0, 0, :].unsqueeze(0)
     sin = torch.sin(freqs).to(t.dtype)[:, 0, 0, :].unsqueeze(0)
 
-    # sbhd -> bshd for the Liger kernel, then back.
+    # SBHD -> BHSD for the Liger kernel, then back.
     t_liger = t_rot.permute(1, 2, 0, 3)
     rotated = LigerMegatronRopeFunction.apply(t_liger, cos, sin)
     rotated = rotated.permute(2, 0, 1, 3)

--- a/src/liger_kernel/megatron/rope.py
+++ b/src/liger_kernel/megatron/rope.py
@@ -1,0 +1,110 @@
+"""Megatron-Core compatible RoPE backed by the Liger Triton kernel.
+
+Megatron applies rotary positional embeddings through a single dispatcher,
+``megatron.core.models.common.embeddings.rope_utils.apply_rotary_pos_emb``,
+which is called **once per tensor** (first for the query, then for the key).
+Liger's Triton RoPE kernel (:class:`liger_kernel.ops.rope.LigerRopeFunction`)
+is instead a *fused* q/k kernel that rotates both tensors in one launch.
+
+To reuse the existing, battle-tested Liger kernel without writing a second
+Triton kernel, :class:`LigerMegatronRopeFunction` rotates a single tensor by
+passing it as the ``q`` argument and a one-head throwaway ``k`` (negligible
+extra work — one head out of typically dozens). The public entry point
+:func:`liger_apply_rotary_pos_emb_bshd` handles the layout / precision
+conversion between Megatron's convention and Liger's:
+
+  * Megatron ``t``     : ``[seq, batch, heads, head_dim]`` (sbhd)
+  * Megatron ``freqs`` : ``[seq, 1, 1, rot_dim]`` (already the doubled
+    ``cat(freqs, freqs)`` produced by ``RotaryEmbedding``)
+  * Liger ``q``        : ``[batch, heads, seq, head_dim]`` (bshd)
+  * Liger ``cos``/``sin`` : ``[1, seq, rot_dim]``
+
+Only the standard non-fused, non-interleaved, non-multi-latent ``bshd`` path
+is handled here. The monkey-patch delegates every other path (fused TE/Apex
+RoPE, packed ``thd`` sequences, interleaved rotation, multi-latent attention,
+``mscale != 1``, per-batch ``freqs``) back to Megatron's native implementation
+so numerics never silently change.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from liger_kernel.ops.rope import rope_backward
+from liger_kernel.ops.rope import rope_forward
+
+
+class LigerMegatronRopeFunction(torch.autograd.Function):
+    """Single-tensor RoPE autograd op reusing Liger's fused q/k Triton kernel.
+
+    Megatron rotates the query and key in two separate calls, so a fused q/k
+    kernel does not map directly. We reuse :func:`liger_kernel.ops.rope.rope_forward`
+    by treating the input as ``q`` and slicing a one-head throwaway ``k`` from
+    it; the kernel copies its inputs (transpose + ``.contiguous()``) before
+    writing, so the throwaway never aliases the real tensor and the input is
+    left untouched.
+
+    Args:
+        t: ``[batch, heads, seq, head_dim]`` tensor to rotate.
+        cos: ``[1, seq, head_dim]`` cosine table (doubled, ``[cos, cos]``).
+        sin: ``[1, seq, head_dim]`` sine table (doubled, ``[sin, sin]``).
+
+    Returns:
+        The rotated tensor, same shape/dtype as ``t``.
+    """
+
+    @staticmethod
+    def forward(ctx, t, cos, sin):
+        # One-head throwaway "k". rope_forward makes contiguous copies of both
+        # tensors before the kernel writes, so slicing from `t` is safe.
+        dummy_k = t[:, :1]
+        t_out, _dummy_out, cos, sin = rope_forward(t, dummy_k, cos, sin)
+        ctx.save_for_backward(cos, sin)
+        return t_out
+
+    @staticmethod
+    def backward(ctx, dt):
+        cos, sin = ctx.saved_tensors
+        dummy_dk = dt[:, :1]
+        dt_out, _dummy_dk_out = rope_backward(dt, dummy_dk, cos, sin)
+        return dt_out, None, None
+
+
+def liger_apply_rotary_pos_emb_bshd(t: torch.Tensor, freqs: torch.Tensor) -> torch.Tensor:
+    """Liger drop-in for Megatron's ``_apply_rotary_pos_emb_bshd`` (standard path).
+
+    Equivalent to Megatron-Core's
+
+        t = (t * cos(freqs)) + (rotate_half(t) * sin(freqs))
+
+    for the non-interleaved, non-multi-latent case, but the elementwise rotation
+    runs in Liger's Triton kernel. Partial rotary embeddings (``rot_dim < head_dim``)
+    are supported: the trailing ``t_pass`` slice is carried through unchanged.
+
+    Args:
+        t: ``[seq, batch, heads, head_dim]`` query or key tensor.
+        freqs: ``[seq, 1, 1, rot_dim]`` rotary frequencies (Megatron's doubled
+            ``cat(freqs, freqs)``).
+
+    Returns:
+        Rotated tensor, same shape/dtype as ``t``.
+    """
+    rot_dim = freqs.shape[-1]
+
+    # Split off the (possibly empty) non-rotary tail so partial-rotary configs work.
+    t_rot, t_pass = t[..., :rot_dim], t[..., rot_dim:]
+
+    # Megatron computes cos/sin in `t`'s dtype (see _apply_rotary_pos_emb_bshd);
+    # match that so the monkey-patch is a bit-faithful drop-in. freqs is
+    # [seq, 1, 1, rot_dim]; Liger wants [1, seq, rot_dim].
+    cos = torch.cos(freqs).to(t.dtype)[:, 0, 0, :].unsqueeze(0)
+    sin = torch.sin(freqs).to(t.dtype)[:, 0, 0, :].unsqueeze(0)
+
+    # sbhd -> bshd for the Liger kernel, then back.
+    t_liger = t_rot.permute(1, 2, 0, 3)
+    rotated = LigerMegatronRopeFunction.apply(t_liger, cos, sin)
+    rotated = rotated.permute(2, 0, 1, 3)
+
+    # cat also re-materializes a contiguous tensor (Megatron's native path does
+    # the same); handles the full-rotary case where t_pass is empty.
+    return torch.cat((rotated, t_pass), dim=-1)

--- a/src/liger_kernel/megatron/rope.py
+++ b/src/liger_kernel/megatron/rope.py
@@ -6,8 +6,7 @@ which is called **once per tensor** (first for the query, then for the key).
 Liger's Triton RoPE kernel (:class:`liger_kernel.ops.rope.LigerRopeFunction`)
 is instead a *fused* q/k kernel that rotates both tensors in one launch.
 
-To reuse the existing, battle-tested Liger kernel without writing a second
-Triton kernel, :class:`LigerMegatronRopeFunction` rotates a single tensor by
+To reuse the existing, Liger kernel, :class:`LigerMegatronRopeFunction` rotates a single tensor by
 passing it as the ``q`` argument and a one-head throwaway ``k`` (negligible
 extra work — one head out of typically dozens). The public entry point
 :func:`liger_apply_rotary_pos_emb_bshd` handles the layout / precision

--- a/test/megatron/test_monkey_patch.py
+++ b/test/megatron/test_monkey_patch.py
@@ -1135,7 +1135,7 @@ def test_rms_norm_only_patch_does_not_touch_ce_symbols(fake_megatron_ce):
 # modules (``megatron.core.transformer.attention`` does
 # ``from …rope_utils import apply_rotary_pos_emb``), so the patch must rebind
 # the name on every module that holds the original — not just the definition
-# module. It also routes only the standard unfused ``bshd`` path through Liger,
+# module. It also routes only the standard unfused non-packed path through Liger,
 # delegating fused / thd / interleaved / MLA / mscale / mRoPE configs back to
 # the captured native function so numerics never silently change.
 
@@ -1259,7 +1259,7 @@ def _rope_config(apply_rope_fusion=False, rotary_interleaved=False, multi_latent
     ],
 )
 def test_rope_patch_delegates_unsupported_paths_to_native(fake_megatron_rope, kwargs, config_kwargs):
-    """Every path Liger's bshd kernel doesn't cover must fall through to the
+    """Every path Liger's standard RoPE adapter doesn't cover must fall through to the
     captured native function (observable via the sentinel it returns)."""
     rope_utils, _ = fake_megatron_rope
     from liger_kernel.megatron import apply_liger_kernel_to_megatron
@@ -1319,7 +1319,7 @@ def test_rope_patch_delegates_with_older_megatron_signature():
 
 def test_rope_patch_delegates_per_batch_freqs_to_native(fake_megatron_rope):
     """mRoPE-style per-batch ``freqs`` (shape[1] > 1) is not covered by the
-    bshd kernel and must delegate to native."""
+    non-packed adapter and must delegate to native."""
     rope_utils, _ = fake_megatron_rope
     from liger_kernel.megatron import apply_liger_kernel_to_megatron
 
@@ -1336,7 +1336,7 @@ def test_rope_patch_delegates_per_batch_freqs_to_native(fake_megatron_rope):
 # ---------------------------------------------------------------------------
 
 
-def _ref_rope_bshd(t, freqs):
+def _ref_rope_sbhd(t, freqs):
     """Native Megatron RoPE (non-interleaved, mscale=1) for the supported path."""
     rot_dim = freqs.shape[-1]
     t_rot, t_pass = t[..., :rot_dim], t[..., rot_dim:]
@@ -1362,7 +1362,7 @@ def test_rope_patch_end_to_end_matches_native(fake_megatron_rope):
     theta = torch.outer(torch.arange(seq, device=_device, dtype=torch.float32), inv_freq)
     freqs = torch.cat((theta, theta), dim=-1).reshape(seq, 1, 1, head_dim)
 
-    ref = _ref_rope_bshd(t.clone(), freqs)
+    ref = _ref_rope_sbhd(t.clone(), freqs)
     # Call through the consumer-module binding — proves attention picks up Liger.
     got = attention.apply_rotary_pos_emb(t.clone(), freqs, _rope_config())
 

--- a/test/megatron/test_monkey_patch.py
+++ b/test/megatron/test_monkey_patch.py
@@ -20,6 +20,7 @@ Liger learns to patch:
   3. RMSNorm patch tests
   4. Cross-kernel public-API surface tests
   5. End-to-end integration through patched CE symbols
+  6. RoPE patch tests
 """
 
 import sys
@@ -188,6 +189,60 @@ def _install_fake_megatron_rms_norm(
     return backends, transformer_block
 
 
+# Sentinel returned by the stub's native ``apply_rotary_pos_emb`` so delegation
+# (unsupported-path fallback) is observable without a real megatron install.
+_NATIVE_ROPE_SENTINEL = object()
+
+
+def _install_fake_megatron_rope(with_symbol: bool = True, with_consumer: bool = True):
+    """Install the RoPE slice of the Megatron stub.
+
+    Returns ``(rope_utils_module, attention_module)`` so tests can inspect the
+    rebind. The ``attention`` stub holds ``apply_rotary_pos_emb`` *by value*
+    (mirroring Megatron's ``from …rope_utils import apply_rotary_pos_emb`` at
+    import time) so tests can verify the patch rebinds every importer, not just
+    the definition module.
+    """
+    _, megatron_core = _ensure_megatron_roots()
+
+    models = sys.modules.get("megatron.core.models") or types.ModuleType("megatron.core.models")
+    common = sys.modules.get("megatron.core.models.common") or types.ModuleType("megatron.core.models.common")
+    embeddings = sys.modules.get("megatron.core.models.common.embeddings") or types.ModuleType(
+        "megatron.core.models.common.embeddings"
+    )
+    rope_utils = types.ModuleType("megatron.core.models.common.embeddings.rope_utils")
+
+    if with_symbol:
+
+        def original_apply_rotary_pos_emb(t, freqs, config, cu_seqlens=None, mscale=1.0, cp_group=None):
+            return _NATIVE_ROPE_SENTINEL
+
+        rope_utils.apply_rotary_pos_emb = original_apply_rotary_pos_emb
+
+    sys.modules["megatron.core.models"] = models
+    sys.modules["megatron.core.models.common"] = common
+    sys.modules["megatron.core.models.common.embeddings"] = embeddings
+    sys.modules["megatron.core.models.common.embeddings.rope_utils"] = rope_utils
+    megatron_core.models = models
+    models.common = common
+    common.embeddings = embeddings
+    embeddings.rope_utils = rope_utils
+
+    attention = None
+    if with_consumer:
+        transformer = sys.modules.get("megatron.core.transformer") or types.ModuleType("megatron.core.transformer")
+        attention = types.ModuleType("megatron.core.transformer.attention")
+        # Value-copy the symbol, exactly like Megatron's attention module does.
+        if with_symbol:
+            attention.apply_rotary_pos_emb = rope_utils.apply_rotary_pos_emb
+        sys.modules["megatron.core.transformer"] = transformer
+        sys.modules["megatron.core.transformer.attention"] = attention
+        megatron_core.transformer = transformer
+        transformer.attention = attention
+
+    return rope_utils, attention
+
+
 def _uninstall_fake_megatron():
     """Tear down every stub module installed by either installer."""
     for mod in [
@@ -202,7 +257,12 @@ def _uninstall_fake_megatron():
         "megatron.core.models",
         "megatron.core.transformer.transformer_block",
         "megatron.core.transformer.torch_norm",
+        "megatron.core.transformer.attention",
         "megatron.core.transformer",
+        # RoPE side
+        "megatron.core.models.common.embeddings.rope_utils",
+        "megatron.core.models.common.embeddings",
+        "megatron.core.models.common",
         # Shared roots
         "megatron.core",
         "megatron",
@@ -224,6 +284,15 @@ def fake_megatron_rms_norm():
     backends, transformer_block = _install_fake_megatron_rms_norm()
     try:
         yield backends, transformer_block
+    finally:
+        _uninstall_fake_megatron()
+
+
+@pytest.fixture
+def fake_megatron_rope():
+    rope_utils, attention = _install_fake_megatron_rope()
+    try:
+        yield rope_utils, attention
     finally:
         _uninstall_fake_megatron()
 
@@ -793,7 +862,9 @@ def test_import_from_root():
     try:
         from liger_kernel.megatron import LigerMegatronCrossEntropy  # noqa: F401
         from liger_kernel.megatron import LigerMegatronRMSNorm  # noqa: F401
+        from liger_kernel.megatron import LigerMegatronRopeFunction  # noqa: F401
         from liger_kernel.megatron import apply_liger_kernel_to_megatron  # noqa: F401
+        from liger_kernel.megatron import liger_apply_rotary_pos_emb_bshd  # noqa: F401
     except Exception:
         pytest.fail("Importing public Megatron symbols from liger_kernel.megatron failed.")
 
@@ -1023,3 +1094,206 @@ def test_rms_norm_only_patch_does_not_touch_ce_symbols(fake_megatron_ce):
 
     assert fused_ce.fused_vocab_parallel_cross_entropy is fused_before
     assert unfused_ce.vocab_parallel_cross_entropy is unfused_before
+
+
+# ===========================================================================
+# 6. RoPE patch tests
+# ===========================================================================
+# Liger's RoPE patch replaces a single dispatcher,
+# ``megatron.core.models.common.embeddings.rope_utils.apply_rotary_pos_emb``.
+# The wrinkle is that Megatron imports the symbol *by value* into consumer
+# modules (``megatron.core.transformer.attention`` does
+# ``from …rope_utils import apply_rotary_pos_emb``), so the patch must rebind
+# the name on every module that holds the original — not just the definition
+# module. It also routes only the standard unfused ``bshd`` path through Liger,
+# delegating fused / thd / interleaved / MLA / mscale / mRoPE configs back to
+# the captured native function so numerics never silently change.
+
+
+# ---------------------------------------------------------------------------
+# 6.1 Symbol replacement + rebind-everywhere.
+# ---------------------------------------------------------------------------
+
+
+def test_rope_patch_replaces_definition_module_symbol(fake_megatron_rope):
+    rope_utils, _ = fake_megatron_rope
+    from liger_kernel.megatron import apply_liger_kernel_to_megatron
+
+    original = rope_utils.apply_rotary_pos_emb
+    apply_liger_kernel_to_megatron(rms_norm=False, rope=True)
+
+    assert rope_utils.apply_rotary_pos_emb is not original
+    assert rope_utils.apply_rotary_pos_emb.__name__ == "liger_apply_rotary_pos_emb"
+    assert getattr(rope_utils.apply_rotary_pos_emb, "__liger_patched__", False) is True
+    assert rope_utils.apply_rotary_pos_emb.__wrapped__ is original
+
+
+def test_rope_patch_rebinds_symbol_on_consumer_module(fake_megatron_rope):
+    """The core contract: a module that imported the symbol by value (like
+    ``attention``) must be rebound too, otherwise live call sites keep the
+    original function."""
+    rope_utils, attention = fake_megatron_rope
+    from liger_kernel.megatron import apply_liger_kernel_to_megatron
+
+    original = attention.apply_rotary_pos_emb
+    apply_liger_kernel_to_megatron(rms_norm=False, rope=True)
+
+    assert attention.apply_rotary_pos_emb is not original
+    assert attention.apply_rotary_pos_emb is rope_utils.apply_rotary_pos_emb
+    assert attention.apply_rotary_pos_emb.__name__ == "liger_apply_rotary_pos_emb"
+
+
+def test_rope_patch_with_rope_false_leaves_symbol_untouched(fake_megatron_rope):
+    rope_utils, attention = fake_megatron_rope
+    from liger_kernel.megatron import apply_liger_kernel_to_megatron
+
+    before_def = rope_utils.apply_rotary_pos_emb
+    before_consumer = attention.apply_rotary_pos_emb
+
+    apply_liger_kernel_to_megatron(rms_norm=False, rope=False)
+
+    assert rope_utils.apply_rotary_pos_emb is before_def
+    assert attention.apply_rotary_pos_emb is before_consumer
+
+
+def test_rope_patch_is_idempotent(fake_megatron_rope):
+    rope_utils, attention = fake_megatron_rope
+    from liger_kernel.megatron import apply_liger_kernel_to_megatron
+
+    apply_liger_kernel_to_megatron(rms_norm=False, rope=True)
+    def_first = rope_utils.apply_rotary_pos_emb
+    consumer_first = attention.apply_rotary_pos_emb
+
+    apply_liger_kernel_to_megatron(rms_norm=False, rope=True)
+    assert rope_utils.apply_rotary_pos_emb is def_first
+    assert attention.apply_rotary_pos_emb is consumer_first
+    # __wrapped__ chains back to the original native function, not the first wrapper.
+    assert def_first.__wrapped__.__name__ == "original_apply_rotary_pos_emb"
+
+
+# ---------------------------------------------------------------------------
+# 6.2 Missing-megatron / missing-symbol errors.
+# ---------------------------------------------------------------------------
+
+
+def test_rope_patch_raises_when_megatron_not_installed():
+    _uninstall_fake_megatron()
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def blocking_import(name, *args, **kwargs):
+        if name == "megatron" or name.startswith("megatron."):
+            raise ImportError(f"No module named {name!r}")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=blocking_import):
+        from liger_kernel.megatron import apply_liger_kernel_to_megatron
+
+        with pytest.raises(ImportError, match="requires megatron-core"):
+            apply_liger_kernel_to_megatron(rms_norm=False, rope=True)
+
+
+def test_rope_patch_raises_when_symbol_missing():
+    _install_fake_megatron_rope(with_symbol=False)
+    try:
+        from liger_kernel.megatron import apply_liger_kernel_to_megatron
+
+        with pytest.raises(ImportError, match="symbol path may have changed"):
+            apply_liger_kernel_to_megatron(rms_norm=False, rope=True)
+    finally:
+        _uninstall_fake_megatron()
+
+
+# ---------------------------------------------------------------------------
+# 6.3 Unsupported-path delegation to native.
+# ---------------------------------------------------------------------------
+
+
+def _rope_config(apply_rope_fusion=False, rotary_interleaved=False, multi_latent_attention=False):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        apply_rope_fusion=apply_rope_fusion,
+        rotary_interleaved=rotary_interleaved,
+        multi_latent_attention=multi_latent_attention,
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs, config_kwargs",
+    [
+        ({"cu_seqlens": True}, {}),  # packed thd
+        ({"mscale": 2.0}, {}),  # yarn/mscale scaling
+        ({}, {"apply_rope_fusion": True}),  # fused TE/Apex path
+        ({}, {"rotary_interleaved": True}),  # interleaved rotation
+        ({}, {"multi_latent_attention": True}),  # MLA
+    ],
+)
+def test_rope_patch_delegates_unsupported_paths_to_native(fake_megatron_rope, kwargs, config_kwargs):
+    """Every path Liger's bshd kernel doesn't cover must fall through to the
+    captured native function (observable via the sentinel it returns)."""
+    rope_utils, _ = fake_megatron_rope
+    from liger_kernel.megatron import apply_liger_kernel_to_megatron
+
+    apply_liger_kernel_to_megatron(rms_norm=False, rope=True)
+
+    t = torch.zeros(4, 1, 2, 8)
+    freqs = torch.zeros(4, 1, 1, 8)
+    call_kwargs = dict(kwargs)
+    if call_kwargs.get("cu_seqlens") is True:
+        call_kwargs["cu_seqlens"] = torch.zeros(2, dtype=torch.int32)
+
+    result = rope_utils.apply_rotary_pos_emb(t, freqs, _rope_config(**config_kwargs), **call_kwargs)
+    assert result is _NATIVE_ROPE_SENTINEL
+
+
+def test_rope_patch_delegates_per_batch_freqs_to_native(fake_megatron_rope):
+    """mRoPE-style per-batch ``freqs`` (shape[1] > 1) is not covered by the
+    bshd kernel and must delegate to native."""
+    rope_utils, _ = fake_megatron_rope
+    from liger_kernel.megatron import apply_liger_kernel_to_megatron
+
+    apply_liger_kernel_to_megatron(rms_norm=False, rope=True)
+
+    t = torch.zeros(4, 2, 2, 8)
+    freqs = torch.zeros(4, 2, 1, 8)  # batch dim > 1
+    result = rope_utils.apply_rotary_pos_emb(t, freqs, _rope_config())
+    assert result is _NATIVE_ROPE_SENTINEL
+
+
+# ---------------------------------------------------------------------------
+# 6.4 End-to-end: patched symbol produces correct RoPE on the supported path.
+# ---------------------------------------------------------------------------
+
+
+def _ref_rope_bshd(t, freqs):
+    """Native Megatron RoPE (non-interleaved, mscale=1) for the supported path."""
+    rot_dim = freqs.shape[-1]
+    t_rot, t_pass = t[..., :rot_dim], t[..., rot_dim:]
+    cos_ = torch.cos(freqs).to(t.dtype)
+    sin_ = torch.sin(freqs).to(t.dtype)
+    x1, x2 = torch.chunk(t_rot, 2, dim=-1)
+    rotated = (t_rot * cos_) + (torch.cat((-x2, x1), dim=-1) * sin_)
+    return torch.cat((rotated, t_pass), dim=-1)
+
+
+@pytest.mark.skipif(_device == "cpu", reason="Liger Triton kernels require an accelerator.")
+def test_rope_patch_end_to_end_matches_native(fake_megatron_rope):
+    rope_utils, attention = fake_megatron_rope
+    from liger_kernel.megatron import apply_liger_kernel_to_megatron
+
+    apply_liger_kernel_to_megatron(rms_norm=False, rope=True)
+
+    seq, batch, heads, head_dim = 32, 2, 4, 64
+    torch.manual_seed(0)
+    t = torch.randn(seq, batch, heads, head_dim, device=_device, dtype=torch.float32)
+    half = head_dim // 2
+    inv_freq = 1.0 / (10000.0 ** (torch.arange(0, half, device=_device, dtype=torch.float32) / half))
+    theta = torch.outer(torch.arange(seq, device=_device, dtype=torch.float32), inv_freq)
+    freqs = torch.cat((theta, theta), dim=-1).reshape(seq, 1, 1, head_dim)
+
+    ref = _ref_rope_bshd(t.clone(), freqs)
+    # Call through the consumer-module binding — proves attention picks up Liger.
+    got = attention.apply_rotary_pos_emb(t.clone(), freqs, _rope_config())
+
+    assert got.shape == t.shape
+    assert_verbose_allclose(got.float(), ref.float(), atol=1e-4, rtol=1e-4)

--- a/test/megatron/test_monkey_patch.py
+++ b/test/megatron/test_monkey_patch.py
@@ -194,7 +194,11 @@ def _install_fake_megatron_rms_norm(
 _NATIVE_ROPE_SENTINEL = object()
 
 
-def _install_fake_megatron_rope(with_symbol: bool = True, with_consumer: bool = True):
+def _install_fake_megatron_rope(
+    with_symbol: bool = True,
+    with_consumer: bool = True,
+    with_mla_interleaving_parameter: bool = True,
+):
     """Install the RoPE slice of the Megatron stub.
 
     Returns ``(rope_utils_module, attention_module)`` so tests can inspect the
@@ -211,11 +215,37 @@ def _install_fake_megatron_rope(with_symbol: bool = True, with_consumer: bool = 
         "megatron.core.models.common.embeddings"
     )
     rope_utils = types.ModuleType("megatron.core.models.common.embeddings.rope_utils")
+    rope_utils._last_call = None
 
     if with_symbol:
+        if with_mla_interleaving_parameter:
 
-        def original_apply_rotary_pos_emb(t, freqs, config, cu_seqlens=None, mscale=1.0, cp_group=None):
-            return _NATIVE_ROPE_SENTINEL
+            def original_apply_rotary_pos_emb(
+                t,
+                freqs,
+                config,
+                cu_seqlens=None,
+                mscale=1.0,
+                cp_group=None,
+                mla_rotary_interleaved=False,
+            ):
+                rope_utils._last_call = {
+                    "cu_seqlens": cu_seqlens,
+                    "mscale": mscale,
+                    "cp_group": cp_group,
+                    "mla_rotary_interleaved": mla_rotary_interleaved,
+                }
+                return _NATIVE_ROPE_SENTINEL
+
+        else:
+
+            def original_apply_rotary_pos_emb(t, freqs, config, cu_seqlens=None, mscale=1.0, cp_group=None):
+                rope_utils._last_call = {
+                    "cu_seqlens": cu_seqlens,
+                    "mscale": mscale,
+                    "cp_group": cp_group,
+                }
+                return _NATIVE_ROPE_SENTINEL
 
         rope_utils.apply_rotary_pos_emb = original_apply_rotary_pos_emb
 
@@ -1244,6 +1274,47 @@ def test_rope_patch_delegates_unsupported_paths_to_native(fake_megatron_rope, kw
 
     result = rope_utils.apply_rotary_pos_emb(t, freqs, _rope_config(**config_kwargs), **call_kwargs)
     assert result is _NATIVE_ROPE_SENTINEL
+
+
+def test_rope_patch_delegates_mla_interleaving_to_native(fake_megatron_rope):
+    """Current Megatron passes MLA interleaving as a call-time argument."""
+    rope_utils, _ = fake_megatron_rope
+    from liger_kernel.megatron import apply_liger_kernel_to_megatron
+
+    apply_liger_kernel_to_megatron(rms_norm=False, rope=True)
+
+    t = torch.zeros(4, 1, 2, 8)
+    freqs = torch.zeros(4, 1, 1, 8)
+    result = rope_utils.apply_rotary_pos_emb(
+        t,
+        freqs,
+        _rope_config(),
+        mla_rotary_interleaved=True,
+    )
+
+    assert result is _NATIVE_ROPE_SENTINEL
+    assert rope_utils._last_call["mla_rotary_interleaved"] is True
+
+
+def test_rope_patch_delegates_with_older_megatron_signature():
+    """Fallback remains compatible with Megatron versions predating the MLA argument."""
+    rope_utils, _ = _install_fake_megatron_rope(with_mla_interleaving_parameter=False)
+    try:
+        from liger_kernel.megatron import apply_liger_kernel_to_megatron
+
+        apply_liger_kernel_to_megatron(rms_norm=False, rope=True)
+
+        t = torch.zeros(4, 1, 2, 8)
+        freqs = torch.zeros(4, 1, 1, 8)
+        result = rope_utils.apply_rotary_pos_emb(
+            t,
+            freqs,
+            _rope_config(apply_rope_fusion=True),
+        )
+
+        assert result is _NATIVE_ROPE_SENTINEL
+    finally:
+        _uninstall_fake_megatron()
 
 
 def test_rope_patch_delegates_per_batch_freqs_to_native(fake_megatron_rope):

--- a/test/megatron/test_rope.py
+++ b/test/megatron/test_rope.py
@@ -1,0 +1,128 @@
+"""Unit tests for Liger's Megatron-Core RoPE adapter.
+
+These tests deliberately do not import megatron-core; the adapter's contract is
+verified against a local re-implementation of Megatron's
+``_apply_rotary_pos_emb_bshd`` (non-interleaved, non-multi-latent path). The
+parametrization style mirrors ``test/megatron/test_rms_norm.py``.
+"""
+
+import os
+
+import pytest
+import torch
+
+from liger_kernel.megatron.rope import liger_apply_rotary_pos_emb_bshd
+from liger_kernel.utils import infer_device
+from test.utils import assert_verbose_allclose
+from test.utils import set_seed
+from test.utils import supports_bfloat16
+
+device = infer_device()
+
+set_seed(42)
+
+if device == "cuda":
+    os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+
+
+# ---------------------------------------------------------------------------
+# Reference: copy of Megatron-Core's _apply_rotary_pos_emb_bshd (the exact
+# symbol liger_apply_rotary_pos_emb_bshd is a drop-in for), stripped to the
+# non-interleaved / non-multi-latent / mscale=1 path Liger routes.
+# ---------------------------------------------------------------------------
+
+
+def _rotate_half(x):
+    x1, x2 = torch.chunk(x, 2, dim=-1)
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _ref_apply_rotary_pos_emb_bshd(t, freqs):
+    rot_dim = freqs.shape[-1]
+    t, t_pass = t[..., :rot_dim], t[..., rot_dim:]
+    cos_ = torch.cos(freqs).to(t.dtype)
+    sin_ = torch.sin(freqs).to(t.dtype)
+    t = (t * cos_) + (_rotate_half(t) * sin_)
+    return torch.cat((t, t_pass), dim=-1)
+
+
+def _make_freqs(seq_len, rot_dim, dtype, base=10000.0):
+    """Megatron-style doubled rotary frequencies of shape [seq, 1, 1, rot_dim].
+
+    ``rot_dim`` must be even; the table is ``cat(theta, theta)`` so the left and
+    right halves match (Liger's kernel reads only the left half and mirrors it,
+    matching Megatron's ``emb = cat(freqs, freqs)`` construction).
+    """
+    half = rot_dim // 2
+    inv_freq = 1.0 / (base ** (torch.arange(0, half, dtype=torch.float32, device=device) / half))
+    positions = torch.arange(seq_len, dtype=torch.float32, device=device)
+    theta = torch.outer(positions, inv_freq)  # [seq, half]
+    emb = torch.cat((theta, theta), dim=-1)  # [seq, rot_dim]
+    return emb.reshape(seq_len, 1, 1, rot_dim).to(dtype)
+
+
+# ---------------------------------------------------------------------------
+# Forward + backward correctness.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(device == "cpu", reason="Liger Triton kernels require an accelerator.")
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
+@pytest.mark.parametrize(
+    "seq_len, batch, heads, head_dim, rot_dim",
+    [
+        (64, 2, 4, 32, 32),  # full rotary
+        (128, 1, 8, 64, 64),  # full rotary, more heads
+        (48, 3, 4, 64, 32),  # partial rotary (t_pass non-empty)
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype, atol, rtol",
+    [
+        (torch.float32, 1e-5, 1e-5),
+        pytest.param(
+            torch.bfloat16,
+            1e-2,
+            1e-2,
+            marks=pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this GPU"),
+        ),
+    ],
+)
+def test_correctness(seq_len, batch, heads, head_dim, rot_dim, dtype, atol, rtol):
+    # Megatron layout: [seq, batch, heads, head_dim].
+    _t = torch.randn(seq_len, batch, heads, head_dim, device=device, dtype=dtype)
+    do = torch.randn(seq_len, batch, heads, head_dim, device=device, dtype=dtype)
+    freqs = _make_freqs(seq_len, rot_dim, dtype)
+
+    t1 = _t.clone().requires_grad_(True)
+    t2 = _t.clone().requires_grad_(True)
+
+    ref_o = _ref_apply_rotary_pos_emb_bshd(t1, freqs)
+    ref_o.backward(do, retain_graph=True)
+
+    liger_o = liger_apply_rotary_pos_emb_bshd(t2, freqs)
+    liger_o.backward(do, retain_graph=True)
+
+    assert_verbose_allclose(ref_o, liger_o, atol=atol, rtol=rtol)
+    assert_verbose_allclose(t1.grad, t2.grad, atol=atol, rtol=rtol, max_print=20)
+
+
+@pytest.mark.skipif(device == "cpu", reason="Liger Triton kernels require an accelerator.")
+def test_forward_does_not_modify_input():
+    """The adapter must not mutate its input (Megatron reuses q/k tensors)."""
+    seq_len, batch, heads, head_dim = 16, 2, 4, 32
+    t = torch.randn(seq_len, batch, heads, head_dim, device=device, dtype=torch.float32)
+    snapshot = t.detach().clone()
+    freqs = _make_freqs(seq_len, head_dim, torch.float32)
+    _ = liger_apply_rotary_pos_emb_bshd(t, freqs)
+    assert torch.equal(t, snapshot)
+
+
+@pytest.mark.skipif(device == "cpu", reason="Liger Triton kernels require an accelerator.")
+def test_output_shape_and_dtype_preserved():
+    seq_len, batch, heads, head_dim, rot_dim = 32, 2, 4, 64, 32
+    t = torch.randn(seq_len, batch, heads, head_dim, device=device, dtype=torch.float32)
+    freqs = _make_freqs(seq_len, rot_dim, torch.float32)
+    out = liger_apply_rotary_pos_emb_bshd(t, freqs)
+    assert out.shape == t.shape
+    assert out.dtype == t.dtype


### PR DESCRIPTION
Adds Liger's Triton RoPE to Megatron-Core

apply_liger_kernel_to_megatron(rope=True) reroutes Megatron's apply_rotary_pos_emb dispatcher — rebinding the symbol on every module that imported it by value (e.g. megatron.core.transformer.attention) — to Liger's kernel for the standard unfused bshd path. Fused (TE/Apex) RoPE, packed thd sequences, interleaved rotation, multi-latent attention, mscale scaling and per-batch/mRoPE freqs transparently fall back to the native implementation so numerics never silently change.

Megatron applies RoPE once per tensor (query, then key) while Liger's kernel is fused q/k; LigerMegatronRopeFunction reuses the existing kernel by passing a one-head throwaway k (negligible extra work), avoiding a second Triton kernel.

- src/liger_kernel/megatron/rope.py: adapter + single-tensor autograd op
- monkey_patch.py: rope flag + _patch_apply_rotary_pos_emb (rebind-everywhere)
- __init__.py: exports
- test/megatron/test_rope.py: correctness vs native bshd reference
- test/megatron/test_monkey_patch.py: RoPE patch-mechanism tests
- benchmark/scripts/benchmark_megatron_rope.py: liger vs torch vs megatron
- examples/megatron/README.md: rope=True docs

## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
