### PR TITLE
Add requires-python >=3.10 to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "Efficient Triton kernels for LLM Training"
 urls = { "Homepage" = "https://github.com/linkedin/Liger-Kernel" }
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { file = "LICENSE" }
+requires-python = ">=3.10"
 dynamic = ["dependencies", "optional-dependencies"]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary

Fixes #1302.

`pyproject.toml` has no `requires-python`, so pip resolves and installs liger-kernel on any interpreter. Users on unsupported Pythons get runtime failures instead of a clean "requires Python >= X" resolver message.

This adds `requires-python = ">=3.10"`, matching the project's own floor: every CI test workflow (nvi-ci, amd-ci, checkstyle, benchmark) and the release-publish workflow run Python 3.10.

Picking up the hand-off from #1307 (closed by its author due to inactivity, fix noted as still valid).

## Testing Done

Metadata-only change. Verified the line parses and the floor matches CI:

```
$ python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['requires-python'])"
>=3.10
```