### PR TITLE
perf(embedding): tune launch configs and add cache-eviction hints

### DIFF
--- a/src/liger_kernel/ops/experimental/embedding.py
+++ b/src/liger_kernel/ops/experimental/embedding.py
@@ -5,6 +5,41 @@ import triton.language as tl
 from liger_kernel.ops.utils import ensure_contiguous
 
 
+def _next_pow2(x):
+    return triton.next_power_of_2(x)
+
+
+def _fwd_config(n_elements, embedding_dim):
+    """Tuned forward launch config (RTX 5060 Ti, Blackwell SM 12.0).
+
+    Swept offline (see optimization/embedding): wide BLOCK_SIZE_N tiles with
+    8 warps cut forward time consistently for embedding_dim >= 1024; mid dims
+    (512/768) prefer a 64x512 tile. Small dims keep the stock-like (128,128,4).
+    """
+    d = embedding_dim
+    if d < 256:
+        tile_n = _next_pow2(min(128, d))
+        return 128, tile_n, 4
+    if d < 1024:
+        return 64, 512, 4
+    return 128, 512, 8
+
+
+def _bwd_config(n_elements, embedding_dim):
+    """Tuned backward config; the atomic-add kernel wins with wide N tiles at
+    moderate token counts ((64,512,16)) and a (128,256,8) tile for very large
+    token counts. Mid/small dims stay on the stock-like conservative tile."""
+    d = embedding_dim
+    if d < 256:
+        tile_n = _next_pow2(min(128, d))
+        return 128, tile_n, 4
+    if d < 1024:
+        return 128, 128, 4
+    if n_elements <= 16384:
+        return 64, 512, 16
+    return 128, 256, 8
+
+
 @triton.jit
 def embedding_forward_kernel(
     embeddings_ptr,
@@ -22,7 +57,7 @@ def embedding_forward_kernel(
     start_n = pid_n * BLOCK_SIZE_N
     offsets_m = start_m + tl.arange(0, BLOCK_SIZE_M)
     mask_m = offsets_m < n_elements
-    indices = tl.load(indices_ptr + offsets_m, mask=mask_m, other=0)
+    indices = tl.load(indices_ptr + offsets_m, mask=mask_m, other=0, eviction_policy="evict_first")
     offsets_n = start_n + tl.arange(0, BLOCK_SIZE_N)
     mask_n = offsets_n < embedding_dim
 
@@ -31,10 +66,13 @@ def embedding_forward_kernel(
         embeddings_ptr + embedding_offsets,
         mask=mask_m[:, None] & mask_n[None, :],
         other=0.0,
+        eviction_policy="evict_last",
     )
 
     output_offsets = offsets_m[:, None] * embedding_dim + offsets_n[None, :]
-    tl.store(output_ptr + output_offsets, embeddings, mask=mask_m[:, None] & mask_n[None, :])
+    tl.store(
+        output_ptr + output_offsets, embeddings, mask=mask_m[:, None] & mask_n[None, :], eviction_policy="evict_first"
+    )
 
 
 @triton.jit
@@ -54,7 +92,7 @@ def embedding_backward_kernel(
     start_n = pid_n * BLOCK_SIZE_N
     offsets_m = start_m + tl.arange(0, BLOCK_SIZE_M)
     mask_m = offsets_m < n_elements
-    indices = tl.load(indices_ptr + offsets_m, mask=mask_m, other=0)
+    indices = tl.load(indices_ptr + offsets_m, mask=mask_m, other=0, eviction_policy="evict_first")
     offsets_n = start_n + tl.arange(0, BLOCK_SIZE_N)
     mask_n = offsets_n < embedding_dim
 
@@ -62,6 +100,7 @@ def embedding_backward_kernel(
         grad_output_ptr + offsets_m[:, None] * embedding_dim + offsets_n[None, :],
         mask=mask_m[:, None] & mask_n[None, :],
         other=0.0,
+        eviction_policy="evict_first",
     )
 
     grad_weight_offsets = indices[:, None] * embedding_dim + offsets_n[None, :]
@@ -89,8 +128,7 @@ class LigerEmbeddingFunction(torch.autograd.Function):
         n_elements = indices.numel()
         embedding_dim = embeddings.shape[1]
 
-        BLOCK_SIZE_M = triton.next_power_of_2(min(128, embedding_dim))
-        BLOCK_SIZE_N = triton.next_power_of_2(min(128, embedding_dim))
+        BLOCK_SIZE_M, BLOCK_SIZE_N, num_warps = _fwd_config(n_elements, embedding_dim)
         grid = (
             triton.cdiv(n_elements, BLOCK_SIZE_M),
             triton.cdiv(embedding_dim, BLOCK_SIZE_N),
@@ -104,6 +142,7 @@ class LigerEmbeddingFunction(torch.autograd.Function):
             embedding_dim=embedding_dim,
             BLOCK_SIZE_M=BLOCK_SIZE_M,
             BLOCK_SIZE_N=BLOCK_SIZE_N,
+            num_warps=num_warps,
         )
 
         ctx.save_for_backward(indices, embeddings)
@@ -121,8 +160,7 @@ class LigerEmbeddingFunction(torch.autograd.Function):
         n_elements = indices.numel()
         embedding_dim = embedding_table.shape[1]
 
-        BLOCK_SIZE_M = triton.next_power_of_2(min(128, embedding_dim))
-        BLOCK_SIZE_N = triton.next_power_of_2(min(128, embedding_dim))
+        BLOCK_SIZE_M, BLOCK_SIZE_N, num_warps = _bwd_config(n_elements, embedding_dim)
         grid = (
             triton.cdiv(n_elements, BLOCK_SIZE_M),
             triton.cdiv(embedding_dim, BLOCK_SIZE_N),
@@ -136,6 +174,7 @@ class LigerEmbeddingFunction(torch.autograd.Function):
             embedding_dim=embedding_dim,
             BLOCK_SIZE_M=BLOCK_SIZE_M,
             BLOCK_SIZE_N=BLOCK_SIZE_N,
+            num_warps=num_warps,
         )
 
         return grad_weight, None

--- a/test/transformers/test_embedding.py
+++ b/test/transformers/test_embedding.py
@@ -11,7 +11,6 @@ device = infer_device()
 SLEEP_SECONDS = 0.1
 
 
-@pytest.mark.skip(reason="LigerEmbedding is under experimentation")
 @pytest.mark.parametrize(
     "num_embeddings, embedding_dim, padding_idx",
     [
@@ -23,18 +22,24 @@ SLEEP_SECONDS = 0.1
         (1000, 120, None),
         (1000, 500, None),
         (30522, 768, None),
+        (128256, 4096, None),  # tokenizer scale (e.g. llama-3-8b)
         (100, 64, 0),
         (1000, 128, 50),
         (30522, 768, 1),
     ],
 )
 @pytest.mark.parametrize(
-    "dtype, atol, rtol, device",
+    "dtype, atol, rtol",
     [
-        (torch.float32, 1e-6, 1e-5, device),
+        (torch.float32, 1e-6, 1e-5),
+        # bf16 backward accumulates in bf16 (dtype-rounded atomics), so the
+        # tolerance reflects measured accumulation-order noise calibrated on
+        # this hardware (see optimization/embedding/correctness.py), while
+        # forward is bit-exact (pure gather, no arithmetic).
+        (torch.bfloat16, 0.125, 0.0),
     ],
 )
-def test_embedding_correctness(num_embeddings, embedding_dim, padding_idx, dtype, atol, rtol, device):
+def test_embedding_correctness(num_embeddings, embedding_dim, padding_idx, dtype, atol, rtol):
     print(f"\nTesting embedding with size: ({num_embeddings}, {embedding_dim}), padding_idx: {padding_idx}")
     torch.manual_seed(42)
 


### PR DESCRIPTION
## Summary

Experimental Liger Triton embedding op (`src/liger_kernel/ops/experimental/embedding.py`) tuned on an RTX 5060 Ti (Blackwell, SM 12.0).

**Forward** — `_fwd_config` selects launch shape per `embedding_dim`: (128, 512) @ 8 warps for D ≥ 1024, (64, 512) @ 4 warps for mid dims (512–768), stock-like (128, tile, 4) for small D. Up to −10.7% fwd at BT=1024, −8.6% at D=768, −6.9% at D=512; ≈0 at memory-bound large sizes.

**Backward** — `_bwd_config`: (64, 512) @ 16 warps for BT ≤ 16k, (128, 256) @ 8 otherwise, conservative tiles for small D. 2–6% faster on the atomic-add kernel.

**Cache-eviction hints** — `evict_last` on the random-row table gather (rows are re-read by every column tile), `evict_first` on one-shot index/output loads. Train step (fwd+bwd) faster in 8/8 measured regimes (+0.3…+3.1%); the step is dominated by the fixed `zeros_like` gradient memset (~2.3 ms / 1 GB bf16 table).

Rejected after interleaved A/B: int32 index precompute, 256×256 bwd tile (net ≈0).

## Validation
- Correctness oracle: 38/38 — forward bit-exact vs torch; fp32 bwd atol 2e-5/rtol 1e-5; bf16 bwd vs float64 index-summed single-rounded golden (atol 0.125 uniform / 0.5 skewed), margin ≥ 2× above observed.
- Mutation audit: 2/2 planted bugs detected (index off-by-one, swapped grid axes).
- `test/transformers/test_embedding.py`: un-skipped (was `@pytest.mark.skip`), added bf16 dtype + tokenizer-scale case → 24/24 pass.

Full study (harness, variants, sweep CSV, report): `optimization/embedding/` — kept on the fork's main, not part of this PR.