### PR TITLE
Add Hopper CuTe DSL fused scaled cross entropy

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ pip install -e ".[dev]" --extra-index-url https://triton-ascend.osinfra.cn/pypi/
 - `transformers >= 4.x`: Required if you plan to use the transformers models patching APIs. The specific model you are working will dictate the minimum version of transformers.
 - `cuda-tile`: Required when enabling the optional cuTile backend on CUDA. Use this when your environment already provides CUDA Toolkit 13.1 or newer, or an existing tileiras compiler installation.
 - `cuda-tile[tileiras]`: Required when enabling the optional cuTile backend with the tileiras compiler installed directly into your Python environment.
-- `nvidia-cutlass-dsl`: Required when enabling the optional CuTe DSL backend on CUDA (the CUDA-only Python DSL shipped with NVIDIA CUTLASS, `import cutlass.cute`). Targets Hopper (SM90) and Blackwell (SM100/SM110).
+- `nvidia-cutlass-dsl >= 4.5.2`: Required when enabling the optional CuTe DSL backend on CUDA (the CUDA-only Python DSL shipped with NVIDIA CUTLASS, `import cutlass.cute`). Targets Hopper (SM90) and Blackwell (SM100/SM110).
 
 > **Note:**
 > Our kernels inherit the full spectrum of hardware compatibility offered by [Triton](https://github.com/triton-lang/triton).
@@ -217,7 +217,35 @@ pip install "liger-kernel[cutedsl]"
 LIGER_KERNEL_IMPL=cutedsl python your_script.py
 ```
 
-It currently provides genuine `cutlass.cute` implementations of **RMSNorm** and **cross entropy**. Any op without a CuTe DSL kernel transparently falls back to the default Triton kernel, so selecting the backend is always safe. Selecting it on a non-CUDA device, or without `nvidia-cutlass-dsl` installed, raises an error.
+It currently provides genuine `cutlass.cute` implementations of **RMSNorm**, **cross entropy**, and
+Hopper **fused scaled cross entropy** (`LigerFusedScaledCrossEntropySM90Function`). The SM90 scaled
+kernel is an *additional* operator, not a replacement for the Triton `LigerFusedLinearCrossEntropyFunction`:
+it fuses `x @ weight.T` with the softmax, takes BF16 `input`/`weight` plus `ignore_index`, and returns
+the per-token negative log-likelihood `[M]` plus optional vocabulary entropy — reductions are composed in PyTorch. Backward
+therefore receives the per-token upstream gradient `[M]`, which is used verbatim as the row scale of
+`dZ`; a scalar `grad_output` is rejected rather than silently reduced. `temperature` defaults to
+`1.0` and applies the same `logits / temperature` semantics as Verl.
+Set `return_entropy=True` to additionally return differentiable per-token
+vocabulary entropy in BF16; its backward contribution follows Verl's PPO
+formula. Both NLL and entropy are zeroed for `ignore_index` rows.
+`m_tiles_per_cluster` (>= 1,
+default `1`) selects the forward schedule: `1` uses the fastest M-outer self-TMA forward, values `> 1`
+use the M-fast forward with that many live M tiles per cluster. Backward executes `dZ`, `dX = dZ @ W`,
+and `dW = dZ.T @ X` inside one persistent cluster-2 CUDA kernel. Its device-side wave loop aliases
+phase-specific shared memory, uses W multicast for dX, transposed TMA for dW, and HBM atomics between
+waves. Backward uses a fixed reusable BF16 `dZ` workspace covering 1024 tokens; wave zero
+plain-stores BF16 `dW`, and later waves use Hopper BF16 TMA reduce-add. Ops without a CuTe DSL kernel
+transparently fall back to the default Triton kernel. Selecting the backend on a non-CUDA device, or
+without `nvidia-cutlass-dsl` installed, raises an error.
+
+```python
+from liger_kernel.ops.cutedsl.ops import LigerFusedScaledCrossEntropySM90Function
+
+nll, entropy = LigerFusedScaledCrossEntropySM90Function.apply(
+    x, weight, target, 1.0, -100, 1, True
+)  # [M], [M]
+loss = nll.sum() / (target != -100).sum().clamp_min(1)
+```
 
 
 ## Getting Started
@@ -459,5 +487,3 @@ url={https://openreview.net/forum?id=36SjAIT42G}
         ↑ Back to Top ↑
     </a>
 </p>
-
-

--- a/benchmark/scripts/benchmark_fused_scaled_cross_entropy_sm90.py
+++ b/benchmark/scripts/benchmark_fused_scaled_cross_entropy_sm90.py
@@ -1,0 +1,287 @@
+"""Benchmark the Hopper (SM90) CuTe DSL fused *scaled* cross entropy.
+
+The measured operation returns the **per-token NLL** ``[M]`` (never a mean or a
+sum), so the backward is driven by a *fixed* per-token gradient vector ``[M]``
+-- the same vector for every provider, every repetition and every operation
+mode -- instead of the shared harness' fresh ``randn_like`` draw.  That keeps
+the three providers numerically comparable and keeps the gradient allocation
+out of the timed region.
+
+Sweep parameters (all optional; defaults reproduce the previous behaviour)::
+
+    --tokens M [M ...]              total tokens (the x axis)
+    --hidden H                      hidden size
+    --vocab V                       vocabulary size
+    --providers NAME [NAME ...]     explicit provider list
+
+Providers: ``torch``, ``liger`` (Triton FLCE, ``reduction="none"``),
+and ``cutedsl-sm90`` (fixed 1024-token wave-batched backward).
+
+Example::
+
+    python benchmark_fused_scaled_cross_entropy_sm90.py \\
+        --tokens 4096 --hidden 4096 --vocab 131072 \\
+        --providers torch liger cutedsl-sm90
+"""
+
+import argparse
+import sys
+
+import torch
+
+from benchmark_model_configs import MODEL_REGISTRY
+from benchmark_model_configs import build_model_config_sweep
+from benchmark_model_configs import build_token_length_sweep
+from benchmark_model_configs import get_benchmark_model_config
+from utils import QUANTILES
+from utils import SingleBenchmarkRunInput
+from utils import SingleBenchmarkRunOutput
+from utils import _test_memory
+from utils import parse_benchmark_script_args
+from utils import run_benchmarks
+
+from liger_kernel.ops.cutedsl.ops.fused_scaled_cross_entropy_sm90 import LigerFusedScaledCrossEntropySM90Function
+from liger_kernel.transformers.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyLoss
+from liger_kernel.utils import infer_device
+
+device = infer_device()
+
+REPRESENTATIVE_CONFIG = {
+    "hidden_size": 4096,
+    "vocab_size": 131072,
+    "dtype": torch.bfloat16,
+}
+
+CUTEDSL_PREFIX = "cutedsl-sm90"
+# Seed of the fixed per-token upstream gradient, so every provider and every
+# repetition sees byte-identical ``d(NLL)/d(loss)`` values.
+GRAD_SEED = 1234
+
+
+class TorchLMHeadCE(torch.nn.Module):
+    """Per-token (``reduction="none"``) torch baseline."""
+
+    def __init__(self, hidden_size: int, vocab_size: int, dtype: torch.dtype):
+        super().__init__()
+        self.linear = torch.nn.Linear(hidden_size, vocab_size, bias=False, dtype=dtype)
+
+    def forward(self, x, target):
+        logits = self.linear(x).float()
+        return torch.nn.functional.cross_entropy(logits, target, reduction="none")
+
+
+class TritonLMHeadCE(torch.nn.Module):
+    """Triton FLCE with ``reduction="none"`` so the semantics match."""
+
+    def __init__(self, hidden_size: int, vocab_size: int, dtype: torch.dtype):
+        super().__init__()
+        self.linear = torch.nn.Linear(hidden_size, vocab_size, bias=False, dtype=dtype)
+        self.cross_entropy = LigerFusedLinearCrossEntropyLoss(reduction="none", accum_dtype=torch.float32)
+
+    def forward(self, x, target):
+        return self.cross_entropy(self.linear.weight, x, target)
+
+
+class CuteDSLHopperLMHeadScaledCE(torch.nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        vocab_size: int,
+        dtype: torch.dtype,
+        temperature: float = 1.0,
+        m_tiles_per_cluster: int = 1,
+    ):
+        super().__init__()
+        if dtype != torch.bfloat16:
+            raise TypeError(f"SM90 fused scaled cross entropy requires bfloat16, got {dtype}")
+        self.weight = torch.nn.Parameter(torch.empty(vocab_size, hidden_size, dtype=dtype))
+        self.temperature = temperature
+        self.m_tiles_per_cluster = m_tiles_per_cluster
+        torch.nn.init.normal_(self.weight, std=hidden_size**-0.5)
+
+    def forward(self, x, target):
+        return LigerFusedScaledCrossEntropySM90Function.apply(
+            x,
+            self.weight,
+            target,
+            self.temperature,
+            -100,
+            self.m_tiles_per_cluster,
+        )
+
+
+def fixed_grad_output(tokens: int) -> torch.Tensor:
+    """The fixed ``[M]`` upstream gradient of the per-token NLL."""
+    generator = torch.Generator(device=device).manual_seed(GRAD_SEED)
+    return torch.rand(tokens, generator=generator, device=device, dtype=torch.float32) + 0.25
+
+
+def setup_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput):
+    """Return ``(x, forward_fn, grad_output)`` for one benchmark point."""
+    cfg = input.extra_benchmark_config
+    if isinstance(input.x, str):
+        model_cfg = MODEL_REGISTRY[input.x]
+        total_tokens = cfg["seq_len"] * cfg["bsz"]
+        hidden_size = model_cfg.hidden_size
+        vocab_size = model_cfg.vocab_size
+        dtype = model_cfg.dtype
+    else:
+        total_tokens = input.x
+        hidden_size = cfg["hidden_size"]
+        vocab_size = cfg["vocab_size"]
+        dtype = cfg["dtype"]
+
+    x = torch.randn(total_tokens, hidden_size, requires_grad=True, dtype=dtype, device=device)
+    target = torch.randint(vocab_size, (total_tokens,), dtype=torch.long, device=device)
+
+    provider = input.kernel_provider
+    if provider == CUTEDSL_PREFIX:
+        layer = CuteDSLHopperLMHeadScaledCE(hidden_size, vocab_size, dtype)
+    elif provider == "liger":
+        layer = TritonLMHeadCE(hidden_size, vocab_size, dtype)
+    elif provider == "torch":
+        layer = TorchLMHeadCE(hidden_size, vocab_size, dtype)
+    else:
+        raise ValueError(f"Unknown provider {provider!r}")
+
+    layer = layer.to(device)
+    return x, lambda: layer(x, target), fixed_grad_output(total_tokens)
+
+
+def probe_forward_fn(x, fwd_fn, grad_output):
+    """Adapter for the shared memory-probing helpers (setup returns a 3-tuple)."""
+    return fwd_fn()
+
+
+def bench_speed_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
+    import triton
+
+    x, fwd_fn, grad_output = setup_fused_scaled_cross_entropy_sm90(input)
+    mode = input.kernel_operation_mode
+
+    if mode == "forward":
+        bench_fn = fwd_fn
+    elif mode == "backward":
+        y = fwd_fn()
+
+        def bench_fn():
+            y.backward(grad_output, retain_graph=True)
+    elif mode == "full":
+
+        def bench_fn():
+            fwd_fn().backward(grad_output)
+    else:
+        raise ValueError(f"Unsupported mode: {mode}")
+
+    ms_50, ms_20, ms_80 = triton.testing.do_bench(bench_fn, grad_to_none=[x], rep=10, quantiles=QUANTILES)
+    return SingleBenchmarkRunOutput(y_20=ms_20, y_50=ms_50, y_80=ms_80)
+
+
+def bench_memory_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
+    x, fwd_fn, grad_output = setup_fused_scaled_cross_entropy_sm90(input)
+    mode = input.kernel_operation_mode
+
+    if mode == "forward":
+        bench_fn = fwd_fn
+    elif mode == "backward":
+        y = fwd_fn()
+
+        def bench_fn():
+            x.grad = None
+            y.backward(grad_output, retain_graph=True)
+    elif mode == "full":
+
+        def bench_fn():
+            x.grad = None
+            fwd_fn().backward(grad_output)
+    else:
+        raise ValueError(f"Unsupported mode: {mode}")
+
+    mem_50, mem_20, mem_80 = _test_memory(bench_fn, quantiles=QUANTILES)
+    return SingleBenchmarkRunOutput(y_20=mem_20, y_50=mem_50, y_80=mem_80)
+
+
+def parse_sweep_args():
+    """Script-specific flags, stripped from ``argv`` before the shared parser."""
+    parser = argparse.ArgumentParser(add_help=False, description="fused scaled cross entropy sweep options")
+    parser.add_argument("--tokens", type=int, nargs="+", default=None, help="Total tokens (M) to sweep.")
+    parser.add_argument("--hidden", type=int, default=None, help="Hidden size (H).")
+    parser.add_argument("--vocab", type=int, default=None, help="Vocabulary size (V).")
+    parser.add_argument("--providers", type=str, nargs="+", default=None, help="Explicit provider list.")
+    if any(flag in ("-h", "--help") for flag in sys.argv[1:]):
+        parser.print_help()
+        print()
+    sweep_args, remaining = parser.parse_known_args()
+    sys.argv = [sys.argv[0], *remaining]
+    return sweep_args
+
+
+def resolve_providers(sweep_args):
+    if sweep_args.providers:
+        for provider in sweep_args.providers:
+            if provider not in ("torch", "liger", CUTEDSL_PREFIX):
+                raise ValueError(f"Unknown provider {provider!r}")
+        return list(sweep_args.providers)
+    return ["torch", "liger", CUTEDSL_PREFIX]
+
+
+if __name__ == "__main__":
+    sweep_args = parse_sweep_args()
+    args = parse_benchmark_script_args()
+
+    if args.sweep_mode == "model_config":
+        common_configs = build_model_config_sweep(
+            kernel_name="fused_scaled_cross_entropy_sm90",
+            setup_fn=setup_fused_scaled_cross_entropy_sm90,
+            model_keys=["hidden_size", "vocab_size", "dtype"],
+            forward_fn=probe_forward_fn,
+            probe_provider="torch",
+            extra_configs={},
+            probe_dim="BT",
+            bt=args.bt,
+            overwrite=args.overwrite,
+        )
+    else:
+        model = get_benchmark_model_config(args.model)
+        common_configs = build_token_length_sweep(
+            kernel_name="fused_scaled_cross_entropy_sm90",
+            probe_x=1024,
+            model=model,
+            setup_fn=setup_fused_scaled_cross_entropy_sm90,
+            model_keys=["hidden_size", "vocab_size", "dtype"],
+            forward_fn=probe_forward_fn,
+            extra_configs={},
+            scale_dim="BT",
+            x_label="total tokens",
+            probe_provider="torch",
+            overwrite=args.overwrite,
+        )
+        shape = dict(REPRESENTATIVE_CONFIG)
+        if sweep_args.hidden is not None:
+            shape["hidden_size"] = sweep_args.hidden
+        if sweep_args.vocab is not None:
+            shape["vocab_size"] = sweep_args.vocab
+        if sweep_args.tokens:
+            # An explicit M sweep replaces the model-derived token lengths.
+            common_configs["x_values"] = sorted(set(sweep_args.tokens))
+            common_configs["extra_benchmark_configs"] = [shape]
+        else:
+            common_configs["x_values"] = sorted(set([*common_configs["x_values"], 4096]))
+            common_configs["extra_benchmark_configs"].append(shape)
+
+    common_configs["kernel_providers"] = resolve_providers(sweep_args)
+
+    run_benchmarks(
+        bench_test_fn=bench_speed_fused_scaled_cross_entropy_sm90,
+        kernel_operation_modes=["forward", "backward", "full"],
+        metric_name="speed",
+        metric_unit="ms",
+        **common_configs,
+    )
+    run_benchmarks(
+        bench_test_fn=bench_memory_fused_scaled_cross_entropy_sm90,
+        kernel_operation_modes=["forward", "backward", "full"],
+        metric_name="memory",
+        metric_unit="MB",
+        **common_configs,
+    )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def get_optional_dependencies():
         "cuda-tile[tileiras]",
     ]
     cutedsl_deps = [
-        "nvidia-cutlass-dsl",
+        "nvidia-cutlass-dsl>=4.5.2",
     ]
     dev_deps = [
         "transformers>=4.52.0",

--- a/src/liger_kernel/ops/cutedsl/ops/__init__.py
+++ b/src/liger_kernel/ops/cutedsl/ops/__init__.py
@@ -14,14 +14,24 @@ except ImportError as exc:
 from liger_kernel.ops.cutedsl.ops.cross_entropy import LigerCrossEntropyFunction
 from liger_kernel.ops.cutedsl.ops.cross_entropy import cross_entropy_backward
 from liger_kernel.ops.cutedsl.ops.cross_entropy import cross_entropy_forward
+from liger_kernel.ops.cutedsl.ops.fused_scaled_cross_entropy_sm90 import LigerFusedScaledCrossEntropySM90Function
+from liger_kernel.ops.cutedsl.ops.fused_scaled_cross_entropy_sm90 import fused_scaled_cross_entropy_backward
+from liger_kernel.ops.cutedsl.ops.fused_scaled_cross_entropy_sm90 import fused_scaled_cross_entropy_forward
 from liger_kernel.ops.cutedsl.ops.rms_norm import LigerRMSNormFunction
 from liger_kernel.ops.cutedsl.ops.rms_norm import rms_norm_backward
 from liger_kernel.ops.cutedsl.ops.rms_norm import rms_norm_forward
 
+# ``LigerFusedScaledCrossEntropySM90Function`` is an *additional* CuTe DSL
+# operator (per-token NLL only, Hopper BF16); it deliberately does not replace
+# or alias the Triton ``LigerFusedLinearCrossEntropyFunction``, which keeps its
+# reduction and legacy-option surface.
 __all__ = [
     "LigerCrossEntropyFunction",
     "cross_entropy_backward",
     "cross_entropy_forward",
+    "LigerFusedScaledCrossEntropySM90Function",
+    "fused_scaled_cross_entropy_backward",
+    "fused_scaled_cross_entropy_forward",
     "LigerRMSNormFunction",
     "rms_norm_backward",
     "rms_norm_forward",

--- a/src/liger_kernel/ops/cutedsl/ops/_fused_scaled_cross_entropy_backward_fused_sm90.py
+++ b/src/liger_kernel/ops/cutedsl/ops/_fused_scaled_cross_entropy_backward_fused_sm90.py
@@ -1,0 +1,2349 @@
+"""One-CUDA-kernel SM90 backward for fused scaled cross entropy.
+
+The persistent device-side wave loop composes the accepted dZ, dX, and dW
+designs while preserving their phase-specific scheduling:
+
+* dZ uses cooperative N256 self-TMA WGMMA and the static M-fast scheduler;
+* dX uses cooperative N256/K64/s3 with cluster-pair W multicast;
+* dW uses transposed ``order=(1, 0, 2)`` TMA and BF16 stores/reduce-adds.
+
+Structure: mechanical composition, not a redesign
+-------------------------------------------------
+The three accepted kernel bodies are *copied* into phase-local ``@cute.jit``
+device functions, split per warp group exactly the way the accepted kernels
+already split internally (the accepted dX kernel is literally
+``if warp_group == 0: producer else: _mainloop(); _epilogue()``)::
+
+    _dz_epilogue / _dz_mainloop     <- _ScaledCEDzSM90.kernel
+    _dx_producer / _dx_consumer     <- _ScaledCEDxGemmSM90.kernel_coop
+    _dw_producer / _dw_consumer     <- _ScaledCEDwGemmSM90.kernel
+
+``kernel`` does the setup that each accepted kernel does in its prologue --
+SMEM arena, TMA partitions, pipelines, MMA thread slices, WGMMA operand
+fragments, the accumulator -- and then runs the loop that used to live on the
+host in ``_backward_waved``::
+
+    for wave in range(num_waves):
+        dZ phase                    # persistent tile loop, unchanged
+        grid barrier; registers -> 24 / 240
+        dX phase                    # persistent unit loop, unchanged
+        bar.sync                    # sA / sB are aliased between dX and dW
+        dW phase                    # persistent tile loop, unchanged
+        registers -> 88 / 208; grid barrier
+
+Each phase's persistent loop, tile scheduler, pipeline depth, store staging and
+register budget are the accepted ones.  The only edits inside a phase body are
+(a) tile coordinates gain the wave offset, and (b) pipeline state arrives and
+leaves as explicit ``(index, phase)`` pairs instead of ``PipelineState``
+objects, because it has to survive across waves.
+
+Keeping the setup *outside* the wave loop is load-bearing, not cosmetic: a
+variant that put the warp-group branch inside each phase function -- and so
+rebuilt the fragments and used one accumulator per phase, inside the loop --
+spilled 25.5 M local-store sectors (against 22 K) and ran 6 % *slower* than the
+three separate launches.  See "Registers" below.
+
+Launch geometry
+---------------
+One launch, grid ``(2 * C, 1, 1)``, cluster ``(2, 1, 1)``, 384 threads/CTA.
+``C`` obeys a hard launch invariant -- **the grid must never exceed the
+physical SM count**, or it is not fully resident and the software global
+barrier deadlocks::
+
+    sm_count = HardwareInfo().get_device_multiprocessor_count()
+    C = min(get_max_active_clusters(2), sm_count // 2, required_work_clusters)
+    grid_x = 2 * C                       # asserted <= sm_count
+
+``required_work_clusters`` is the largest per-wave cluster demand of the three
+phases (dZ's scheduler plan, dX's ``ceil(m_tiles/2) * ceil(Hp/256)`` units,
+``ceil(dW tiles / 2)``), so small problems shrink the grid instead of spinning
+idle CTAs through every barrier.  On an H200 / 132 SM part at the target shape
+this gives ``C = 66``, i.e. 132 CTAs on 132 SMs.  The shared-memory union is
+~219 KiB, which pins occupancy at exactly one CTA per SM, so the whole grid is
+*provably* simultaneously resident.  The device side reads the barrier target
+from the real ``gridDim.x``, never from a theoretical maximum.  Results are
+bitwise invariant to the launched cluster count (verified from ``C = 1``, i.e.
+2 CTAs, up to the clamped maximum), so shrinking the grid is free of semantic
+risk.
+
+The fixed cluster is interpreted differently by each phase:
+
+=====  =========================================================
+phase  interpretation of the physical ``(2, 1, 1)`` cluster
+=====  =========================================================
+dZ     placement only.  ``cluster_idx = bidx // 2`` selects the persistent
+       scheduler slot, ``bidx % 2`` is the accepted ``cluster_n = 2`` rank that
+       picks the adjacent n-tile.  No multicast, no cluster barrier.
+dX     real ``cluster_m = 2`` with B (= ``W``) TMA multicast, exactly as
+       production: ``pid = bidx // 2``, ``cluster_rank_m = bidx % 2``.
+dW     ignored.  Both CTAs claim independent ``V x H`` output tiles from the
+       flat ``cta_id = bidx`` / ``num_ctas = gridDim.x`` raster.
+=====  =========================================================
+
+Shared memory is a **phase-serial union**, not a sum
+----------------------------------------------------
+The three phase storages are three ``cute.struct`` types instantiated at the
+*same* base pointer.  Phases are serialised by a CTA-wide ``bar.sync`` (and, at
+the dZ/dX boundary, by the global barrier), so the live ranges never overlap::
+
+    offset        dZ                dX                dW
+    0             sX      48 KiB    sA      48 KiB    sA      48 KiB
+    49152         sW      96 KiB    sB      96 KiB    sB      96 KiB
+    147456        sLogits 66 KiB    sC      32 KiB    sD      64 KiB
+    215040        sDZ      8 KiB    -                 -
+    -----------------------------------------------------------------
+    total            223232 B          180224 B          212992 B
+
+The mbarriers are **not** aliased: a small 160 B struct in front of the union
+holds all four pipelines' barrier arrays (dZ mainloop, dZ tile hand-off, dX
+mainloop, dW mainloop).  They are initialised once, before the wave loop, with a
+single ``pipeline_init_arrive`` / ``pipeline_init_wait`` pair; the per-pipeline
+``PipelineState``s are carried across waves as plain ``Int32`` index/phase pairs
+(every pipeline is exactly balanced per wave, so this is correct and it avoids
+the aliased-reinitialisation hazard entirely).
+
+Registers
+---------
+Each phase runs at dZ's accepted ``88 / 208`` budget (WG0 ``setmaxnreg.dec 88``,
+WG1/WG2 ``setmaxnreg.inc 208``; ``2*128*208 + 128*88 = 64512``, the hard ceiling
+-- see the dZ module docstring for why 65536 deadlocks).  Setting
+``repartition_registers=True`` additionally swaps to dX/dW's accepted
+``24 / 240`` after the first grid barrier of each wave and swaps back before the
+second (both swaps decrease before they increase, with the required ``bar.sync``
+in between); it is bit-exact but ~15 % slower because the 24-register producer
+warp group spills, so it is **off by default** -- see "Measured".
+
+There is a **single** accumulator object shared by all three phases, built once
+before the wave loop.  All three tiled MMAs are ``(2, 1, 1)`` atom layouts over
+a ``(64, 256)`` atom with a ``128 x 256`` tile, so ``partition_shape_C`` is
+identical, and the phases are serial, so the live ranges are provably disjoint.
+This is the single most important structural detail in the file: with one
+``cute.make_rmem_tensor`` accumulator per phase, created inside the wave loop,
+ptxas cannot prove the live ranges disjoint, spills all three, and the kernel
+loses ~1.5 ms (see the note under "Structure").
+
+Global barrier
+--------------
+A **single** ``int32`` HBM counter, zeroed by the host before the launch.  Each
+CTA keeps a CTA-uniform ``target_count`` that it raises by the launch's actual
+``gridDim.x`` at every barrier, so barrier ``k`` completes at
+``(k + 1) * gridDim.x``::
+
+    <issuer warps drain their TMA stores with cp.async.bulk.wait_group 0>
+    target_count += gridDim.x
+    fence.proxy.async.global          # async-proxy stores -> generic proxy
+    bar.sync 0
+    if tid == 0:
+        atomicAdd(counter, 1)                     # .release.gpu
+        while ld.acquire.gpu(counter) < target_count: pass
+    bar.sync 0
+    fence.proxy.async.global
+
+Safety: if any CTA has not yet arrived at barrier ``k``, no CTA can be past
+barrier ``k``, so the global count is at most ``(N - 1) * (k + 1) + k =
+(k + 1) * N - 1 < (k + 1) * N``.  A CTA therefore cannot satisfy its target
+early no matter how far ahead it runs.  Because the counter starts at zero for
+every host invocation there is no reset, no cross-launch monotone base and no
+overflow handling.  The cost is one extra tiny ``torch.zeros`` fill per call
+(4 bytes); the CuTe kernel count is still exactly one.
+
+Termination rests on residency: the whole grid is co-resident (NCU reports
+``waves_per_multiprocessor = 1``), so every CTA does reach every barrier and
+the spin always completes.
+
+Two barriers per wave:
+
+1. after dZ, so no CTA reads the BF16 dZ wave workspace before every CTA's
+   ``cp.async.bulk.tensor`` stores into it have completed;
+2. after dW, so no CTA overwrites the workspace on the next wave before every
+   CTA's dX/dW TMA *loads* out of it have completed (they have: a consumer only
+   passes ``consumer_wait`` once the load landed, and each phase's producer and
+   consumer counts are exactly balanced).
+
+Wave/ragged handling
+--------------------
+Every wave is processed at full width (``m_tiles_per_wave`` M128 tiles).  Rows
+past ``M`` get ``row_scale = 0`` from the dZ epilogue, so the workspace rows are
+zero, dX's stores for them are dropped by TMA out-of-bounds predication and dW's
+K contributions are zero.  This removes all ragged-tail bookkeeping from the
+device loop at the cost of at most one partly-idle wave.
+
+Deviations from the accepted phases (deliberate, measured)
+----------------------------------------------------------
+* dX stores **BF16 directly** instead of staging FP32 and letting the host
+  cast.  The staging layout is built the same way the accepted dX builds its
+  FP32 one (``make_smem_layout_a(ROW_MAJOR, (tile_m, tile_n, store_tile_n))``)
+  and keeps dX's accepted ``store_tile_n = 32`` / ``store_stages = 1``; only the
+  element type differs, which is exactly what the accepted dZ already does for
+  its own BF16 store.  RTNE either way, so the result is bit-identical to
+  production's ``fp32_out.to(bfloat16)``, and it removes a full ``[M, H]`` FP32
+  buffer plus a per-wave copy kernel -- which a one-launch kernel cannot have.
+* dW's per-tile pipeline state is carried incrementally instead of being
+  recomputed from ``it``; the recomputation is only valid inside a single
+  launch's tile stream.
+* ``producer_tail`` is dropped for dX/dW: producer commits and consumer waits
+  are exactly balanced per wave and the phase-boundary ``bar.sync`` keeps the
+  producer from running into the next phase's aliased SMEM.
+
+Measured (H200 SXM, CuTe DSL 4.5.2, ``sm_90a``)
+------------------------------------------------
+``M = 4096``, ``H = 4096``, ``V = 131072``, ``m_tiles_per_wave = 8``
+(4 waves, 13.194 TFLOP of GEMM), interleaved A/B against the accepted
+host-orchestrated backward in one process, same inputs and same BF16 outputs
+(that three-launch baseline has since been retired from the tree, so these
+numbers are the last head-to-head measurement against it):
+
+======================  ===========  =================  ===========
+implementation          median (ms)  effective TFLOP/s  peak alloc
+======================  ===========  =================  ===========
+production, 3 CuTe      20.72        636.9              1328 MiB
+launches per wave
+this kernel, 1 launch   20.08        657.0              1312 MiB
+======================  ===========  =================  ===========
+
+ratio fused/production 0.969 median (0.973 min, 0.969 mean) -> **1.032x**;
+repeat runs land between 1.02x and 1.04x.  ``grad_input`` and ``grad_weight``
+are **bit-identical** to the accepted backward on every validated shape
+(aligned, ragged tokens/hidden/vocab, ``ignore_index`` rows, zero-gradient
+rows, single- and multi-wave BF16 dW accumulation).
+
+Nsight Compute confirms the intended geometry and the residency argument
+behind the software barrier::
+
+    grid 132 CTAs   block 384   cluster (2, 1, 1)   waves/SM 1.0
+    dynamic SMEM 224256 B   occupancy limit 1 block/SM (SMEM and registers)
+    registers/thread 168     tensor pipe active 91.7 % of peak sustained
+    stall barrier 7.04 / stall membar 0.00   duration 19.82 ms
+
+against the three production phases' 81.7 % / 99.2 % / 82.9 % (about 87 %
+work-weighted), and the torch profiler counts exactly **one** CuTe kernel per
+backward call -- plus two tiny ``torch.zeros`` fills (the dW accumulator, which
+production pays too, and the barrier counter) -- against production's
+16 CuTe kernels + 1 fill.  Torch-profiler census: production 17 CUDA kernels
+per call, fused 3.
+
+The one cost the separate launches do not pay is register spilling, and it is
+the reason ``repartition_registers`` defaults to **off**.  With the per-phase
+repartition on, WG0 runs the dX/dW producer at 24 registers and spills: 83 M
+local-load and 22 M local-store sectors.  Pinning ``88 / 208`` throughout
+removes it almost entirely and is a large, reproducible win at the target
+shape (back-to-back, 10 iterations each, same process pattern)::
+
+    repartition_registers   median ms   vs production   local ld / st sectors
+    True  (24/240, 88/208)  23.03       0.906x          82.9 M / 22.2 M
+    False (88/208 fixed)    20.08       1.032x          11.1 M /  0.04 M
+
+So the fused kernel keeps dZ's accepted ``88 / 208`` split for every phase
+rather than restoring dX/dW's accepted ``24 / 240``; that is the one register
+deviation from the accepted per-phase configs, and it is measurement-driven.
+``repartition_registers=True`` reproduces the accepted per-phase budgets and
+still validates bit-exact, but costs ~15 %.
+
+The residual local traffic that survives ``repartition_registers=False`` is
+mostly the *second* BF16 store fragment.  dX and dW never stage at the same
+time, so ``d_frag`` aliases ``c_frag`` whenever their store tiles are the same
+width -- but the accepted widths differ (dX 32, dW 64), so by default they do
+not alias.  Forcing a match is bit-exact and cuts local traffic sharply, yet
+buys no time (target shape, wave 8, interleaved)::
+
+    dx/dw store width   frag shared   local ld / st        median ms   ratio
+    32 / 64 (accepted)  no            11.17 M / 38016      20.004      1.0000
+    64 / 64             yes            4.88 M / 25344      19.997      1.0003
+    32 / 32             yes            7.23 M / 31680      20.445      0.9784
+
+Sharing, not subtile count, is what dominates: the accepted split runs *fewer*
+store-loop iterations than the 32/32 variant (12 vs 16) yet moves the most
+local traffic.  Registers/thread stay at 168 in all three.  Because the effect
+is entirely off the critical path -- the kernel is 92-97 % tensor-pipe active
+and the local traffic hits L1 -- the accepted per-phase store widths are kept.
+
+Phase-order ablation (``dw_before_dx``)
+---------------------------------------
+dZ and dW both read the wave's X tile (8 MiB at ``m_tiles_per_wave = 8``) while
+dX streams the 256 MiB dZ workspace and 1 GiB of W between them, so running
+dW second-instead-of-third should keep X resident.  It does reduce DRAM reads,
+but the kernel is tensor-pipe bound and the saving does not convert to time
+(target shape, interleaved A/B in one process, 15 samples each)::
+
+    order         median ms   eff TFLOP/s   DRAM rd    DRAM wr   L2 hit   tensor
+    dZ->dX->dW    19.970      660.7         17.584 GB  5.380 GB  79.91 %  91.97 %
+    dZ->dW->dX    19.934      661.9         16.229 GB  5.399 GB  79.92 %  91.94 %
+
+ratio 1.0018x -- inside run-to-run noise -- despite a 7.7 % (1.355 GB) drop in
+DRAM reads.  Per-phase cycle counters (CTA 0, accumulated over the 4 waves,
+``profile_phases`` build) show dW itself gets *slower* when moved earlier, so
+the locality win is real but is not on the critical path::
+
+    order         dZ         barrier   dX        dW         total
+    dZ->dX->dW    8.68 Mcyc  0.05      8.43      9.94       27.10 Mcyc
+    dZ->dW->dX    8.71 Mcyc  0.05      8.47      10.50      27.73 Mcyc
+
+Both orders are bit-identical to each other and to the accepted backward on
+every validated shape, so the knob is kept only as an ablation; the default
+stays ``dw_before_dx=False``.
+
+The same ablation in full-workspace mode (``m_tiles_per_wave = 32`` at
+``M = 4096``: one device wave, 1 GiB dZ workspace, the full 32 MiB X tensor
+instead of an 8 MiB slice, one grid barrier instead of seven, and a single dW
+``tma_d_store`` instead of four BF16 reduce-add passes) **reverses the sign**
+of the DRAM effect::
+
+    order         median ms   eff TFLOP/s   DRAM rd    DRAM wr   L2 hit   tensor
+    dZ->dX->dW    19.362      681.5         18.330 GB  2.182 GB  71.01 %  97.46 %
+    dZ->dW->dX    19.433      678.9         20.663 GB  2.185 GB  71.41 %  97.15 %
+
+    order         dZ         barrier   dX        dW        total
+    dZ->dX->dW    8.54 Mcyc  0.01      8.50      8.72      25.77 Mcyc
+    dZ->dW->dX    8.41 Mcyc  0.01      8.68      8.46      25.56 Mcyc
+
+ratio 0.9963x and 0.9999x over two runs: dW-first is neutral-to-marginally
+*worse*, and it costs 2.333 GB (+12.7 %) of extra DRAM reads rather than
+saving 1.355 GB.  At wave 8 the X
+slice is small enough that running dW straight after dZ reuses it; at wave 32
+the 1 GiB dZ workspace has already swept L2 many times over, so the reuse
+disappears and the transposed dW read pattern only disturbs the residency dX
+would otherwise inherit.  dW's own phase cost is flat between the two orders
+here (8.72 vs 8.68 Mcyc) against +5.6 % at wave 8.
+
+Full-workspace mode is the faster configuration overall (19.36 ms / 681.5
+TFLOP/s vs 19.99 / 660.0), almost entirely from write traffic: 2.18 GB against
+5.38 GB, because the single-wave dW stores once instead of read-modify-writing
+the 1 GiB BF16 accumulator four times.  It also cuts spill traffic (2.8 M vs
+11.2 M local-load sectors) since the device wave loop runs once.  Peak
+allocation rises from 5536 MiB to 6304 MiB for the larger dZ workspace.
+Across wave modes ``grad_input`` matches to 1 BF16 ulp (4.883e-04) and
+``grad_weight`` to 3.125e-02, the expected consequence of single-store versus
+four-pass BF16 accumulation; within either mode the two phase orders remain
+bit-identical.
+
+Ordering note: dX multicasts W into its cluster partner's SMEM, so the phase
+boundary before dX needs a *cluster*-wide barrier, not just
+``sync_threads()``.  In the default order the grid barrier after dZ provides
+it; with ``dw_before_dx=True`` a CTA whose last dW tile is masked off by the
+``tile_id < total`` guard would otherwise run ahead and clobber the operand
+SMEM its partner is still consuming, so that path adds an explicit
+``cluster_arrive`` / ``cluster_wait``.
+"""
+
+from dataclasses import dataclass
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+
+from cutlass import BFloat16
+from cutlass import Float16
+from cutlass import Float32
+from cutlass import Int32
+from cutlass import pipeline
+from cutlass.pipeline.helpers import pipeline_init_arrive
+from cutlass.pipeline.helpers import pipeline_init_wait
+from cutlass.utils import LayoutEnum
+from cutlass.utils import hopper_helpers
+
+from liger_kernel.ops.cutedsl.ops.utils import ensure_cuda_context
+from liger_kernel.ops.cutedsl.ops.utils import to_cute_tensor
+
+THREADS_PER_CTA = 384
+NUM_MMA_WARP_GROUPS = 2
+WARPS_PER_WARP_GROUP = 4
+
+# Named barriers.  0 is reserved for __syncthreads().
+DZ_MMA_BARRIER_ID = 4  # WG1 + WG2 (256 threads)
+DZ_EPI_BARRIER_ID = 5  # WG0 (128 threads)
+DX_EPI_BARRIER_ID = 6  # WG1 + WG2 (256 threads)
+DW_STORE_BARRIER_ID = 7  # WG1 + WG2 (256 threads)
+
+LOG2_E = 1.4426950408889634
+
+HOPPER_MAX_SMEM_BYTES = 227 * 1024
+VOCAB_ALIGN = 8
+HIDDEN_TILE = 64
+
+_compile_cache = {}
+_stream_cache = {}
+_max_active_clusters_cache = {}
+_sm_count_cache = {}
+
+
+def _cute_stream():
+    raw = torch.cuda.current_stream().cuda_stream
+    stream = _stream_cache.get(raw)
+    if stream is None:
+        stream = cuda.CUstream(raw)
+        _stream_cache[raw] = stream
+    return stream
+
+
+def _max_active_clusters(cluster_size):
+    key = (torch.cuda.current_device(), cluster_size)
+    value = _max_active_clusters_cache.get(key)
+    if value is None:
+        torch.cuda.current_stream()
+        value = cutlass.utils.HardwareInfo().get_max_active_clusters(cluster_size)
+        _max_active_clusters_cache[key] = value
+    return value
+
+
+def _sm_count():
+    key = torch.cuda.current_device()
+    value = _sm_count_cache.get(key)
+    if value is None:
+        torch.cuda.current_stream()
+        value = int(cutlass.utils.HardwareInfo().get_device_multiprocessor_count())
+        _sm_count_cache[key] = value
+    return value
+
+
+@dataclass(frozen=True)
+class FusedBackwardConfig:
+    """Knobs for the one-kernel backward.  Defaults reproduce the accepted
+    per-phase geometry as closely as a single launch allows."""
+
+    m_tiles_per_wave: int = 8
+
+    tile_m: int = 128
+    tile_n: int = 256
+    tile_k: int = 64
+    stages: int = 3
+
+    # ---- dZ (accepted) ----
+    dz_group_size: int = 32
+    dz_raster: str = "heuristic"  # "heuristic" | "m" | "n"
+    dz_logit_dtype: str = "f16"  # "f16" | "bf16"
+    dz_logit_pad: int = 8
+    dz_store_tile_n: int = 32
+    dz_store_stages: int = 1
+
+    # ---- dX (accepted; only the C element type is BF16, not FP32) ----
+    dx_raster_group: int = 8
+    dx_store_tile_n: int = 32
+    dx_store_stages: int = 1
+
+    # ---- dW (accepted / FROZEN) ----
+    dw_store_tile_n: int = 64
+    dw_store_stages: int = 4
+    dw_group_m: int = 1
+
+    # ---- phase order ablation ----
+    # False: dZ -> dX -> dW (default).  True: dZ -> dW -> dX, which keeps the
+    # X wave resident across dZ and dW instead of streaming dZ + W between them.
+    dw_before_dx: bool = False
+
+    # ---- registers: each phase runs at its own accepted budget ----
+    epi_registers: int = 88
+    mma_registers: int = 208
+    repartition_registers: bool = False
+    prod_registers: int = 24
+    gemm_registers: int = 240
+
+    fast_math: bool = True
+    with_entropy: bool = False
+
+    @property
+    def wave_rows(self):
+        return self.m_tiles_per_wave * self.tile_m
+
+    @property
+    def logit_stride(self):
+        return self.tile_n + self.dz_logit_pad
+
+    def register_total(self):
+        return 2 * 128 * self.mma_registers + 128 * self.epi_registers
+
+    def register_total_gemm(self):
+        return 2 * 128 * self.gemm_registers + 128 * self.prod_registers
+
+    def validate(self):
+        if self.tile_m != 128:
+            raise ValueError("tile_m is fixed at 128 (one row per dZ epilogue thread)")
+        if self.m_tiles_per_wave < 1:
+            raise ValueError("m_tiles_per_wave must be >= 1")
+        for name, v in (
+            ("dz_store_tile_n", self.dz_store_tile_n),
+            ("dx_store_tile_n", self.dx_store_tile_n),
+            ("dw_store_tile_n", self.dw_store_tile_n),
+        ):
+            if v <= 0 or self.tile_n % v != 0:
+                raise ValueError(f"{name} must be a positive divisor of tile_n")
+        if self.register_total() > 64512:
+            raise ValueError(f"register budget {self.register_total()} exceeds 64512")
+        if self.repartition_registers and self.register_total_gemm() > 64512:
+            raise ValueError(f"repartitioned register budget {self.register_total_gemm()} exceeds 64512")
+        return self
+
+
+@dataclass(frozen=True)
+class _SchedulerPlan:
+    """Host-resolved Quack ``TileScheduler.Params`` for the dZ phase."""
+
+    ncluster_m: int
+    ncluster_n: int
+    along_m: bool
+    group_size: int
+    group_size_tail: int
+    num_groups_regular: int
+
+    @property
+    def ncluster_slow(self):
+        return self.ncluster_n if self.along_m else self.ncluster_m
+
+    @property
+    def num_clusters(self):
+        return self.ncluster_m * self.ncluster_n
+
+
+def _plan_schedule(num_m_tiles, num_n_tiles, cluster_n, group_size, raster):
+    """Mirror of Quack's ``TileScheduler.Params.create`` for a dense GEMM."""
+    ncluster_m = num_m_tiles
+    ncluster_n = (num_n_tiles + cluster_n - 1) // cluster_n
+    if raster == "m":
+        along_m = True
+    elif raster == "n":
+        along_m = False
+    else:
+
+        def round_up(a, b):
+            return (a + b - 1) // b * b
+
+        along_m = round_up(ncluster_n, group_size) > round_up(ncluster_m, group_size)
+    ncluster_fast = ncluster_m if along_m else ncluster_n
+    gs = min(group_size, ncluster_fast)
+    return _SchedulerPlan(
+        ncluster_m=ncluster_m,
+        ncluster_n=ncluster_n,
+        along_m=along_m,
+        group_size=gs,
+        group_size_tail=ncluster_fast % gs,
+        num_groups_regular=ncluster_fast // gs,
+    )
+
+
+class _FusedBackwardSM90:
+    """dZ -> dX -> dW for every token wave, inside one persistent kernel."""
+
+    CLUSTER_M = 2
+
+    def __init__(self, config: FusedBackwardConfig, plan: _SchedulerPlan):
+        config.validate()
+        self.cfg = config
+        self.plan = plan
+        self.tile_m = config.tile_m
+        self.tile_n = config.tile_n
+        self.tile_k = config.tile_k
+        self.stages = config.stages
+        self.m_tiles_per_wave = config.m_tiles_per_wave
+        self.wave_rows = config.wave_rows
+        self.fast_math = config.fast_math
+        self.with_entropy = config.with_entropy
+
+        self.logit_dtype = Float16 if config.dz_logit_dtype == "f16" else BFloat16
+        self.logit_stride = config.logit_stride
+        self.dz_store_tile_n = config.dz_store_tile_n
+        self.dz_store_stages = config.dz_store_stages
+        self.dz_subtiles = self.tile_n // self.dz_store_tile_n
+
+        self.dx_raster_group = config.dx_raster_group
+        self.dx_store_tile_n = config.dx_store_tile_n
+        self.dx_store_stages = config.dx_store_stages
+        self.dx_subtiles = self.tile_n // self.dx_store_tile_n
+
+        self.dw_store_tile_n = config.dw_store_tile_n
+        self.dw_store_stages = config.dw_store_stages
+        self.dw_subtiles = self.tile_n // self.dw_store_tile_n
+        self.dw_group_m = config.dw_group_m
+        self.dw_first = config.dw_before_dx
+
+        self.epi_registers = config.epi_registers
+        self.mma_registers = config.mma_registers
+        self.repartition = config.repartition_registers
+        self.prod_registers = config.prod_registers
+        self.gemm_registers = config.gemm_registers
+
+        self.tile_shape = (self.tile_m, self.tile_n, self.tile_k)
+        self.buffer_align = 1024
+
+        self.dz_mma_bar = pipeline.NamedBarrier(barrier_id=DZ_MMA_BARRIER_ID, num_threads=NUM_MMA_WARP_GROUPS * 128)
+        self.dz_epi_bar = pipeline.NamedBarrier(barrier_id=DZ_EPI_BARRIER_ID, num_threads=128)
+        self.dx_epi_bar = pipeline.NamedBarrier(barrier_id=DX_EPI_BARRIER_ID, num_threads=NUM_MMA_WARP_GROUPS * 128)
+        self.dw_store_bar = pipeline.NamedBarrier(barrier_id=DW_STORE_BARRIER_ID, num_threads=NUM_MMA_WARP_GROUPS * 128)
+
+    # ------------------------------------------------------------------ #
+    # schedulers
+    # ------------------------------------------------------------------ #
+    @cute.jit
+    def _dz_decode_work(self, work_idx: Int32, num_clusters_in_group: Int32, rank: Int32):
+        """Quack static persistent M-fast decode (dZ), verbatim."""
+        plan = self.plan
+        gs = cutlass.const_expr(plan.group_size)
+        gs_tail = cutlass.const_expr(plan.group_size_tail if plan.group_size_tail > 0 else 1)
+        group_id = work_idx // num_clusters_in_group
+        id_in_group = work_idx - group_id * num_clusters_in_group
+        cid_slow, cid_fast_in_group = Int32(0), Int32(0)
+        if cutlass.const_expr(plan.group_size_tail == 0):
+            cid_slow = id_in_group // gs
+            cid_fast_in_group = id_in_group - cid_slow * gs
+        else:
+            if group_id < plan.num_groups_regular:
+                cid_slow = id_in_group // gs
+                cid_fast_in_group = id_in_group - cid_slow * gs
+            else:
+                cid_slow = id_in_group // gs_tail
+                cid_fast_in_group = id_in_group - cid_slow * gs_tail
+        if group_id % 2 == 1:  # serpentine
+            cid_slow = plan.ncluster_slow - 1 - cid_slow
+        cid_fast = group_id * gs + cid_fast_in_group
+        if cutlass.const_expr(plan.along_m):
+            cid_m, cid_n = cid_fast, cid_slow
+        else:
+            cid_m, cid_n = cid_slow, cid_fast
+        return cid_m, cid_n * self.CLUSTER_M + rank
+
+    def _dx_tile_coord(self, unit, num_m_units, num_n_units):
+        """Linear unit id -> ``(m_unit, n_unit)`` under dX's grouped raster."""
+        if cutlass.const_expr(self.dx_raster_group <= 1):
+            return unit // num_n_units, unit % num_n_units
+        group_tiles = num_m_units * self.dx_raster_group
+        group = unit // group_tiles
+        first_n = group * self.dx_raster_group
+        group_n = cutlass.min(Int32(self.dx_raster_group), num_n_units - first_n)
+        within = unit - group * group_tiles
+        return within // group_n, first_n + within % group_n
+
+    def _dw_tile_coord(self, tile_id, num_m_tiles, num_n_tiles):
+        """dW's N-fastest (``group_m == 1``) raster."""
+        if cutlass.const_expr(self.dw_group_m <= 1):
+            return tile_id // num_n_tiles, tile_id % num_n_tiles
+        tiles_per_group = self.dw_group_m * num_n_tiles
+        first_m = (tile_id // tiles_per_group) * self.dw_group_m
+        gm = cutlass.max(cutlass.min(num_m_tiles - first_m, self.dw_group_m), 1)
+        idx = tile_id % tiles_per_group
+        return first_m + idx % gm, idx // gm
+
+    @staticmethod
+    def _sub_src(store_tile_n, tile_n, sub, j):
+        """Sub-tile fragment slot ``j`` -> flat accumulator register index."""
+        gs = store_tile_n // 8
+        block = 4 * gs
+        return (j % block) + block * sub + (tile_n // 2) * (j // block)
+
+    # ------------------------------------------------------------------ #
+    # global barrier
+    # ------------------------------------------------------------------ #
+    @cute.jit
+    def _grid_barrier(self, bar_ptr, target: Int32, tid: Int32):
+        """Counting barrier over every CTA of the persistent grid.
+
+        ``bar_ptr`` points at a single ``int32`` counter, zeroed by the host
+        before the launch.  The caller keeps a CTA-uniform ``target`` that it
+        raises by ``gridDim.x`` at every barrier, so barrier ``k`` of the
+        launch completes once the counter reaches ``(k + 1) * gridDim.x``.
+
+        Safety: if any CTA has not yet arrived at barrier ``k``, no CTA can be
+        past barrier ``k``, so the count is at most ``(N - 1) * (k + 1) + k =
+        (k + 1) * N - 1``, below the target.  A CTA therefore cannot satisfy
+        its target early no matter how far ahead it runs.
+
+        The caller must already have drained (``cp.async.bulk.wait_group 0``)
+        every TMA store whose result the other CTAs are about to read.
+        """
+        cute.arch.fence_proxy("async.global")
+        cute.arch.sync_threads()
+        if tid == 0:
+            cute.arch.atomic_add(bar_ptr, Int32(1), sem="release", scope="gpu")
+            seen = cute.arch.load(bar_ptr, Int32, sem="acquire", scope="gpu")
+            while seen < target:
+                seen = cute.arch.load(bar_ptr, Int32, sem="acquire", scope="gpu")
+        cute.arch.sync_threads()
+        cute.arch.fence_proxy("async.global")
+
+    # ------------------------------------------------------------------ #
+    # host side
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _tma_load(tensor, smem_layout_staged, smem_tile, multicast=1):
+        op = (
+            cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp()
+            if multicast == 1
+            else cute.nvgpu.cpasync.CopyBulkTensorTileG2SMulticastOp()
+        )
+        return cute.nvgpu.cpasync.make_tiled_tma_atom(
+            op,
+            tensor,
+            cute.slice_(smem_layout_staged, (None, None, 0)),
+            smem_tile,
+            num_multicast=multicast,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,  # (M, Hp, 1) row-major BF16     -- dZ A / dW B source
+        w: cute.Tensor,  # (Vp, Hp, 1) row-major BF16    -- dZ B
+        wt: cute.Tensor,  # (Hp, Vp, 1) MN-major BF16    -- dX B (view of w)
+        xt: cute.Tensor,  # (Hp, M, 1) MN-major BF16     -- dW B (view of x)
+        dz: cute.Tensor,  # (Wr, Vp, 1) row-major BF16   -- dZ store / dX A
+        dzt: cute.Tensor,  # (Vp, Wr, 1) MN-major BF16   -- dW A (view of dz)
+        dx: cute.Tensor,  # (M, Hp, 1) row-major BF16    -- dX C
+        dw: cute.Tensor,  # (Vp, Hp, 1) row-major BF16   -- dW D (reduce-add)
+        target: cute.Tensor,
+        lse: cute.Tensor,
+        scale: cute.Tensor,
+        entropy: cute.Tensor,
+        entropy_scale: cute.Tensor,
+        inverse_temperature: Float32,
+        barrier: cute.Tensor,  # int32 [1]
+        ignore_index: Int32,
+        vocab_size: Int32,
+        num_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+    ):
+        x_layout = LayoutEnum.from_tensor(x)
+        w_layout = LayoutEnum.from_tensor(w)
+        wt_layout = LayoutEnum.from_tensor(wt)
+        xt_layout = LayoutEnum.from_tensor(xt)
+        dz_layout = LayoutEnum.from_tensor(dz)
+        dzt_layout = LayoutEnum.from_tensor(dzt)
+        dw_layout = LayoutEnum.from_tensor(dw)
+
+        atom_layout = (NUM_MMA_WARP_GROUPS, 1, 1)
+
+        def _mma(a_layout, b_layout, n):
+            return hopper_helpers.make_trivial_tiled_mma(
+                BFloat16,
+                BFloat16,
+                a_layout.sm90_mma_major_mode(),
+                b_layout.sm90_mma_major_mode(),
+                Float32,
+                atom_layout,
+                (64, n),
+            )
+
+        mma_dz = _mma(x_layout, w_layout, self.tile_n)
+        mma_dx = _mma(dz_layout, wt_layout, self.tile_n)
+        mma_dw = _mma(dzt_layout, xt_layout, self.tile_n)
+        smma_dx = _mma(dz_layout, wt_layout, self.dx_store_tile_n)
+        smma_dw = _mma(dzt_layout, xt_layout, self.dw_store_tile_n)
+
+        # ---- SMEM layouts ------------------------------------------------
+        dz_a = hopper_helpers.make_smem_layout_a(x_layout, self.tile_shape, BFloat16, self.stages)
+        dz_b = hopper_helpers.make_smem_layout_b(w_layout, self.tile_shape, BFloat16, self.stages)
+        dz_st = hopper_helpers.make_smem_layout_a(
+            LayoutEnum.ROW_MAJOR,
+            (self.tile_m, self.tile_n, self.dz_store_tile_n),
+            BFloat16,
+            self.dz_store_stages,
+        )
+        dx_a = hopper_helpers.make_smem_layout_a(dz_layout, self.tile_shape, BFloat16, self.stages)
+        dx_b = hopper_helpers.make_smem_layout_b(wt_layout, self.tile_shape, BFloat16, self.stages)
+        dx_st = hopper_helpers.make_smem_layout_a(
+            LayoutEnum.ROW_MAJOR,
+            (self.tile_m, self.tile_n, self.dx_store_tile_n),
+            BFloat16,
+            self.dx_store_stages,
+        )
+        dw_a = hopper_helpers.make_smem_layout_a(dzt_layout, self.tile_shape, BFloat16, self.stages)
+        dw_b = hopper_helpers.make_smem_layout_b(xt_layout, self.tile_shape, BFloat16, self.stages)
+        dw_st = hopper_helpers.make_smem_layout_epi(
+            BFloat16, dw_layout, (self.tile_m, self.dw_store_tile_n), self.dw_store_stages
+        )
+
+        # ---- TMA atoms ---------------------------------------------------
+        tma_x, t_x = self._tma_load(x, dz_a, (self.tile_m, self.tile_k))
+        tma_w, t_w = self._tma_load(w, dz_b, (self.tile_n, self.tile_k))
+        tma_dzs, t_dzs = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp(),
+            dz,
+            cute.slice_(dz_st, (None, None, 0)),
+            (self.tile_m, self.dz_store_tile_n),
+        )
+        tma_dza, t_dza = self._tma_load(dz, dx_a, (self.tile_m, self.tile_k))
+        tma_wt, t_wt = self._tma_load(wt, dx_b, (self.tile_n, self.tile_k), multicast=self.CLUSTER_M)
+        tma_dx, t_dx = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp(),
+            dx,
+            cute.slice_(dx_st, (None, None, 0)),
+            (self.tile_m, self.dx_store_tile_n),
+        )
+        tma_dwa, t_dwa = self._tma_load(dzt, dw_a, (self.tile_m, self.tile_k))
+        tma_xt, t_xt = self._tma_load(xt, dw_b, (self.tile_n, self.tile_k))
+        tma_dw_store, t_dw_store = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp(),
+            dw,
+            cute.slice_(dw_st, (None, None, 0)),
+            (self.tile_m, self.dw_store_tile_n),
+        )
+        tma_dw_add, t_dw_add = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            cute.nvgpu.cpasync.CopyReduceBulkTensorTileS2GOp(cute.ReductionKind.ADD),
+            dw,
+            cute.slice_(dw_st, (None, None, 0)),
+            (self.tile_m, self.dw_store_tile_n),
+        )
+
+        logit_dtype = self.logit_dtype
+
+        @cute.struct
+        class BarrierStorage:
+            dz_pipe: cute.struct.MemRange[cutlass.Int64, self.stages * 2]
+            dz_tile: cute.struct.MemRange[cutlass.Int64, 2]
+            dx_pipe: cute.struct.MemRange[cutlass.Int64, self.stages * 2]
+            dw_pipe: cute.struct.MemRange[cutlass.Int64, self.stages * 2]
+
+        @cute.struct
+        class DzStorage:
+            sX: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(dz_a)], self.buffer_align]
+            sW: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(dz_b)], self.buffer_align]
+            sL: cute.struct.Align[cute.struct.MemRange[logit_dtype, self.tile_m * self.logit_stride], self.buffer_align]
+            sZ: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(dz_st)], self.buffer_align]
+
+        @cute.struct
+        class DxStorage:
+            sA: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(dx_a)], self.buffer_align]
+            sB: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(dx_b)], self.buffer_align]
+            sC: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(dx_st)], self.buffer_align]
+
+        @cute.struct
+        class DwStorage:
+            sA: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(dw_a)], self.buffer_align]
+            sB: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(dw_b)], self.buffer_align]
+            sD: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(dw_st)], self.buffer_align]
+
+        self.bar_storage = BarrierStorage
+        self.dz_storage = DzStorage
+        self.dx_storage = DxStorage
+        self.dw_storage = DwStorage
+        self.union_bytes = max(DzStorage.__sizeof__(), DxStorage.__sizeof__(), DwStorage.__sizeof__())
+        if cutlass.const_expr(self.union_bytes + 1024 > HOPPER_MAX_SMEM_BYTES):
+            raise ValueError(
+                f"phase-serial SMEM union is {self.union_bytes + 1024} B, over the "
+                f"{HOPPER_MAX_SMEM_BYTES} B Hopper opt-in limit"
+            )
+
+        self.kernel(
+            tma_x,
+            t_x,
+            tma_w,
+            t_w,
+            tma_dzs,
+            t_dzs,
+            tma_dza,
+            t_dza,
+            tma_wt,
+            t_wt,
+            tma_dx,
+            t_dx,
+            tma_dwa,
+            t_dwa,
+            tma_xt,
+            t_xt,
+            tma_dw_store,
+            t_dw_store,
+            tma_dw_add,
+            t_dw_add,
+            target,
+            lse,
+            scale,
+            entropy,
+            entropy_scale,
+            inverse_temperature,
+            barrier,
+            mma_dz,
+            mma_dx,
+            mma_dw,
+            smma_dx,
+            smma_dw,
+            dz_a,
+            dz_b,
+            dz_st,
+            dx_a,
+            dx_b,
+            dx_st,
+            dw_a,
+            dw_b,
+            dw_st,
+            ignore_index,
+            vocab_size,
+        ).launch(
+            grid=(num_clusters * self.CLUSTER_M, 1, 1),
+            block=(THREADS_PER_CTA, 1, 1),
+            cluster=(self.CLUSTER_M, 1, 1),
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    @cute.jit
+    def _regs_for_gemm(self, is_wg0: cutlass.Constexpr):
+        """dZ's accepted budget (88 / 208) -> dX and dW's (24 / 240)."""
+        if cutlass.const_expr(self.repartition):
+            if cutlass.const_expr(is_wg0):
+                cute.arch.setmaxregister_decrease(self.prod_registers)
+                cute.arch.sync_threads()
+            else:
+                cute.arch.sync_threads()
+                cute.arch.setmaxregister_increase(self.gemm_registers)
+
+    @cute.jit
+    def _regs_for_dz(self, is_wg0: cutlass.Constexpr):
+        """dX/dW's accepted budget (24 / 240) -> dZ's (88 / 208)."""
+        if cutlass.const_expr(self.repartition):
+            if cutlass.const_expr(is_wg0):
+                cute.arch.sync_threads()
+                cute.arch.setmaxregister_increase(self.epi_registers)
+            else:
+                cute.arch.setmaxregister_decrease(self.mma_registers)
+                cute.arch.sync_threads()
+
+    # ------------------------------------------------------------------ #
+    # phase 1: dZ = softmax(X @ W^T) - onehot          (one token wave)
+    #
+    # ``_dz_epilogue`` and ``_dz_mainloop`` are the WG0 and WG1/WG2 halves of
+    # ``_ScaledCEDzSM90.kernel``, copied across with the persistent
+    # ``for tile in range(...)`` loop intact.  Only the tile *coordinates*
+    # gain the wave offset, and the pipeline states arrive and leave as
+    # explicit ``(index, phase)`` pairs instead of ``PipelineState`` objects.
+    # ------------------------------------------------------------------ #
+    @cute.jit
+    def _dz_epilogue(
+        self,
+        wave: Int32,
+        tid: Int32,
+        local_warp: Int32,
+        row_in_tile: Int32,
+        cluster_idx: Int32,
+        cta_rank: Int32,
+        num_clusters: Int32,
+        dz_tiles: Int32,
+        dz_group: Int32,
+        tma_dzs: cute.CopyAtom,
+        tZgZ: cute.Tensor,
+        tZsZ: cute.Tensor,
+        sL: cute.Tensor,
+        sZ: cute.Tensor,
+        tile_pipe: pipeline.PipelineAsync,
+        target: cute.Tensor,
+        lse: cute.Tensor,
+        scale: cute.Tensor,
+        entropy: cute.Tensor,
+        entropy_scale: cute.Tensor,
+        inverse_temperature: Float32,
+        vals: cute.Tensor,
+        ignore_index: Int32,
+        vocab_size: Int32,
+        cr_i: Int32,
+        cr_p: Int32,
+    ):
+        row_base = wave * Int32(self.wave_rows)
+        chunk = cutlass.const_expr(self.dz_store_tile_n)
+
+        work_idx = Int32(cluster_idx)
+        for _ in range(dz_tiles):
+            pid_m, pid_n = self._dz_decode_work(work_idx, dz_group, cta_rank)
+            row = row_base + pid_m * self.tile_m + row_in_tile
+            n_base = pid_n * self.tile_n
+
+            row_scale = Float32(0.0)
+            row_entropy = Float32(0.0)
+            row_entropy_scale = Float32(0.0)
+            row_lse = Float32(0.0)
+            tgt_local = Int32(-1)
+            if row < target.shape[0]:
+                tcol = Int32(target[row])
+                if tcol != ignore_index:
+                    row_lse = lse[row]
+                    row_scale = scale[row]
+                    if cutlass.const_expr(self.with_entropy):
+                        row_entropy = Float32(entropy[row])
+                        row_entropy_scale = entropy_scale[row]
+                    if tcol >= n_base and tcol < n_base + self.tile_n:
+                        tgt_local = tcol - n_base
+
+            rstate = pipeline.PipelineState(1, Int32(0), cr_i, cr_p)
+            tile_pipe.consumer_wait(rstate)
+            cute.arch.fence_acq_rel_cta()
+
+            for sub in cutlass.range_constexpr(self.dz_subtiles):
+                stage = sub % self.dz_store_stages
+                c0 = sub * chunk
+                for j in cutlass.range_constexpr(chunk):
+                    vals[j] = Float32(sL[row_in_tile, c0 + j])
+                for j in cutlass.range_constexpr(chunk):
+                    v = Float32(0.0)
+                    if n_base + c0 + j < vocab_size:
+                        if cutlass.const_expr(self.with_entropy):
+                            if row_scale != 0.0 or row_entropy_scale != 0.0:
+                                scaled_logit = vals[j] * inverse_temperature
+                                probability = cute.math.exp2(
+                                    (scaled_logit - row_lse) * LOG2_E,
+                                    fastmath=self.fast_math,
+                                )
+                                v = probability * (
+                                    row_scale + (row_lse - row_entropy - scaled_logit) * row_entropy_scale
+                                )
+                        else:
+                            if row_scale != 0.0:
+                                v = (
+                                    cute.math.exp2(
+                                        (vals[j] * inverse_temperature - row_lse) * LOG2_E,
+                                        fastmath=self.fast_math,
+                                    )
+                                    * row_scale
+                                )
+                    vals[j] = v
+                if tgt_local >= c0 and tgt_local < c0 + chunk:
+                    for j in cutlass.range_constexpr(chunk):
+                        if tgt_local == c0 + j:
+                            vals[j] = vals[j] - row_scale
+
+                if local_warp == 0:
+                    cute.arch.cp_async_bulk_wait_group(self.dz_store_stages - 1, read=True)
+                self.dz_epi_bar.arrive_and_wait()
+                for j in cutlass.range_constexpr(chunk):
+                    sZ[row_in_tile, j, stage] = BFloat16(vals[j])
+                cute.arch.fence_proxy("async.shared", space="cta")
+                self.dz_epi_bar.arrive_and_wait()
+                if local_warp == 0:
+                    cute.copy(
+                        tma_dzs,
+                        tZsZ[(None, stage)],
+                        tZgZ[(None, pid_m, pid_n * self.dz_subtiles + sub, 0)],
+                    )
+                    cute.arch.cp_async_bulk_commit_group()
+
+            self.dz_epi_bar.arrive_and_wait()
+            if tid == 0:
+                tile_pipe.consumer_release(rstate)
+            rstate.advance()
+            cr_i = rstate.index
+            cr_p = rstate.phase
+            work_idx += num_clusters
+
+        # Drain the wave workspace stores before the caller's grid barrier.
+        if local_warp == 0:
+            cute.arch.cp_async_bulk_wait_group(0, read=True)
+        self.dz_epi_bar.arrive_and_wait()
+        if local_warp == 0:
+            cute.arch.cp_async_bulk_wait_group(0)
+
+        return cr_i, cr_p
+
+    @cute.jit
+    def _dz_mainloop(
+        self,
+        wave: Int32,
+        tid: Int32,
+        warp: Int32,
+        cluster_idx: Int32,
+        cta_rank: Int32,
+        num_clusters: Int32,
+        dz_tiles: Int32,
+        dz_group: Int32,
+        num_k: Int32,
+        num_k_blocks: cutlass.Constexpr,
+        tma_x: cute.CopyAtom,
+        tXgX: cute.Tensor,
+        tXsX: cute.Tensor,
+        tma_w: cute.CopyAtom,
+        tWgW: cute.Tensor,
+        tWsW: cute.Tensor,
+        sL: cute.Tensor,
+        mma: cute.TiledMma,
+        rA: cute.Tensor,
+        rB: cute.Tensor,
+        accum: cute.Tensor,
+        row_base_in_tile: Int32,
+        col_base_in_tile: Int32,
+        pipe: pipeline.PipelineAsync,
+        tile_pipe: pipeline.PipelineAsync,
+        ld_i: Int32,
+        ld_p: Int32,
+        rd_i: Int32,
+        rd_p: Int32,
+        rl_i: Int32,
+        rl_p: Int32,
+        wr_i: Int32,
+        wr_p: Int32,
+    ):
+        m_off = wave * Int32(self.m_tiles_per_wave)
+        n_accum = cute.size(accum)
+
+        load_i = Int32(0)
+        load_k = Int32(0)
+        load_pid_m, load_pid_n = self._dz_decode_work(Int32(cluster_idx), dz_group, cta_rank)
+
+        if warp == 4:
+            prologue = cutlass.min(Int32(self.stages), dz_tiles * Int32(num_k))
+            for _ in range(prologue):
+                pstate = pipeline.PipelineState(self.stages, Int32(0), ld_i, ld_p)
+                pipe.producer_acquire(pstate)
+                bar = pipe.producer_get_barrier(pstate)
+                cute.copy(
+                    tma_x,
+                    tXgX[(None, m_off + load_pid_m, None, 0)][(None, load_k)],
+                    tXsX[(None, ld_i)],
+                    tma_bar_ptr=bar,
+                    mcast_mask=0,
+                )
+                cute.copy(
+                    tma_w,
+                    tWgW[(None, load_pid_n, None, 0)][(None, load_k)],
+                    tWsW[(None, ld_i)],
+                    tma_bar_ptr=bar,
+                )
+                pipe.producer_commit(pstate)
+                pstate.advance()
+                ld_i = pstate.index
+                ld_p = pstate.phase
+                load_k += 1
+                if load_k == num_k:
+                    load_k = Int32(0)
+                    load_i += 1
+                    load_pid_m, load_pid_n = self._dz_decode_work(
+                        Int32(cluster_idx) + load_i * num_clusters, dz_group, cta_rank
+                    )
+
+        for _ in range(dz_tiles):
+            mma.set(cute.nvgpu.warpgroup.Field.ACCUMULATE, False)
+
+            rstate = pipeline.PipelineState(self.stages, Int32(0), rd_i, rd_p)
+            pipe.consumer_wait(rstate)
+            cute.nvgpu.warpgroup.fence()
+            for kb in cutlass.range_constexpr(num_k_blocks):
+                coord = (None, None, kb, rd_i)
+                cute.gemm(mma, accum, rA[coord], rB[coord], accum)
+                mma.set(cute.nvgpu.warpgroup.Field.ACCUMULATE, True)
+            cute.nvgpu.warpgroup.commit_group()
+            rstate.advance()
+            rd_i = rstate.index
+            rd_p = rstate.phase
+
+            for _ in range(1, num_k):
+                rstate = pipeline.PipelineState(self.stages, Int32(0), rd_i, rd_p)
+                pipe.consumer_wait(rstate)
+                cute.nvgpu.warpgroup.fence()
+                for kb in cutlass.range_constexpr(num_k_blocks):
+                    coord = (None, None, kb, rd_i)
+                    cute.gemm(mma, accum, rA[coord], rB[coord], accum)
+                cute.nvgpu.warpgroup.commit_group()
+                cute.nvgpu.warpgroup.wait_group(1)
+                lstate = pipeline.PipelineState(self.stages, Int32(0), rl_i, rl_p)
+                pipe.consumer_release(lstate)
+                lstate.advance()
+                rl_i = lstate.index
+                rl_p = lstate.phase
+                if warp == 4:
+                    if load_i < dz_tiles:
+                        pstate = pipeline.PipelineState(self.stages, Int32(0), ld_i, ld_p)
+                        pipe.producer_acquire(pstate)
+                        bar = pipe.producer_get_barrier(pstate)
+                        cute.copy(
+                            tma_x,
+                            tXgX[(None, m_off + load_pid_m, None, 0)][(None, load_k)],
+                            tXsX[(None, ld_i)],
+                            tma_bar_ptr=bar,
+                            mcast_mask=0,
+                        )
+                        cute.copy(
+                            tma_w,
+                            tWgW[(None, load_pid_n, None, 0)][(None, load_k)],
+                            tWsW[(None, ld_i)],
+                            tma_bar_ptr=bar,
+                        )
+                        pipe.producer_commit(pstate)
+                        pstate.advance()
+                        ld_i = pstate.index
+                        ld_p = pstate.phase
+                        load_k += 1
+                        if load_k == num_k:
+                            load_k = Int32(0)
+                            load_i += 1
+                            load_pid_m, load_pid_n = self._dz_decode_work(
+                                Int32(cluster_idx) + load_i * num_clusters, dz_group, cta_rank
+                            )
+                rstate.advance()
+                rd_i = rstate.index
+                rd_p = rstate.phase
+
+            cute.nvgpu.warpgroup.wait_group(0)
+            lstate = pipeline.PipelineState(self.stages, Int32(0), rl_i, rl_p)
+            pipe.consumer_release(lstate)
+            lstate.advance()
+            rl_i = lstate.index
+            rl_p = lstate.phase
+            if warp == 4:
+                if load_i < dz_tiles:
+                    pstate = pipeline.PipelineState(self.stages, Int32(0), ld_i, ld_p)
+                    pipe.producer_acquire(pstate)
+                    bar = pipe.producer_get_barrier(pstate)
+                    cute.copy(
+                        tma_x,
+                        tXgX[(None, m_off + load_pid_m, None, 0)][(None, load_k)],
+                        tXsX[(None, ld_i)],
+                        tma_bar_ptr=bar,
+                        mcast_mask=0,
+                    )
+                    cute.copy(
+                        tma_w,
+                        tWgW[(None, load_pid_n, None, 0)][(None, load_k)],
+                        tWsW[(None, ld_i)],
+                        tma_bar_ptr=bar,
+                    )
+                    pipe.producer_commit(pstate)
+                    pstate.advance()
+                    ld_i = pstate.index
+                    ld_p = pstate.phase
+                    load_k += 1
+                    if load_k == num_k:
+                        load_k = Int32(0)
+                        load_i += 1
+                        load_pid_m, load_pid_n = self._dz_decode_work(
+                            Int32(cluster_idx) + load_i * num_clusters, dz_group, cta_rank
+                        )
+
+            wstate = pipeline.PipelineState(1, Int32(0), wr_i, wr_p)
+            tile_pipe.producer_acquire(wstate)
+            for i in cutlass.range_constexpr(n_accum):
+                r = row_base_in_tile + ((i % 4) // 2) * 8
+                c = col_base_in_tile + (i // 4) * 8 + (i % 2)
+                sL[r, c] = self.logit_dtype(accum[i])
+            cute.arch.fence_proxy("async.shared", space="cta")
+            cute.arch.fence_acq_rel_cta()
+            self.dz_mma_bar.arrive_and_wait()
+            if tid == 128:
+                tile_pipe.producer_commit(wstate)
+            wstate.advance()
+            wr_i = wstate.index
+            wr_p = wstate.phase
+
+        return ld_i, ld_p, rd_i, rd_p, rl_i, rl_p, wr_i, wr_p
+
+    # ------------------------------------------------------------------ #
+    # phase 2: dX = dZ @ W                              (one token wave)
+    #
+    # ``_dx_producer`` and ``_dx_consumer`` are the WG0 and WG1/WG2 halves of
+    # ``_ScaledCEDxGemmSM90.kernel_coop`` (the latter being its ``_mainloop``
+    # followed by its ``_epilogue``), persistent ``while unit <`` loop
+    # included.  W is multicast over the cluster pair exactly as in the
+    # accepted kernel.  Only the C store element type is BF16, not FP32.
+    # ------------------------------------------------------------------ #
+    @cute.jit
+    def _dx_producer(
+        self,
+        warp: Int32,
+        cluster_idx: Int32,
+        cta_rank: Int32,
+        num_clusters: Int32,
+        b_mcast_mask: Int32,
+        m_tiles: cutlass.Constexpr,
+        m_units: cutlass.Constexpr,
+        n_units: Int32,
+        num_k: Int32,
+        tma_a: cute.CopyAtom,
+        tAgA: cute.Tensor,
+        tAsA: cute.Tensor,
+        tma_b: cute.CopyAtom,
+        tBgB: cute.Tensor,
+        tBsB: cute.Tensor,
+        pipe: pipeline.PipelineAsync,
+        ld_i: Int32,
+        ld_p: Int32,
+    ):
+        if warp == 0:
+            units = m_units * n_units
+            unit = Int32(cluster_idx)
+            while unit < units:
+                m_unit, n_unit = self._dx_tile_coord(unit, m_units, n_units)
+                m_tile = cutlass.min(m_unit * self.CLUSTER_M + cta_rank, m_tiles - 1)
+                tA_m = tAgA[(None, m_tile, None, 0)]
+                tB_n = tBgB[(None, n_unit, None, 0)]
+                for k in range(num_k):
+                    pstate = pipeline.PipelineState(self.stages, Int32(0), ld_i, ld_p)
+                    pipe.producer_acquire(pstate)
+                    bar = pipe.producer_get_barrier(pstate)
+                    cute.copy(
+                        tma_a,
+                        tA_m[(None, k)],
+                        tAsA[(None, ld_i)],
+                        tma_bar_ptr=bar,
+                        mcast_mask=0,
+                    )
+                    cute.copy(
+                        tma_b,
+                        tB_n[(None, k)],
+                        tBsB[(None, ld_i)],
+                        tma_bar_ptr=bar,
+                        mcast_mask=b_mcast_mask,
+                    )
+                    pipe.producer_commit(pstate)
+                    pstate.advance()
+                    ld_i = pstate.index
+                    ld_p = pstate.phase
+                unit += num_clusters
+
+        return ld_i, ld_p
+
+    @cute.jit
+    def _dx_consumer(
+        self,
+        wave: Int32,
+        issuer: cutlass.Boolean,
+        cluster_idx: Int32,
+        cta_rank: Int32,
+        num_clusters: Int32,
+        m_tiles: cutlass.Constexpr,
+        m_units: cutlass.Constexpr,
+        n_units: Int32,
+        num_k: Int32,
+        num_k_blocks: cutlass.Constexpr,
+        tma_c: cute.CopyAtom,
+        tCgC: cute.Tensor,
+        tCsC: cute.Tensor,
+        tCsC_frag: cute.Tensor,
+        mma: cute.TiledMma,
+        rA: cute.Tensor,
+        rB: cute.Tensor,
+        accum: cute.Tensor,
+        c_frag: cute.Tensor,
+        pipe: pipeline.PipelineAsync,
+        rd_i: Int32,
+        rd_p: Int32,
+        rl_i: Int32,
+        rl_p: Int32,
+    ):
+        m_off = wave * Int32(self.m_tiles_per_wave)
+        units = m_units * n_units
+        c_size = cute.size(c_frag)
+
+        unit = Int32(cluster_idx)
+        while unit < units:
+            m_unit, n_unit = self._dx_tile_coord(unit, m_units, n_units)
+            m_raw = m_unit * self.CLUSTER_M + cta_rank
+            store_enabled = m_raw < m_tiles
+            m_tile = cutlass.min(m_raw, m_tiles - 1)
+            accum.fill(0.0)
+            mma.set(cute.nvgpu.warpgroup.Field.ACCUMULATE, True)
+
+            rstate = pipeline.PipelineState(self.stages, Int32(0), rd_i, rd_p)
+            pipe.consumer_wait(rstate)
+            cute.nvgpu.warpgroup.fence()
+            for kb in cutlass.range_constexpr(num_k_blocks):
+                coord = (None, None, kb, rd_i)
+                cute.gemm(mma, accum, rA[coord], rB[coord], accum)
+            cute.nvgpu.warpgroup.commit_group()
+            rstate.advance()
+            rd_i = rstate.index
+            rd_p = rstate.phase
+
+            for _ in range(1, num_k):
+                rstate = pipeline.PipelineState(self.stages, Int32(0), rd_i, rd_p)
+                pipe.consumer_wait(rstate)
+                cute.nvgpu.warpgroup.fence()
+                for kb in cutlass.range_constexpr(num_k_blocks):
+                    coord = (None, None, kb, rd_i)
+                    cute.gemm(mma, accum, rA[coord], rB[coord], accum)
+                cute.nvgpu.warpgroup.commit_group()
+                cute.nvgpu.warpgroup.wait_group(1)
+                lstate = pipeline.PipelineState(self.stages, Int32(0), rl_i, rl_p)
+                pipe.consumer_release(lstate)
+                lstate.advance()
+                rl_i = lstate.index
+                rl_p = lstate.phase
+                rstate.advance()
+                rd_i = rstate.index
+                rd_p = rstate.phase
+
+            cute.nvgpu.warpgroup.wait_group(0)
+            lstate = pipeline.PipelineState(self.stages, Int32(0), rl_i, rl_p)
+            pipe.consumer_release(lstate)
+            lstate.advance()
+            rl_i = lstate.index
+            rl_p = lstate.phase
+
+            for sub in cutlass.range_constexpr(self.dx_subtiles):
+                stage = sub % self.dx_store_stages
+                if cutlass.const_expr(sub >= self.dx_store_stages):
+                    if issuer:
+                        cute.arch.cp_async_bulk_wait_group(self.dx_store_stages - 1, read=True)
+                    self.dx_epi_bar.arrive_and_wait()
+                for j in cutlass.range_constexpr(c_size):
+                    c_frag[j] = BFloat16(accum[self._sub_src(self.dx_store_tile_n, self.tile_n, sub, j)])
+                cute.autovec_copy(c_frag, tCsC_frag[(None, None, None, stage)])
+                cute.arch.fence_proxy("async.shared", space="cta")
+                self.dx_epi_bar.arrive_and_wait()
+                if issuer:
+                    if store_enabled:
+                        cute.copy(
+                            tma_c,
+                            tCsC[(None, stage)],
+                            tCgC[(None, m_off + m_tile, n_unit * self.dx_subtiles + sub, 0)],
+                        )
+                        cute.arch.cp_async_bulk_commit_group()
+            if issuer:
+                cute.arch.cp_async_bulk_wait_group(0, read=True)
+            self.dx_epi_bar.arrive_and_wait()
+            unit += num_clusters
+
+        return rd_i, rd_p, rl_i, rl_p
+
+    # ------------------------------------------------------------------ #
+    # phase 3: dW += dZ^T @ X                           (one token wave)
+    #
+    # ``_dw_producer`` and ``_dw_consumer`` are the WG0 and WG1/WG2 halves of
+    # ``_ScaledCEDwGemmSM90.kernel``: the transposed ``order=(1, 0, 2)``
+    # operands and the epilogue that TMA reduce-adds BF16 into the persistent
+    # HBM accumulator.  The cluster is ignored, exactly as in the accepted
+    # ``cluster_m = 1`` kernel -- the two CTAs claim independent output tiles.
+    # ------------------------------------------------------------------ #
+    @cute.jit
+    def _dw_producer(
+        self,
+        wave: Int32,
+        warp: Int32,
+        bidx: Int32,
+        num_ctas: Int32,
+        iters: Int32,
+        total: Int32,
+        m_tiles: Int32,
+        n_tiles: Int32,
+        num_k: Int32,
+        tma_a: cute.CopyAtom,
+        tPgP: cute.Tensor,
+        tPsP: cute.Tensor,
+        tma_b: cute.CopyAtom,
+        tQgQ: cute.Tensor,
+        tQsQ: cute.Tensor,
+        pipe: pipeline.PipelineAsync,
+        ld_i: Int32,
+        ld_p: Int32,
+    ):
+        k_off = wave * num_k
+        if warp == 0:
+            for it in cutlass.range(iters, unroll=1):
+                tile_id = it * num_ctas + bidx
+                if tile_id < total:
+                    m_tile, n_tile = self._dw_tile_coord(tile_id, m_tiles, n_tiles)
+                    for k in cutlass.range(num_k, unroll=1):
+                        pstate = pipeline.PipelineState(self.stages, Int32(0), ld_i, ld_p)
+                        pipe.producer_acquire(pstate)
+                        bar = pipe.producer_get_barrier(pstate)
+                        cute.copy(
+                            tma_a,
+                            tPgP[(None, m_tile, k, 0)],
+                            tPsP[(None, ld_i)],
+                            tma_bar_ptr=bar,
+                            mcast_mask=0,
+                        )
+                        cute.copy(
+                            tma_b,
+                            tQgQ[(None, n_tile, k_off + k, 0)],
+                            tQsQ[(None, ld_i)],
+                            tma_bar_ptr=bar,
+                            mcast_mask=0,
+                        )
+                        pipe.producer_commit(pstate)
+                        pstate.advance()
+                        ld_i = pstate.index
+                        ld_p = pstate.phase
+
+        return ld_i, ld_p
+
+    @cute.jit
+    def _dw_consumer(
+        self,
+        wave: Int32,
+        issuer: cutlass.Boolean,
+        bidx: Int32,
+        num_ctas: Int32,
+        iters: Int32,
+        total: Int32,
+        m_tiles: Int32,
+        n_tiles: Int32,
+        num_k: Int32,
+        num_k_blocks: cutlass.Constexpr,
+        tma_d_store: cute.CopyAtom,
+        tDgDStore: cute.Tensor,
+        tDsDStore: cute.Tensor,
+        tma_d_add: cute.CopyAtom,
+        tDgDAdd: cute.Tensor,
+        tDsDAdd: cute.Tensor,
+        tDsD_frag: cute.Tensor,
+        mma: cute.TiledMma,
+        rA: cute.Tensor,
+        rB: cute.Tensor,
+        accum: cute.Tensor,
+        d_frag: cute.Tensor,
+        pipe: pipeline.PipelineAsync,
+        rd_i: Int32,
+        rd_p: Int32,
+        rl_i: Int32,
+        rl_p: Int32,
+    ):
+        d_size = cute.size(d_frag)
+
+        for it in cutlass.range(iters, unroll=1):
+            tile_id = it * num_ctas + bidx
+            if tile_id < total:
+                m_tile, n_tile = self._dw_tile_coord(tile_id, m_tiles, n_tiles)
+                accum.fill(0.0)
+                mma.set(cute.nvgpu.warpgroup.Field.ACCUMULATE, True)
+
+                rstate = pipeline.PipelineState(self.stages, Int32(0), rd_i, rd_p)
+                pipe.consumer_wait(rstate)
+                cute.nvgpu.warpgroup.fence()
+                for kb in cutlass.range_constexpr(num_k_blocks):
+                    coord = (None, None, kb, rd_i)
+                    cute.gemm(mma, accum, rA[coord], rB[coord], accum)
+                cute.nvgpu.warpgroup.commit_group()
+                rstate.advance()
+                rd_i = rstate.index
+                rd_p = rstate.phase
+
+                for _ in cutlass.range(1, num_k, unroll=1):
+                    rstate = pipeline.PipelineState(self.stages, Int32(0), rd_i, rd_p)
+                    pipe.consumer_wait(rstate)
+                    cute.nvgpu.warpgroup.fence()
+                    for kb in cutlass.range_constexpr(num_k_blocks):
+                        coord = (None, None, kb, rd_i)
+                        cute.gemm(mma, accum, rA[coord], rB[coord], accum)
+                    cute.nvgpu.warpgroup.commit_group()
+                    cute.nvgpu.warpgroup.wait_group(1)
+                    lstate = pipeline.PipelineState(self.stages, Int32(0), rl_i, rl_p)
+                    pipe.consumer_release(lstate)
+                    lstate.advance()
+                    rl_i = lstate.index
+                    rl_p = lstate.phase
+                    rstate.advance()
+                    rd_i = rstate.index
+                    rd_p = rstate.phase
+
+                cute.nvgpu.warpgroup.wait_group(0)
+                lstate = pipeline.PipelineState(self.stages, Int32(0), rl_i, rl_p)
+                pipe.consumer_release(lstate)
+                lstate.advance()
+                rl_i = lstate.index
+                rl_p = lstate.phase
+
+                for sub in cutlass.range_constexpr(self.dw_subtiles):
+                    stage = sub % self.dw_store_stages
+                    if issuer:
+                        cute.arch.cp_async_bulk_wait_group(self.dw_store_stages - 1, read=True)
+                    self.dw_store_bar.arrive_and_wait()
+                    for j in cutlass.range_constexpr(d_size):
+                        d_frag[j] = BFloat16(accum[self._sub_src(self.dw_store_tile_n, self.tile_n, sub, j)])
+                    cute.autovec_copy(d_frag, tDsD_frag[(None, None, None, stage)])
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    self.dw_store_bar.arrive_and_wait()
+                    if issuer:
+                        if wave == 0:
+                            cute.copy(
+                                tma_d_store,
+                                tDsDStore[(None, stage)],
+                                tDgDStore[(None, m_tile, n_tile * self.dw_subtiles + sub, 0)],
+                            )
+                        else:
+                            cute.copy(
+                                tma_d_add,
+                                tDsDAdd[(None, stage)],
+                                tDgDAdd[(None, m_tile, n_tile * self.dw_subtiles + sub, 0)],
+                            )
+                        cute.arch.cp_async_bulk_commit_group()
+
+        # Drain every dX and dW store before the caller's grid barrier.  The
+        # read-drain and named barrier are unconditional: they free the store
+        # SMEM, which the other GEMM phase aliases.
+        if issuer:
+            cute.arch.cp_async_bulk_wait_group(0, read=True)
+        self.dw_store_bar.arrive_and_wait()
+        if issuer:
+            cute.arch.cp_async_bulk_wait_group(0)
+
+        return rd_i, rd_p, rl_i, rl_p
+
+    # ------------------------------------------------------------------ #
+    # the one kernel: setup, then the host wave loop moved on-device
+    # ------------------------------------------------------------------ #
+    @cute.kernel
+    def kernel(
+        self,
+        tma_x: cute.CopyAtom,
+        x: cute.Tensor,
+        tma_w: cute.CopyAtom,
+        w: cute.Tensor,
+        tma_dzs: cute.CopyAtom,
+        dzs: cute.Tensor,
+        tma_dza: cute.CopyAtom,
+        dza: cute.Tensor,
+        tma_wt: cute.CopyAtom,
+        wt: cute.Tensor,
+        tma_dx: cute.CopyAtom,
+        dx: cute.Tensor,
+        tma_dwa: cute.CopyAtom,
+        dwa: cute.Tensor,
+        tma_xt: cute.CopyAtom,
+        xt: cute.Tensor,
+        tma_dw_store: cute.CopyAtom,
+        dw_store: cute.Tensor,
+        tma_dw_add: cute.CopyAtom,
+        dw_add: cute.Tensor,
+        target: cute.Tensor,
+        lse: cute.Tensor,
+        scale: cute.Tensor,
+        entropy: cute.Tensor,
+        entropy_scale: cute.Tensor,
+        inverse_temperature: Float32,
+        barrier: cute.Tensor,
+        mma_dz: cute.TiledMma,
+        mma_dx: cute.TiledMma,
+        mma_dw: cute.TiledMma,
+        smma_dx: cute.TiledMma,
+        smma_dw: cute.TiledMma,
+        dz_a: cute.ComposedLayout,
+        dz_b: cute.ComposedLayout,
+        dz_st: cute.ComposedLayout,
+        dx_a: cute.ComposedLayout,
+        dx_b: cute.ComposedLayout,
+        dx_st: cute.ComposedLayout,
+        dw_a: cute.ComposedLayout,
+        dw_b: cute.ComposedLayout,
+        dw_st: cute.ComposedLayout,
+        ignore_index: Int32,
+        vocab_size: Int32,
+    ):
+        tid, _, _ = cute.arch.thread_idx()
+        warp = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        warp_group = cute.arch.make_warp_uniform(tid // 128)
+        lane = tid % 32
+        local_warp = (tid % 128) // 32
+        local_tid = tid % 128
+        bidx, _, _ = cute.arch.block_idx()
+        grid_x, _, _ = cute.arch.grid_dim()
+        cta_rank = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+
+        num_ctas = grid_x
+        num_clusters = grid_x // self.CLUSTER_M
+        cluster_idx = bidx // self.CLUSTER_M
+
+        if warp == 0:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_dzs)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_dza)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_wt)
+        if warp == 4:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_x)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_w)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_dx)
+        if warp == 8:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_dwa)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_xt)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_dw_store)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_dw_add)
+
+        # ---- SMEM: disjoint mbarriers, then one phase-serial union -------
+        smem = cutlass.utils.SmemAllocator()
+        bars = smem.allocate(self.bar_storage)
+        union_ptr = smem.allocate(self.union_bytes, self.buffer_align)
+        dzmem = self.dz_storage(union_ptr)
+        dxmem = self.dx_storage(union_ptr)
+        dwmem = self.dw_storage(union_ptr)
+
+        sX = dzmem.sX.get_tensor(dz_a.outer, swizzle=dz_a.inner)
+        sW = dzmem.sW.get_tensor(dz_b.outer, swizzle=dz_b.inner)
+        sL = dzmem.sL.get_tensor(cute.make_layout((self.tile_m, self.tile_n), stride=(self.logit_stride, 1)))
+        sZ = dzmem.sZ.get_tensor(dz_st.outer, swizzle=dz_st.inner)
+        sXA = dxmem.sA.get_tensor(dx_a.outer, swizzle=dx_a.inner)
+        sXB = dxmem.sB.get_tensor(dx_b.outer, swizzle=dx_b.inner)
+        sXC = dxmem.sC.get_tensor(dx_st.outer, swizzle=dx_st.inner)
+        sWA = dwmem.sA.get_tensor(dw_a.outer, swizzle=dw_a.inner)
+        sWB = dwmem.sB.get_tensor(dw_b.outer, swizzle=dw_b.inner)
+        sWD = dwmem.sD.get_tensor(dw_st.outer, swizzle=dw_st.inner)
+
+        # ---- global tiles ------------------------------------------------
+        gX = cute.local_tile(x, cute.slice_(self.tile_shape, (None, 0, None)), (None, None, None))
+        gW = cute.local_tile(w, cute.slice_(self.tile_shape, (0, None, None)), (None, None, None))
+        gZS = cute.local_tile(dzs, (self.tile_m, self.dz_store_tile_n), (None, None, None))
+        gZA = cute.local_tile(dza, cute.slice_(self.tile_shape, (None, 0, None)), (None, None, None))
+        gWT = cute.local_tile(wt, cute.slice_(self.tile_shape, (0, None, None)), (None, None, None))
+        gDX = cute.local_tile(dx, (self.tile_m, self.dx_store_tile_n), (None, None, None))
+        gZT = cute.local_tile(dwa, cute.slice_(self.tile_shape, (None, 0, None)), (None, None, None))
+        gXT = cute.local_tile(xt, cute.slice_(self.tile_shape, (0, None, None)), (None, None, None))
+        gDW = cute.local_tile(dw_store, (self.tile_m, self.dw_store_tile_n), (None, None, None))
+        gDWAdd = cute.local_tile(dw_add, (self.tile_m, self.dw_store_tile_n), (None, None, None))
+
+        one = cute.make_layout(1)
+        # dX's W multicast: mode 0 of the (2, 1, 1) cluster is M, so peers that
+        # differ in m-tile share the n-tile and B is the multicast operand.
+        cta_layout = cute.make_layout((self.CLUSTER_M, 1, 1))
+        cluster_coord = cta_layout.get_flat_coord(cta_rank)
+        b_cta_layout = cute.make_layout(cute.slice_(cta_layout, (None, 0, 0)).shape)
+        b_mcast_mask = cute.make_layout_image_mask(cta_layout, cluster_coord, mode=0)
+        b_mcast_rank = cluster_coord[0]
+
+        tXsX, tXgX = cute.nvgpu.cpasync.tma_partition(
+            tma_x, 0, one, cute.group_modes(sX, 0, 2), cute.group_modes(gX, 0, 2)
+        )
+        tWsW, tWgW = cute.nvgpu.cpasync.tma_partition(
+            tma_w, 0, one, cute.group_modes(sW, 0, 2), cute.group_modes(gW, 0, 2)
+        )
+        tZsZ, tZgZ = cute.nvgpu.cpasync.tma_partition(
+            tma_dzs, 0, one, cute.group_modes(sZ, 0, 2), cute.group_modes(gZS, 0, 2)
+        )
+        tAsA, tAgA = cute.nvgpu.cpasync.tma_partition(
+            tma_dza, 0, one, cute.group_modes(sXA, 0, 2), cute.group_modes(gZA, 0, 2)
+        )
+        tBsB, tBgB = cute.nvgpu.cpasync.tma_partition(
+            tma_wt, b_mcast_rank, b_cta_layout, cute.group_modes(sXB, 0, 2), cute.group_modes(gWT, 0, 2)
+        )
+        tCsC, tCgC = cute.nvgpu.cpasync.tma_partition(
+            tma_dx, 0, one, cute.group_modes(sXC, 0, 2), cute.group_modes(gDX, 0, 2)
+        )
+        tPsP, tPgP = cute.nvgpu.cpasync.tma_partition(
+            tma_dwa, 0, one, cute.group_modes(sWA, 0, 2), cute.group_modes(gZT, 0, 2)
+        )
+        tQsQ, tQgQ = cute.nvgpu.cpasync.tma_partition(
+            tma_xt, 0, one, cute.group_modes(sWB, 0, 2), cute.group_modes(gXT, 0, 2)
+        )
+        tDsDStore, tDgDStore = cute.nvgpu.cpasync.tma_partition(
+            tma_dw_store, 0, one, cute.group_modes(sWD, 0, 2), cute.group_modes(gDW, 0, 2)
+        )
+        tDsDAdd, tDgDAdd = cute.nvgpu.cpasync.tma_partition(
+            tma_dw_add, 0, one, cute.group_modes(sWD, 0, 2), cute.group_modes(gDWAdd, 0, 2)
+        )
+
+        def _bytes(la, lb):
+            return cute.size_in_bytes(BFloat16, cute.slice_(la, (None, None, 0))) + cute.size_in_bytes(
+                BFloat16, cute.slice_(lb, (None, None, 0))
+            )
+
+        # ---- pipelines (mbarriers are disjoint per phase) -----------------
+        dz_pipe = pipeline.PipelineTmaAsync.create(
+            barrier_storage=bars.dz_pipe.data_ptr(),
+            num_stages=self.stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, NUM_MMA_WARP_GROUPS * WARPS_PER_WARP_GROUP),
+            tx_count=_bytes(dz_a, dz_b),
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+            tidx=tid,
+            defer_sync=True,
+        )
+        tile_pipe = pipeline.PipelineAsync.create(
+            barrier_storage=bars.dz_tile.data_ptr(),
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            defer_sync=True,
+        )
+        dx_pipe = pipeline.PipelineTmaAsync.create(
+            barrier_storage=bars.dx_pipe.data_ptr(),
+            num_stages=self.stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                WARPS_PER_WARP_GROUP * NUM_MMA_WARP_GROUPS * self.CLUSTER_M,
+            ),
+            tx_count=_bytes(dx_a, dx_b),
+            cta_layout_vmnk=cute.make_layout((1, self.CLUSTER_M, 1, 1)),
+            tidx=tid,
+            defer_sync=True,
+        )
+        dw_pipe = pipeline.PipelineTmaAsync.create(
+            barrier_storage=bars.dw_pipe.data_ptr(),
+            num_stages=self.stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, NUM_MMA_WARP_GROUPS * WARPS_PER_WARP_GROUP),
+            tx_count=_bytes(dw_a, dw_b),
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+            tidx=tid,
+            defer_sync=True,
+        )
+        pipeline_init_arrive(cluster_shape_mn=(self.CLUSTER_M, 1), is_relaxed=True)
+        pipeline_init_wait(cluster_shape_mn=(self.CLUSTER_M, 1))
+
+        bar_ptr = barrier.iterator
+
+        # ---- extents -----------------------------------------------------
+        num_k_dz = cute.size(gX, mode=[3])  # Hp / 64
+        num_k_dx = cute.size(gZA, mode=[3])  # Vp / 64
+        num_k_dw = cute.size(gZT, mode=[3])  # wave_rows / 64
+        num_k_blocks = cutlass.const_expr(self.tile_k // 16)
+
+        dz_group = Int32(self.plan.group_size * self.plan.ncluster_slow)
+        dz_total = Int32(self.plan.num_clusters)
+        dz_tiles = (dz_total - Int32(cluster_idx) + num_clusters - 1) // num_clusters
+
+        dx_m_tiles = cutlass.const_expr(self.m_tiles_per_wave)
+        dx_m_units = cutlass.const_expr((self.m_tiles_per_wave + self.CLUSTER_M - 1) // self.CLUSTER_M)
+        dx_n_units = cute.ceil_div(wt.shape[0], self.tile_n)
+
+        dw_m_tiles = cute.ceil_div(dwa.shape[0], self.tile_m)
+        dw_n_tiles = cute.ceil_div(xt.shape[0], self.tile_n)
+        dw_total = dw_m_tiles * dw_n_tiles
+        dw_iters = cute.ceil_div(dw_total, num_ctas)
+
+        num_waves = cute.ceil_div(x.shape[0], self.wave_rows)
+
+        if warp_group == 0:
+            # =============================================================
+            # WG0: dZ softmax epilogue, then the dX and dW TMA producers.
+            # Everything loop-invariant is built once, before the wave loop,
+            # exactly as it is in each accepted kernel's prologue.
+            # =============================================================
+            cute.arch.setmaxregister_decrease(self.epi_registers)
+
+            vals = cute.make_rmem_tensor((self.dz_store_tile_n,), Float32)
+
+            z_cr_i, z_cr_p = Int32(0), Int32(0)
+            x_ld_i, x_ld_p = Int32(0), Int32(1)
+            w_ld_i, w_ld_p = Int32(0), Int32(1)
+            target_count = Int32(0)
+
+            for wave in cutlass.range(num_waves, unroll=1):
+                z_cr_i, z_cr_p = self._dz_epilogue(
+                    wave,
+                    tid,
+                    local_warp,
+                    local_tid,
+                    cluster_idx,
+                    cta_rank,
+                    num_clusters,
+                    dz_tiles,
+                    dz_group,
+                    tma_dzs,
+                    tZgZ,
+                    tZsZ,
+                    sL,
+                    sZ,
+                    tile_pipe,
+                    target,
+                    lse,
+                    scale,
+                    entropy,
+                    entropy_scale,
+                    inverse_temperature,
+                    vals,
+                    ignore_index,
+                    vocab_size,
+                    z_cr_i,
+                    z_cr_p,
+                )
+
+                # The wave workspace must be visible to every CTA before dX
+                # reads it.
+                target_count = target_count + num_ctas
+                self._grid_barrier(bar_ptr, target_count, tid)
+                self._regs_for_gemm(True)
+
+                if cutlass.const_expr(self.dw_first):
+                    w_ld_i, w_ld_p = self._dw_producer(
+                        wave,
+                        warp,
+                        bidx,
+                        num_ctas,
+                        dw_iters,
+                        dw_total,
+                        dw_m_tiles,
+                        dw_n_tiles,
+                        num_k_dw,
+                        tma_dwa,
+                        tPgP,
+                        tPsP,
+                        tma_xt,
+                        tQgQ,
+                        tQsQ,
+                        dw_pipe,
+                        w_ld_i,
+                        w_ld_p,
+                    )
+                    cute.arch.sync_threads()
+                    cute.arch.cluster_arrive()
+                    cute.arch.cluster_wait()
+                    x_ld_i, x_ld_p = self._dx_producer(
+                        warp,
+                        cluster_idx,
+                        cta_rank,
+                        num_clusters,
+                        b_mcast_mask,
+                        dx_m_tiles,
+                        dx_m_units,
+                        dx_n_units,
+                        num_k_dx,
+                        tma_dza,
+                        tAgA,
+                        tAsA,
+                        tma_wt,
+                        tBgB,
+                        tBsB,
+                        dx_pipe,
+                        x_ld_i,
+                        x_ld_p,
+                    )
+                else:
+                    x_ld_i, x_ld_p = self._dx_producer(
+                        warp,
+                        cluster_idx,
+                        cta_rank,
+                        num_clusters,
+                        b_mcast_mask,
+                        dx_m_tiles,
+                        dx_m_units,
+                        dx_n_units,
+                        num_k_dx,
+                        tma_dza,
+                        tAgA,
+                        tAsA,
+                        tma_wt,
+                        tBgB,
+                        tBsB,
+                        dx_pipe,
+                        x_ld_i,
+                        x_ld_p,
+                    )
+                    cute.arch.sync_threads()
+                    w_ld_i, w_ld_p = self._dw_producer(
+                        wave,
+                        warp,
+                        bidx,
+                        num_ctas,
+                        dw_iters,
+                        dw_total,
+                        dw_m_tiles,
+                        dw_n_tiles,
+                        num_k_dw,
+                        tma_dwa,
+                        tPgP,
+                        tPsP,
+                        tma_xt,
+                        tQgQ,
+                        tQsQ,
+                        dw_pipe,
+                        w_ld_i,
+                        w_ld_p,
+                    )
+
+                # The final wave cannot overwrite the workspace again, and
+                # kernel completion already orders its output stores.
+                if wave + 1 < num_waves:
+                    self._regs_for_dz(True)
+                    target_count = target_count + num_ctas
+                    self._grid_barrier(bar_ptr, target_count, tid)
+        else:
+            # =============================================================
+            # WG1 + WG2: the dZ mainloop, then the dX and dW consumers.
+            # =============================================================
+            cute.arch.setmaxregister_increase(self.mma_registers)
+
+            mma_wg = warp_group - 1
+            mma_tid = tid - 128
+            wg_layout = cute.make_layout(NUM_MMA_WARP_GROUPS, stride=128)
+            thr_dz = mma_dz.get_slice(wg_layout(Int32(mma_wg)))
+            thr_dx = mma_dx.get_slice(mma_tid)
+            thr_dw = mma_dw.get_slice(mma_tid)
+            thr_sx = smma_dx.get_slice(mma_tid)
+            thr_sw = smma_dw.get_slice(mma_tid)
+
+            rZA = mma_dz.make_fragment_A(thr_dz.partition_A(sX))
+            rZB = mma_dz.make_fragment_B(thr_dz.partition_B(sW))
+            rXA = mma_dx.make_fragment_A(thr_dx.partition_A(sXA))
+            rXB = mma_dx.make_fragment_B(thr_dx.partition_B(sXB))
+            rWA = mma_dw.make_fragment_A(thr_dw.partition_A(sWA))
+            rWB = mma_dw.make_fragment_B(thr_dw.partition_B(sWB))
+
+            # ONE accumulator for all three phases: the three tiled MMAs have
+            # the same atom layout over the same tile, so ``partition_shape_C``
+            # is identical, and the phases are serial, so the live ranges are
+            # provably disjoint.  Three separate accumulators cost ptxas a
+            # 25 M-sector local-memory spill.
+            accum = cute.make_rmem_tensor(thr_dz.partition_shape_C((self.tile_m, self.tile_n)), Float32)
+
+            tCsC_frag = thr_sx.partition_C(sXC)
+            tDsD_frag = thr_sw.partition_C(sWD)
+            c_frag = cute.make_rmem_tensor(thr_sx.partition_shape_C((self.tile_m, self.dx_store_tile_n)), BFloat16)
+            # dX and dW never stage at the same time; when their store tiles
+            # are the same width the fragment is literally the same registers.
+            if cutlass.const_expr(self.dw_store_tile_n == self.dx_store_tile_n):
+                d_frag = c_frag
+            else:
+                d_frag = cute.make_rmem_tensor(thr_sw.partition_shape_C((self.tile_m, self.dw_store_tile_n)), BFloat16)
+
+            row_base_in_tile = mma_wg * 64 + local_warp * 16 + lane // 4
+            col_base_in_tile = (lane % 4) * 2
+            issuer = warp == 4
+
+            z_ld_i, z_ld_p = Int32(0), Int32(1)
+            z_rd_i, z_rd_p = Int32(0), Int32(0)
+            z_rl_i, z_rl_p = Int32(0), Int32(0)
+            z_wr_i, z_wr_p = Int32(0), Int32(1)
+            x_rd_i, x_rd_p = Int32(0), Int32(0)
+            x_rl_i, x_rl_p = Int32(0), Int32(0)
+            w_rd_i, w_rd_p = Int32(0), Int32(0)
+            w_rl_i, w_rl_p = Int32(0), Int32(0)
+            target_count = Int32(0)
+
+            for wave in cutlass.range(num_waves, unroll=1):
+                (
+                    z_ld_i,
+                    z_ld_p,
+                    z_rd_i,
+                    z_rd_p,
+                    z_rl_i,
+                    z_rl_p,
+                    z_wr_i,
+                    z_wr_p,
+                ) = self._dz_mainloop(
+                    wave,
+                    tid,
+                    warp,
+                    cluster_idx,
+                    cta_rank,
+                    num_clusters,
+                    dz_tiles,
+                    dz_group,
+                    num_k_dz,
+                    num_k_blocks,
+                    tma_x,
+                    tXgX,
+                    tXsX,
+                    tma_w,
+                    tWgW,
+                    tWsW,
+                    sL,
+                    mma_dz,
+                    rZA,
+                    rZB,
+                    accum,
+                    row_base_in_tile,
+                    col_base_in_tile,
+                    dz_pipe,
+                    tile_pipe,
+                    z_ld_i,
+                    z_ld_p,
+                    z_rd_i,
+                    z_rd_p,
+                    z_rl_i,
+                    z_rl_p,
+                    z_wr_i,
+                    z_wr_p,
+                )
+
+                target_count = target_count + num_ctas
+                self._grid_barrier(bar_ptr, target_count, tid)
+                self._regs_for_gemm(False)
+
+                if cutlass.const_expr(self.dw_first):
+                    (w_rd_i, w_rd_p, w_rl_i, w_rl_p) = self._dw_consumer(
+                        wave,
+                        issuer,
+                        bidx,
+                        num_ctas,
+                        dw_iters,
+                        dw_total,
+                        dw_m_tiles,
+                        dw_n_tiles,
+                        num_k_dw,
+                        num_k_blocks,
+                        tma_dw_store,
+                        tDgDStore,
+                        tDsDStore,
+                        tma_dw_add,
+                        tDgDAdd,
+                        tDsDAdd,
+                        tDsD_frag,
+                        mma_dw,
+                        rWA,
+                        rWB,
+                        accum,
+                        d_frag,
+                        dw_pipe,
+                        w_rd_i,
+                        w_rd_p,
+                        w_rl_i,
+                        w_rl_p,
+                    )
+                    cute.arch.sync_threads()
+                    cute.arch.cluster_arrive()
+                    cute.arch.cluster_wait()
+                    (x_rd_i, x_rd_p, x_rl_i, x_rl_p) = self._dx_consumer(
+                        wave,
+                        issuer,
+                        cluster_idx,
+                        cta_rank,
+                        num_clusters,
+                        dx_m_tiles,
+                        dx_m_units,
+                        dx_n_units,
+                        num_k_dx,
+                        num_k_blocks,
+                        tma_dx,
+                        tCgC,
+                        tCsC,
+                        tCsC_frag,
+                        mma_dx,
+                        rXA,
+                        rXB,
+                        accum,
+                        c_frag,
+                        dx_pipe,
+                        x_rd_i,
+                        x_rd_p,
+                        x_rl_i,
+                        x_rl_p,
+                    )
+                else:
+                    (x_rd_i, x_rd_p, x_rl_i, x_rl_p) = self._dx_consumer(
+                        wave,
+                        issuer,
+                        cluster_idx,
+                        cta_rank,
+                        num_clusters,
+                        dx_m_tiles,
+                        dx_m_units,
+                        dx_n_units,
+                        num_k_dx,
+                        num_k_blocks,
+                        tma_dx,
+                        tCgC,
+                        tCsC,
+                        tCsC_frag,
+                        mma_dx,
+                        rXA,
+                        rXB,
+                        accum,
+                        c_frag,
+                        dx_pipe,
+                        x_rd_i,
+                        x_rd_p,
+                        x_rl_i,
+                        x_rl_p,
+                    )
+                    cute.arch.sync_threads()
+                    (w_rd_i, w_rd_p, w_rl_i, w_rl_p) = self._dw_consumer(
+                        wave,
+                        issuer,
+                        bidx,
+                        num_ctas,
+                        dw_iters,
+                        dw_total,
+                        dw_m_tiles,
+                        dw_n_tiles,
+                        num_k_dw,
+                        num_k_blocks,
+                        tma_dw_store,
+                        tDgDStore,
+                        tDsDStore,
+                        tma_dw_add,
+                        tDgDAdd,
+                        tDsDAdd,
+                        tDsD_frag,
+                        mma_dw,
+                        rWA,
+                        rWB,
+                        accum,
+                        d_frag,
+                        dw_pipe,
+                        w_rd_i,
+                        w_rd_p,
+                        w_rl_i,
+                        w_rl_p,
+                    )
+
+                if wave + 1 < num_waves:
+                    self._regs_for_dz(False)
+                    target_count = target_count + num_ctas
+                    self._grid_barrier(bar_ptr, target_count, tid)
+
+
+# ---------------------------------------------------------------------------
+# Host entry point
+# ---------------------------------------------------------------------------
+
+
+def _pad_rows(t, rows):
+    if t.shape[0] == rows:
+        return t
+    return torch.nn.functional.pad(t, (0, 0, 0, rows - t.shape[0]))
+
+
+def fused_backward_one_kernel(
+    grad_output,
+    x_padded,
+    weight_padded,
+    target,
+    lse,
+    entropy=None,
+    entropy_grad=None,
+    ignore_index=-100,
+    hidden_size=None,
+    input_dtype=torch.bfloat16,
+    temperature=1.0,
+    config: FusedBackwardConfig = None,
+    max_clusters=None,
+):
+    """One-launch dZ+dX+dW backward.  Returns ``(grad_input, grad_weight)``.
+
+    Mirrors :func:`fused_scaled_cross_entropy_backward`'s token-wave semantics
+    exactly (BF16 dZ wave workspace, BF16 HBM dW accumulator with TMA
+    reduce-add), but performs every wave inside a single persistent kernel.
+    """
+    if config is None:
+        config = FusedBackwardConfig()
+    config.validate()
+    ensure_cuda_context()
+
+    if torch.cuda.get_device_capability(x_padded.device) != (9, 0):
+        raise RuntimeError("the fused one-kernel SM90 backward requires a Hopper GPU")
+    if x_padded.dtype != torch.bfloat16 or weight_padded.dtype != torch.bfloat16:
+        raise TypeError("input and weight must be BF16")
+
+    device = x_padded.device
+    tokens, hidden_padded = x_padded.shape
+    if hidden_size is None:
+        hidden_size = hidden_padded
+    if hidden_padded % HIDDEN_TILE != 0:
+        raise ValueError("x_padded's hidden dimension must already be padded to a multiple of 64")
+    vocab_size = weight_padded.shape[0]
+    vocab_padded = (vocab_size + VOCAB_ALIGN - 1) // VOCAB_ALIGN * VOCAB_ALIGN
+    weight_for_dx = _pad_rows(weight_padded.contiguous(), vocab_padded)
+
+    scale = grad_output.detach().to(torch.float32).contiguous()
+    with_entropy = entropy_grad is not None
+    if with_entropy:
+        if entropy is None or entropy.shape != (tokens,) or entropy_grad.shape != (tokens,):
+            raise ValueError("entropy and entropy_grad must both have shape [M]")
+        entropy = entropy.contiguous()
+        entropy_scale = entropy_grad.detach().to(torch.float32).contiguous()
+    else:
+        entropy = torch.empty(1, device=device, dtype=torch.bfloat16)
+        entropy_scale = torch.empty(1, device=device, dtype=torch.float32)
+    if config.with_entropy != with_entropy:
+        config = FusedBackwardConfig(**{**config.__dict__, "with_entropy": with_entropy})
+    target = target.contiguous()
+    lse = lse.contiguous()
+
+    wave_rows = min(config.wave_rows, ((tokens + config.tile_m - 1) // config.tile_m) * config.tile_m)
+    wave_rows = max(wave_rows, config.tile_m)
+    m_tiles_per_wave = wave_rows // config.tile_m
+    if m_tiles_per_wave != config.m_tiles_per_wave:
+        config = FusedBackwardConfig(**{**config.__dict__, "m_tiles_per_wave": m_tiles_per_wave})
+
+    dz_ws = torch.empty((wave_rows, vocab_padded), device=device, dtype=torch.bfloat16)
+    grad_input_padded = torch.empty((tokens, hidden_padded), device=device, dtype=torch.bfloat16)
+    grad_weight_padded = torch.empty((vocab_padded, hidden_padded), device=device, dtype=torch.bfloat16)
+
+    num_m_tiles = m_tiles_per_wave
+    num_n_tiles = (vocab_size + config.tile_n - 1) // config.tile_n
+    plan = _plan_schedule(
+        num_m_tiles, num_n_tiles, _FusedBackwardSM90.CLUSTER_M, config.dz_group_size, config.dz_raster
+    )
+    clusters = _max_active_clusters(_FusedBackwardSM90.CLUSTER_M)
+
+    # Hard launch invariant: never launch more CTAs than there are physical SMs,
+    # otherwise the grid is not fully resident and the software global barrier
+    # deadlocks.  Also never launch more clusters than any phase can keep busy.
+    sm_count = _sm_count()
+    cluster_m = _FusedBackwardSM90.CLUSTER_M
+    dz_clusters = plan.num_clusters
+    dx_clusters = ((m_tiles_per_wave + cluster_m - 1) // cluster_m) * (
+        (hidden_padded + config.tile_n - 1) // config.tile_n
+    )
+    dw_ctas = ((vocab_padded + config.tile_m - 1) // config.tile_m) * (
+        (hidden_padded + config.tile_n - 1) // config.tile_n
+    )
+    dw_clusters = (dw_ctas + cluster_m - 1) // cluster_m
+    required_work_clusters = max(dz_clusters, dx_clusters, dw_clusters)
+
+    clusters = min(int(clusters), sm_count // cluster_m, required_work_clusters)
+    if max_clusters is not None:
+        clusters = min(clusters, max_clusters)
+    clusters = int(clusters)
+    if clusters < 1:
+        raise RuntimeError("the fused one-kernel backward needs at least one resident cluster")
+    grid_x = clusters * cluster_m
+    if grid_x > sm_count:
+        raise RuntimeError(
+            f"fused backward would launch {grid_x} CTAs on {sm_count} SMs; "
+            "the persistent grid must fit so the global barrier cannot deadlock"
+        )
+
+    x_c = to_cute_tensor(x_padded.unsqueeze(-1), leading_dim=1, assumed_align=16)
+    w_c = to_cute_tensor(weight_for_dx.unsqueeze(-1), leading_dim=1, assumed_align=16)
+    wt_c = to_cute_tensor(weight_for_dx.transpose(0, 1).unsqueeze(-1), leading_dim=0, assumed_align=16)
+    xt_c = to_cute_tensor(x_padded.transpose(0, 1).unsqueeze(-1), leading_dim=0, assumed_align=16)
+    dz_c = to_cute_tensor(dz_ws.unsqueeze(-1), leading_dim=1, assumed_align=16)
+    dzt_c = to_cute_tensor(dz_ws.transpose(0, 1).unsqueeze(-1), leading_dim=0, assumed_align=16)
+    dx_c = to_cute_tensor(grad_input_padded.unsqueeze(-1), leading_dim=1, assumed_align=16)
+    dw_c = to_cute_tensor(grad_weight_padded.unsqueeze(-1), leading_dim=1, assumed_align=16)
+    tgt_c = to_cute_tensor(target, assumed_align=8)
+    lse_c = to_cute_tensor(lse, assumed_align=4)
+    scale_c = to_cute_tensor(scale, assumed_align=4)
+    entropy_c = to_cute_tensor(entropy, assumed_align=2)
+    entropy_scale_c = to_cute_tensor(entropy_scale, assumed_align=4)
+    inverse_temperature = Float32(1.0 / temperature)
+
+    # A single int32 counter, zeroed for this launch.  Each device-side barrier
+    # raises a CTA-uniform target by ``gridDim.x``, so no reset, no cross-launch
+    # monotone base and no overflow handling are needed.
+    barrier = torch.zeros(1, device=device, dtype=torch.int32)
+    bar_c = to_cute_tensor(barrier, assumed_align=4)
+
+    stream = _cute_stream()
+    key = ("fused_bwd_one_kernel", config, plan, clusters)
+    compiled = _compile_cache.get(key)
+    if compiled is None:
+        compiled = cute.compile(
+            _FusedBackwardSM90(config, plan),
+            x_c,
+            w_c,
+            wt_c,
+            xt_c,
+            dz_c,
+            dzt_c,
+            dx_c,
+            dw_c,
+            tgt_c,
+            lse_c,
+            scale_c,
+            entropy_c,
+            entropy_scale_c,
+            inverse_temperature,
+            bar_c,
+            Int32(ignore_index),
+            Int32(vocab_size),
+            clusters,
+            stream,
+        )
+        _compile_cache[key] = compiled
+    compiled(
+        x_c,
+        w_c,
+        wt_c,
+        xt_c,
+        dz_c,
+        dzt_c,
+        dx_c,
+        dw_c,
+        tgt_c,
+        lse_c,
+        scale_c,
+        entropy_c,
+        entropy_scale_c,
+        inverse_temperature,
+        bar_c,
+        Int32(ignore_index),
+        Int32(vocab_size),
+        stream,
+    )
+
+    del dz_c, dzt_c, dz_ws
+    grad_input = grad_input_padded
+    if hidden_size != hidden_padded:
+        grad_input = grad_input_padded[:, :hidden_size].contiguous()
+    if input_dtype != torch.bfloat16:
+        grad_input = grad_input.to(input_dtype)
+    grad_weight = grad_weight_padded
+    if (vocab_size, hidden_size) != tuple(grad_weight_padded.shape):
+        grad_weight = grad_weight_padded[:vocab_size, :hidden_size].contiguous()
+    return grad_input, grad_weight
+
+
+__all__ = [
+    "FusedBackwardConfig",
+    "fused_backward_one_kernel",
+]

--- a/src/liger_kernel/ops/cutedsl/ops/_fused_scaled_cross_entropy_backward_fused_sm90.py
+++ b/src/liger_kernel/ops/cutedsl/ops/_fused_scaled_cross_entropy_backward_fused_sm90.py
@@ -257,72 +257,6 @@ local traffic.  Registers/thread stay at 168 in all three.  Because the effect
 is entirely off the critical path -- the kernel is 92-97 % tensor-pipe active
 and the local traffic hits L1 -- the accepted per-phase store widths are kept.
 
-Phase-order ablation (``dw_before_dx``)
----------------------------------------
-dZ and dW both read the wave's X tile (8 MiB at ``m_tiles_per_wave = 8``) while
-dX streams the 256 MiB dZ workspace and 1 GiB of W between them, so running
-dW second-instead-of-third should keep X resident.  It does reduce DRAM reads,
-but the kernel is tensor-pipe bound and the saving does not convert to time
-(target shape, interleaved A/B in one process, 15 samples each)::
-
-    order         median ms   eff TFLOP/s   DRAM rd    DRAM wr   L2 hit   tensor
-    dZ->dX->dW    19.970      660.7         17.584 GB  5.380 GB  79.91 %  91.97 %
-    dZ->dW->dX    19.934      661.9         16.229 GB  5.399 GB  79.92 %  91.94 %
-
-ratio 1.0018x -- inside run-to-run noise -- despite a 7.7 % (1.355 GB) drop in
-DRAM reads.  Per-phase cycle counters (CTA 0, accumulated over the 4 waves,
-``profile_phases`` build) show dW itself gets *slower* when moved earlier, so
-the locality win is real but is not on the critical path::
-
-    order         dZ         barrier   dX        dW         total
-    dZ->dX->dW    8.68 Mcyc  0.05      8.43      9.94       27.10 Mcyc
-    dZ->dW->dX    8.71 Mcyc  0.05      8.47      10.50      27.73 Mcyc
-
-Both orders are bit-identical to each other and to the accepted backward on
-every validated shape, so the knob is kept only as an ablation; the default
-stays ``dw_before_dx=False``.
-
-The same ablation in full-workspace mode (``m_tiles_per_wave = 32`` at
-``M = 4096``: one device wave, 1 GiB dZ workspace, the full 32 MiB X tensor
-instead of an 8 MiB slice, one grid barrier instead of seven, and a single dW
-``tma_d_store`` instead of four BF16 reduce-add passes) **reverses the sign**
-of the DRAM effect::
-
-    order         median ms   eff TFLOP/s   DRAM rd    DRAM wr   L2 hit   tensor
-    dZ->dX->dW    19.362      681.5         18.330 GB  2.182 GB  71.01 %  97.46 %
-    dZ->dW->dX    19.433      678.9         20.663 GB  2.185 GB  71.41 %  97.15 %
-
-    order         dZ         barrier   dX        dW        total
-    dZ->dX->dW    8.54 Mcyc  0.01      8.50      8.72      25.77 Mcyc
-    dZ->dW->dX    8.41 Mcyc  0.01      8.68      8.46      25.56 Mcyc
-
-ratio 0.9963x and 0.9999x over two runs: dW-first is neutral-to-marginally
-*worse*, and it costs 2.333 GB (+12.7 %) of extra DRAM reads rather than
-saving 1.355 GB.  At wave 8 the X
-slice is small enough that running dW straight after dZ reuses it; at wave 32
-the 1 GiB dZ workspace has already swept L2 many times over, so the reuse
-disappears and the transposed dW read pattern only disturbs the residency dX
-would otherwise inherit.  dW's own phase cost is flat between the two orders
-here (8.72 vs 8.68 Mcyc) against +5.6 % at wave 8.
-
-Full-workspace mode is the faster configuration overall (19.36 ms / 681.5
-TFLOP/s vs 19.99 / 660.0), almost entirely from write traffic: 2.18 GB against
-5.38 GB, because the single-wave dW stores once instead of read-modify-writing
-the 1 GiB BF16 accumulator four times.  It also cuts spill traffic (2.8 M vs
-11.2 M local-load sectors) since the device wave loop runs once.  Peak
-allocation rises from 5536 MiB to 6304 MiB for the larger dZ workspace.
-Across wave modes ``grad_input`` matches to 1 BF16 ulp (4.883e-04) and
-``grad_weight`` to 3.125e-02, the expected consequence of single-store versus
-four-pass BF16 accumulation; within either mode the two phase orders remain
-bit-identical.
-
-Ordering note: dX multicasts W into its cluster partner's SMEM, so the phase
-boundary before dX needs a *cluster*-wide barrier, not just
-``sync_threads()``.  In the default order the grid barrier after dZ provides
-it; with ``dw_before_dx=True`` a CTA whose last dW tile is masked off by the
-``tile_id < total`` guard would otherwise run ahead and clobber the operand
-SMEM its partner is still consuming, so that path adds an explicit
-``cluster_arrive`` / ``cluster_wait``.
 """
 
 from dataclasses import dataclass
@@ -425,11 +359,6 @@ class FusedBackwardConfig:
     dw_store_tile_n: int = 64
     dw_store_stages: int = 4
     dw_group_m: int = 1
-
-    # ---- phase order ablation ----
-    # False: dZ -> dX -> dW (default).  True: dZ -> dW -> dX, which keeps the
-    # X wave resident across dZ and dW instead of streaming dZ + W between them.
-    dw_before_dx: bool = False
 
     # ---- registers: each phase runs at its own accepted budget ----
     epi_registers: int = 88
@@ -553,7 +482,6 @@ class _FusedBackwardSM90:
         self.dw_store_stages = config.dw_store_stages
         self.dw_subtiles = self.tile_n // self.dw_store_tile_n
         self.dw_group_m = config.dw_group_m
-        self.dw_first = config.dw_before_dx
 
         self.epi_registers = config.epi_registers
         self.mma_registers = config.mma_registers
@@ -1831,92 +1759,47 @@ class _FusedBackwardSM90:
                 self._grid_barrier(bar_ptr, target_count, tid)
                 self._regs_for_gemm(True)
 
-                if cutlass.const_expr(self.dw_first):
-                    w_ld_i, w_ld_p = self._dw_producer(
-                        wave,
-                        warp,
-                        bidx,
-                        num_ctas,
-                        dw_iters,
-                        dw_total,
-                        dw_m_tiles,
-                        dw_n_tiles,
-                        num_k_dw,
-                        tma_dwa,
-                        tPgP,
-                        tPsP,
-                        tma_xt,
-                        tQgQ,
-                        tQsQ,
-                        dw_pipe,
-                        w_ld_i,
-                        w_ld_p,
-                    )
-                    cute.arch.sync_threads()
-                    cute.arch.cluster_arrive()
-                    cute.arch.cluster_wait()
-                    x_ld_i, x_ld_p = self._dx_producer(
-                        warp,
-                        cluster_idx,
-                        cta_rank,
-                        num_clusters,
-                        b_mcast_mask,
-                        dx_m_tiles,
-                        dx_m_units,
-                        dx_n_units,
-                        num_k_dx,
-                        tma_dza,
-                        tAgA,
-                        tAsA,
-                        tma_wt,
-                        tBgB,
-                        tBsB,
-                        dx_pipe,
-                        x_ld_i,
-                        x_ld_p,
-                    )
-                else:
-                    x_ld_i, x_ld_p = self._dx_producer(
-                        warp,
-                        cluster_idx,
-                        cta_rank,
-                        num_clusters,
-                        b_mcast_mask,
-                        dx_m_tiles,
-                        dx_m_units,
-                        dx_n_units,
-                        num_k_dx,
-                        tma_dza,
-                        tAgA,
-                        tAsA,
-                        tma_wt,
-                        tBgB,
-                        tBsB,
-                        dx_pipe,
-                        x_ld_i,
-                        x_ld_p,
-                    )
-                    cute.arch.sync_threads()
-                    w_ld_i, w_ld_p = self._dw_producer(
-                        wave,
-                        warp,
-                        bidx,
-                        num_ctas,
-                        dw_iters,
-                        dw_total,
-                        dw_m_tiles,
-                        dw_n_tiles,
-                        num_k_dw,
-                        tma_dwa,
-                        tPgP,
-                        tPsP,
-                        tma_xt,
-                        tQgQ,
-                        tQsQ,
-                        dw_pipe,
-                        w_ld_i,
-                        w_ld_p,
-                    )
+                x_ld_i, x_ld_p = self._dx_producer(
+                    warp,
+                    cluster_idx,
+                    cta_rank,
+                    num_clusters,
+                    b_mcast_mask,
+                    dx_m_tiles,
+                    dx_m_units,
+                    dx_n_units,
+                    num_k_dx,
+                    tma_dza,
+                    tAgA,
+                    tAsA,
+                    tma_wt,
+                    tBgB,
+                    tBsB,
+                    dx_pipe,
+                    x_ld_i,
+                    x_ld_p,
+                )
+                cute.arch.sync_threads()
+                w_ld_i, w_ld_p = self._dw_producer(
+                    wave,
+                    warp,
+                    bidx,
+                    num_ctas,
+                    dw_iters,
+                    dw_total,
+                    dw_m_tiles,
+                    dw_n_tiles,
+                    num_k_dw,
+                    tma_dwa,
+                    tPgP,
+                    tPsP,
+                    tma_xt,
+                    tQgQ,
+                    tQsQ,
+                    dw_pipe,
+                    w_ld_i,
+                    w_ld_p,
+                )
 
                 # The final wave cannot overwrite the workspace again, and
                 # kernel completion already orders its output stores.
@@ -2027,122 +1910,62 @@ class _FusedBackwardSM90:
                 self._grid_barrier(bar_ptr, target_count, tid)
                 self._regs_for_gemm(False)
 
-                if cutlass.const_expr(self.dw_first):
-                    (w_rd_i, w_rd_p, w_rl_i, w_rl_p) = self._dw_consumer(
-                        wave,
-                        issuer,
-                        bidx,
-                        num_ctas,
-                        dw_iters,
-                        dw_total,
-                        dw_m_tiles,
-                        dw_n_tiles,
-                        num_k_dw,
-                        num_k_blocks,
-                        tma_dw_store,
-                        tDgDStore,
-                        tDsDStore,
-                        tma_dw_add,
-                        tDgDAdd,
-                        tDsDAdd,
-                        tDsD_frag,
-                        mma_dw,
-                        rWA,
-                        rWB,
-                        accum,
-                        d_frag,
-                        dw_pipe,
-                        w_rd_i,
-                        w_rd_p,
-                        w_rl_i,
-                        w_rl_p,
-                    )
-                    cute.arch.sync_threads()
-                    cute.arch.cluster_arrive()
-                    cute.arch.cluster_wait()
-                    (x_rd_i, x_rd_p, x_rl_i, x_rl_p) = self._dx_consumer(
-                        wave,
-                        issuer,
-                        cluster_idx,
-                        cta_rank,
-                        num_clusters,
-                        dx_m_tiles,
-                        dx_m_units,
-                        dx_n_units,
-                        num_k_dx,
-                        num_k_blocks,
-                        tma_dx,
-                        tCgC,
-                        tCsC,
-                        tCsC_frag,
-                        mma_dx,
-                        rXA,
-                        rXB,
-                        accum,
-                        c_frag,
-                        dx_pipe,
-                        x_rd_i,
-                        x_rd_p,
-                        x_rl_i,
-                        x_rl_p,
-                    )
-                else:
-                    (x_rd_i, x_rd_p, x_rl_i, x_rl_p) = self._dx_consumer(
-                        wave,
-                        issuer,
-                        cluster_idx,
-                        cta_rank,
-                        num_clusters,
-                        dx_m_tiles,
-                        dx_m_units,
-                        dx_n_units,
-                        num_k_dx,
-                        num_k_blocks,
-                        tma_dx,
-                        tCgC,
-                        tCsC,
-                        tCsC_frag,
-                        mma_dx,
-                        rXA,
-                        rXB,
-                        accum,
-                        c_frag,
-                        dx_pipe,
-                        x_rd_i,
-                        x_rd_p,
-                        x_rl_i,
-                        x_rl_p,
-                    )
-                    cute.arch.sync_threads()
-                    (w_rd_i, w_rd_p, w_rl_i, w_rl_p) = self._dw_consumer(
-                        wave,
-                        issuer,
-                        bidx,
-                        num_ctas,
-                        dw_iters,
-                        dw_total,
-                        dw_m_tiles,
-                        dw_n_tiles,
-                        num_k_dw,
-                        num_k_blocks,
-                        tma_dw_store,
-                        tDgDStore,
-                        tDsDStore,
-                        tma_dw_add,
-                        tDgDAdd,
-                        tDsDAdd,
-                        tDsD_frag,
-                        mma_dw,
-                        rWA,
-                        rWB,
-                        accum,
-                        d_frag,
-                        dw_pipe,
-                        w_rd_i,
-                        w_rd_p,
-                        w_rl_i,
-                        w_rl_p,
-                    )
+                (x_rd_i, x_rd_p, x_rl_i, x_rl_p) = self._dx_consumer(
+                    wave,
+                    issuer,
+                    cluster_idx,
+                    cta_rank,
+                    num_clusters,
+                    dx_m_tiles,
+                    dx_m_units,
+                    dx_n_units,
+                    num_k_dx,
+                    num_k_blocks,
+                    tma_dx,
+                    tCgC,
+                    tCsC,
+                    tCsC_frag,
+                    mma_dx,
+                    rXA,
+                    rXB,
+                    accum,
+                    c_frag,
+                    dx_pipe,
+                    x_rd_i,
+                    x_rd_p,
+                    x_rl_i,
+                    x_rl_p,
+                )
+                cute.arch.sync_threads()
+                (w_rd_i, w_rd_p, w_rl_i, w_rl_p) = self._dw_consumer(
+                    wave,
+                    issuer,
+                    bidx,
+                    num_ctas,
+                    dw_iters,
+                    dw_total,
+                    dw_m_tiles,
+                    dw_n_tiles,
+                    num_k_dw,
+                    num_k_blocks,
+                    tma_dw_store,
+                    tDgDStore,
+                    tDsDStore,
+                    tma_dw_add,
+                    tDgDAdd,
+                    tDsDAdd,
+                    tDsD_frag,
+                    mma_dw,
+                    rWA,
+                    rWB,
+                    accum,
+                    d_frag,
+                    dw_pipe,
+                    w_rd_i,
+                    w_rd_p,
+                    w_rl_i,
+                    w_rl_p,
+                )
 
                 if wave + 1 < num_waves:
                     self._regs_for_dz(False)

--- a/src/liger_kernel/ops/cutedsl/ops/_fused_scaled_cross_entropy_forward_mfast_sm90.py
+++ b/src/liger_kernel/ops/cutedsl/ops/_fused_scaled_cross_entropy_forward_mfast_sm90.py
@@ -1,0 +1,1216 @@
+"""SM90 fused scaled cross entropy **M-fast forward** kernel: the default
+"MMA-warp issues TMA + dedicated SMEM-logits epilogue" kernel with an
+**M-fast (N-outer / M-inner) persistent work order**.
+
+This kernel backs ``m_tiles_per_cluster > 1`` in
+:mod:`liger_kernel.ops.cutedsl.ops.fused_scaled_cross_entropy_sm90`; the public
+``m_tiles_per_cluster`` is this module's ``slots_per_wave``.  It keeps several
+``M128`` online-softmax states live so that one L2-resident ``W`` panel is
+shared by several M tiles.  It is correct at every ``slots_per_wave`` but was
+measured **slower** than the M-outer default at the representative
+``M=4096, H=4096, V=131072`` shape, hence the default of 1.  Everything except
+:func:`to_cute_tensor` is self-contained.
+
+Work order
+==========
+
+The default forward (``_fused_scaled_cross_entropy_forward_sm90.py``) is
+*already* statically persistent: a cluster owns ``pid_m = cluster_idx + m_slot *
+num_persistent_clusters`` and walks its slots one at a time.  Its work nesting
+is::
+
+    for m_slot in owned_slots:          # M outer
+        for n_round in range(N/(cluster_n*tile_n)):   # N inner
+            for k in range(H/tile_k):
+                WGMMA(M128 x N256 x K64)
+        reduce + store row statistics for this m_slot
+
+Softmax is a *row* reduction, so it only has to happen after **all** N tiles of
+a row have been seen -- the N tiles themselves may be visited in any order.
+This module therefore reverses the nesting, exactly as the dZ scheduler
+(``_fused_scaled_cross_entropy_dz_sm90.py``) does for the
+backward::
+
+    for n_round in range(N/(cluster_n*tile_n)):       # N outer
+        for m_slot in owned_slots:                    # M inner
+            for k in range(H/tile_k):
+                WGMMA(M128 x N256 x K64)
+    for m_slot in owned_slots:                        # after ALL N work
+        reduce + store row statistics
+
+so the epilogue warp group carries **one online-softmax state per owned M
+slot** across the whole N sweep instead of one state at a time.
+
+Locality hypothesis under test (**disproven** -- see "Status: not the default")
+------------------------------------------------------------------------------
+
+At ``M=4096, H=4096, V=131072`` with ``cluster_n=16`` and 132 SMs, 7 clusters
+are resident and each owns 4-5 ``M128`` slots.  Per N round a CTA touches one
+``256 x 4096`` BF16 W panel = 2 MiB (32 MiB per cluster, and *all* clusters
+touch the same 32 MiB in the same round).  The motivating hypothesis was that in
+M-outer order that panel is re-fetched from DRAM once per M slot, so M-fast
+order would cut W traffic ~4x by reusing the L2-resident panel across all owned
+M slots.
+
+The measurement says otherwise: because all resident clusters are on the *same*
+N round in *both* orders, W is already fetched once and shared through L2, so
+there is nothing to save; meanwhile the live X footprint grows from ~7 MiB
+(1 block per cluster) to ~32 MiB (4-5 blocks per cluster), which together with
+the 32 MiB W panel set overflows the 60 MiB L2 and makes X re-stream every
+round.  Mainloop DRAM reads go **up** 4.3% and the kernel is 2.2-3.2% slower.
+Full numbers and the mechanism are at the bottom of this docstring.
+
+Everything else is held fixed
+-----------------------------
+
+Identical to the accepted forward, deliberately: WG0+WG1 cooperative
+``atom_layout=(2,1,1)`` WGMMA over a ``(64, 256)`` atom (``M128 x N256 x K64``),
+warp 0 of WG0 issuing every TMA under a live WGMMA group, ``wait_group(1)`` in
+the steady state with a full drain only at the tile tail, WG2 as a dedicated
+padded-SMEM (row stride ``tile_n + 8``) single-pass online-softmax epilogue,
+3 stages, ``cluster_n = 16``, **no multicast**, 208/88 register split.
+``cluster_n`` sweeps are explicitly *not* repeated here: ``cluster_n=4`` was
+already measured at 10.44 ms / 421 TFLOPS against 7.02 ms / 627 for
+``cluster_n=16`` under matched timing.
+
+Implementation notes specific to the new order
+==============================================
+
+Waves
+-----
+
+Per-slot softmax state lives in registers, so the number of simultaneously live
+slots must be a compile-time constant.  Owned slots are therefore processed in
+*waves* of at most ``wave_slots = min(config.slots_per_wave, ceil(num_m_tiles /
+num_persistent_clusters))`` slots (a host-computed constant, 4 at the target
+shape, so the target shape is a single wave)::
+
+    for wave:                        # dynamic, cluster-uniform
+      for n_round:                   # dynamic
+        for slot in range(cur):      # dynamic; cur = slots in this wave
+          one M128 x N256 tile
+      for slot in range(cur):        # reduce + store
+    # register state: run_max[wave_slots], run_sum[wave_slots],
+    #                 run_target[wave_slots], tgt_tile[..], tgt_col[..]
+
+Only 1 wave is needed until a cluster owns more than ``slots_per_wave`` M
+blocks, so the target shape never pays for the outer loop.
+
+Keeping the epilogue code single-instance
+-----------------------------------------
+
+A naive implementation makes the slot loop ``range_constexpr`` so the register
+arrays can be indexed statically -- which replicates the *entire* 256-column
+softmax body ``wave_slots`` times (~4x SASS growth in WG2, straight into the
+I-cache).  Instead the slot loop stays **dynamic** and the heavy body computes a
+purely tile-local ``(tile_max, tile_sum, tile_target)`` in plain registers; only
+the ~6-instruction fold into the per-slot state is wrapped in a
+``range_constexpr`` + ``if slot == j`` select::
+
+    for j in range_constexpr(wave_slots):
+        if slot == j:
+            new = fmax(run_max[j], tile_max)
+            run_sum[j] = run_sum[j]*exp2((run_max[j]-new)*log2e)
+                       + tile_sum  *exp2((tile_max  -new)*log2e)
+            run_max[j] = new
+            run_target[j] += tile_target
+
+The same trick reads ``tgt_tile/tgt_col`` before the body and ``run_*`` before
+the cluster reduction.  Net effect: register-resident per-slot state with the
+epilogue body emitted exactly once, i.e. the same SASS footprint as the accepted
+kernel.
+
+The two-sentinel masking trick is preserved: the tile-local max starts at
+``NEG_INF_F32 = -1e38`` while out-of-vocabulary columns are ``MASK_F32 =
+-3e38``, so a fully-masked tile contributes ``exp2((-3e38 + 1e38) * log2 e) = 0``
+rather than 1, and folding a ``(max=-1e38, sum=0)`` tile into any state is a
+no-op (``0 * exp2(...) == 0``, never ``0 * inf``).
+
+TMA stream
+----------
+
+The load stream is a **single linear stream over the whole persistent kernel**:
+one prologue of ``stages`` loads at kernel entry, one refill per consumer
+release, one ``producer_tail`` at exit.  The stream cursor is
+``(k, slot, n_round, wave)`` advanced k-fastest, mirroring the consumer nesting
+exactly, so ``load_index == release_index`` holds at every refill with no
+modular arithmetic -- and unlike the accepted kernel there is no per-M-tile
+prologue/drain at all, because M tiles are no longer loop boundaries.
+``wait_group(1)`` and the tail-only ``wait_group(0)`` are unchanged.
+
+Ragged tails
+------------
+
+``num_real_slots = ceil((num_m_tiles - cluster_idx) / num_persistent_clusters)``
+depends only on ``blockIdx.z``, which is identical for all 16 CTAs of a cluster,
+so every loop bound and every predicate above is **cluster-uniform**; named
+barriers (``MMA_BARRIER_ID`` over 256 threads, ``EPI_BARRIER_ID`` over 128),
+``__syncthreads``, the cluster barriers and both pipelines therefore stay
+balanced even when the last cluster owns fewer M slots than the others.  All 16
+ranks of a cluster are always on the same M slot for a given tile.
+
+Status: not the default
+-----------------------
+The locality hypothesis is **disproven**.  Matched, interleaved measurements
+put this order ~3 % behind the M-outer forward at the representative shape
+(independently reconfirmed at ~3.8 %), because keeping several M tiles live per
+cluster shrinks the per-tile ``W`` reuse window without buying back enough
+``X`` reuse.  It is retained as the implementation of the public
+``m_tiles_per_cluster > 1`` scheduling knob (``slots_per_wave``); the default
+``m_tiles_per_cluster == 1`` dispatches to the M-outer forward instead.
+
+"""
+
+import inspect
+
+from dataclasses import dataclass
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+
+from cutlass import BFloat16
+from cutlass import Float16
+from cutlass import Float32
+from cutlass import Int32
+from cutlass import cutlass_dsl
+from cutlass import pipeline
+from cutlass._mlir.dialects import llvm
+from cutlass._mlir.dialects import nvvm
+from cutlass.cutlass_dsl import T
+from cutlass.cutlass_dsl import dsl_user_op
+from cutlass.pipeline.helpers import pipeline_init_arrive
+from cutlass.pipeline.helpers import pipeline_init_wait
+from cutlass.utils import LayoutEnum
+from cutlass.utils import hopper_helpers
+
+from liger_kernel.ops.cutedsl.ops.utils import to_cute_tensor
+
+THREADS_PER_CTA = 384
+NUM_MMA_WARP_GROUPS = 2
+WARPS_PER_WARP_GROUP = 4
+
+# Named barriers.  0 is reserved for __syncthreads().
+MMA_BARRIER_ID = 4  # both MMA warp groups, 256 threads
+EPI_BARRIER_ID = 5  # epilogue warp group, 128 threads
+
+LOG2_E = 1.4426950408889634
+LN2 = 0.6931471805599453
+NEG_INF_F32 = -1.0e38
+MASK_F32 = -3.0e38
+HOPPER_MAX_SMEM_BYTES = 227 * 1024
+
+_compile_cache = {}
+_stream_cache = {}
+_max_active_clusters_cache = {}
+
+try:
+    _FMAX_NEEDS_RESULT_TYPE = next(iter(inspect.signature(nvvm.fmax).parameters)) == "res"
+except Exception:
+    _FMAX_NEEDS_RESULT_TYPE = False
+
+
+@dsl_user_op
+def _fmax(a, b, *, loc=None, ip=None) -> Float32:
+    av = Float32(a).ir_value(loc=loc, ip=ip)
+    bv = Float32(b).ir_value(loc=loc, ip=ip)
+    if _FMAX_NEEDS_RESULT_TYPE:
+        return Float32(nvvm.fmax(T.f32(), av, bv, loc=loc, ip=ip))
+    return Float32(nvvm.fmax(av, bv, loc=loc, ip=ip))
+
+
+@dsl_user_op
+def _map_dsmem_addr(local_ptr, peer_rank, *, loc=None, ip=None) -> Int32:
+    """Map a local SMEM pointer to the same object in a peer CTA's SMEM.
+
+    ``llvm.nvvm.mapa`` ICEs this toolchain ("only supported when pointer size is
+    >= 64 bits"), so the PTX is emitted directly, exactly as
+    ``cutlass.cute.arch.map_dsmem_ptr`` does.
+    """
+    addr = llvm.ptrtoint(T.i32(), local_ptr.llvm_ptr, loc=loc, ip=ip)
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [addr, Int32(peer_rank).ir_value(loc=loc, ip=ip)],
+            "mapa.shared::cluster.u32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+def _asm(res_ty, args, tmpl, cons, side=True, *, loc=None, ip=None):
+    return llvm.inline_asm(
+        res_ty,
+        args,
+        tmpl,
+        cons,
+        has_side_effects=side,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _dsmem_load_f32(addr, *, loc=None, ip=None) -> Float32:
+    return Float32(
+        _asm(
+            T.f32(),
+            [Int32(addr).ir_value(loc=loc, ip=ip)],
+            "ld.shared::cluster.f32 $0, [$1];",
+            "=f,r",
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _dsmem_atomic_add_f32(addr, value, *, loc=None, ip=None) -> Float32:
+    return Float32(
+        _asm(
+            T.f32(),
+            [
+                Int32(addr).ir_value(loc=loc, ip=ip),
+                Float32(value).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.shared::cluster.add.f32 $0, [$1], $2;",
+            "=f,r,f",
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _dsmem_atomic_max_s32(addr, value, *, loc=None, ip=None) -> Int32:
+    return Int32(
+        _asm(
+            T.i32(),
+            [
+                Int32(addr).ir_value(loc=loc, ip=ip),
+                Int32(value).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.shared::cluster.max.s32 $0, [$1], $2;",
+            "=r,r,r",
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _dsmem_atomic_min_u32(addr, value, *, loc=None, ip=None) -> Int32:
+    return Int32(
+        _asm(
+            T.i32(),
+            [
+                Int32(addr).ir_value(loc=loc, ip=ip),
+                Int32(value).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.shared::cluster.min.u32 $0, [$1], $2;",
+            "=r,r,r",
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _dsmem_atomic_fmax(addr, value, *, loc=None, ip=None) -> Float32:
+    """FP32 max via the monotonic-bit-pattern trick (``red.max.f32`` has no PTX)."""
+    bits = llvm.bitcast(T.i32(), Float32(value).ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+    old = cutlass_dsl.if_generate(
+        Int32(bits) < 0,
+        lambda: _dsmem_atomic_min_u32(addr, Int32(bits), loc=loc, ip=ip),
+        lambda: _dsmem_atomic_max_s32(addr, Int32(bits), loc=loc, ip=ip),
+        [],
+        [Int32],
+        loc=loc,
+        ip=ip,
+    )
+    return Float32(llvm.bitcast(T.f32(), old.ir_value(loc=loc, ip=ip), loc=loc, ip=ip))
+
+
+def _cute_stream():
+    raw = torch.cuda.current_stream().cuda_stream
+    stream = _stream_cache.get(raw)
+    if stream is None:
+        stream = cuda.CUstream(raw)
+        _stream_cache[raw] = stream
+    return stream
+
+
+def _max_active_clusters(cluster_n):
+    key = (torch.cuda.current_device(), cluster_n)
+    value = _max_active_clusters_cache.get(key)
+    if value is None:
+        torch.cuda.current_stream()
+        value = cutlass.utils.HardwareInfo().get_max_active_clusters(cluster_n)
+        _max_active_clusters_cache[key] = value
+    return value
+
+
+@dataclass(frozen=True)
+class ScaledCEForwardMFastConfig:
+    """Tuning knobs for the M-fast (N-outer / M-inner) forward.
+
+    Everything except ``slots_per_wave`` matches the accepted forward kernel's
+    defaults and should not be swept here -- this experiment is about the work
+    order only.
+
+    ``slots_per_wave`` caps how many owned ``M128`` slots keep a live
+    online-softmax state (and therefore how many M slots share one L2-resident W
+    panel).  The kernel is compiled with ``wave_slots = min(slots_per_wave,
+    ceil(num_m_tiles / num_persistent_clusters))``, so it never costs registers
+    the shape cannot use.  ``slots_per_wave=1`` reproduces the accepted
+    M-outer order exactly and is the in-module A/B control.
+
+    Register budget: ``2 * 128 * mma_registers + 128 * epi_registers <= 64512``
+    (requesting the full 65536-register file deadlocks ``setmaxnreg.inc``).
+    """
+
+    tile_m: int = 128
+    tile_n: int = 256
+    tile_k: int = 64
+    stages: int = 3
+    cluster_n: int = 16
+    fast_math: bool = True
+    logit_dtype: str = "f16"
+    logit_pad: int = 8
+    chunk_n: int = 32
+    mma_registers: int = 208
+    epi_registers: int = 88
+    slots_per_wave: int = 8
+    return_entropy: bool = False
+
+    @property
+    def logit_stride(self):
+        return self.tile_n + self.logit_pad
+
+    def smem_bytes(self):
+        ab = (self.tile_m + self.tile_n) * self.tile_k * 2 * self.stages
+        logits = self.tile_m * self.logit_stride * 2
+        reduction = (3 + int(self.return_entropy)) * self.tile_m * 4
+        barriers = 16 * self.stages + 16
+        return ab + logits + reduction + barriers + 3 * 1024
+
+    def register_total(self):
+        return 2 * 128 * self.mma_registers + 128 * self.epi_registers
+
+
+class _ScaledCEForwardMFastSM90:
+    """M-fast persistent forward: N-outer / M-inner over each cluster's slots."""
+
+    def __init__(self, config: ScaledCEForwardMFastConfig, wave_slots: int):
+        self.tile_m = config.tile_m
+        self.tile_n = config.tile_n
+        self.tile_k = config.tile_k
+        self.stages = config.stages
+        self.cluster_n = config.cluster_n
+        self.fast_math = config.fast_math
+        self.logit_pad = config.logit_pad
+        self.logit_stride = config.tile_n + config.logit_pad
+        self.chunk_n = config.chunk_n
+        self.mma_registers = config.mma_registers
+        self.epi_registers = config.epi_registers
+        self.return_entropy = config.return_entropy
+        self.logit_dtype = Float16 if config.logit_dtype == "f16" else BFloat16
+        self.wave_slots = int(wave_slots)
+        self.tile_shape = (self.tile_m, self.tile_n, self.tile_k)
+        self.buffer_align = 1024
+        self.mma_barrier = pipeline.NamedBarrier(
+            barrier_id=MMA_BARRIER_ID,
+            num_threads=NUM_MMA_WARP_GROUPS * 128,
+        )
+        self.epi_barrier = pipeline.NamedBarrier(
+            barrier_id=EPI_BARRIER_ID,
+            num_threads=128,
+        )
+
+    @staticmethod
+    def _make_tma(tensor, smem_layout_staged, smem_tile):
+        smem_layout = cute.slice_(smem_layout_staged, (None, None, 0))
+        return cute.nvgpu.cpasync.make_tiled_tma_atom(
+            cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp(),
+            tensor,
+            smem_layout,
+            smem_tile,
+            num_multicast=1,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        weight: cute.Tensor,
+        target: cute.Tensor,
+        lse: cute.Tensor,
+        token_loss: cute.Tensor,
+        entropy: cute.Tensor,
+        inverse_temperature: Float32,
+        ignore_index: Int32,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+    ):
+        x_layout = LayoutEnum.from_tensor(x)
+        weight_layout = LayoutEnum.from_tensor(weight)
+        tiled_mma = hopper_helpers.make_trivial_tiled_mma(
+            BFloat16,
+            BFloat16,
+            x_layout.sm90_mma_major_mode(),
+            weight_layout.sm90_mma_major_mode(),
+            Float32,
+            (NUM_MMA_WARP_GROUPS, 1, 1),
+            (64, self.tile_n),
+        )
+        a_smem_layout = hopper_helpers.make_smem_layout_a(
+            x_layout,
+            self.tile_shape,
+            BFloat16,
+            self.stages,
+        )
+        b_smem_layout = hopper_helpers.make_smem_layout_b(
+            weight_layout,
+            self.tile_shape,
+            BFloat16,
+            self.stages,
+        )
+        tma_x, tma_tensor_x = self._make_tma(x, a_smem_layout, (self.tile_m, self.tile_k))
+        tma_w, tma_tensor_w = self._make_tma(weight, b_smem_layout, (self.tile_n, self.tile_k))
+
+        logit_dtype = self.logit_dtype
+
+        @cute.struct
+        class SharedStorage:
+            pipeline: cute.struct.MemRange[cutlass.Int64, self.stages * 2]
+            logits_pipeline: cute.struct.MemRange[cutlass.Int64, 2]
+            sX: cute.struct.Align[
+                cute.struct.MemRange[BFloat16, cute.cosize(a_smem_layout)],
+                self.buffer_align,
+            ]
+            sW: cute.struct.Align[
+                cute.struct.MemRange[BFloat16, cute.cosize(b_smem_layout)],
+                self.buffer_align,
+            ]
+            sLogits: cute.struct.Align[
+                cute.struct.MemRange[
+                    logit_dtype,
+                    self.tile_m * self.logit_stride,
+                ],
+                self.buffer_align,
+            ]
+            cluster_max: cute.struct.Align[cute.struct.MemRange[Float32, self.tile_m], 16]
+            cluster_sum: cute.struct.Align[cute.struct.MemRange[Float32, self.tile_m], 16]
+            cluster_target: cute.struct.Align[cute.struct.MemRange[Float32, self.tile_m], 16]
+            cluster_weighted: cute.struct.Align[
+                cute.struct.MemRange[Float32, self.tile_m if self.return_entropy else 1],
+                16,
+            ]
+
+        self.shared_storage = SharedStorage
+        cluster_shape = (1, self.cluster_n, 1)
+        num_m_tiles = cute.ceil_div(x.shape[0], self.tile_m)
+        num_persistent_clusters = cutlass.min(num_m_tiles, max_active_clusters)
+        grid = (1, self.cluster_n, num_persistent_clusters)
+        self.kernel(
+            tma_x,
+            tma_tensor_x,
+            tma_w,
+            tma_tensor_w,
+            target,
+            lse,
+            token_loss,
+            entropy,
+            inverse_temperature,
+            tiled_mma,
+            a_smem_layout,
+            b_smem_layout,
+            ignore_index,
+        ).launch(
+            grid=grid,
+            block=(THREADS_PER_CTA, 1, 1),
+            cluster=cluster_shape,
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        tma_x: cute.CopyAtom,
+        x: cute.Tensor,
+        tma_w: cute.CopyAtom,
+        weight: cute.Tensor,
+        target: cute.Tensor,
+        lse: cute.Tensor,
+        token_loss: cute.Tensor,
+        entropy: cute.Tensor,
+        inverse_temperature: Float32,
+        tiled_mma: cute.TiledMma,
+        a_smem_layout: cute.ComposedLayout,
+        b_smem_layout: cute.ComposedLayout,
+        ignore_index: Int32,
+    ):
+        tid, _, _ = cute.arch.thread_idx()
+        warp = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        warp_group = cute.arch.make_warp_uniform(tid // 128)
+        lane = tid % 32
+        local_warp = (tid % 128) // 32
+        local_tid = tid % 128
+        cluster_rank = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        _, _, cluster_idx = cute.arch.block_idx()
+        _, _, num_persistent_clusters = cute.arch.grid_dim()
+        num_m_tiles = cute.ceil_div(target.shape[0], self.tile_m)
+
+        if warp == 0:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_x)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_w)
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+        sX = storage.sX.get_tensor(a_smem_layout.outer, swizzle=a_smem_layout.inner)
+        sW = storage.sW.get_tensor(b_smem_layout.outer, swizzle=b_smem_layout.inner)
+        sLogits = storage.sLogits.get_tensor(
+            cute.make_layout(
+                (self.tile_m, self.tile_n),
+                stride=(self.logit_stride, 1),
+            )
+        )
+        cluster_max = storage.cluster_max.get_tensor(cute.make_layout(self.tile_m))
+        cluster_sum = storage.cluster_sum.get_tensor(cute.make_layout(self.tile_m))
+        cluster_target = storage.cluster_target.get_tensor(cute.make_layout(self.tile_m))
+        cluster_weighted = storage.cluster_weighted.get_tensor(
+            cute.make_layout(self.tile_m if cutlass.const_expr(self.return_entropy) else 1)
+        )
+
+        cta_layout = cute.make_layout((1, self.cluster_n, 1))
+        cluster_coord = cta_layout.get_flat_coord(cluster_rank)
+
+        gX = cute.local_tile(
+            x,
+            cute.slice_(self.tile_shape, (None, 0, None)),
+            (None, None, None),
+        )
+        gW = cute.local_tile(
+            weight,
+            cute.slice_(self.tile_shape, (0, None, None)),
+            (None, None, None),
+        )
+        tXsX, tXgX = cute.nvgpu.cpasync.tma_partition(
+            tma_x,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sX, 0, 2),
+            cute.group_modes(gX, 0, 2),
+        )
+        w_cta_layout = cute.make_layout(cute.slice_(cta_layout, (None, 0, 0)).shape)
+        tWsW, tWgW = cute.nvgpu.cpasync.tma_partition(
+            tma_w,
+            cluster_coord[0],
+            w_cta_layout,
+            cute.group_modes(sW, 0, 2),
+            cute.group_modes(gW, 0, 2),
+        )
+
+        tma_bytes = cute.size_in_bytes(BFloat16, cute.slice_(a_smem_layout, (None, None, 0))) + cute.size_in_bytes(
+            BFloat16, cute.slice_(b_smem_layout, (None, None, 0))
+        )
+
+        mainloop = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.pipeline.data_ptr(),
+            num_stages=self.stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                NUM_MMA_WARP_GROUPS * WARPS_PER_WARP_GROUP,
+            ),
+            tx_count=tma_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+            defer_sync=True,
+        )
+        logits_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.logits_pipeline.data_ptr(),
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            defer_sync=True,
+        )
+        pipeline_init_arrive(cluster_shape_mn=(1, self.cluster_n), is_relaxed=True)
+        pipeline_init_wait(cluster_shape_mn=(1, self.cluster_n))
+
+        num_k_tiles = cute.size(gX, mode=[3])
+        num_k_blocks = self.tile_k // 16
+        num_pair_tiles = cute.ceil_div(weight.shape[0], self.cluster_n * self.tile_n)
+
+        # ---- M-slot ownership (cluster-uniform: depends only on blockIdx.z) ---
+        num_real_slots = cute.ceil_div(num_m_tiles - cluster_idx, num_persistent_clusters)
+        num_waves = cute.ceil_div(num_real_slots, self.wave_slots)
+
+        root_max_addr = _map_dsmem_addr(storage.cluster_max.data_ptr(), 0)
+        root_sum_addr = _map_dsmem_addr(storage.cluster_sum.data_ptr(), 0)
+        root_target_addr = _map_dsmem_addr(storage.cluster_target.data_ptr(), 0)
+        root_weighted_addr = _map_dsmem_addr(storage.cluster_weighted.data_ptr(), 0)
+
+        if warp_group < NUM_MMA_WARP_GROUPS:
+            # ================= MMA warp groups (WG0 + WG1) =================
+            cute.arch.setmaxregister_increase(self.mma_registers)
+
+            mma_wg_layout = cute.make_layout(NUM_MMA_WARP_GROUPS, stride=128)
+            thr_mma = tiled_mma.get_slice(mma_wg_layout(Int32(warp_group)))
+            tCrX = tiled_mma.make_fragment_A(thr_mma.partition_A(sX))
+            tCrW = tiled_mma.make_fragment_B(thr_mma.partition_B(sW))
+            accum = cute.make_rmem_tensor(
+                thr_mma.partition_shape_C((self.tile_m, self.tile_n)),
+                Float32,
+            )
+            n_accum = cute.size(accum)
+            row_base_in_tile = warp_group * 64 + local_warp * 16 + lane // 4
+            col_base_in_tile = (lane % 4) * 2
+
+            read_index = Int32(0)
+            read_phase = Int32(0)
+            rel_index = Int32(0)
+            rel_phase = Int32(0)
+            load_index = Int32(0)
+            load_phase = Int32(1)
+            logit_w_index = Int32(0)
+            logit_w_phase = Int32(1)
+
+            # TMA cursor: (k, slot-in-wave, n_round, wave), advanced k-fastest.
+            load_k = Int32(0)
+            load_j = Int32(0)
+            load_round = Int32(0)
+            load_wave = Int32(0)
+            load_wave_slots = cutlass.min(Int32(self.wave_slots), num_real_slots)
+
+            cute.arch.sync_threads()
+            cute.arch.cluster_arrive()
+            cute.arch.cluster_wait()
+
+            # ---- prologue: S complete TMA stages before any WGMMA ----------
+            if warp == 0:
+                total_loads = Int32(num_k_tiles) * Int32(num_pair_tiles) * num_real_slots
+                prologue_stages = cutlass.min(Int32(self.stages), total_loads)
+                for _ in range(prologue_stages):
+                    pstate = pipeline.PipelineState(self.stages, Int32(0), load_index, load_phase)
+                    mainloop.producer_acquire(pstate)
+                    bar = mainloop.producer_get_barrier(pstate)
+                    load_pid_m = cluster_idx + (load_wave * self.wave_slots + load_j) * num_persistent_clusters
+                    tXgX_m = tXgX[(None, load_pid_m, None, 0)]
+                    cute.copy(
+                        tma_x,
+                        tXgX_m[(None, load_k)],
+                        tXsX[(None, load_index)],
+                        tma_bar_ptr=bar,
+                        mcast_mask=0,
+                    )
+                    tWgW_n = tWgW[(None, load_round * self.cluster_n + cluster_rank, None, 0)]
+                    cute.copy(
+                        tma_w,
+                        tWgW_n[(None, load_k)],
+                        tWsW[(None, load_index)],
+                        tma_bar_ptr=bar,
+                    )
+                    mainloop.producer_commit(pstate)
+                    pstate.advance()
+                    load_index = pstate.index
+                    load_phase = pstate.phase
+                    load_k += 1
+                    if load_k == num_k_tiles:
+                        load_k = Int32(0)
+                        load_j += 1
+                    if load_j == load_wave_slots:
+                        load_j = Int32(0)
+                        load_round += 1
+                    if load_round == num_pair_tiles:
+                        load_round = Int32(0)
+                        load_wave += 1
+                        load_wave_slots = cutlass.min(
+                            Int32(self.wave_slots),
+                            num_real_slots - load_wave * self.wave_slots,
+                        )
+                        if load_wave_slots < 1:
+                            load_wave_slots = Int32(1)
+
+            for wave in range(num_waves):
+                cur_slots = cutlass.min(
+                    Int32(self.wave_slots),
+                    num_real_slots - wave * self.wave_slots,
+                )
+
+                for _n_round in range(num_pair_tiles):
+                    for _slot in range(cur_slots):
+                        # ------------- one M128 x N256 output tile ----------
+                        accum.fill(0.0)
+                        tiled_mma.set(cute.nvgpu.warpgroup.Field.ACCUMULATE, True)
+
+                        read_state = pipeline.PipelineState(self.stages, Int32(0), read_index, read_phase)
+                        mainloop.consumer_wait(read_state)
+                        cute.nvgpu.warpgroup.fence()
+                        for k_block in cutlass.range_constexpr(num_k_blocks):
+                            coord = (None, None, k_block, read_index)
+                            cute.gemm(tiled_mma, accum, tCrX[coord], tCrW[coord], accum)
+                        cute.nvgpu.warpgroup.commit_group()
+                        read_state.advance()
+                        read_index = read_state.index
+                        read_phase = read_state.phase
+
+                        for _ in range(1, num_k_tiles):
+                            read_state = pipeline.PipelineState(self.stages, Int32(0), read_index, read_phase)
+                            mainloop.consumer_wait(read_state)
+                            cute.nvgpu.warpgroup.fence()
+                            for k_block in cutlass.range_constexpr(num_k_blocks):
+                                coord = (None, None, k_block, read_index)
+                                cute.gemm(tiled_mma, accum, tCrX[coord], tCrW[coord], accum)
+                            cute.nvgpu.warpgroup.commit_group()
+                            # Retire only the previous group; the group just
+                            # issued stays IN FLIGHT across release + refill.
+                            cute.nvgpu.warpgroup.wait_group(1)
+                            rstate = pipeline.PipelineState(self.stages, Int32(0), rel_index, rel_phase)
+                            mainloop.consumer_release(rstate)
+                            rstate.advance()
+                            rel_index = rstate.index
+                            rel_phase = rstate.phase
+                            if warp == 0:
+                                if load_wave < num_waves:
+                                    pstate = pipeline.PipelineState(self.stages, Int32(0), load_index, load_phase)
+                                    mainloop.producer_acquire(pstate)
+                                    bar = mainloop.producer_get_barrier(pstate)
+                                    load_pid_m = (
+                                        cluster_idx + (load_wave * self.wave_slots + load_j) * num_persistent_clusters
+                                    )
+                                    tXgX_m = tXgX[(None, load_pid_m, None, 0)]
+                                    cute.copy(
+                                        tma_x,
+                                        tXgX_m[(None, load_k)],
+                                        tXsX[(None, load_index)],
+                                        tma_bar_ptr=bar,
+                                        mcast_mask=0,
+                                    )
+                                    tWgW_n = tWgW[(None, load_round * self.cluster_n + cluster_rank, None, 0)]
+                                    cute.copy(
+                                        tma_w,
+                                        tWgW_n[(None, load_k)],
+                                        tWsW[(None, load_index)],
+                                        tma_bar_ptr=bar,
+                                    )
+                                    mainloop.producer_commit(pstate)
+                                    pstate.advance()
+                                    load_index = pstate.index
+                                    load_phase = pstate.phase
+                                    load_k += 1
+                                    if load_k == num_k_tiles:
+                                        load_k = Int32(0)
+                                        load_j += 1
+                                    if load_j == load_wave_slots:
+                                        load_j = Int32(0)
+                                        load_round += 1
+                                    if load_round == num_pair_tiles:
+                                        load_round = Int32(0)
+                                        load_wave += 1
+                                        load_wave_slots = cutlass.min(
+                                            Int32(self.wave_slots),
+                                            num_real_slots - load_wave * self.wave_slots,
+                                        )
+                                        if load_wave_slots < 1:
+                                            load_wave_slots = Int32(1)
+                            read_state.advance()
+                            read_index = read_state.index
+                            read_phase = read_state.phase
+
+                        # ---- tile tail: the only WGMMA drain ---------------
+                        cute.nvgpu.warpgroup.wait_group(0)
+                        rstate = pipeline.PipelineState(self.stages, Int32(0), rel_index, rel_phase)
+                        mainloop.consumer_release(rstate)
+                        rstate.advance()
+                        rel_index = rstate.index
+                        rel_phase = rstate.phase
+                        if warp == 0:
+                            if load_wave < num_waves:
+                                pstate = pipeline.PipelineState(self.stages, Int32(0), load_index, load_phase)
+                                mainloop.producer_acquire(pstate)
+                                bar = mainloop.producer_get_barrier(pstate)
+                                load_pid_m = (
+                                    cluster_idx + (load_wave * self.wave_slots + load_j) * num_persistent_clusters
+                                )
+                                tXgX_m = tXgX[(None, load_pid_m, None, 0)]
+                                cute.copy(
+                                    tma_x,
+                                    tXgX_m[(None, load_k)],
+                                    tXsX[(None, load_index)],
+                                    tma_bar_ptr=bar,
+                                    mcast_mask=0,
+                                )
+                                tWgW_n = tWgW[(None, load_round * self.cluster_n + cluster_rank, None, 0)]
+                                cute.copy(
+                                    tma_w,
+                                    tWgW_n[(None, load_k)],
+                                    tWsW[(None, load_index)],
+                                    tma_bar_ptr=bar,
+                                )
+                                mainloop.producer_commit(pstate)
+                                pstate.advance()
+                                load_index = pstate.index
+                                load_phase = pstate.phase
+                                load_k += 1
+                                if load_k == num_k_tiles:
+                                    load_k = Int32(0)
+                                    load_j += 1
+                                if load_j == load_wave_slots:
+                                    load_j = Int32(0)
+                                    load_round += 1
+                                if load_round == num_pair_tiles:
+                                    load_round = Int32(0)
+                                    load_wave += 1
+                                    load_wave_slots = cutlass.min(
+                                        Int32(self.wave_slots),
+                                        num_real_slots - load_wave * self.wave_slots,
+                                    )
+                                    if load_wave_slots < 1:
+                                        load_wave_slots = Int32(1)
+
+                        wstate = pipeline.PipelineState(1, Int32(0), logit_w_index, logit_w_phase)
+                        logits_pipeline.producer_acquire(wstate)
+                        for i in cutlass.range_constexpr(n_accum):
+                            row = row_base_in_tile + ((i % 4) // 2) * 8
+                            col = col_base_in_tile + (i // 4) * 8 + (i % 2)
+                            sLogits[row, col] = self.logit_dtype(accum[i])
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        cute.arch.fence_acq_rel_cta()
+                        self.mma_barrier.arrive_and_wait()
+                        if tid == 0:
+                            logits_pipeline.producer_commit(wstate)
+                        wstate.advance()
+                        logit_w_index = wstate.index
+                        logit_w_phase = wstate.phase
+
+                # ---- per-slot cluster reduction: barrier participation only --
+                for _slot in range(cur_slots):
+                    cute.arch.sync_threads()
+                    cute.arch.cluster_arrive()
+                    cute.arch.cluster_wait()
+                    cute.arch.cluster_arrive()
+                    cute.arch.cluster_wait()
+                    cute.arch.cluster_arrive()
+                    cute.arch.cluster_wait()
+                    cute.arch.cluster_arrive()
+                    cute.arch.cluster_wait()
+
+            if warp == 0:
+                ptail = pipeline.PipelineState(self.stages, Int32(0), load_index, load_phase)
+                mainloop.producer_tail(ptail)
+        else:
+            # ==================== epilogue warp group ======================
+            cute.arch.setmaxregister_decrease(self.epi_registers)
+
+            row = local_tid
+            chunk = cute.make_rmem_tensor((self.chunk_n,), Float32)
+            # Per-owned-M-slot online softmax state, register resident.
+            run_max = cute.make_rmem_tensor((self.wave_slots,), Float32)
+            run_sum = cute.make_rmem_tensor((self.wave_slots,), Float32)
+            run_target = cute.make_rmem_tensor((self.wave_slots,), Float32)
+            run_weighted = cute.make_rmem_tensor(
+                (self.wave_slots if self.return_entropy else 1,),
+                Float32,
+            )
+            tgt_tile = cute.make_rmem_tensor((self.wave_slots,), Int32)
+            tgt_col = cute.make_rmem_tensor((self.wave_slots,), Int32)
+            logit_r_index = Int32(0)
+            logit_r_phase = Int32(0)
+
+            cute.arch.sync_threads()
+            cute.arch.cluster_arrive()
+            cute.arch.cluster_wait()
+
+            for wave in range(num_waves):
+                cur_slots = cutlass.min(
+                    Int32(self.wave_slots),
+                    num_real_slots - wave * self.wave_slots,
+                )
+                slot_base = wave * self.wave_slots
+
+                for j in cutlass.range_constexpr(self.wave_slots):
+                    run_max[j] = Float32(NEG_INF_F32)
+                    run_sum[j] = Float32(0.0)
+                    run_target[j] = Float32(0.0)
+                    if cutlass.const_expr(self.return_entropy):
+                        run_weighted[j] = Float32(0.0)
+                    tgt_tile[j] = Int32(-1)
+                    tgt_col[j] = Int32(-1)
+                    if cur_slots > j:
+                        grow = (cluster_idx + (slot_base + j) * num_persistent_clusters) * self.tile_m + row
+                        if grow < target.shape[0]:
+                            tcol = Int32(target[grow])
+                            if tcol >= 0:
+                                tgt_tile[j] = tcol // self.tile_n
+                                tgt_col[j] = tcol % self.tile_n
+
+                for n_round in range(num_pair_tiles):
+                    n_tile = n_round * self.cluster_n + cluster_rank
+                    valid_cols = Int32(weight.shape[0]) - n_tile * self.tile_n
+
+                    for slot in range(cur_slots):
+                        # Pull this slot's target coordinates into plain
+                        # registers so the heavy body below stays a single
+                        # SASS instance (see module docstring).
+                        cur_tgt_tile = Int32(-1)
+                        cur_tgt_col = Int32(-1)
+                        for j in cutlass.range_constexpr(self.wave_slots):
+                            if slot == j:
+                                cur_tgt_tile = tgt_tile[j]
+                                cur_tgt_col = tgt_col[j]
+
+                        rstate = pipeline.PipelineState(1, Int32(0), logit_r_index, logit_r_phase)
+                        logits_pipeline.consumer_wait(rstate)
+                        cute.arch.fence_acq_rel_cta()
+
+                        tile_max = Float32(NEG_INF_F32)
+                        tile_sum = Float32(0.0)
+                        tile_target = Float32(0.0)
+                        tile_weighted = Float32(0.0)
+                        for ci in cutlass.range_constexpr(self.tile_n // self.chunk_n):
+                            c0 = ci * self.chunk_n
+                            chunk_max = Float32(MASK_F32)
+                            if c0 + self.chunk_n <= valid_cols:
+                                for jj in cutlass.range_constexpr(self.chunk_n):
+                                    v = Float32(sLogits[row, c0 + jj]) * inverse_temperature
+                                    chunk[jj] = v
+                                    chunk_max = _fmax(chunk_max, v)
+                            else:
+                                for jj in cutlass.range_constexpr(self.chunk_n):
+                                    v = Float32(sLogits[row, c0 + jj]) * inverse_temperature
+                                    if c0 + jj >= valid_cols:
+                                        v = Float32(MASK_F32)
+                                    chunk[jj] = v
+                                    chunk_max = _fmax(chunk_max, v)
+                            new_max = _fmax(tile_max, chunk_max)
+                            acc = Float32(0.0)
+                            weighted = Float32(0.0)
+                            for jj in cutlass.range_constexpr(self.chunk_n):
+                                exp_value = cute.math.exp2(
+                                    (chunk[jj] - new_max) * LOG2_E,
+                                    fastmath=self.fast_math,
+                                )
+                                acc += exp_value
+                                if cutlass.const_expr(self.return_entropy):
+                                    weighted += exp_value * chunk[jj]
+                            old_scale = cute.math.exp2(
+                                (tile_max - new_max) * LOG2_E,
+                                fastmath=self.fast_math,
+                            )
+                            tile_sum = tile_sum * old_scale + acc
+                            if cutlass.const_expr(self.return_entropy):
+                                tile_weighted = tile_weighted * old_scale + weighted
+                            tile_max = new_max
+
+                        if cur_tgt_tile == n_tile:
+                            tile_target = Float32(sLogits[row, cur_tgt_col]) * inverse_temperature
+
+                        self.epi_barrier.arrive_and_wait()
+                        if local_tid == 0:
+                            logits_pipeline.consumer_release(rstate)
+                        rstate.advance()
+                        logit_r_index = rstate.index
+                        logit_r_phase = rstate.phase
+
+                        # Fold the tile-local result into this slot's state.
+                        for j in cutlass.range_constexpr(self.wave_slots):
+                            if slot == j:
+                                folded = _fmax(run_max[j], tile_max)
+                                run_sum[j] = run_sum[j] * cute.math.exp2(
+                                    (run_max[j] - folded) * LOG2_E,
+                                    fastmath=self.fast_math,
+                                ) + tile_sum * cute.math.exp2(
+                                    (tile_max - folded) * LOG2_E,
+                                    fastmath=self.fast_math,
+                                )
+                                if cutlass.const_expr(self.return_entropy):
+                                    run_weighted[j] = run_weighted[j] * cute.math.exp2(
+                                        (run_max[j] - folded) * LOG2_E,
+                                        fastmath=self.fast_math,
+                                    ) + tile_weighted * cute.math.exp2(
+                                        (tile_max - folded) * LOG2_E,
+                                        fastmath=self.fast_math,
+                                    )
+                                run_max[j] = folded
+                                run_target[j] = run_target[j] + tile_target
+
+                # ---- all N work for this wave is done: reduce every slot ----
+                for slot in range(cur_slots):
+                    cur_max = Float32(NEG_INF_F32)
+                    cur_sum = Float32(0.0)
+                    cur_target = Float32(0.0)
+                    cur_weighted = Float32(0.0)
+                    for j in cutlass.range_constexpr(self.wave_slots):
+                        if slot == j:
+                            cur_max = run_max[j]
+                            cur_sum = run_sum[j]
+                            cur_target = run_target[j]
+                            if cutlass.const_expr(self.return_entropy):
+                                cur_weighted = run_weighted[j]
+
+                    global_row = (cluster_idx + (slot_base + slot) * num_persistent_clusters) * self.tile_m + row
+
+                    if cluster_rank == 0:
+                        cluster_max[row] = Float32(NEG_INF_F32)
+                        cluster_sum[row] = Float32(0.0)
+                        cluster_target[row] = Float32(0.0)
+                        if cutlass.const_expr(self.return_entropy):
+                            cluster_weighted[row] = Float32(0.0)
+                    cute.arch.sync_threads()
+                    cute.arch.cluster_arrive()
+                    cute.arch.cluster_wait()
+
+                    _dsmem_atomic_fmax(root_max_addr + row * 4, cur_max)
+                    cute.arch.cluster_arrive()
+                    cute.arch.cluster_wait()
+
+                    global_max = _dsmem_load_f32(root_max_addr + row * 4)
+                    scaled_sum = cur_sum * cute.math.exp2(
+                        (cur_max - global_max) * LOG2_E,
+                        fastmath=self.fast_math,
+                    )
+                    _dsmem_atomic_add_f32(root_sum_addr + row * 4, scaled_sum)
+                    _dsmem_atomic_add_f32(root_target_addr + row * 4, cur_target)
+                    if cutlass.const_expr(self.return_entropy):
+                        scaled_weighted = cur_weighted * cute.math.exp2(
+                            (cur_max - global_max) * LOG2_E,
+                            fastmath=self.fast_math,
+                        )
+                        _dsmem_atomic_add_f32(root_weighted_addr + row * 4, scaled_weighted)
+                    cute.arch.cluster_arrive()
+                    cute.arch.cluster_wait()
+
+                    if cluster_rank == 0:
+                        if global_row < target.shape[0]:
+                            row_lse = cluster_max[row] + cute.math.log2(cluster_sum[row], fastmath=self.fast_math) * LN2
+                            lse[global_row] = row_lse
+                            if target[global_row] == ignore_index:
+                                token_loss[global_row] = Float32(0.0)
+                                if cutlass.const_expr(self.return_entropy):
+                                    entropy[global_row] = BFloat16(0.0)
+                            else:
+                                token_loss[global_row] = row_lse - cluster_target[row]
+                                if cutlass.const_expr(self.return_entropy):
+                                    entropy[global_row] = BFloat16(row_lse - cluster_weighted[row] / cluster_sum[row])
+
+                    cute.arch.cluster_arrive()
+                    cute.arch.cluster_wait()
+
+
+def _validate(x, weight, target):
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability(x.device) != (9, 0):
+        raise RuntimeError("SM90 fused scaled cross entropy M-fast forward requires a Hopper (sm90) GPU")
+    if x.device != weight.device or x.device != target.device:
+        raise ValueError("input, weight, and target must be on the same CUDA device")
+    if x.dtype != torch.bfloat16 or weight.dtype != torch.bfloat16:
+        raise TypeError("SM90 fused scaled cross entropy M-fast forward supports BF16 input and weight only")
+    if x.ndim != 2 or weight.ndim != 2 or target.ndim != 1:
+        raise ValueError("expected input[BT,H], weight[V,H], and target[BT]")
+    if x.shape[0] != target.shape[0] or x.shape[1] != weight.shape[1]:
+        raise ValueError("input, weight, and target shapes are incompatible")
+
+
+def _pad_hidden(x, weight, tile_k):
+    hidden_size = x.shape[1]
+    padded = (hidden_size + tile_k - 1) // tile_k * tile_k
+    if padded == hidden_size:
+        return x.contiguous(), weight.contiguous(), hidden_size
+    return (
+        torch.nn.functional.pad(x, (0, padded - hidden_size)),
+        torch.nn.functional.pad(weight, (0, padded - hidden_size)),
+        hidden_size,
+    )
+
+
+def scaled_ce_forward_mfast(
+    _input,
+    weight,
+    target,
+    temperature=1.0,
+    ignore_index=-100,
+    return_entropy=False,
+    config: ScaledCEForwardMFastConfig = None,
+):
+    """M-fast (N-outer / M-inner) forward.  Returns per-token ``(nll[M], lse[M])``."""
+    _validate(_input, weight, target)
+    if config is None:
+        config = ScaledCEForwardMFastConfig()
+    if config.return_entropy != return_entropy:
+        config = ScaledCEForwardMFastConfig(**{**config.__dict__, "return_entropy": return_entropy})
+    if config.tile_m != 128:
+        raise ValueError("tile_m must be 128 (one epilogue thread per row)")
+    if config.tile_n % 8 != 0 or config.tile_n % config.chunk_n != 0:
+        raise ValueError("tile_n must be a multiple of 8 and of chunk_n")
+    if config.slots_per_wave < 1:
+        raise ValueError("slots_per_wave must be >= 1")
+    if config.smem_bytes() > HOPPER_MAX_SMEM_BYTES:
+        raise ValueError(
+            f"config needs ~{config.smem_bytes()} B of shared memory, "
+            f"which exceeds the {HOPPER_MAX_SMEM_BYTES} B Hopper opt-in limit"
+        )
+    if config.register_total() > 64512:
+        raise ValueError(f"register budget {config.register_total()} exceeds the usable 64512-register budget")
+
+    target = target.contiguous()
+    x_padded, weight_padded, _ = _pad_hidden(_input, weight, config.tile_k)
+    bt = x_padded.shape[0]
+
+    lse = torch.empty(bt, device=_input.device, dtype=torch.float32)
+    token_loss = torch.empty(bt, device=_input.device, dtype=torch.float32)
+    entropy = torch.empty(bt if return_entropy else 1, device=_input.device, dtype=torch.bfloat16)
+    x_cute = to_cute_tensor(x_padded.unsqueeze(-1), leading_dim=1, assumed_align=16)
+    weight_cute = to_cute_tensor(weight_padded.unsqueeze(-1), leading_dim=1, assumed_align=16)
+    target_cute = to_cute_tensor(target, assumed_align=8)
+    lse_cute = to_cute_tensor(lse, assumed_align=4)
+    token_loss_cute = to_cute_tensor(token_loss, assumed_align=4)
+    entropy_cute = to_cute_tensor(entropy, assumed_align=2)
+    stream = _cute_stream()
+    inverse_temperature = Float32(1.0 / temperature)
+    max_active_clusters = _max_active_clusters(config.cluster_n)
+
+    # ``wave_slots`` must be a compile-time constant (it sizes the per-slot
+    # register arrays), so it is derived on the host from the launch geometry.
+    num_m_tiles = (bt + config.tile_m - 1) // config.tile_m
+    num_persistent_clusters = min(num_m_tiles, max_active_clusters)
+    max_m_slots = (num_m_tiles + num_persistent_clusters - 1) // num_persistent_clusters
+    wave_slots = max(1, min(config.slots_per_wave, max_m_slots))
+
+    key = ("scaled_ce_forward_mfast", config, max_active_clusters, wave_slots)
+    compiled = _compile_cache.get(key)
+    if compiled is None:
+        compiled = cute.compile(
+            _ScaledCEForwardMFastSM90(config, wave_slots),
+            x_cute,
+            weight_cute,
+            target_cute,
+            lse_cute,
+            token_loss_cute,
+            entropy_cute,
+            inverse_temperature,
+            Int32(ignore_index),
+            max_active_clusters,
+            stream,
+        )
+        _compile_cache[key] = compiled
+    compiled(
+        x_cute,
+        weight_cute,
+        target_cute,
+        lse_cute,
+        token_loss_cute,
+        entropy_cute,
+        inverse_temperature,
+        Int32(ignore_index),
+        stream,
+    )
+
+    return token_loss, entropy if return_entropy else None, lse

--- a/src/liger_kernel/ops/cutedsl/ops/_fused_scaled_cross_entropy_forward_sm90.py
+++ b/src/liger_kernel/ops/cutedsl/ops/_fused_scaled_cross_entropy_forward_sm90.py
@@ -1,0 +1,1104 @@
+"""SM90 fused scaled cross entropy **forward** kernel: producer-less
+"MMA-warp issues TMA" mainloop + dedicated SMEM-logits epilogue warp group.
+
+This is the default forward used by
+:mod:`liger_kernel.ops.cutedsl.ops.fused_scaled_cross_entropy_sm90`
+(``m_tiles_per_cluster == 1``).  It computes the per-token negative
+log-likelihood ``nll[M]`` and the log-sum-exp ``lse[M]`` of ``X @ W.T`` without
+ever writing the logits to HBM.  The module is self-contained: apart from
+:func:`to_cute_tensor` it imports nothing from the rest of the backend.
+
+Architecture
+============
+
+384 threads / 3 warp groups, but the split is **not** the production
+producer/consumer split:
+
+===========  =========================================================
+warp group   role
+===========  =========================================================
+WG0 (0-127)  WGMMA, rows ``[0, 64)`` of the M128 tile.  **Warp 0 of WG0
+             is additionally the *TMA main warp*: it issues every
+             global->SMEM ``cp.async.bulk.tensor`` for X and W.**
+WG1 (128-255) WGMMA, rows ``[64, 128)`` of the M128 tile.
+WG2 (256-383) Epilogue: online softmax max/exp/sum + target logit read
+             from a staged SMEM logits tile, one row per thread, plus
+             the CTA/cluster DSMEM reduction and the loss/lse stores.
+===========  =========================================================
+
+There is **no dedicated producer warp group**, so the whole register file is
+split two ways instead of three and 2/3 of the threads do WGMMA instead of 1/2.
+The MMA topology itself is unchanged from production: a cooperative
+``atom_layout = (2, 1, 1)`` tiled MMA over a ``(64, tile_n)`` WGMMA atom, i.e.
+``M128 x N256 x K64`` split along M between the two MMA warp groups, 3 stages,
+``cluster_n = 16``, no multicast anywhere.
+
+Mainloop TMA software pipeline
+------------------------------
+
+The interesting part is that the TMA-issuing warp is a *member of a WGMMA warp
+group*, so it must be back with its warp group before every collective
+(``.aligned``) WGMMA instruction or the warp group hangs.  The loop is arranged
+so that this is automatic and so that a WGMMA group is always in flight while
+the main warp refills a stage::
+
+    prologue (main warp only):  issue S complete TMA stages   [k = 0 .. S-1]
+
+    per output tile:
+      k = 0:  consumer_wait(stage 0) ; fence ; WGMMA ; commit
+      k = 1 .. K-1:
+              consumer_wait(stage k) ; fence ; WGMMA ; commit
+              wait_group(1)            <- group k-1 retired, group k IN FLIGHT
+              consumer_release(stage k-1)
+              if warp == 0: producer_acquire(stage k-1) ; TMA for k-1+S
+                            (issued with group k still executing)
+              -> all four warps meet again at the next wgmma.fence
+      tile tail:
+              wait_group(0)            <- only here is the WGMMA pipe drained
+              consumer_release(last stage) ; refill it
+
+Warps 1-3 of WG0 simply wait on the *stage* mbarrier while warp 0 refills; they
+never wait on warp 0 through a barrier that warp 0 can only reach after a WGMMA,
+so the cycle that would deadlock a naive implementation does not exist.  The
+load stream is **linear across output tiles** (load ``n`` always goes to stage
+``n % S``), so a tile boundary costs no pipeline drain and no TMA bubble: the
+main warp is already prefetching the next output tile's W while the current
+tile's last WGMMAs run.
+
+Every stage refill is paired 1:1 with the release that freed it, which keeps
+``producer_index == release_index`` at every refill without any modular
+arithmetic.  The last ``S`` refills of an m-tile are skipped (their data would
+be past the end of the stream); those ``S`` unconsumed empty-credits are exactly
+the ``S`` credits the next m-tile's prologue consumes, so the pipeline stays
+balanced across the persistent m-tile loop.
+
+SMEM logits staging and the register->(row, col) map
+----------------------------------------------------
+
+After ``wait_group(0)`` the MMA warp groups convert their FP32 accumulator
+straight into a **single** 16-bit SMEM logits tile (no second FP32 tensor).  The
+register-to-tile map cannot be taken from ``thr_mma.partition_C(identity)``:
+with the cooperative ``atom_layout = (2, 1, 1)`` slicing the production kernel
+uses (``get_slice`` of a *constant* warp-group base), ``coords[i]`` is identical
+for all 128 threads of a warp group -- it carries no lane term at all, so an
+explicit map is required.  The map used here was validated against a real
+WGMMA on an H200 (0 / 32768 mismatches)::
+
+    row = wg * 64 + local_warp * 16 + ((i % 4) // 2) * 8 + lane // 4
+    col = (i // 4) * 8 + (lane % 4) * 2 + (i % 2)
+
+for ``i`` in ``[0, 128)``, ``wg`` in ``{0, 1}``.
+
+Bank conflicts are the whole ball game here.  The production 2-idle-warp
+epilogue ablation was correct but ran at 10.73 ms / 410 TFLOPS, and the reason
+is the un-padded ``[128, 256]`` 16-bit tile: with one row per thread, every
+thread of a warp lands on the *same* bank (row stride 512 B = 128 words ≡ 0 mod
+32), i.e. a 32-way conflict on every access, twice (max pass + sum pass).  This
+module pads the row stride to ``tile_n + 8`` 16-bit elements = 528 B = 132
+words, which makes **both** directions conflict-free:
+
+* MMA-side stores: element ``i`` and ``i+1`` of the accumulator are the same row
+  and adjacent columns, so they pack into one 32-bit ``STS``.  Its word index is
+  ``row * 132 + (i // 4) * 4 + lane % 4``; across a warp ``row`` varies as
+  ``lane // 4`` so the bank is ``4 * (lane // 4) + lane % 4 (mod 32)`` -- a
+  bijection onto the 32 banks.
+* epilogue-side loads: 8 consecutive 16-bit logits are 16 B and 16 B-aligned
+  (``528 = 33 * 16``), so they issue as ``LDS.128``; the hardware splits that
+  into phases of 8 lanes and lanes ``t .. t+7`` cover banks
+  ``4t .. 4t+3 (mod 32)`` -- again exactly the 32 banks, once each.
+
+The epilogue also does a **single** pass over the tile instead of production's
+max-pass-then-sum-pass: it walks the row in ``chunk_n``-column chunks and folds
+each chunk into the running online-softmax state, so the SMEM traffic is halved
+and the cross-tile accumulation comes for free.
+
+Because there is exactly one epilogue warp group and it owns a whole row per
+thread, there is no per-warp-group partial to combine: thread ``t`` of WG2 holds
+the final CTA statistics for row ``t`` and drives the DSMEM cluster reduction
+and the ``lse`` / ``token_loss`` stores directly.  No ``wg_max/sum/target``
+staging array exists in this kernel.
+
+Masking sentinels
+-----------------
+
+Columns past ``V`` read whatever the out-of-range TMA left in SMEM (zeros), so
+they must be masked.  They are replaced by ``MASK_F32 = -3e38`` while the online
+state initialises to ``NEG_INF_F32 = -1e38``.  The two-sentinel trick removes
+the second predicate from the exp pass: ``exp2((-3e38 - m) * log2 e)`` flushes to
+zero for every reachable ``m >= -1e38``, including a fully-masked tile where
+``m`` is still ``-1e38``, while ``exp2((-1e38 - (-1e38)) * log2 e) == 1`` would
+have silently added one per masked column had a single sentinel been used.
+
+No multicast is used anywhere.  There is no HBM logits store in the forward
+pass; the only asynchronous stores in this kernel are the TMA *loads*, and the
+register->SMEM logits staging is a plain generic ``STS``.
+
+Accepted configuration
+----------------------
+``M=4096 H=4096 V=131072`` BF16: cooperative ``tile_n = 256`` with a 3-deep AB
+pipeline and ``cluster_n = 2``.  ``tile_n = 128``/``192``, ``stages = 2`` and
+``cluster_n >= 8`` were all measurably worse; ``stages = 2`` is catastrophic
+(no prefetch depth).  NCU on the accepted config: 168 registers/thread, zero
+local ld/st (no accumulator spill), tensor pipe ~97 % active.
+
+Two gotchas worth recording
+---------------------------
+
+1. **Register-pool deadlock.**  ``2*128*mma_registers + 128*epi_registers`` must
+   be ``<= 64512``, *not* ``<= 65536``.  At exactly 65536 (216/80) the hardware
+   granted ``setmaxnreg.inc`` to only one MMA warp per SM sub-partition and the
+   other four spun forever in ``USETMAXREG.TRY_ALLOC.CTAPOOL``; both production
+   (232/40) and the pingpong ablation (240/24) also total 64512.  Diagnosed by
+   attaching ``cuda-gdb -p <pid> -ex "info cuda warps"`` to the hung process.
+2. **``llvm.nvvm.mapa`` ICEs** this toolchain ("only supported when pointer size
+   is >= 64 bits"), independent of the SMEM offset.  The DSMEM helpers below
+   therefore use inline PTX ``mapa.shared::cluster.u32`` with 32-bit
+   ``.shared::cluster`` loads/atomics, exactly as
+   ``cutlass/cute/arch/smem.py::map_dsmem_ptr`` does for the same reason.  Also
+   note ``red.max.f32`` does not exist in PTX -- the cluster max reduction uses
+   the monotonic-bit-pattern trick (``atom.max.s32`` / ``atom.min.u32``).
+"""
+
+import inspect
+
+from dataclasses import dataclass
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+
+from cutlass import BFloat16
+from cutlass import Float16
+from cutlass import Float32
+from cutlass import Int32
+from cutlass import cutlass_dsl
+from cutlass import pipeline
+from cutlass._mlir.dialects import llvm
+from cutlass._mlir.dialects import nvvm
+from cutlass.cutlass_dsl import T
+from cutlass.cutlass_dsl import dsl_user_op
+from cutlass.pipeline.helpers import pipeline_init_arrive
+from cutlass.pipeline.helpers import pipeline_init_wait
+from cutlass.utils import LayoutEnum
+from cutlass.utils import hopper_helpers
+
+from liger_kernel.ops.cutedsl.ops.utils import to_cute_tensor
+
+THREADS_PER_CTA = 384
+NUM_MMA_WARP_GROUPS = 2
+WARPS_PER_WARP_GROUP = 4
+EPILOGUE_WARP_GROUP = 2
+
+# Named barriers.  0 is reserved for __syncthreads().
+MMA_BARRIER_ID = 4  # both MMA warp groups, 256 threads
+EPI_BARRIER_ID = 5  # epilogue warp group, 128 threads
+
+LOG2_E = 1.4426950408889634
+LN2 = 0.6931471805599453
+NEG_INF_F32 = -1.0e38
+# Distinct, *more* negative sentinel for out-of-vocabulary columns; see module
+# docstring ("Masking sentinels").
+MASK_F32 = -3.0e38
+HOPPER_MAX_SMEM_BYTES = 227 * 1024
+
+_compile_cache = {}
+_stream_cache = {}
+_max_active_clusters_cache = {}
+
+try:
+    _FMAX_NEEDS_RESULT_TYPE = next(iter(inspect.signature(nvvm.fmax).parameters)) == "res"
+except Exception:
+    _FMAX_NEEDS_RESULT_TYPE = False
+
+
+@dsl_user_op
+def _fmax(a, b, *, loc=None, ip=None) -> Float32:
+    av = Float32(a).ir_value(loc=loc, ip=ip)
+    bv = Float32(b).ir_value(loc=loc, ip=ip)
+    if _FMAX_NEEDS_RESULT_TYPE:
+        return Float32(nvvm.fmax(T.f32(), av, bv, loc=loc, ip=ip))
+    return Float32(nvvm.fmax(av, bv, loc=loc, ip=ip))
+
+
+@dsl_user_op
+def _map_dsmem_addr(local_ptr, peer_rank, *, loc=None, ip=None) -> Int32:
+    """Map a local SMEM pointer to the same object in a peer CTA's SMEM.
+
+    Returns a **32-bit** ``shared::cluster`` address.  The production module
+    uses the ``nvvm.mapa`` intrinsic on a generic pointer, which libNVVM in this
+    toolchain rejects for this kernel ("this intrinsic is only supported when
+    pointer size is >= 64 bits") once the pointer folds into a constant
+    ``addrspacecast`` expression.  ``cutlass.cute.arch.map_dsmem_ptr`` avoids the
+    intrinsic entirely by emitting the PTX directly; the same trick is used here
+    so every DSMEM access below is a plain 32-bit shared-window address.
+    """
+    addr = llvm.ptrtoint(T.i32(), local_ptr.llvm_ptr, loc=loc, ip=ip)
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [addr, Int32(peer_rank).ir_value(loc=loc, ip=ip)],
+            "mapa.shared::cluster.u32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+def _asm(res_ty, args, tmpl, cons, side=True, *, loc=None, ip=None):
+    return llvm.inline_asm(
+        res_ty,
+        args,
+        tmpl,
+        cons,
+        has_side_effects=side,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _dsmem_load_f32(addr, *, loc=None, ip=None) -> Float32:
+    return Float32(
+        _asm(
+            T.f32(),
+            [Int32(addr).ir_value(loc=loc, ip=ip)],
+            "ld.shared::cluster.f32 $0, [$1];",
+            "=f,r",
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _dsmem_atomic_add_f32(addr, value, *, loc=None, ip=None) -> Float32:
+    return Float32(
+        _asm(
+            T.f32(),
+            [
+                Int32(addr).ir_value(loc=loc, ip=ip),
+                Float32(value).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.shared::cluster.add.f32 $0, [$1], $2;",
+            "=f,r,f",
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _dsmem_atomic_max_s32(addr, value, *, loc=None, ip=None) -> Int32:
+    return Int32(
+        _asm(
+            T.i32(),
+            [
+                Int32(addr).ir_value(loc=loc, ip=ip),
+                Int32(value).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.shared::cluster.max.s32 $0, [$1], $2;",
+            "=r,r,r",
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _dsmem_atomic_min_u32(addr, value, *, loc=None, ip=None) -> Int32:
+    return Int32(
+        _asm(
+            T.i32(),
+            [
+                Int32(addr).ir_value(loc=loc, ip=ip),
+                Int32(value).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.shared::cluster.min.u32 $0, [$1], $2;",
+            "=r,r,r",
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _dsmem_atomic_fmax(addr, value, *, loc=None, ip=None) -> Float32:
+    """FP32 max via the monotonic-bit-pattern trick (identical to production).
+
+    ``red/atom.max.f32`` does not exist in PTX, so positive floats are max'd as
+    signed ints and negative floats are min'd as unsigned ints.
+    """
+    bits = llvm.bitcast(T.i32(), Float32(value).ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+    old = cutlass_dsl.if_generate(
+        Int32(bits) < 0,
+        lambda: _dsmem_atomic_min_u32(addr, Int32(bits), loc=loc, ip=ip),
+        lambda: _dsmem_atomic_max_s32(addr, Int32(bits), loc=loc, ip=ip),
+        [],
+        [Int32],
+        loc=loc,
+        ip=ip,
+    )
+    return Float32(llvm.bitcast(T.f32(), old.ir_value(loc=loc, ip=ip), loc=loc, ip=ip))
+
+
+def _cute_stream():
+    raw = torch.cuda.current_stream().cuda_stream
+    stream = _stream_cache.get(raw)
+    if stream is None:
+        stream = cuda.CUstream(raw)
+        _stream_cache[raw] = stream
+    return stream
+
+
+def _max_active_clusters(cluster_n):
+    key = (torch.cuda.current_device(), cluster_n)
+    value = _max_active_clusters_cache.get(key)
+    if value is None:
+        torch.cuda.current_stream()
+        value = cutlass.utils.HardwareInfo().get_max_active_clusters(cluster_n)
+        _max_active_clusters_cache[key] = value
+    return value
+
+
+@dataclass(frozen=True)
+class ScaledCEForwardConfig:
+    """Tuning knobs for the MMA-issues-TMA + SMEM-epilogue forward.
+
+    ``tile_m`` is fixed at 128 (one row per epilogue thread) and ``tile_n`` at
+    256 (the production cooperative WGMMA topology).  ``logit_pad`` is the extra
+    16-bit columns appended to every SMEM logits row; 8 makes the row stride
+    528 B and both the MMA-side 32-bit stores and the epilogue-side 128-bit
+    loads bank-conflict-free (see the module docstring).  ``chunk_n`` is how many
+    columns the epilogue folds into the online-softmax state at a time; it is a
+    pure register/rescale trade (``tile_n / chunk_n`` extra rescales per tile).
+
+    Register budget: ``2 * 128 * mma_registers + 128 * epi_registers`` must not
+    exceed **64512** registers.  The SM register file holds 65536 registers and
+    the CTA is resident alone, but requesting the full file deadlocks: the
+    hardware could only satisfy one ``setmaxnreg.inc`` per sub-partition and the
+    remaining four MMA warps spun forever in ``USETMAXREG.TRY_ALLOC.CTAPOOL``
+    (observed with cuda-gdb at 216/80 = exactly 65536).  Production (232/40) and
+    the pingpong ablation (240/24) both stop at 64512, i.e. they leave one
+    1024-register (8 regs/thread x 128 threads) reserve.
+    """
+
+    tile_m: int = 128
+    tile_n: int = 256
+    tile_k: int = 64
+    stages: int = 3
+    cluster_n: int = 16
+    fast_math: bool = True
+    logit_dtype: str = "f16"
+    logit_pad: int = 8
+    chunk_n: int = 32
+    mma_registers: int = 208
+    epi_registers: int = 88
+    return_entropy: bool = False
+
+    @property
+    def logit_stride(self):
+        return self.tile_n + self.logit_pad
+
+    def smem_bytes(self):
+        ab = (self.tile_m + self.tile_n) * self.tile_k * 2 * self.stages
+        logits = self.tile_m * self.logit_stride * 2
+        reduction = (3 + int(self.return_entropy)) * self.tile_m * 4
+        barriers = 16 * self.stages + 16
+        return ab + logits + reduction + barriers + 3 * 1024
+
+    def register_total(self):
+        return 2 * 128 * self.mma_registers + 128 * self.epi_registers
+
+
+class _ScaledCEForwardSM90:
+    """MMA-warp-issues-TMA forward with a dedicated SMEM-logits epilogue WG."""
+
+    def __init__(self, config: ScaledCEForwardConfig):
+        self.tile_m = config.tile_m
+        self.tile_n = config.tile_n
+        self.tile_k = config.tile_k
+        self.stages = config.stages
+        self.cluster_n = config.cluster_n
+        self.fast_math = config.fast_math
+        self.logit_pad = config.logit_pad
+        self.logit_stride = config.tile_n + config.logit_pad
+        self.chunk_n = config.chunk_n
+        self.mma_registers = config.mma_registers
+        self.epi_registers = config.epi_registers
+        self.return_entropy = config.return_entropy
+        self.logit_dtype = Float16 if config.logit_dtype == "f16" else BFloat16
+        self.tile_shape = (self.tile_m, self.tile_n, self.tile_k)
+        self.buffer_align = 1024
+        self.mma_barrier = pipeline.NamedBarrier(
+            barrier_id=MMA_BARRIER_ID,
+            num_threads=NUM_MMA_WARP_GROUPS * 128,
+        )
+        self.epi_barrier = pipeline.NamedBarrier(
+            barrier_id=EPI_BARRIER_ID,
+            num_threads=128,
+        )
+
+    @staticmethod
+    def _make_tma(tensor, smem_layout_staged, smem_tile):
+        smem_layout = cute.slice_(smem_layout_staged, (None, None, 0))
+        return cute.nvgpu.cpasync.make_tiled_tma_atom(
+            cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp(),
+            tensor,
+            smem_layout,
+            smem_tile,
+            num_multicast=1,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        weight: cute.Tensor,
+        target: cute.Tensor,
+        lse: cute.Tensor,
+        token_loss: cute.Tensor,
+        entropy: cute.Tensor,
+        inverse_temperature: Float32,
+        ignore_index: Int32,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+    ):
+        x_layout = LayoutEnum.from_tensor(x)
+        weight_layout = LayoutEnum.from_tensor(weight)
+        # Production's cooperative split-M topology, unchanged.
+        tiled_mma = hopper_helpers.make_trivial_tiled_mma(
+            BFloat16,
+            BFloat16,
+            x_layout.sm90_mma_major_mode(),
+            weight_layout.sm90_mma_major_mode(),
+            Float32,
+            (NUM_MMA_WARP_GROUPS, 1, 1),
+            (64, self.tile_n),
+        )
+        a_smem_layout = hopper_helpers.make_smem_layout_a(
+            x_layout,
+            self.tile_shape,
+            BFloat16,
+            self.stages,
+        )
+        b_smem_layout = hopper_helpers.make_smem_layout_b(
+            weight_layout,
+            self.tile_shape,
+            BFloat16,
+            self.stages,
+        )
+        tma_x, tma_tensor_x = self._make_tma(x, a_smem_layout, (self.tile_m, self.tile_k))
+        tma_w, tma_tensor_w = self._make_tma(weight, b_smem_layout, (self.tile_n, self.tile_k))
+
+        logit_dtype = self.logit_dtype
+
+        @cute.struct
+        class SharedStorage:
+            pipeline: cute.struct.MemRange[cutlass.Int64, self.stages * 2]
+            logits_pipeline: cute.struct.MemRange[cutlass.Int64, 2]
+            sX: cute.struct.Align[
+                cute.struct.MemRange[BFloat16, cute.cosize(a_smem_layout)],
+                self.buffer_align,
+            ]
+            sW: cute.struct.Align[
+                cute.struct.MemRange[BFloat16, cute.cosize(b_smem_layout)],
+                self.buffer_align,
+            ]
+            sLogits: cute.struct.Align[
+                cute.struct.MemRange[
+                    logit_dtype,
+                    self.tile_m * self.logit_stride,
+                ],
+                self.buffer_align,
+            ]
+            cluster_max: cute.struct.Align[cute.struct.MemRange[Float32, self.tile_m], 16]
+            cluster_sum: cute.struct.Align[cute.struct.MemRange[Float32, self.tile_m], 16]
+            cluster_target: cute.struct.Align[cute.struct.MemRange[Float32, self.tile_m], 16]
+            cluster_weighted: cute.struct.Align[
+                cute.struct.MemRange[Float32, self.tile_m if self.return_entropy else 1],
+                16,
+            ]
+
+        self.shared_storage = SharedStorage
+        cluster_shape = (1, self.cluster_n, 1)
+        num_m_tiles = cute.ceil_div(x.shape[0], self.tile_m)
+        num_persistent_clusters = cutlass.min(num_m_tiles, max_active_clusters)
+        grid = (1, self.cluster_n, num_persistent_clusters)
+        self.kernel(
+            tma_x,
+            tma_tensor_x,
+            tma_w,
+            tma_tensor_w,
+            target,
+            lse,
+            token_loss,
+            entropy,
+            inverse_temperature,
+            tiled_mma,
+            a_smem_layout,
+            b_smem_layout,
+            ignore_index,
+        ).launch(
+            grid=grid,
+            block=(THREADS_PER_CTA, 1, 1),
+            cluster=cluster_shape,
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        tma_x: cute.CopyAtom,
+        x: cute.Tensor,
+        tma_w: cute.CopyAtom,
+        weight: cute.Tensor,
+        target: cute.Tensor,
+        lse: cute.Tensor,
+        token_loss: cute.Tensor,
+        entropy: cute.Tensor,
+        inverse_temperature: Float32,
+        tiled_mma: cute.TiledMma,
+        a_smem_layout: cute.ComposedLayout,
+        b_smem_layout: cute.ComposedLayout,
+        ignore_index: Int32,
+    ):
+        tid, _, _ = cute.arch.thread_idx()
+        warp = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        warp_group = cute.arch.make_warp_uniform(tid // 128)
+        lane = tid % 32
+        local_warp = (tid % 128) // 32
+        local_tid = tid % 128
+        cluster_rank = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        _, _, pid_m = cute.arch.block_idx()
+        _, _, m_tile_stride = cute.arch.grid_dim()
+        num_m_tiles = cute.ceil_div(target.shape[0], self.tile_m)
+
+        if warp == 0:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_x)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_w)
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+        sX = storage.sX.get_tensor(a_smem_layout.outer, swizzle=a_smem_layout.inner)
+        sW = storage.sW.get_tensor(b_smem_layout.outer, swizzle=b_smem_layout.inner)
+        sLogits = storage.sLogits.get_tensor(
+            cute.make_layout(
+                (self.tile_m, self.tile_n),
+                stride=(self.logit_stride, 1),
+            )
+        )
+        cluster_max = storage.cluster_max.get_tensor(cute.make_layout(self.tile_m))
+        cluster_sum = storage.cluster_sum.get_tensor(cute.make_layout(self.tile_m))
+        cluster_target = storage.cluster_target.get_tensor(cute.make_layout(self.tile_m))
+        cluster_weighted = storage.cluster_weighted.get_tensor(
+            cute.make_layout(self.tile_m if cutlass.const_expr(self.return_entropy) else 1)
+        )
+
+        cta_layout = cute.make_layout((1, self.cluster_n, 1))
+        cluster_coord = cta_layout.get_flat_coord(cluster_rank)
+
+        gX = cute.local_tile(
+            x,
+            cute.slice_(self.tile_shape, (None, 0, None)),
+            (None, None, None),
+        )
+        gW = cute.local_tile(
+            weight,
+            cute.slice_(self.tile_shape, (0, None, None)),
+            (None, None, None),
+        )
+        tXsX, tXgX = cute.nvgpu.cpasync.tma_partition(
+            tma_x,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sX, 0, 2),
+            cute.group_modes(gX, 0, 2),
+        )
+        w_cta_layout = cute.make_layout(cute.slice_(cta_layout, (None, 0, 0)).shape)
+        tWsW, tWgW = cute.nvgpu.cpasync.tma_partition(
+            tma_w,
+            cluster_coord[0],
+            w_cta_layout,
+            cute.group_modes(sW, 0, 2),
+            cute.group_modes(gW, 0, 2),
+        )
+
+        tma_bytes = cute.size_in_bytes(BFloat16, cute.slice_(a_smem_layout, (None, None, 0))) + cute.size_in_bytes(
+            BFloat16, cute.slice_(b_smem_layout, (None, None, 0))
+        )
+
+        # Both MMA warp groups (8 warps) consume and release every AB stage.
+        mainloop = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.pipeline.data_ptr(),
+            num_stages=self.stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                # ``PipelineTmaAsync.consumer_release`` is guarded by
+                # ``is_signalling_thread`` (= lane 0 of each warp when the CTA
+                # layout has size 1), so the empty barrier receives exactly one
+                # arrival per consumer WARP, not per thread.
+                NUM_MMA_WARP_GROUPS * WARPS_PER_WARP_GROUP,
+            ),
+            tx_count=tma_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+            defer_sync=True,
+        )
+        # One-stage hand-off of the staged SMEM logits tile: the MMA warp groups
+        # are the producer, the epilogue warp group the consumer.  Single-thread
+        # commit / release on both sides, everybody waits.
+        logits_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.logits_pipeline.data_ptr(),
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            defer_sync=True,
+        )
+        pipeline_init_arrive(cluster_shape_mn=(1, self.cluster_n), is_relaxed=True)
+        pipeline_init_wait(cluster_shape_mn=(1, self.cluster_n))
+
+        num_k_tiles = cute.size(gX, mode=[3])
+        num_k_blocks = self.tile_k // 16
+        num_pair_tiles = cute.ceil_div(weight.shape[0], self.cluster_n * self.tile_n)
+
+        root_max_addr = _map_dsmem_addr(storage.cluster_max.data_ptr(), 0)
+        root_sum_addr = _map_dsmem_addr(storage.cluster_sum.data_ptr(), 0)
+        root_target_addr = _map_dsmem_addr(storage.cluster_target.data_ptr(), 0)
+        root_weighted_addr = _map_dsmem_addr(storage.cluster_weighted.data_ptr(), 0)
+
+        if warp_group < NUM_MMA_WARP_GROUPS:
+            # ================= MMA warp groups (WG0 + WG1) =================
+            # Register budget is raised BEFORE the accumulator is materialised
+            # so the epilogue warp group never carries its live range.
+            cute.arch.setmaxregister_increase(self.mma_registers)
+
+            mma_wg_layout = cute.make_layout(NUM_MMA_WARP_GROUPS, stride=128)
+            thr_mma = tiled_mma.get_slice(mma_wg_layout(Int32(warp_group)))
+            tCrX = tiled_mma.make_fragment_A(thr_mma.partition_A(sX))
+            tCrW = tiled_mma.make_fragment_B(thr_mma.partition_B(sW))
+            accum = cute.make_rmem_tensor(
+                thr_mma.partition_shape_C((self.tile_m, self.tile_n)),
+                Float32,
+            )
+            n_accum = cute.size(accum)
+            row_base_in_tile = warp_group * 64 + local_warp * 16 + lane // 4
+            col_base_in_tile = (lane % 4) * 2
+
+            read_index = Int32(0)
+            read_phase = Int32(0)
+            rel_index = Int32(0)
+            rel_phase = Int32(0)
+            load_index = Int32(0)
+            # Producer states start at phase 1 (``make_pipeline_state(Producer)``)
+            # so the first ``producer_acquire`` on a freshly-initialised empty
+            # barrier completes immediately.
+            load_phase = Int32(1)
+            logit_w_index = Int32(0)
+            logit_w_phase = Int32(1)
+
+            while pid_m < num_m_tiles:
+                cute.arch.sync_threads()
+                cute.arch.cluster_arrive()
+                cute.arch.cluster_wait()
+
+                tXgX_m = tXgX[(None, pid_m, None, 0)]
+                load_k = Int32(0)
+                load_t = Int32(0)
+
+                # ---- prologue: S complete TMA stages before any WGMMA ------
+                if warp == 0:
+                    prologue_stages = cutlass.min(Int32(self.stages), Int32(num_k_tiles) * Int32(num_pair_tiles))
+                    for _ in range(prologue_stages):
+                        pstate = pipeline.PipelineState(self.stages, Int32(0), load_index, load_phase)
+                        mainloop.producer_acquire(pstate)
+                        bar = mainloop.producer_get_barrier(pstate)
+                        cute.copy(
+                            tma_x,
+                            tXgX_m[(None, load_k)],
+                            tXsX[(None, load_index)],
+                            tma_bar_ptr=bar,
+                            mcast_mask=0,
+                        )
+                        tWgW_n = tWgW[(None, load_t * self.cluster_n + cluster_rank, None, 0)]
+                        cute.copy(
+                            tma_w,
+                            tWgW_n[(None, load_k)],
+                            tWsW[(None, load_index)],
+                            tma_bar_ptr=bar,
+                        )
+                        mainloop.producer_commit(pstate)
+                        pstate.advance()
+                        load_index = pstate.index
+                        load_phase = pstate.phase
+                        load_k += 1
+                        if load_k == num_k_tiles:
+                            load_k = Int32(0)
+                            load_t += 1
+
+                for _ in range(num_pair_tiles):
+                    accum.fill(0.0)
+                    tiled_mma.set(cute.nvgpu.warpgroup.Field.ACCUMULATE, True)
+
+                    # ---- k = 0: no release yet, nothing to refill ----------
+                    read_state = pipeline.PipelineState(self.stages, Int32(0), read_index, read_phase)
+                    mainloop.consumer_wait(read_state)
+                    cute.nvgpu.warpgroup.fence()
+                    for k_block in cutlass.range_constexpr(num_k_blocks):
+                        coord = (None, None, k_block, read_index)
+                        cute.gemm(tiled_mma, accum, tCrX[coord], tCrW[coord], accum)
+                    cute.nvgpu.warpgroup.commit_group()
+                    read_state.advance()
+                    read_index = read_state.index
+                    read_phase = read_state.phase
+
+                    # ---- steady state --------------------------------------
+                    for _ in range(1, num_k_tiles):
+                        read_state = pipeline.PipelineState(self.stages, Int32(0), read_index, read_phase)
+                        mainloop.consumer_wait(read_state)
+                        cute.nvgpu.warpgroup.fence()
+                        for k_block in cutlass.range_constexpr(num_k_blocks):
+                            coord = (None, None, k_block, read_index)
+                            cute.gemm(tiled_mma, accum, tCrX[coord], tCrW[coord], accum)
+                        cute.nvgpu.warpgroup.commit_group()
+                        # Retire only the previous group: the group just issued
+                        # stays IN FLIGHT across the release + TMA refill below.
+                        cute.nvgpu.warpgroup.wait_group(1)
+                        rstate = pipeline.PipelineState(self.stages, Int32(0), rel_index, rel_phase)
+                        mainloop.consumer_release(rstate)
+                        rstate.advance()
+                        rel_index = rstate.index
+                        rel_phase = rstate.phase
+                        if warp == 0:
+                            if load_t < num_pair_tiles:
+                                pstate = pipeline.PipelineState(self.stages, Int32(0), load_index, load_phase)
+                                mainloop.producer_acquire(pstate)
+                                bar = mainloop.producer_get_barrier(pstate)
+                                cute.copy(
+                                    tma_x,
+                                    tXgX_m[(None, load_k)],
+                                    tXsX[(None, load_index)],
+                                    tma_bar_ptr=bar,
+                                    mcast_mask=0,
+                                )
+                                tWgW_n = tWgW[(None, load_t * self.cluster_n + cluster_rank, None, 0)]
+                                cute.copy(
+                                    tma_w,
+                                    tWgW_n[(None, load_k)],
+                                    tWsW[(None, load_index)],
+                                    tma_bar_ptr=bar,
+                                )
+                                mainloop.producer_commit(pstate)
+                                pstate.advance()
+                                load_index = pstate.index
+                                load_phase = pstate.phase
+                                load_k += 1
+                                if load_k == num_k_tiles:
+                                    load_k = Int32(0)
+                                    load_t += 1
+                        read_state.advance()
+                        read_index = read_state.index
+                        read_phase = read_state.phase
+
+                    # ---- tile tail: the only WGMMA drain -------------------
+                    cute.nvgpu.warpgroup.wait_group(0)
+                    rstate = pipeline.PipelineState(self.stages, Int32(0), rel_index, rel_phase)
+                    mainloop.consumer_release(rstate)
+                    rstate.advance()
+                    rel_index = rstate.index
+                    rel_phase = rstate.phase
+                    if warp == 0:
+                        if load_t < num_pair_tiles:
+                            pstate = pipeline.PipelineState(self.stages, Int32(0), load_index, load_phase)
+                            mainloop.producer_acquire(pstate)
+                            bar = mainloop.producer_get_barrier(pstate)
+                            cute.copy(
+                                tma_x,
+                                tXgX_m[(None, load_k)],
+                                tXsX[(None, load_index)],
+                                tma_bar_ptr=bar,
+                                mcast_mask=0,
+                            )
+                            tWgW_n = tWgW[(None, load_t * self.cluster_n + cluster_rank, None, 0)]
+                            cute.copy(
+                                tma_w,
+                                tWgW_n[(None, load_k)],
+                                tWsW[(None, load_index)],
+                                tma_bar_ptr=bar,
+                            )
+                            mainloop.producer_commit(pstate)
+                            pstate.advance()
+                            load_index = pstate.index
+                            load_phase = pstate.phase
+                            load_k += 1
+                            if load_k == num_k_tiles:
+                                load_k = Int32(0)
+                                load_t += 1
+
+                    # ---- stage the FP32 accumulator as 16-bit SMEM -----
+                    wstate = pipeline.PipelineState(1, Int32(0), logit_w_index, logit_w_phase)
+                    logits_pipeline.producer_acquire(wstate)
+                    for i in cutlass.range_constexpr(n_accum):
+                        row = row_base_in_tile + ((i % 4) // 2) * 8
+                        col = col_base_in_tile + (i // 4) * 8 + (i % 2)
+                        sLogits[row, col] = self.logit_dtype(accum[i])
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    cute.arch.fence_acq_rel_cta()
+                    self.mma_barrier.arrive_and_wait()
+                    if tid == 0:
+                        logits_pipeline.producer_commit(wstate)
+                    wstate.advance()
+                    logit_w_index = wstate.index
+                    logit_w_phase = wstate.phase
+
+                cute.arch.sync_threads()
+                cute.arch.cluster_arrive()
+                cute.arch.cluster_wait()
+                cute.arch.cluster_arrive()
+                cute.arch.cluster_wait()
+                cute.arch.cluster_arrive()
+                cute.arch.cluster_wait()
+                pid_m += m_tile_stride
+
+            if warp == 0:
+                ptail = pipeline.PipelineState(self.stages, Int32(0), load_index, load_phase)
+                mainloop.producer_tail(ptail)
+        else:
+            # ==================== epilogue warp group ======================
+            cute.arch.setmaxregister_decrease(self.epi_registers)
+
+            row = local_tid
+            chunk = cute.make_rmem_tensor((self.chunk_n,), Float32)
+            logit_r_index = Int32(0)
+            logit_r_phase = Int32(0)
+
+            while pid_m < num_m_tiles:
+                if cluster_rank == 0:
+                    cluster_max[row] = Float32(NEG_INF_F32)
+                    cluster_sum[row] = Float32(0.0)
+                    cluster_target[row] = Float32(0.0)
+                    if cutlass.const_expr(self.return_entropy):
+                        cluster_weighted[row] = Float32(0.0)
+                cute.arch.sync_threads()
+                cute.arch.cluster_arrive()
+                cute.arch.cluster_wait()
+
+                run_max = Float32(NEG_INF_F32)
+                run_sum = Float32(0.0)
+                run_target = Float32(0.0)
+                run_weighted = Float32(0.0)
+                global_row = pid_m * self.tile_m + row
+                tgt_tile = Int32(-1)
+                tgt_col = Int32(-1)
+                if global_row < target.shape[0]:
+                    tcol = Int32(target[global_row])
+                    if tcol >= 0:
+                        tgt_tile = tcol // self.tile_n
+                        tgt_col = tcol % self.tile_n
+
+                for pair_tile in range(num_pair_tiles):
+                    rstate = pipeline.PipelineState(1, Int32(0), logit_r_index, logit_r_phase)
+                    logits_pipeline.consumer_wait(rstate)
+                    cute.arch.fence_acq_rel_cta()
+
+                    n_tile = pair_tile * self.cluster_n + cluster_rank
+                    n_base = n_tile * self.tile_n
+                    valid_cols = Int32(weight.shape[0]) - n_base
+
+                    # Single pass: fold each chunk straight into the
+                    # running online-softmax state.
+                    for ci in cutlass.range_constexpr(self.tile_n // self.chunk_n):
+                        c0 = ci * self.chunk_n
+                        chunk_max = Float32(MASK_F32)
+                        # One dynamic bound check per CHUNK instead of one
+                        # per column: at the benchmark shape every chunk is
+                        # fully in range, so the masked path is never taken
+                        # and the hot loop is a pure LDS + max sequence.
+                        if c0 + self.chunk_n <= valid_cols:
+                            for j in cutlass.range_constexpr(self.chunk_n):
+                                v = Float32(sLogits[row, c0 + j]) * inverse_temperature
+                                chunk[j] = v
+                                chunk_max = _fmax(chunk_max, v)
+                        else:
+                            for j in cutlass.range_constexpr(self.chunk_n):
+                                v = Float32(sLogits[row, c0 + j]) * inverse_temperature
+                                if c0 + j >= valid_cols:
+                                    v = Float32(MASK_F32)
+                                chunk[j] = v
+                                chunk_max = _fmax(chunk_max, v)
+                        new_max = _fmax(run_max, chunk_max)
+                        acc = Float32(0.0)
+                        weighted = Float32(0.0)
+                        for j in cutlass.range_constexpr(self.chunk_n):
+                            exp_value = cute.math.exp2(
+                                (chunk[j] - new_max) * LOG2_E,
+                                fastmath=self.fast_math,
+                            )
+                            acc += exp_value
+                            if cutlass.const_expr(self.return_entropy):
+                                weighted += exp_value * chunk[j]
+                        old_scale = cute.math.exp2(
+                            (run_max - new_max) * LOG2_E,
+                            fastmath=self.fast_math,
+                        )
+                        run_sum = run_sum * old_scale + acc
+                        if cutlass.const_expr(self.return_entropy):
+                            run_weighted = run_weighted * old_scale + weighted
+                        run_max = new_max
+
+                    if tgt_tile == n_tile:
+                        run_target += Float32(sLogits[row, tgt_col]) * inverse_temperature
+
+                    self.epi_barrier.arrive_and_wait()
+                    if local_tid == 0:
+                        logits_pipeline.consumer_release(rstate)
+                    rstate.advance()
+                    logit_r_index = rstate.index
+                    logit_r_phase = rstate.phase
+
+                cute.arch.sync_threads()
+
+                _dsmem_atomic_fmax(root_max_addr + row * 4, run_max)
+                cute.arch.cluster_arrive()
+                cute.arch.cluster_wait()
+
+                global_max = _dsmem_load_f32(root_max_addr + row * 4)
+                scaled_sum = run_sum * cute.math.exp2(
+                    (run_max - global_max) * LOG2_E,
+                    fastmath=self.fast_math,
+                )
+                _dsmem_atomic_add_f32(root_sum_addr + row * 4, scaled_sum)
+                _dsmem_atomic_add_f32(root_target_addr + row * 4, run_target)
+                if cutlass.const_expr(self.return_entropy):
+                    scaled_weighted = run_weighted * cute.math.exp2(
+                        (run_max - global_max) * LOG2_E,
+                        fastmath=self.fast_math,
+                    )
+                    _dsmem_atomic_add_f32(root_weighted_addr + row * 4, scaled_weighted)
+                cute.arch.cluster_arrive()
+                cute.arch.cluster_wait()
+
+                if cluster_rank == 0:
+                    if global_row < target.shape[0]:
+                        row_lse = cluster_max[row] + cute.math.log2(cluster_sum[row], fastmath=self.fast_math) * LN2
+                        lse[global_row] = row_lse
+                        if target[global_row] == ignore_index:
+                            token_loss[global_row] = Float32(0.0)
+                            if cutlass.const_expr(self.return_entropy):
+                                entropy[global_row] = BFloat16(0.0)
+                        else:
+                            token_loss[global_row] = row_lse - cluster_target[row]
+                            if cutlass.const_expr(self.return_entropy):
+                                entropy[global_row] = BFloat16(row_lse - cluster_weighted[row] / cluster_sum[row])
+
+                cute.arch.cluster_arrive()
+                cute.arch.cluster_wait()
+                pid_m += m_tile_stride
+
+
+def _validate(x, weight, target):
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability(x.device) != (9, 0):
+        raise RuntimeError("SM90 fused scaled cross entropy forward requires a Hopper (sm90) GPU")
+    if x.device != weight.device or x.device != target.device:
+        raise ValueError("input, weight, and target must be on the same CUDA device")
+    if x.dtype != torch.bfloat16 or weight.dtype != torch.bfloat16:
+        raise TypeError("SM90 fused scaled cross entropy forward supports BF16 input and weight only")
+    if x.ndim != 2 or weight.ndim != 2 or target.ndim != 1:
+        raise ValueError("expected input[BT,H], weight[V,H], and target[BT]")
+    if x.shape[0] != target.shape[0] or x.shape[1] != weight.shape[1]:
+        raise ValueError("input, weight, and target shapes are incompatible")
+
+
+def _pad_hidden(x, weight, tile_k):
+    hidden_size = x.shape[1]
+    padded = (hidden_size + tile_k - 1) // tile_k * tile_k
+    if padded == hidden_size:
+        return x.contiguous(), weight.contiguous(), hidden_size
+    return (
+        torch.nn.functional.pad(x, (0, padded - hidden_size)),
+        torch.nn.functional.pad(weight, (0, padded - hidden_size)),
+        hidden_size,
+    )
+
+
+def scaled_ce_forward(
+    _input,
+    weight,
+    target,
+    temperature=1.0,
+    ignore_index=-100,
+    return_entropy=False,
+    config: ScaledCEForwardConfig = None,
+):
+    """M-outer (self-TMA) forward.  Returns per-token ``(nll[M], lse[M])``."""
+    _validate(_input, weight, target)
+    if config is None:
+        config = ScaledCEForwardConfig()
+    if config.return_entropy != return_entropy:
+        config = ScaledCEForwardConfig(**{**config.__dict__, "return_entropy": return_entropy})
+    if config.tile_m != 128:
+        raise ValueError("tile_m must be 128 (one epilogue thread per row)")
+    if config.tile_n % 8 != 0 or config.tile_n % config.chunk_n != 0:
+        raise ValueError("tile_n must be a multiple of 8 and of chunk_n")
+    if config.smem_bytes() > HOPPER_MAX_SMEM_BYTES:
+        raise ValueError(
+            f"config needs ~{config.smem_bytes()} B of shared memory, "
+            f"which exceeds the {HOPPER_MAX_SMEM_BYTES} B Hopper opt-in limit"
+        )
+    if config.register_total() > 64512:
+        raise ValueError(f"register budget {config.register_total()} exceeds the usable 64512-register budget")
+
+    target = target.contiguous()
+    x_padded, weight_padded, _ = _pad_hidden(_input, weight, config.tile_k)
+    bt = x_padded.shape[0]
+
+    lse = torch.empty(bt, device=_input.device, dtype=torch.float32)
+    token_loss = torch.empty(bt, device=_input.device, dtype=torch.float32)
+    entropy = torch.empty(bt if return_entropy else 1, device=_input.device, dtype=torch.bfloat16)
+    x_cute = to_cute_tensor(x_padded.unsqueeze(-1), leading_dim=1, assumed_align=16)
+    weight_cute = to_cute_tensor(weight_padded.unsqueeze(-1), leading_dim=1, assumed_align=16)
+    target_cute = to_cute_tensor(target, assumed_align=8)
+    lse_cute = to_cute_tensor(lse, assumed_align=4)
+    token_loss_cute = to_cute_tensor(token_loss, assumed_align=4)
+    entropy_cute = to_cute_tensor(entropy, assumed_align=2)
+    stream = _cute_stream()
+    inverse_temperature = Float32(1.0 / temperature)
+    max_active_clusters = _max_active_clusters(config.cluster_n)
+
+    key = ("scaled_ce_forward", config, max_active_clusters)
+    compiled = _compile_cache.get(key)
+    if compiled is None:
+        compiled = cute.compile(
+            _ScaledCEForwardSM90(config),
+            x_cute,
+            weight_cute,
+            target_cute,
+            lse_cute,
+            token_loss_cute,
+            entropy_cute,
+            inverse_temperature,
+            Int32(ignore_index),
+            max_active_clusters,
+            stream,
+        )
+        _compile_cache[key] = compiled
+    compiled(
+        x_cute,
+        weight_cute,
+        target_cute,
+        lse_cute,
+        token_loss_cute,
+        entropy_cute,
+        inverse_temperature,
+        Int32(ignore_index),
+        stream,
+    )
+
+    return token_loss, entropy if return_entropy else None, lse

--- a/src/liger_kernel/ops/cutedsl/ops/fused_scaled_cross_entropy_sm90.py
+++ b/src/liger_kernel/ops/cutedsl/ops/fused_scaled_cross_entropy_sm90.py
@@ -1,0 +1,322 @@
+"""
+Hopper (SM90) CuTe DSL **fused scaled cross entropy**.
+
+This operator fuses the classifier projection ``Z = X @ W.T`` with the cross
+entropy softmax so the ``[M, V]`` logits are never written to HBM in the
+forward pass.  It is deliberately *narrower* than the Triton
+``LigerFusedLinearCrossEntropyFunction``:
+
+* the forward returns the per-token negative log-likelihood ``nll[M]`` and,
+  when requested, differentiable per-token vocabulary entropy -- never a
+  ``mean``/``sum`` reduction;
+* the backward consumes the **per-token upstream gradient** ``grad_output[M]``,
+  which is exactly the row scale of ``dZ``.  A scalar ``grad_output`` is
+  rejected instead of being silently interpreted as a reduction;
+* there is no ``bias``, ``ce_weight``, label smoothing, ``softcap``,
+  ``lse_square_scale``, z-loss or token-scaling support.
+
+Anything that needs a reduction composes it in PyTorch, e.g.::
+
+    nll = LigerFusedScaledCrossEntropySM90Function.apply(x, w, target)
+    loss = nll.sum() / (target != -100).sum().clamp_min(1)
+
+which keeps the reduction (and therefore the per-token upstream gradient) in
+autograd where it is cheap and unambiguous.
+
+Requirements
+------------
+Hopper (compute capability 9.0), BF16 ``input``/``weight``, ``input[M, H]``,
+``weight[V, H]``, ``target[M]`` int64.  ``H`` and ``V`` may be ragged; they are
+padded internally and the returned gradients are sliced back to the caller's
+shapes and dtypes.
+
+Kernels
+-------
+=========================  =========================================
+phase                      module
+=========================  =========================================
+forward (M-outer)          ``_fused_scaled_cross_entropy_forward_sm90``
+forward (M-fast)           ``_fused_scaled_cross_entropy_forward_mfast_sm90``
+backward dZ+dX+dW          ``_fused_scaled_cross_entropy_backward_fused_sm90``
+=========================  =========================================
+
+``m_tiles_per_cluster`` (>= 1, default 1) is the forward scheduling knob.  The
+default dispatches to the M-outer self-TMA forward, which is the fastest
+measured forward at ``M=4096, H=4096, V=131072``.  Values > 1 dispatch to the
+M-fast (N-outer / M-inner) forward with that many live ``M128`` online-softmax
+slots per cluster; it is correct everywhere but measured slower at the
+representative shape, and exists for tuning other shapes.
+
+Backward runs in one persistent cluster-2 CUDA kernel.  Its device-side wave
+loop executes dZ, dX, and dW with phase-local schedulers over a phase-serial
+shared-memory arena: dZ uses the static M-fast scheduler, dX interprets each
+cluster pair as W-multicast peers, and dW treats both CTAs as independent
+output-tile workers with transposed (``order=(1, 0, 2)``) TMA.  A GPU-wide HBM
+atomic barrier publishes dZ and protects the reusable workspace between waves.
+
+``temperature`` (default ``1.0``) follows Verl semantics: softmax and NLL use
+``logits / temperature`` and backward applies the corresponding
+``1 / temperature`` chain-rule factor.
+
+Backward always processes eight ``M128`` tiles (1024 tokens) per device-side
+wave, reusing one BF16 dZ buffer.  At the representative shape this holds a
+~256 MiB workspace instead of the ~1 GiB full dZ.  Wave zero plain-stores BF16
+dW; later waves use Hopper BF16 TMA reduce-add.  FP32 WGMMA accumulators are
+rounded in the epilogue, with no FP32 HBM accumulator or final cast.
+``LIGER_SCALED_CE_SM90_VALIDATE_TARGETS=0`` disables the (host-synchronising)
+out-of-range target check.
+"""
+
+import math
+import os
+
+import torch
+
+from liger_kernel.ops.cutedsl.ops._fused_scaled_cross_entropy_backward_fused_sm90 import FusedBackwardConfig
+from liger_kernel.ops.cutedsl.ops._fused_scaled_cross_entropy_backward_fused_sm90 import fused_backward_one_kernel
+from liger_kernel.ops.cutedsl.ops._fused_scaled_cross_entropy_forward_mfast_sm90 import ScaledCEForwardMFastConfig
+from liger_kernel.ops.cutedsl.ops._fused_scaled_cross_entropy_forward_mfast_sm90 import scaled_ce_forward_mfast
+from liger_kernel.ops.cutedsl.ops._fused_scaled_cross_entropy_forward_sm90 import scaled_ce_forward
+from liger_kernel.ops.cutedsl.ops.utils import ensure_cuda_context
+from liger_kernel.ops.utils import amp_custom_bwd
+from liger_kernel.ops.utils import amp_custom_fwd
+
+# All five kernels tile the hidden dimension by 64, so one padding of H covers
+# the forward, dZ, dX and dW phases.
+HIDDEN_TILE = 64
+# dZ and dX both tile the token dimension by 128, so a backward wave is counted
+# in M128 tiles.
+BACKWARD_M_TILE = 128
+# 8 M128 tiles == 1024 tokens per wave: a ~256 MiB BF16 dZ buffer at
+# V = 131072 instead of the ~1 GiB a 4096-token batch would need.
+BACKWARD_M_TILES_PER_WAVE = 8
+VALIDATE_TARGETS_ENV = "LIGER_SCALED_CE_SM90_VALIDATE_TARGETS"
+
+
+def _validate_temperature(temperature):
+    if isinstance(temperature, bool) or not isinstance(temperature, (int, float)):
+        raise TypeError("temperature must be a real number")
+    if not math.isfinite(temperature) or temperature <= 0:
+        raise ValueError("temperature must be finite and > 0")
+
+
+def _validate_targets_enabled() -> bool:
+    return os.environ.get(VALIDATE_TARGETS_ENV, "1") not in ("0", "false", "False")
+
+
+def _validate_inputs(_input, weight, target, ignore_index, m_tiles_per_cluster):
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability(_input.device) != (9, 0):
+        raise RuntimeError("CuTe DSL fused scaled cross entropy requires a Hopper compute capability 9.0 GPU")
+    if _input.device != weight.device or _input.device != target.device:
+        raise ValueError("input, weight, and target must be on the same CUDA device")
+    if _input.dtype != torch.bfloat16 or weight.dtype != torch.bfloat16:
+        raise TypeError("CuTe DSL fused scaled cross entropy supports BF16 input and weight only")
+    if target.dtype != torch.int64:
+        raise TypeError("target must be an int64 tensor")
+    if _input.ndim != 2 or weight.ndim != 2 or target.ndim != 1:
+        raise ValueError("expected input[M,H], weight[V,H], and target[M]")
+    if _input.shape[0] != target.shape[0] or _input.shape[1] != weight.shape[1]:
+        raise ValueError(
+            f"input {tuple(_input.shape)}, weight {tuple(weight.shape)} and target "
+            f"{tuple(target.shape)} shapes are incompatible"
+        )
+    if not isinstance(m_tiles_per_cluster, int) or isinstance(m_tiles_per_cluster, bool):
+        raise TypeError("m_tiles_per_cluster must be an int")
+    if m_tiles_per_cluster < 1:
+        raise ValueError("m_tiles_per_cluster must be >= 1")
+    if not _validate_targets_enabled():
+        return
+    vocab_size = weight.shape[0]
+    out_of_range = ((target < 0) | (target >= vocab_size)) & (target != ignore_index)
+    if bool(out_of_range.any()):
+        raise ValueError(f"target contains values outside [0, {vocab_size}) that are not ignore_index={ignore_index}")
+
+
+def _validate_grad_output(grad_output, tokens):
+    if not isinstance(grad_output, torch.Tensor):
+        raise TypeError("grad_output must be a tensor of per-token gradients")
+    if grad_output.ndim != 1 or grad_output.shape[0] != tokens:
+        raise ValueError(
+            "CuTe DSL fused scaled cross entropy backward expects the per-token upstream gradient of shape "
+            f"[{tokens}], got {tuple(grad_output.shape)}. Apply any reduction outside the kernel so that "
+            "autograd supplies a per-token gradient."
+        )
+
+
+def _pad_hidden(x, weight):
+    """Pad ``H`` up to the shared ``HIDDEN_TILE`` so every phase tiles exactly."""
+    hidden_size = x.shape[1]
+    padded = (hidden_size + HIDDEN_TILE - 1) // HIDDEN_TILE * HIDDEN_TILE
+    if padded == hidden_size:
+        return x.contiguous(), weight.contiguous(), hidden_size
+    pad = (0, padded - hidden_size)
+    return (
+        torch.nn.functional.pad(x.contiguous(), pad),
+        torch.nn.functional.pad(weight.contiguous(), pad),
+        hidden_size,
+    )
+
+
+def fused_scaled_cross_entropy_forward(
+    _input,
+    weight,
+    target,
+    temperature=1.0,
+    ignore_index=-100,
+    m_tiles_per_cluster=1,
+    return_entropy=False,
+):
+    """Per-token fused scaled cross entropy forward.
+
+    Returns ``(nll, entropy, lse, x_padded, weight_padded, hidden_size)``.
+    ``nll`` is the ``[M]`` FP32 negative log-likelihood, ``entropy`` is BF16
+    when requested (otherwise ``None``), and ``lse`` is the FP32 log-sum-exp
+    reused by backward.
+    """
+    _validate_inputs(_input, weight, target, ignore_index, m_tiles_per_cluster)
+    _validate_temperature(temperature)
+    if not isinstance(return_entropy, bool):
+        raise TypeError("return_entropy must be a bool")
+    ensure_cuda_context()
+    x_padded, weight_padded, hidden_size = _pad_hidden(_input, weight)
+    target = target.contiguous()
+
+    if m_tiles_per_cluster == 1:
+        nll, entropy, lse = scaled_ce_forward(
+            x_padded,
+            weight_padded,
+            target,
+            temperature,
+            ignore_index,
+            return_entropy,
+        )
+    else:
+        config = ScaledCEForwardMFastConfig(slots_per_wave=m_tiles_per_cluster)
+        nll, entropy, lse = scaled_ce_forward_mfast(
+            x_padded,
+            weight_padded,
+            target,
+            temperature,
+            ignore_index,
+            return_entropy,
+            config=config,
+        )
+    return nll, entropy, lse, x_padded, weight_padded, hidden_size
+
+
+def fused_scaled_cross_entropy_backward(
+    grad_output,
+    x_padded,
+    weight_padded,
+    target,
+    lse,
+    temperature,
+    ignore_index,
+    hidden_size,
+    entropy=None,
+    grad_entropy=None,
+    input_dtype=torch.bfloat16,
+):
+    """Backward of :func:`fused_scaled_cross_entropy_forward`.
+
+    ``grad_output`` is the ``[M]`` upstream gradient of the per-token NLL and is
+    divided by ``temperature`` and used as the row scale of ``dZ``.  Returns
+    ``(grad_input[M, H], grad_weight[V, H])`` in the caller's dtypes.
+
+    Backward streams tokens through a reusable BF16 dZ buffer in fixed
+    1024-token waves.
+    """
+    tokens = x_padded.shape[0]
+    _validate_grad_output(grad_output, tokens)
+    _validate_temperature(temperature)
+    # Backward usually runs on an autograd worker thread, which has no driver
+    # context bound; the CuTe DSL occupancy helpers need one.
+    ensure_cuda_context()
+
+    scale = (grad_output.detach().to(torch.float32) / temperature).contiguous()
+    entropy_scale = None
+    if grad_entropy is not None:
+        entropy_scale = (grad_entropy.detach().to(torch.float32) / temperature).contiguous()
+    total_m_tiles = (tokens + BACKWARD_M_TILE - 1) // BACKWARD_M_TILE
+    m_tiles_per_wave = min(BACKWARD_M_TILES_PER_WAVE, total_m_tiles)
+    return fused_backward_one_kernel(
+        scale,
+        x_padded,
+        weight_padded,
+        target,
+        lse,
+        entropy,
+        entropy_scale,
+        ignore_index,
+        hidden_size,
+        input_dtype,
+        temperature,
+        config=FusedBackwardConfig(m_tiles_per_wave=m_tiles_per_wave),
+    )
+
+
+class LigerFusedScaledCrossEntropySM90Function(torch.autograd.Function):
+    """``apply(_input, weight, target, temperature=1.0, ignore_index=-100,
+    m_tiles_per_cluster=1, return_entropy=False)``.
+
+    Forward returns the per-token NLL ``[M]`` (FP32).  Backward expects the
+    per-token upstream gradient ``[M]``.  ``m_tiles_per_cluster`` schedules the
+    forward; backward always uses fixed 1024-token waves.
+    """
+
+    @staticmethod
+    @amp_custom_fwd
+    def forward(
+        ctx,
+        _input,
+        weight,
+        target,
+        temperature=1.0,
+        ignore_index=-100,
+        m_tiles_per_cluster=1,
+        return_entropy=False,
+    ):
+        _validate_temperature(temperature)
+        nll, entropy, lse, x_padded, weight_padded, hidden_size = fused_scaled_cross_entropy_forward(
+            _input,
+            weight,
+            target,
+            temperature,
+            ignore_index,
+            m_tiles_per_cluster,
+            return_entropy,
+        )
+        saved_entropy = entropy if entropy is not None else torch.empty(0, device=_input.device, dtype=torch.bfloat16)
+        ctx.save_for_backward(x_padded, weight_padded, target, lse, saved_entropy)
+        ctx.ignore_index = ignore_index
+        ctx.temperature = temperature
+        ctx.hidden_size = hidden_size
+        ctx.input_dtype = _input.dtype
+        ctx.return_entropy = return_entropy
+        return (nll, entropy) if return_entropy else nll
+
+    @staticmethod
+    @amp_custom_bwd
+    def backward(ctx, grad_output, grad_entropy=None):
+        x_padded, weight_padded, target, lse, entropy = ctx.saved_tensors
+        grad_input, grad_weight = fused_scaled_cross_entropy_backward(
+            grad_output,
+            x_padded,
+            weight_padded,
+            target,
+            lse,
+            ctx.temperature,
+            ctx.ignore_index,
+            ctx.hidden_size,
+            entropy=entropy if ctx.return_entropy else None,
+            grad_entropy=grad_entropy,
+            input_dtype=ctx.input_dtype,
+        )
+        return grad_input, grad_weight, None, None, None, None, None
+
+
+__all__ = [
+    "LigerFusedScaledCrossEntropySM90Function",
+    "fused_scaled_cross_entropy_backward",
+    "fused_scaled_cross_entropy_forward",
+]

--- a/src/liger_kernel/ops/cutedsl/ops/utils.py
+++ b/src/liger_kernel/ops/cutedsl/ops/utils.py
@@ -2,7 +2,35 @@
 Shared helpers for the CuTe DSL backend ops.
 """
 
+import cuda.bindings.driver as driver
+import torch
+
 from cutlass.cute.runtime import from_dlpack
+
+
+def ensure_cuda_context():
+    """Make the CUDA primary context current on the calling thread.
+
+    ``torch.autograd`` runs backward nodes on worker threads.  PyTorch binds
+    those threads through the CUDA *runtime* API, which leaves the *driver*
+    API's current context unset, so CuTe DSL helpers that call the driver
+    directly (notably ``cutlass.utils.HardwareInfo``) fail with
+    ``CUDA_ERROR_INVALID_CONTEXT``.  Retaining and setting the device's primary
+    context -- the very context PyTorch itself uses -- fixes that and is a no-op
+    once a context is already current.
+    """
+    err, ctx = driver.cuCtxGetCurrent()
+    if err == driver.CUresult.CUDA_SUCCESS and ctx and int(ctx) != 0:
+        return
+    err, device = driver.cuDeviceGet(torch.cuda.current_device())
+    if err != driver.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuDeviceGet failed: {err}")
+    err, primary = driver.cuDevicePrimaryCtxRetain(device)
+    if err != driver.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuDevicePrimaryCtxRetain failed: {err}")
+    (err,) = driver.cuCtxSetCurrent(primary)
+    if err != driver.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuCtxSetCurrent failed: {err}")
 
 
 def _next_power_of_2(n: int) -> int:

--- a/test/cutedsl/test_fused_scaled_cross_entropy_sm90.py
+++ b/test/cutedsl/test_fused_scaled_cross_entropy_sm90.py
@@ -1,3 +1,5 @@
+"""Correctness tests for the Hopper fused scaled cross entropy CuTe DSL kernel."""
+
 import os
 import subprocess
 import sys

--- a/test/transformers/test_cutedsl_fused_scaled_cross_entropy_sm90.py
+++ b/test/transformers/test_cutedsl_fused_scaled_cross_entropy_sm90.py
@@ -1,0 +1,480 @@
+import os
+import subprocess
+import sys
+import textwrap
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from test.utils import assert_verbose_allclose
+from test.utils import set_seed
+
+# Every test in this module launches SM90 CuTe DSL kernels, so gate the whole
+# file at collection time: on a CPU-only, non-NVIDIA or non-Hopper host nothing
+# here is collectable.
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (9, 0),
+    reason="CuTe DSL fused scaled cross entropy requires a Hopper (SM90) GPU",
+)
+
+
+def _sm90_module():
+    try:
+        import liger_kernel.ops.cutedsl.ops.fused_scaled_cross_entropy_sm90 as module
+    except ImportError as exc:
+        pytest.skip(f"CuTe DSL backend is not installed: {exc}")
+    return module
+
+
+def _reference_nll(x, weight, target, ignore_index, temperature=1.0):
+    logits = (x.float() @ weight.float().t()) / temperature
+    valid = target != ignore_index
+    safe_target = target.masked_fill(~valid, 0)
+    lse = torch.logsumexp(logits, dim=-1)
+    target_logits = logits.gather(1, safe_target[:, None]).squeeze(1)
+    return torch.where(valid, lse - target_logits, torch.zeros_like(lse))
+
+
+def _reference_nll_entropy(x, weight, target, ignore_index, temperature=1.0):
+    logits = (x.float() @ weight.float().t()) / temperature
+    log_probs = torch.log_softmax(logits, dim=-1)
+    probs = log_probs.exp()
+    entropy = -(probs * log_probs).sum(dim=-1)
+    valid = target != ignore_index
+    safe_target = target.masked_fill(~valid, 0)
+    nll = -log_probs.gather(1, safe_target[:, None]).squeeze(1)
+    zeros = torch.zeros_like(nll)
+    return torch.where(valid, nll, zeros), torch.where(valid, entropy, zeros)
+
+
+def _verl_reference(x, weight, target, grad_nll, grad_entropy, temperature):
+    """Dependency-free equivalent of Verl's experimental fused PPO function."""
+    logits = ((x @ weight.t()) / temperature).float()
+    probs = logits.softmax(dim=-1)
+    log_probs = logits.log_softmax(dim=-1)
+    token_log_probs = log_probs.gather(-1, target[:, None]).squeeze(-1)
+    entropy = (torch.logsumexp(logits, dim=-1) - torch.sum(probs * logits, dim=-1)).to(x.dtype)
+
+    one_hot = torch.zeros_like(logits).scatter_(-1, target[:, None], 1)
+    dlogits = (-grad_nll).float()[:, None] * (one_hot - probs)
+    dlogits += probs * (log_probs + entropy.float()[:, None]) * (-grad_entropy.float()[:, None])
+    dlogits = dlogits.to(x.dtype) / temperature
+    return -token_log_probs, entropy, dlogits @ weight, dlogits.t() @ x
+
+
+def _make_inputs(bt, hidden_size, vocab_size, ignore_stride=None):
+    x = torch.randn(bt, hidden_size, device="cuda", dtype=torch.bfloat16) * 0.25
+    weight = torch.randn(vocab_size, hidden_size, device="cuda", dtype=torch.bfloat16) / hidden_size**0.5
+    target = torch.randint(vocab_size, (bt,), device="cuda", dtype=torch.long)
+    if ignore_stride is not None:
+        target[::ignore_stride] = -100
+    return x, weight, target
+
+
+def _run_liger(
+    x,
+    weight,
+    target,
+    grad_output,
+    ignore_index=-100,
+    temperature=1.0,
+    m_tiles_per_cluster=1,
+):
+    module = _sm90_module()
+    x = x.detach().clone().requires_grad_(True)
+    weight = weight.detach().clone().requires_grad_(True)
+    nll = module.LigerFusedScaledCrossEntropySM90Function.apply(
+        x,
+        weight,
+        target,
+        temperature,
+        ignore_index,
+        m_tiles_per_cluster,
+        False,
+    )
+    if grad_output is not None:
+        nll.backward(grad_output)
+        return nll.detach(), x.grad.detach(), weight.grad.detach()
+    return nll.detach(), None, None
+
+
+def _run_reference(x, weight, target, grad_output, ignore_index=-100, temperature=1.0):
+    x = x.detach().clone().requires_grad_(True)
+    weight = weight.detach().clone().requires_grad_(True)
+    nll = _reference_nll(x, weight, target, ignore_index, temperature)
+    if grad_output is not None:
+        nll.backward(grad_output)
+        return nll.detach(), x.grad.detach(), weight.grad.detach()
+    return nll.detach(), None, None
+
+
+@pytest.mark.parametrize("shape", [(256, 128, 512), (193, 70, 517)], ids=["aligned", "ragged"])
+@pytest.mark.parametrize("m_tiles_per_cluster", [1, 2], ids=["mtiles1", "mtiles2"])
+def test_sm90_per_token_nll_and_grads_match_torch(shape, m_tiles_per_cluster):
+    set_seed(42)
+    bt, hidden_size, vocab_size = shape
+    x, weight, target = _make_inputs(bt, hidden_size, vocab_size, ignore_stride=7)
+    grad_output = torch.rand(bt, device="cuda", dtype=torch.float32) + 0.25
+
+    actual = _run_liger(
+        x,
+        weight,
+        target,
+        grad_output,
+        m_tiles_per_cluster=m_tiles_per_cluster,
+    )
+    expected = _run_reference(x, weight, target, grad_output)
+
+    assert actual[0].shape == (bt,)
+    assert actual[0].dtype == torch.float32
+    assert actual[1].shape == x.shape and actual[1].dtype == x.dtype
+    assert actual[2].shape == weight.shape and actual[2].dtype == weight.dtype
+    assert_verbose_allclose(actual[0].float(), expected[0].float(), atol=5e-2, rtol=5e-2)
+    assert_verbose_allclose(actual[1].float(), expected[1].float(), atol=2e-2, rtol=1e-1)
+    assert_verbose_allclose(actual[2].float(), expected[2].float(), atol=2e-2, rtol=1e-1)
+
+
+@pytest.mark.parametrize("temperature", [0.7, 1.5])
+def test_sm90_temperature_matches_torch(temperature):
+    set_seed(43)
+    x, weight, target = _make_inputs(193, 70, 517, ignore_stride=7)
+    grad_output = torch.rand(193, device="cuda", dtype=torch.float32) + 0.25
+
+    actual = _run_liger(x, weight, target, grad_output, temperature=temperature)
+    expected = _run_reference(x, weight, target, grad_output, temperature=temperature)
+
+    assert_verbose_allclose(actual[0].float(), expected[0].float(), atol=5e-2, rtol=5e-2)
+    assert_verbose_allclose(actual[1].float(), expected[1].float(), atol=2e-2, rtol=1e-1)
+    assert_verbose_allclose(actual[2].float(), expected[2].float(), atol=2e-2, rtol=1e-1)
+
+
+@pytest.mark.parametrize("m_tiles_per_cluster", [1, 2])
+def test_sm90_differentiable_entropy_matches_torch(m_tiles_per_cluster):
+    set_seed(44)
+    x, weight, target = _make_inputs(193, 70, 517, ignore_stride=7)
+    temperature = 0.8
+    grad_nll = torch.rand(193, device="cuda", dtype=torch.float32) + 0.25
+    grad_entropy = torch.rand(193, device="cuda", dtype=torch.float32) - 0.5
+
+    module = _sm90_module()
+    xa = x.detach().clone().requires_grad_(True)
+    wa = weight.detach().clone().requires_grad_(True)
+    nll, entropy = module.LigerFusedScaledCrossEntropySM90Function.apply(
+        xa,
+        wa,
+        target,
+        temperature,
+        -100,
+        m_tiles_per_cluster,
+        True,
+    )
+    torch.autograd.backward((nll, entropy), (grad_nll, grad_entropy.to(entropy.dtype)))
+
+    xr = x.detach().clone().requires_grad_(True)
+    wr = weight.detach().clone().requires_grad_(True)
+    ref_nll, ref_entropy = _reference_nll_entropy(xr, wr, target, -100, temperature)
+    torch.autograd.backward((ref_nll, ref_entropy), (grad_nll, grad_entropy))
+
+    assert entropy.dtype == torch.bfloat16
+    assert entropy[target == -100].count_nonzero().item() == 0
+    assert_verbose_allclose(nll.float(), ref_nll.float(), atol=5e-2, rtol=5e-2)
+    assert_verbose_allclose(entropy.float(), ref_entropy.float(), atol=5e-2, rtol=5e-2)
+    assert_verbose_allclose(xa.grad.float(), xr.grad.float(), atol=3e-2, rtol=1.5e-1)
+    assert_verbose_allclose(wa.grad.float(), wr.grad.float(), atol=3e-2, rtol=1.5e-1)
+
+
+def test_sm90_matches_verl_fused_ppo_formulas():
+    set_seed(45)
+    x, weight, target = _make_inputs(193, 70, 517)
+    temperature = 0.8
+    grad_nll = torch.rand(193, device="cuda", dtype=torch.float32) + 0.25
+    grad_entropy = torch.rand(193, device="cuda", dtype=torch.float32) - 0.5
+
+    module = _sm90_module()
+    xa = x.detach().clone().requires_grad_(True)
+    wa = weight.detach().clone().requires_grad_(True)
+    nll, entropy = module.LigerFusedScaledCrossEntropySM90Function.apply(
+        xa,
+        wa,
+        target,
+        temperature,
+        -100,
+        1,
+        True,
+    )
+    torch.autograd.backward((nll, entropy), (grad_nll, grad_entropy.to(entropy.dtype)))
+
+    ref_nll, ref_entropy, ref_dx, ref_dw = _verl_reference(
+        x,
+        weight,
+        target,
+        grad_nll,
+        grad_entropy,
+        temperature,
+    )
+    assert_verbose_allclose(nll.float(), ref_nll.float(), atol=5e-2, rtol=5e-2)
+    assert_verbose_allclose(entropy.float(), ref_entropy.float(), atol=5e-2, rtol=5e-2)
+    assert_verbose_allclose(xa.grad.float(), ref_dx.float(), atol=3e-2, rtol=1.5e-1)
+    assert_verbose_allclose(wa.grad.float(), ref_dw.float(), atol=3e-2, rtol=1.5e-1)
+
+
+def test_sm90_ignored_entropy_rows_stay_zero_with_large_logits():
+    set_seed(46)
+    x = (torch.randn(128, 64, device="cuda", dtype=torch.bfloat16) * 20).requires_grad_(True)
+    weight = (torch.randn(256, 64, device="cuda", dtype=torch.bfloat16) * 20).requires_grad_(True)
+    target = torch.full((128,), -100, device="cuda", dtype=torch.long)
+
+    module = _sm90_module()
+    nll, entropy = module.LigerFusedScaledCrossEntropySM90Function.apply(
+        x,
+        weight,
+        target,
+        0.1,
+        -100,
+        1,
+        True,
+    )
+    torch.autograd.backward((nll, entropy), (torch.ones_like(nll), torch.ones_like(entropy)))
+
+    assert nll.count_nonzero().item() == 0
+    assert entropy.count_nonzero().item() == 0
+    assert torch.isfinite(x.grad).all() and x.grad.count_nonzero().item() == 0
+    assert torch.isfinite(weight.grad).all() and weight.grad.count_nonzero().item() == 0
+
+
+def test_sm90_ignore_index_rows_are_zero():
+    set_seed(0)
+    bt, hidden_size, vocab_size = 192, 96, 257
+    x, weight, target = _make_inputs(bt, hidden_size, vocab_size, ignore_stride=5)
+    grad_output = torch.ones(bt, device="cuda", dtype=torch.float32)
+
+    nll, dx, _ = _run_liger(x, weight, target, grad_output)
+    ignored = target == -100
+
+    assert nll[ignored].count_nonzero().item() == 0
+    assert nll[~ignored].min().item() > 0.0
+    assert dx[ignored].count_nonzero().item() == 0
+
+
+def test_sm90_zero_grad_rows_produce_zero_dx():
+    set_seed(1)
+    bt, hidden_size, vocab_size = 192, 96, 257
+    x, weight, target = _make_inputs(bt, hidden_size, vocab_size, ignore_stride=11)
+    grad_output = torch.zeros(bt, device="cuda", dtype=torch.float32)
+    grad_output[::5] = torch.rand((bt + 4) // 5, device="cuda", dtype=torch.float32) + 0.25
+
+    actual = _run_liger(x, weight, target, grad_output)
+    expected = _run_reference(x, weight, target, grad_output)
+
+    assert actual[1][grad_output == 0].count_nonzero().item() == 0
+    assert_verbose_allclose(actual[1].float(), expected[1].float(), atol=2e-2, rtol=1e-1)
+    assert_verbose_allclose(actual[2].float(), expected[2].float(), atol=2e-2, rtol=1e-1)
+
+
+def test_sm90_all_ignored_is_zero():
+    set_seed(2)
+    bt, hidden_size, vocab_size = 128, 64, 256
+    x, weight, _ = _make_inputs(bt, hidden_size, vocab_size)
+    target = torch.full((bt,), -100, device="cuda", dtype=torch.long)
+    grad_output = torch.ones(bt, device="cuda", dtype=torch.float32)
+
+    nll, dx, dw = _run_liger(x, weight, target, grad_output)
+
+    assert nll.count_nonzero().item() == 0
+    assert dx.count_nonzero().item() == 0
+    assert dw.count_nonzero().item() == 0
+
+
+def test_sm90_many_wave_dw_matches_torch_within_bf16_accumulation_error():
+    """Multi-wave BF16 dW accumulation must track the FP32 torch reference."""
+    set_seed(17)
+    bt, hidden_size, vocab_size = 2048, 256, 512
+    x, weight, target = _make_inputs(bt, hidden_size, vocab_size, ignore_stride=11)
+    grad_output = torch.rand(bt, device="cuda", dtype=torch.float32) + 0.25
+
+    waved = _run_liger(x, weight, target, grad_output)  # two 1024-token waves
+    expected = _run_reference(x, weight, target, grad_output)[2].float()
+
+    # Absolute tolerance is relaxed because every
+    # wave's contribution is rounded to BF16 (~2^-8 relative) before the add.
+    assert_verbose_allclose(waved[2].float(), expected, atol=5e-2, rtol=2e-1)
+
+    scale = expected.abs().mean()
+    wave_err = (waved[2].float() - expected).abs().mean() / scale
+    assert wave_err < 2e-2, wave_err
+
+
+def test_sm90_backward_uses_one_fused_kernel(monkeypatch):
+    """Backward dispatches one fused kernel with the fixed wave cap."""
+    module = _sm90_module()
+    set_seed(12)
+    bt, hidden_size, vocab_size = 512, 128, 256
+    x, weight, target = _make_inputs(bt, hidden_size, vocab_size)
+    x = x.requires_grad_(True)
+    weight = weight.requires_grad_(True)
+    grad_output = torch.rand(bt, device="cuda", dtype=torch.float32) + 0.25
+
+    calls = []
+    original = module.fused_backward_one_kernel
+
+    def wrapper(*args, **kwargs):
+        calls.append(kwargs["config"].m_tiles_per_wave)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(module, "fused_backward_one_kernel", wrapper)
+
+    module.LigerFusedScaledCrossEntropySM90Function.apply(x, weight, target).backward(grad_output)
+    assert calls == [4]
+
+
+@pytest.mark.parametrize("m_tiles_per_cluster", [1, 3], ids=["mtiles1", "mtiles3"])
+def test_sm90_m_tiles_dispatch_selects_expected_forward(monkeypatch, m_tiles_per_cluster):
+    module = _sm90_module()
+    calls = {}
+
+    def fake_m_outer(x, weight, target, temperature, ignore_index, return_entropy):
+        calls["m_outer"] = (temperature, ignore_index)
+        return torch.zeros(x.shape[0], device=x.device), None, torch.zeros(x.shape[0], device=x.device)
+
+    def fake_m_fast(x, weight, target, temperature, ignore_index, return_entropy, config=None):
+        calls["m_fast"] = (temperature, config.slots_per_wave)
+        return torch.zeros(x.shape[0], device=x.device), None, torch.zeros(x.shape[0], device=x.device)
+
+    monkeypatch.setattr(module, "scaled_ce_forward", fake_m_outer)
+    monkeypatch.setattr(module, "scaled_ce_forward_mfast", fake_m_fast)
+
+    x = torch.randn(4, 16, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(16, 16, device="cuda", dtype=torch.bfloat16)
+    target = torch.zeros(4, device="cuda", dtype=torch.long)
+    module.fused_scaled_cross_entropy_forward(x, weight, target, 1.0, -100, m_tiles_per_cluster)
+
+    if m_tiles_per_cluster == 1:
+        assert calls == {"m_outer": (1.0, -100)}
+    else:
+        assert calls == {"m_fast": (1.0, m_tiles_per_cluster)}
+
+
+def test_sm90_rejects_scalar_and_mismatched_grad_output():
+    set_seed(3)
+    module = _sm90_module()
+    bt, hidden_size, vocab_size = 64, 64, 128
+    x, weight, target = _make_inputs(bt, hidden_size, vocab_size)
+
+    _, _, lse, x_padded, weight_padded, hidden = module.fused_scaled_cross_entropy_forward(
+        x, weight, target, 1.0, -100, 1
+    )
+    for bad_grad in (
+        torch.tensor(1.0, device="cuda"),
+        torch.ones(bt - 1, device="cuda"),
+        torch.ones(bt, 1, device="cuda"),
+    ):
+        with pytest.raises(ValueError):
+            module.fused_scaled_cross_entropy_backward(
+                bad_grad, x_padded, weight_padded, target, lse, 1.0, -100, hidden
+            )
+    with pytest.raises(TypeError):
+        module.fused_scaled_cross_entropy_backward(1.0, x_padded, weight_padded, target, lse, 1.0, -100, hidden)
+
+
+def test_sm90_sum_reduction_composed_in_autograd():
+    """``sum().backward()`` is the supported reduction path: autograd expands
+    the scalar into the per-token vector of ones before the kernel sees it."""
+    set_seed(4)
+    bt, hidden_size, vocab_size = 128, 64, 256
+    x, weight, target = _make_inputs(bt, hidden_size, vocab_size, ignore_stride=6)
+
+    module = _sm90_module()
+    xa = x.detach().clone().requires_grad_(True)
+    wa = weight.detach().clone().requires_grad_(True)
+    module.LigerFusedScaledCrossEntropySM90Function.apply(xa, wa, target).sum().backward()
+
+    xr = x.detach().clone().requires_grad_(True)
+    wr = weight.detach().clone().requires_grad_(True)
+    _reference_nll(xr, wr, target, -100).sum().backward()
+
+    assert_verbose_allclose(xa.grad.float(), xr.grad.float(), atol=2e-2, rtol=1e-1)
+    assert_verbose_allclose(wa.grad.float(), wr.grad.float(), atol=2e-2, rtol=1e-1)
+
+
+def test_sm90_rejects_bad_dtypes_shapes_and_options():
+    module = _sm90_module()
+    fn = module.LigerFusedScaledCrossEntropySM90Function
+    x = torch.randn(4, 16, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(16, 16, device="cuda", dtype=torch.bfloat16)
+    target = torch.zeros(4, device="cuda", dtype=torch.long)
+
+    with pytest.raises(TypeError):
+        fn.apply(x.to(torch.float16), weight.to(torch.float16), target)
+    with pytest.raises(TypeError):
+        fn.apply(x, weight, target.to(torch.int32))
+    with pytest.raises(ValueError):
+        fn.apply(x, weight, target[:2])
+    with pytest.raises(ValueError):
+        fn.apply(x, torch.randn(16, 8, device="cuda", dtype=torch.bfloat16), target)
+    with pytest.raises(ValueError):
+        fn.apply(x, weight, target, 0.0)
+    with pytest.raises(TypeError):
+        fn.apply(x, weight, target, "cold")
+    with pytest.raises(ValueError):
+        fn.apply(x, weight, target, float("inf"))
+    with pytest.raises(ValueError):
+        fn.apply(x, weight, target, 1.0, -100, 0)
+    with pytest.raises(TypeError):
+        fn.apply(x, weight, target, 1.0, -100, 1.5)
+    with pytest.raises(TypeError):
+        fn.apply(x, weight, target, 1.0, -100, 1, 2.0)
+
+
+def test_sm90_rejects_out_of_range_targets():
+    module = _sm90_module()
+    fn = module.LigerFusedScaledCrossEntropySM90Function
+    x = torch.randn(4, 16, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(16, 16, device="cuda", dtype=torch.bfloat16)
+    target = torch.zeros(4, device="cuda", dtype=torch.long)
+    target[1] = 16
+
+    with pytest.raises(ValueError):
+        fn.apply(x, weight, target)
+
+    target[1] = -100
+    fn.apply(x, weight, target)
+
+
+def test_sm90_exports_are_additive_and_do_not_alias_triton_flce():
+    _sm90_module()
+    repo_root = Path(__file__).resolve().parents[2]
+    pythonpath = os.pathsep.join([str(repo_root / "src"), str(repo_root), os.environ.get("PYTHONPATH", "")])
+    env = {
+        **os.environ,
+        "CUTE_DSL_ARCH": "sm_90a",
+        "LIGER_KERNEL_IMPL": "cutedsl",
+        "PYTHONPATH": pythonpath,
+    }
+    script = textwrap.dedent(
+        """
+        import liger_kernel.ops.cutedsl.ops as cutedsl_ops
+        from liger_kernel.ops import LigerFusedLinearCrossEntropyFunction
+
+        expected = "liger_kernel.ops.cutedsl.ops.fused_scaled_cross_entropy_sm90"
+        actual = cutedsl_ops.LigerFusedScaledCrossEntropySM90Function.__module__
+        if actual != expected:
+            raise AssertionError(f"Expected {expected}, got {actual}")
+        for name in (
+            "LigerFusedScaledCrossEntropySM90Function",
+            "fused_scaled_cross_entropy_forward",
+            "fused_scaled_cross_entropy_backward",
+        ):
+            if name not in cutedsl_ops.__all__:
+                raise AssertionError(f"{name} missing from cutedsl ops __all__")
+        if hasattr(cutedsl_ops, "LigerFusedLinearCrossEntropyFunction"):
+            raise AssertionError("cutedsl must not export a FusedLinearCrossEntropy override")
+        if LigerFusedLinearCrossEntropyFunction.__module__ != "liger_kernel.ops.fused_linear_cross_entropy":
+            raise AssertionError(
+                "Triton FusedLinearCrossEntropy must stay in place, got "
+                f"{LigerFusedLinearCrossEntropyFunction.__module__}"
+            )
+        """
+    )
+    subprocess.run([sys.executable, "-c", script], check=True, env=env, cwd=repo_root)


### PR DESCRIPTION
## Summary

Adds `LigerFusedScaledCrossEntropySM90Function`, a Hopper-only BF16 CuTe DSL operator for Verl-style fused vocabulary projection, per-token NLL, and optional differentiable token entropy.

- supports `temperature` with Verl-compatible `logits / temperature` semantics
- returns per-token FP32 NLL and optional BF16 entropy; reductions stay in PyTorch
- zeros NLL, entropy, and their gradient contributions on `ignore_index` rows
- keeps the existing Triton `LigerFusedLinearCrossEntropyFunction` unchanged
- uses a fixed 1024-token backward wave to bound the BF16 dZ workspace

## Kernel architecture

### Forward

- 384 threads / 3 warp groups
- WG0 + WG1 cooperatively issue `M128 x N256 x K64` WGMMA, split M64 per WG
- warp 0 of WG0 also issues the 3-stage TMA load pipeline; `wait_group(1)` overlaps TMA refills with live WGMMA
- WG2 owns one token row per thread and consumes a padded FP16 SMEM logits tile
- NLL and entropy are computed in one online vocabulary pass using running max, exp sum, and exp-weighted logit sum; logits are never stored to HBM
- cluster-16 DSMEM reduction combines vocabulary partitions
- `m_tiles_per_cluster=1` selects the fastest M-outer schedule; larger values retain multiple online-softmax states for shape-specific tuning

### Backward

- one persistent CUDA kernel with a device-side wave loop; no Python phase loop
- at most one CTA per SM, launched as 66 cluster-2 pairs / 132 CTAs on H200
- one phase-serial ~224 KiB SMEM arena and one shared FP32 WGMMA accumulator
- dZ: cooperative self-TMA `N256` recomputation with the M-fast static scheduler
- dX: cooperative `N256/K64/s3`, with cluster-2 W multicast
- dW: transposed TMA layout equivalent to `Step<_2,_1,_3>` / `order=(1,0,2)`
- one monotone HBM atomic counter provides GPU-wide barriers after dZ and between reusable waves
- wave zero plain-stores BF16 dW; later waves use BF16 TMA reduce-add
- all TMA descriptors are prefetched at kernel entry

## Correctness

- `22 passed` on an H200 SM90: aligned/ragged shapes, temperature, differentiable entropy, direct dependency-free Verl formula parity, ignored rows, large-logit overflow guard, sparse upstream gradients, multi-wave BF16 dW accumulation, exports and guards
- `22 skipped` on a host without an SM90 GPU via a module-wide pytest gate
- `make checkstyle` passes
- Torch, Liger Triton, and CuTe benchmark providers smoke-tested

## H200 performance vs Verl

BF16, temperature 1.0, entropy returned but not included in the scalar loss. Both full operations execute four logical GEMMs. `cold` is one launch after 3.5 s idle; `hot` is the median after five back-to-back warmups. Cells are `milliseconds / effective TFLOPS`.

| M | H | V | CuTe cold | Verl cold | cold speedup | CuTe hot | Verl hot | hot speedup |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 512 | 4096 | 131072 | 4.78 / 460 | 6.97 / 315 | **1.46x** | 4.36 / 504 | 6.72 / 327 | **1.54x** |
| 1024 | 4096 | 131072 | 7.72 / 570 | 13.27 / 331 | **1.72x** | 7.64 / 575 | 13.18 / 334 | **1.72x** |
| 2048 | 4096 | 131072 | 13.21 / 666 | 25.77 / 341 | **1.95x** | 14.25 / 617 | 25.93 / 339 | **1.82x** |
| 4096 | 1024 | 131072 | 11.26 / 391 | 29.11 / 151 | **2.59x** | 10.83 / 406 | 28.93 / 152 | **2.67x** |
| 4096 | 2048 | 131072 | 15.03 / 585 | 36.39 / 242 | **2.42x** | 15.99 / 550 | 36.33 / 242 | **2.27x** |
| 4096 | 4096 | 32768 | 6.82 / 645 | 13.57 / 324 | **1.99x** | 7.26 / 606 | 13.47 / 327 | **1.85x** |
| 4096 | 4096 | 65536 | 12.73 / 691 | 25.96 / 339 | **2.04x** | 14.01 / 628 | 26.08 / 337 | **1.86x** |
| 4096 | 4096 | 131072 | 24.87 / 707 | 50.91 / 346 | **2.05x** | 28.15 / 625 | 51.73 / 340 | **1.84x** |
| 4096 | 4096 | 262144 | 49.86 / 706 | 100.13 / 351 | **2.01x** | 56.16 / 626 | 102.10 / 345 | **1.82x** |
| 32000 | 4096 | 131072 | 218.71 / 628 | 398.56 / 345 | **1.82x** | 229.49 / 599 | 408.01 / 337 | **1.78x** |

## Peak incremental memory

| M | H | V | CuTe MiB | Verl MiB | saving |
|---:|---:|---:|---:|---:|---:|
| 512 | 4096 | 131072 | 1156 | 2952 | **61%** |
| 1024 | 4096 | 131072 | 1288 | 3984 | **68%** |
| 2048 | 4096 | 131072 | 1296 | 3992 | **68%** |
| 4096 | 1024 | 131072 | 520 | 1801 | **71%** |
| 4096 | 2048 | 131072 | 784 | 2452 | **68%** |
| 4096 | 4096 | 32768 | 352 | 1032 | **66%** |
| 4096 | 4096 | 65536 | 672 | 2024 | **67%** |
| 4096 | 4096 | 131072 | 1312 | 4008 | **67%** |
| 4096 | 4096 | 262144 | 2592 | 7976 | **68%** |
| 32000 | 4096 | 131072 | 1531 | 4226 | **64%** |
