### PR TITLE
[NPU] Fix: recompute true-class CE gradient in fp32 on no-weight backward path

### DIFF
--- a/src/liger_kernel/ops/backends/_ascend/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/cross_entropy.py
@@ -348,6 +348,7 @@ def liger_cross_entropy_backward_kernel_no_weight(
                     # Per-row loss was stored without mean scaling (``reduction`` ``sum`` or ``none``).
                     lse = loss_row + x_y
 
+            ori_X_y = tl.load(X_ptr + X_ptr_offset + y).cast(tl.float32)
             for i in range(0, n_cols, BLOCK_SIZE):
                 X_offsets = i + tl.arange(0, BLOCK_SIZE)
                 X_block = tl.load(
@@ -358,9 +359,12 @@ def liger_cross_entropy_backward_kernel_no_weight(
                 grad = tl.exp(X_block - lse) * final_scale
                 tl.store(dX_ptr + dX_ptr_offset + X_offsets, grad, mask=X_offsets < n_cols)
 
-            target_ptr = dX_ptr + dX_ptr_offset + y
-            target_grad = tl.load(target_ptr).cast(tl.float32)
-            tl.store(target_ptr, target_grad - final_scale)
+            # Recompute dx_y in fp32 and overwrite dX[y]. A read-modify-write of the
+            # low-precision value stored in the loop loses bits when softmax(x_y) -> 1.
+            tl.debug_barrier()
+            softmax_X_y = tl.exp(ori_X_y - lse)
+            dx_y = (softmax_X_y - 1.0) * final_scale
+            tl.store(dX_ptr + dX_ptr_offset + y, dx_y)
 
 
 @triton.jit


### PR DESCRIPTION
## Summary

PR #1329 added `test_correctness_true_class_grad_confident_predictions`, which compares the true-class logit gradient against an fp32 reference and requires Liger to be at least as accurate as PyTorch’s low-precision backward. On Ascend NPU, three cases fail when `label_smoothing=0.0` (`sum`/`mean`, bf16/fp16).

For plain cross-entropy (`no weight`, `no softcap`, `no z-loss`, `label_smoothing=0`), the Ascend backend uses `liger_cross_entropy_backward_kernel_no_weight`. That path wrote `softmax(x_y) * scale` into the low-precision `dX` buffer and then corrected the true-class entry with a read-modify-write (`load dX[y] - scale`). When `softmax(x_y) → 1`, rounding in bf16/fp16 before subtracting the `-1/N` term inflates error—the same failure mode fixed on GPU in #1329.

This change recomputes `dx_y = (softmax(x_y) - 1) * scale` once in fp32 from `X[y]` and `lse`, then overwrites `dX[y]`, matching the intent of the upstream Triton fix while keeping the existing O(V) loop unchanged.

## Performance

<img width="1000" height="600" alt="cross_entropy_speed_full_token_length" src="https://github.com/user-attachments/assets/1cfd61bf-2606-473d-b925-c1991d62f408" />

<img width="1000" height="600" alt="cross_entropy_memory_full_token_length" src="https://github.com/user-attachments/assets/0006e7a6-bec1-4adb-9b0b-fafed72e25d9" />


## Testing

```python
pytest test/transformers/test_cross_entropy.py 
```

<img width="980" height="576" alt="image" src="https://github.com/user-attachments/assets/132a0958-110e-4952-a33f-f76ca3aaed4a" />


- Hardware Type: All NPUs
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
