### PR TITLE
Cast tl.program_id(0) to int64 in llama4_rope and qwen2vl_mrope

### DIFF
--- a/src/liger_kernel/ops/llama4_rope.py
+++ b/src/liger_kernel/ops/llama4_rope.py
@@ -39,7 +39,7 @@ def _llama4_rope_kernel(
     Grid: (batch*seq, head)
     """
     # 2D grid
-    pid_bs = tl.program_id(0)  # over batch*seq
+    pid_bs = tl.program_id(0).to(tl.int64)  # over batch*seq
     pid_h = tl.program_id(1)  # over heads
 
     batch_idx = pid_bs // seq_len

--- a/src/liger_kernel/ops/qwen2vl_mrope.py
+++ b/src/liger_kernel/ops/qwen2vl_mrope.py
@@ -22,7 +22,7 @@ def _triton_qwen2vl_mrope(
     BLOCK_SIZE: tl.constexpr,
     BACKWARD_PASS: tl.constexpr = False,
 ):
-    pid = tl.program_id(0)
+    pid = tl.program_id(0).to(tl.int64)
 
     # locate start address
     q_ptr = q_ptr + pid * (n_qh * hd)


### PR DESCRIPTION
## Summary
- Port the `#804` int64 `tl.program_id(0)` cast to two kernels that missed it: `llama4_rope.py` and `qwen2vl_mrope.py`.
- Same int32 overflow hazard as `rope.py` / `rms_norm.py`; Ascend `llama4_rope` already had `.to(tl.int64)`.

## Test plan
- [ ] Existing `test/transformers/test_llama4_rope.py` and `test_qwen2vl_mrope.py` on GPU CI
- Diff is two one-line casts matching the `#804` pattern

Fixes #1335


Made with [Cursor](https://cursor.com)