### PR TITLE
[Perf] Fuse log-softmax into fused_linear_jsd kernel

### DIFF
--- a/src/liger_kernel/ops/fused_linear_jsd.py
+++ b/src/liger_kernel/ops/fused_linear_jsd.py
@@ -2,10 +2,10 @@ from typing import Optional
 
 import torch
 import triton
+import triton.language as tl
 
 from packaging.version import Version
 
-from liger_kernel.ops.jsd import _jsd_kernel
 from liger_kernel.ops.utils import amp_custom_bwd
 from liger_kernel.ops.utils import amp_custom_fwd
 from liger_kernel.ops.utils import element_mul_kernel
@@ -18,6 +18,138 @@ from liger_kernel.utils import infer_device
 MAX_FUSED_SIZE = 4096 if infer_device() == "xpu" else 65536 // 2
 _TORCH_VERSION = Version(torch.__version__.split("+")[0])
 _ADDMM_SUPPORTS_OUT_DTYPE = _TORCH_VERSION >= Version("2.8.0")
+
+# log2(e): lets us emit the hardware ex2.approx instruction via e^x = 2^(x * LOG2_E)
+LOG2_E = tl.constexpr(1.4426950408889634)
+
+
+@triton.jit
+def _fused_linear_jsd_kernel(
+    X_ptr,  # student logits, X = log Q is derived in-kernel, dX is written back in place
+    X_stride,
+    Y_ptr,  # teacher logits, Y = log P is derived in-kernel
+    Y_stride,
+    loss_ptr,
+    loss_stride,
+    label_ptr,
+    beta: tl.constexpr,
+    n_non_ignore: int,
+    ignore_index: tl.constexpr,
+    temperature,
+    n_cols,
+    BLOCK_SIZE: tl.constexpr,
+    HAS_LABEL: tl.constexpr,
+):
+    # Same math as _jsd_kernel, but the log-probabilities are derived from the logits inside the
+    # kernel, so JSD(P || Q) is fused with the two log-softmaxes and the gradient chain rule:
+    # X = log Q = z_X / temperature - lse_X, Y = log P = z_Y / temperature - lse_Y
+    # JSD(P || Q) = (KL(P || M) + KL(Q || M)) / 2, M = (1/2) * (P + Q) = (1/2) * (e ^ Y + e ^ X)
+    #             = sum(P * log P + Q * log Q - 2 * M * log M) / 2
+    #             = sum(e ^ Y * Y + e ^ X * X - 2 * M * log M) / 2
+    # grad_x_i = 0.5 * Q * (X - log_M)
+    # Chaining through the log-softmax Jacobian gives the gradient w.r.t. the student logits z_X:
+    # dz_i = (dX_i - Q_i * sum_j dX_j) / temperature
+    pid = tl.program_id(0).to(tl.int64)
+    X_ptr += pid * X_stride
+    Y_ptr += pid * Y_stride
+    loss_ptr += pid * loss_stride
+    label_ptr += pid
+
+    # 1. Load label first because if the label is ignore_index, we can return right away
+    if HAS_LABEL:
+        label = tl.load(label_ptr)
+        if label == ignore_index:
+            for i in range(0, n_cols, BLOCK_SIZE):
+                offsets = i + tl.arange(0, BLOCK_SIZE)
+                tl.store(X_ptr + offsets, 0.0, mask=offsets < n_cols)
+            return
+
+    inv_temperature = 1.0 / temperature
+
+    # Online softmax: 2 loads + 1 store (compared with 3 loads + 1 store for the safe softmax)
+    # Refer to Algorithm 3 in the paper: https://arxiv.org/pdf/1805.02867
+
+    # 2. [Online softmax] first pass: find max + sum for both X and Y
+    m_X = float("-inf")  # m is the max value. use the notation from the paper
+    d_X = 0.0  # d is the sum. use the notation from the paper
+    m_Y = float("-inf")
+    d_Y = 0.0
+
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        X = tl.load(X_ptr + offsets, mask=mask, other=float("-inf")).to(tl.float32) * inv_temperature
+        Y = tl.load(Y_ptr + offsets, mask=mask, other=float("-inf")).to(tl.float32) * inv_temperature
+
+        block_max_X = tl.max(X, axis=0)
+        m_new_X = tl.maximum(m_X, block_max_X)
+        d_X = d_X * tl.exp2((m_X - m_new_X) * LOG2_E) + tl.sum(tl.exp2((X - m_new_X) * LOG2_E), axis=0)
+        m_X = m_new_X
+
+        block_max_Y = tl.max(Y, axis=0)
+        m_new_Y = tl.maximum(m_Y, block_max_Y)
+        d_Y = d_Y * tl.exp2((m_Y - m_new_Y) * LOG2_E) + tl.sum(tl.exp2((Y - m_new_Y) * LOG2_E), axis=0)
+        m_Y = m_new_Y
+
+    lse_X = m_X + tl.log(d_X)
+    lse_Y = m_Y + tl.log(d_Y)
+
+    # 3. [Online softmax] second pass: accumulate the loss and dX_sum = sum_j dX_j, the only
+    # cross-column term the log-softmax Jacobian needs
+    loss_sum = 0.0
+    dX_sum = 0.0
+
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        X = tl.load(X_ptr + offsets, mask=mask, other=float("-inf")).to(tl.float32) * inv_temperature - lse_X
+        Y = tl.load(Y_ptr + offsets, mask=mask, other=float("-inf")).to(tl.float32) * inv_temperature - lse_Y
+        Q = tl.exp2(X * LOG2_E)  # = exp(X)
+        P = tl.exp2(Y * LOG2_E)  # = exp(Y)
+
+        if beta == 0.0:  # forward KL
+            loss = P * (Y - X)
+            dX = -P
+        elif beta == 1.0:  # reverse KL
+            loss = Q * (X - Y)
+            dX = loss + Q
+        else:
+            M = beta * P + (1 - beta) * Q
+            log_M = tl.log(M)
+
+            loss = beta * P * Y + (1 - beta) * Q * X - M * log_M
+            dX = (1 - beta) * Q * (X - log_M)
+
+        loss_sum += tl.sum(tl.where(mask, loss, 0.0), axis=0)
+        dX_sum += tl.sum(tl.where(mask, dX, 0.0), axis=0)
+
+    # Pre-compute scaling factor
+    scale = 1.0 / n_non_ignore
+    tl.store(loss_ptr, loss_sum * scale)
+
+    # 4. [Online softmax] third pass: compute gradients w.r.t. the student logits. dX and Q are
+    # recomputed rather than kept alive, since a full row of them does not fit in registers.
+    # Here we use a trick to store X_ptr gradient in X_ptr so we can save memory
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        X = tl.load(X_ptr + offsets, mask=mask, other=float("-inf")).to(tl.float32) * inv_temperature - lse_X
+        Y = tl.load(Y_ptr + offsets, mask=mask, other=float("-inf")).to(tl.float32) * inv_temperature - lse_Y
+        Q = tl.exp2(X * LOG2_E)
+        P = tl.exp2(Y * LOG2_E)
+
+        if beta == 0.0:  # forward KL
+            dX = -P
+        elif beta == 1.0:  # reverse KL
+            dX = Q * (X - Y) + Q
+        else:
+            M = beta * P + (1 - beta) * Q
+            log_M = tl.log(M)
+
+            dX = (1 - beta) * Q * (X - log_M)
+
+        dX = (dX - Q * dX_sum) * inv_temperature * scale
+        tl.store(X_ptr + offsets, dX, mask=mask)
 
 
 def fused_linear_jsd_forward(
@@ -33,7 +165,6 @@ def fused_linear_jsd_forward(
     accum_dtype=None,
 ):
     device = student_input.device
-    dtype = student_input.dtype
 
     # inputs have shape: BT x H
     # materialized activations will have shape: BT x V
@@ -58,7 +189,7 @@ def fused_linear_jsd_forward(
         )
     grad_input = torch.zeros_like(student_input)
     # we use fp32 for loss accumulator
-    loss_1d = torch.zeros((BT, V), dtype=torch.float32, device=device)
+    loss_1d = torch.zeros(BT, dtype=torch.float32, device=device)
 
     if has_label:
         n_non_ignore = (shift_labels != ignore_index).sum().item()
@@ -73,63 +204,48 @@ def fused_linear_jsd_forward(
         student_input_chunk = student_input[start_idx:end_idx]
         teacher_input_chunk = teacher_input[start_idx:end_idx]
 
-        # shape: chunk_size x V
-        # For anything starting from logits to the final JSD loss, we do computation
-        # in FP32 to avoid losing numerical stability.
-        student_logits_chunk = (student_input_chunk @ student_weight.t()).to(torch.float32)
-        teacher_logits_chunk = (teacher_input_chunk @ teacher_weight.t()).to(torch.float32)
+        # when doing matmul, use the original precision
+        student_logits_chunk = student_input_chunk @ student_weight.t()  # chunk_size x V
+        teacher_logits_chunk = teacher_input_chunk @ teacher_weight.t()  # chunk_size x V
         chunk_n_rows = student_logits_chunk.shape[0]
 
         # unreduced loss
-        loss_1d_slice = loss_1d[start_idx:end_idx]  # chunk_size
-        # log-softmax with temperature
-        student_logits_chunk = student_logits_chunk / temperature
-        teacher_logits_chunk = teacher_logits_chunk / temperature
-        student_prob_chunk = torch.log_softmax(student_logits_chunk, dim=-1)
-        teacher_prob_chunk = torch.log_softmax(teacher_logits_chunk, dim=-1)
+        loss_1d_slice = loss_1d[start_idx:end_idx]  # chunk_size,
 
-        # ensure _input and target are contiguous
-        student_prob_chunk = student_prob_chunk.contiguous()
-        teacher_prob_chunk = teacher_prob_chunk.contiguous()
+        # ensure student and teacher logits are contiguous
+        student_logits_chunk = student_logits_chunk.contiguous()
+        teacher_logits_chunk = teacher_logits_chunk.contiguous()
 
-        # Here we calculate the gradient of prob_chunk in place so we can save memory.
-        _jsd_kernel[(chunk_n_rows,)](
-            X_ptr=student_prob_chunk,
-            X_stride=student_prob_chunk.stride(-2),
-            Y_ptr=teacher_prob_chunk,
-            Y_stride=teacher_prob_chunk.stride(-2),
+        # Here we calculate both the loss and the gradient of student_logits_chunk in place so we can save memory.
+        _fused_linear_jsd_kernel[(chunk_n_rows,)](
+            X_ptr=student_logits_chunk,
+            X_stride=student_logits_chunk.stride(-2),
+            Y_ptr=teacher_logits_chunk,
+            Y_stride=teacher_logits_chunk.stride(-2),
             loss_ptr=loss_1d_slice,
-            loss_stride=loss_1d_slice.stride(-2),
-            dX_ptr=student_prob_chunk,
-            dX_stride=student_prob_chunk.stride(-2),
+            loss_stride=loss_1d_slice.stride(-1),  # always 1
             label_ptr=(
                 shift_labels[start_idx:end_idx] if has_label else torch.empty(1, device=device)
             ),  # dummy ptr if no label
             beta=jsd_beta,
             n_non_ignore=n_non_ignore,
             ignore_index=ignore_index,
+            temperature=temperature,
             n_cols=V,
             BLOCK_SIZE=BLOCK_SIZE,
             HAS_LABEL=has_label,
+            num_warps=32 if not is_hip() else 16,
         )
         loss_1d[start_idx:end_idx] = loss_1d_slice
-        # gradients of prob_chunk in place, shape: chunk_size x V
-        # gradients of logits_chunk in place, shape: chunk_size x V
-        student_logits_chunk = (
-            student_prob_chunk
-            - torch.softmax(student_logits_chunk, dim=-1)
-            * student_prob_chunk.sum(dim=-1, keepdim=True).broadcast_to(student_prob_chunk.shape)
-        ) / temperature
-        # now we traverse back to grad w.r.t. input to `lm_head` and grad
-        # w.r.t. `lm_head` which should be computed in original dtype
-        student_logits_chunk = student_logits_chunk.to(dtype)
-        grad_input[start_idx:end_idx] = student_logits_chunk @ student_weight
+
+        grad_logits_chunk = student_logits_chunk  # chunk_size x V
+        grad_input[start_idx:end_idx] = grad_logits_chunk @ student_weight
 
         if grad_weight is not None:
             if accum_dtype is None:
-                grad_weight.add_(student_logits_chunk.t() @ student_input_chunk)
+                grad_weight.add_(grad_logits_chunk.t() @ student_input_chunk)
             else:
-                grad_logits_t = student_logits_chunk.t()
+                grad_logits_t = grad_logits_chunk.t()
                 if (
                     _ADDMM_SUPPORTS_OUT_DTYPE
                     and grad_weight.device.type == "cuda"

--- a/test/transformers/test_fused_linear_jsd.py
+++ b/test/transformers/test_fused_linear_jsd.py
@@ -85,6 +85,7 @@ class LigerLMHeadJSD(torch.nn.Module):
     [
         (8, 128, 1024, 4096),
         (4, 423, 167, 1423),  # random shape
+        (1, 4, 64, 40960),  # V > BLOCK_SIZE: multi-block online softmax + partial trailing block
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`fused_linear_jsd` computed its forward in two steps: two `torch.log_softmax`
calls materialized fp32 log-probability tensors, `_jsd_kernel` consumed them, and
the log-softmax Jacobian was then applied back in PyTorch. This PR replaces that
with a single Triton kernel that derives both log-softmaxes from the logits
in-kernel and applies the chain rule inline.

On an H100 with the default chunking (H=4096, V=128256, bf16): **1.50-2.29x
faster** on the full pass and **9.5-44.2% lower peak memory**, both growing with
B*T. At `num_chunks=1` the same change is 2.37-2.68x faster and 26.3-71.2%
lighter.

Math and dtype contract are unchanged — same expression, same fp32 compute, and
`@amp_custom_fwd` / `@amp_custom_bwd` are kept.

## Details

The technique is the `fused_linear_cross_entropy` pattern applied to JSD:

- **Online softmax in-kernel** instead of materializing log-probs — the same
  algorithm (Milakov & Gimelshein, Algorithm 3) `liger_cross_entropy_kernel` uses.
  JSD needs 3 passes rather than CE's 2: pass 1 builds `m`/`d` for student and
  teacher together, pass 2 accumulates the loss and `dX_sum`, pass 3 recomputes
  `dX` and writes the gradient. `dX_sum` is a cross-column term, so it has to be
  known before any gradient is stored.
- **The GEMM keeps the input dtype**, and the cast to fp32 happens at `tl.load`
  rather than on the whole logits tensor after the matmul.
- **`loss_1d` shrinks from `(BT, V)` to `(BT,)`** — the kernel reduces over V
  itself.
- **The student logits buffer is reused in place as the gradient buffer**, the
  same trick FLCE uses.
- `e^x` is emitted as `exp2(x * log2 e)` to reach the hardware `ex2.approx` path.

Peak memory drops from three structural changes, per chunk of `C` rows at vocab
`V` with `s` = bytes per element of the input dtype:

| | before | after |
|---|---|---|
| `loss_1d` (unchunked, scales with `BT`) | `BT · V · 4` | `BT · 4` |
| the two log-prob tensors | `2 · C · V · 4` | — |
| the two logits tensors | `2 · C · V · 4` | `2 · C · V · s` |

The PyTorch Jacobian expression also allocated several more `C · V` temporaries
(`softmax`, the broadcast product, the subtraction, the dtype cast) that the
kernel no longer needs, so the measured saving exceeds what the table accounts
for. Only `loss_1d` scales with `BT` rather than `C`, which is why the reduction
is largest when chunking is coarsest — at `num_chunks=1`, −26.3% at B*T=1024
rising to −71.2% at B*T=8192.

`ops/jsd.py` is deliberately untouched — see the open questions.

## Benchmarks

Hidden size: 4096, Vocab size: 128256, bf16, NVIDIA H100 80GB HBM3. "Liger old"
is the current implementation; the default `num_chunks` for this shape is 32.
Speed is the median over the benchmark harness's runs, memory is peak allocated.

Speed — full pass (ms, median)

| B*T | torch | Liger old | Liger new | new vs old |
|---|---|---|---|---|
| 1024 | 26.41 | 129.52 | 86.26 | 1.50x |
| 2048 | 50.11 | 152.54 | 88.28 | 1.73x |
| 4096 | 98.43 | 178.41 | 89.98 | 1.98x |
| 8192 | 197.89 | 227.74 | 99.31 | 2.29x |

Memory — full pass (MB, peak)

| B*T | torch | Liger old | Liger new | reduction |
|---|---|---|---|---|
| 1024 | 10609 | 5662 | 5122 | −9.5% |
| 2048 | 17146 | 6250 | 5169 | −17.3% |
| 4096 | 30220 | 7425 | 5265 | −29.1% |
| 8192 | 56368 | 9776 | 5455 | −44.2% |

## Open questions

**1. The fp32 rounding point moved, and #336 is the reason to ask.**
[#336](https://github.com/linkedin/Liger-Kernel/pull/336) ("Fix FusedLinearJSD
precision issue when using AMP") made the path cast logits to fp32 right after the
matmul, so that "all the computation between logit to final JSD loss happen on
FP32", guarded by `test_amp`. This PR still does all logit→loss computation in
fp32 — but in registers rather than in HBM, so the GEMM output itself now rounds
to the input dtype. `chunked_loss/jsd_loss.py` already runs `F.log_softmax` on
unconverted bf16 logits, so the two paths were inconsistent before this change and
are consistent after it. `test_amp` passes. Still, this narrows the intent of
#336, so it should be a maintainer call rather than mine.

**2. Should temperature scale the loss by T² rather than T?**
Hinton et al. 2015 multiply the soft-target objective by T², because soft-target
gradients scale as 1/T² and the factor keeps gradient magnitude stable as T
changes. Liger divides by T once, everywhere: here, and in
`chunked_loss/fused_linear_distillation.py`. There is no `temperature ** 2` in the
repo and no mention of temperature in `docs/`, so users currently have to know to
pre-scale themselves. This PR keeps the existing behaviour — changing semantics
does not belong in a perf PR. Worth deciding: fold T² into the kernel, or document
that the caller owns it.

**3. Why the kernel is here and not in `ops/jsd.py`.**
`_jsd_kernel` takes log-probabilities and is public API — `LigerJSDFunction` is
exported from `ops/__init__.py`, reached via `transformers/jsd.py` and
`functional.py`, and its docstring states the log-space contract. The cutile and
Ascend backends carry the same signature. Rewriting it to take logits would break
all of that, so the fused kernel lives in `fused_linear_jsd.py` and `jsd.py` is
unmodified. The cost is two code paths for the same JSD formula. Dedupe or accept
is a maintainer decision.

**4. Aside: the chunking heuristic looks mis-tuned for JSD.**
While benchmarking I swept `num_chunks` from 1 to 32. Speed scales far more
strongly with chunk size than FLCE's heuristic assumes. torch does not chunk, so
its column is the same series throughout and serves as the fixed reference:

Speed — full pass (ms, median), new kernel

| B*T | torch | nc=1 | nc=8 | nc=32 (current default) | nc=1 vs default |
|---|---|---|---|---|---|
| 1024 | 26.41 | 9.69 | 24.25 | 86.26 | 8.90x |
| 2048 | 50.11 | 16.60 | 26.19 | 88.28 | 5.32x |
| 4096 | 98.43 | 30.08 | 39.81 | 89.98 | 2.99x |
| 8192 | 197.89 | 60.62 | 65.38 | 99.31 | 1.64x |

Memory — full pass (MB, peak), new kernel

| B*T | torch | nc=1 | nc=8 | nc=32 (current default) |
|---|---|---|---|---|
| 1024 | 10609 | 5607 | 5169 | 5122 |
| 2048 | 17146 | 6140 | 5263 | 5169 |
| 4096 | 30220 | 7206 | 5453 | 5265 |
| 8192 | 56368 | 9338 | 5831 | 5455 |

Against torch the new kernel is 2.73x / 3.02x / 3.27x / 3.26x faster at `nc=1`,
but 0.31x / 0.57x / 1.09x / 1.99x of torch's speed at the default — so with the
current heuristic it is *slower than plain torch* below B*T≈4096, and only the
coarse-chunk configuration beats torch everywhere. Part of the reason is
structural: the heuristic pins `num_chunks` at `cdiv(V, H) = 32` for every B*T in
this sweep — the chunk size is grown to absorb a larger B*T instead, so even at
B*T=1024 the sequence is still split into 32 pieces, fragmenting work that would
run faster as a single pass. At B*T=1024, `nc=1` buys 8.9x the speed for 9.5%
more memory, and still sits at roughly half of torch's 10609 MB.

`inc_factor = cdiv(V, H)` is inherited from FLCE, but JSD holds more live buffers
per chunk (two distributions plus M, against CE's one), so the formula does not
transfer and currently splits too finely. Notably `chunked_loss/jsd_loss.py`
already uses a flat `chunk_size = 1024` instead of a formula, so there is
precedent for JSD not following FLCE here. I have left the heuristic alone — it is
independent of this kernel and wants its own PR, but the effect is larger than
this one.

## Testing Done

`test_correctness` gained one shape, `(1, 4, 64, 40960)`. Every pre-existing case
had V ≤ 4096, so with `BLOCK_SIZE = min(32768, next_pow2(V))` they all ran
single-block. The old kernel did not care — blocks were independent — but the new
one carries `m`/`d` rescaling and `dX_sum` across blocks, which is the path
production V=128256 takes. V=40960 also leaves a partial trailing block (8192 of
32768 lanes valid), covering the mask × multi-block interaction. 58 → 66 cases.

`make test`: 3914 passed, 942 skipped, 14 xfailed of 4870 collected. Within that
run, `test_fused_linear_jsd.py` 66/66 and `test_jsd.py` 67/67 — `jsd.py` is
unmodified but no longer imported from here, so it is worth confirming. The eight
new cases cover both dtypes across all four beta branches (0.0 forward KL, 0.1 and
0.5 generalized, 1.0 reverse KL).

`make checkstyle`: clean, no diff.

- Hardware Type: H100-80G-HBM3 (also verified on A100)
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
