### PR TITLE
Fix ZeroDivisionError in fused linear cross entropy when weight vocab dim is 0

### DIFF
--- a/src/liger_kernel/ops/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_cross_entropy.py
@@ -87,6 +87,12 @@ def fused_linear_cross_entropy_forward(
     # for ex: BT = 4096*4, V = 32000, H = 4096 ==> inc_factor = 8, chunk_size = 2048
     BT, H = _input.shape
     V = weight.shape[0]
+    assert V > 0, (
+        f"weight must have a non-empty vocab dimension, got weight.shape={tuple(weight.shape)}. "
+        "This usually means the weight tensor has not been materialized yet, e.g. when using "
+        "DeepSpeed ZeRO-3 and the parameter is accessed directly instead of through the module "
+        "forward (which triggers the all-gather). Gather the parameter before calling this function."
+    )
 
     # widen the transient logits budget to C x BT x H (C=1 is a memory floor, not a perf target)
     inc_factor = triton.cdiv(V, _CHUNK_MEM_CONST * H)

--- a/test/transformers/test_fused_linear_cross_entropy.py
+++ b/test/transformers/test_fused_linear_cross_entropy.py
@@ -8,6 +8,7 @@ from test.utils import assert_verbose_allclose
 from test.utils import set_seed
 
 from liger_kernel.ops import LigerFusedLinearCrossEntropyFunction
+from liger_kernel.ops.fused_linear_cross_entropy import fused_linear_cross_entropy_forward
 from liger_kernel.transformers.functional import CrossEntropyOutput
 from liger_kernel.transformers.functional import liger_fused_linear_cross_entropy
 from liger_kernel.transformers.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyLoss
@@ -1108,3 +1109,22 @@ def test_correctness_reduction_none_per_token_grad_output(B, T, H, V, bias, dtyp
     assert_verbose_allclose(lig_gw, ref_gw, atol=atol, rtol=rtol)
     if bias:
         assert_verbose_allclose(lig_gb, ref_gb, atol=atol, rtol=rtol)
+
+
+def test_empty_weight_raises_clear_error():
+    """
+    Regression test for https://github.com/linkedin/Liger-Kernel/issues/767
+
+    When `weight` has a vocab dimension of 0 (e.g. accessing a DeepSpeed ZeRO-3
+    partitioned parameter directly, before it has been gathered), the chunking
+    math used to divide by `inc_factor = cdiv(V, H)`, which is 0 when V is 0.
+    This raised a cryptic `ZeroDivisionError` deep inside triton. We now raise a
+    clear, actionable error instead.
+    """
+    H = 16
+    weight = torch.randn(0, H)
+    _input = torch.randn(4, H, requires_grad=True)
+    target = torch.randint(0, 10, (4,))
+
+    with pytest.raises(AssertionError, match="non-empty vocab dimension"):
+        fused_linear_cross_entropy_forward(_input, weight, target)


### PR DESCRIPTION
## Summary

Fixes #767. This reopens #1289, which I accidentally closed for good by deleting my fork during a repo cleanup (GitHub won't let a PR reopen once the head repo is gone). Same fix, rebased onto current main.

`fused_linear_cross_entropy_forward` computes chunking as:

```python
V = weight.shape[0]
inc_factor = triton.cdiv(V, H)
chunk_size = triton.next_power_of_2(triton.cdiv(BT, inc_factor))
```

When `weight` has a vocab dim of 0, `inc_factor` is 0 and the next `cdiv` divides by zero. The user just sees `ZeroDivisionError: integer division or modulo by zero` raised from inside triton with nothing pointing at the real cause. That is what the reporter in #767 hit, and it comes up with DeepSpeed ZeRO-3 when a partitioned parameter is touched directly before it has been gathered.

This adds an assert before the chunking math with a message that names the actual problem and what to do about it, instead of letting it fall through to triton.

## Details

Kept it as an assert to match the existing validation style at the top of the same function (`return_z_loss`, `return_token_accuracy`, `return_predicted_tokens` all assert). Happy to switch it to a `ValueError` if you would rather it not be strippable under `-O`.

## Testing Done

Added `test_empty_weight_raises_clear_error` in `test/transformers/test_fused_linear_cross_entropy.py`. It runs on CPU since the assert fires before any kernel launch, so it does not need a GPU.

I do not have a GPU on this machine, so I want to be upfront about what I could and could not verify:

- New test passes, and I confirmed it actually catches the bug: reverting just the source change makes it fail with `ZeroDivisionError: integer division or modulo by zero` from `triton/__init__.py`, and restoring the fix makes it pass.
- No regressions: unmodified main gives 141 failed / 0 passed on this file, and with my change it is 141 failed / 1 passed. Same failures either way, all of them `RuntimeError: 0 active drivers` from triton because there is no CUDA device here. The only difference is my new test passing.
- `ruff check` and `ruff format --check` both clean on the two changed files.
- Could not run `make test` or `make test-convergence` for real, both need a GPU. Would appreciate CI covering those.

- Hardware Type: CPU only (no GPU available, see note above)
- [ ] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence