### PR TITLE
[Hopper] Add CuTe DSL and cuTile fused linear cross entropy

### DIFF
--- a/benchmark/scripts/benchmark_cutedsl_fused_linear_cross_entropy_sm90.py
+++ b/benchmark/scripts/benchmark_cutedsl_fused_linear_cross_entropy_sm90.py
@@ -1,0 +1,148 @@
+import torch
+
+from benchmark_model_configs import MODEL_REGISTRY
+from benchmark_model_configs import build_model_config_sweep
+from benchmark_model_configs import build_token_length_sweep
+from benchmark_model_configs import get_benchmark_model_config
+from utils import SingleBenchmarkRunInput
+from utils import build_memory_bench_fn
+from utils import build_speed_bench_fn
+from utils import parse_benchmark_script_args
+from utils import run_benchmarks
+
+from liger_kernel.ops.cutedsl.ops.fused_linear_cross_entropy_sm90 import LigerFusedLinearCrossEntropySM90Function
+from liger_kernel.transformers.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyLoss
+from liger_kernel.utils import infer_device
+
+try:
+    from quack.linear_cross_entropy import chunked_linear_cross_entropy
+except ImportError:
+    chunked_linear_cross_entropy = None
+
+device = infer_device()
+
+
+class TorchLMHeadCE(torch.nn.Module):
+    def __init__(self, hidden_size, vocab_size, dtype):
+        super().__init__()
+        self.linear = torch.nn.Linear(hidden_size, vocab_size, bias=False, dtype=dtype)
+
+    def forward(self, x, target):
+        return torch.nn.functional.cross_entropy(self.linear(x), target)
+
+
+class LigerLMHeadCE(torch.nn.Module):
+    def __init__(self, hidden_size, vocab_size, dtype):
+        super().__init__()
+        self.linear = torch.nn.Linear(hidden_size, vocab_size, bias=False, dtype=dtype)
+        self.cross_entropy = LigerFusedLinearCrossEntropyLoss()
+
+    def forward(self, x, target):
+        return self.cross_entropy(self.linear.weight, x, target)
+
+
+class CuteDSLHopperLMHeadCE(torch.nn.Module):
+    def __init__(self, hidden_size, vocab_size, dtype):
+        super().__init__()
+        if dtype != torch.bfloat16:
+            raise TypeError("CuTe DSL SM90 FLCE requires bfloat16")
+        self.weight = torch.nn.Parameter(torch.empty(vocab_size, hidden_size, dtype=dtype))
+        torch.nn.init.normal_(self.weight, std=hidden_size**-0.5)
+
+    def forward(self, x, target):
+        return LigerFusedLinearCrossEntropySM90Function.apply(x, self.weight, target)
+
+
+class QuackLMHeadCE(torch.nn.Module):
+    def __init__(self, hidden_size, vocab_size, dtype, tokens):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.empty(vocab_size, hidden_size, dtype=dtype))
+        self.tokens = tokens
+        torch.nn.init.normal_(self.weight, std=hidden_size**-0.5)
+
+    def forward(self, x, target):
+        return chunked_linear_cross_entropy(
+            x,
+            self.weight,
+            target,
+            chunk_size=self.tokens,
+        )
+
+
+def setup_cutedsl_fused_linear_cross_entropy_sm90(input: SingleBenchmarkRunInput):
+    cfg = input.extra_benchmark_config
+    if isinstance(input.x, str):
+        model_cfg = MODEL_REGISTRY[input.x]
+        tokens = cfg["seq_len"] * cfg["bsz"]
+        vocab_size = model_cfg.vocab_size
+        hidden_size = model_cfg.hidden_size
+        dtype = model_cfg.dtype
+    else:
+        tokens = input.x
+        vocab_size = cfg["vocab_size"]
+        hidden_size = cfg["hidden_size"]
+        dtype = cfg["dtype"]
+
+    x = torch.randn(tokens, hidden_size, requires_grad=True, dtype=dtype, device=device)
+    target = torch.randint(vocab_size, (tokens,), dtype=torch.long, device=device)
+
+    if input.kernel_provider == "cutedsl-sm90":
+        module = CuteDSLHopperLMHeadCE(hidden_size, vocab_size, dtype)
+    elif input.kernel_provider == "liger":
+        module = LigerLMHeadCE(hidden_size, vocab_size, dtype)
+    elif input.kernel_provider == "quack":
+        module = QuackLMHeadCE(hidden_size, vocab_size, dtype, tokens)
+    else:
+        module = TorchLMHeadCE(hidden_size, vocab_size, dtype)
+    module = module.to(device)
+    return x, lambda _: module(x, target)
+
+
+if __name__ == "__main__":
+    args = parse_benchmark_script_args()
+
+    if args.sweep_mode == "model_config":
+        common_configs = build_model_config_sweep(
+            kernel_name="cutedsl_fused_linear_cross_entropy_sm90",
+            setup_fn=setup_cutedsl_fused_linear_cross_entropy_sm90,
+            model_keys=["hidden_size", "vocab_size", "dtype"],
+            probe_provider="torch",
+            extra_configs={},
+            probe_dim="BT",
+            bt=args.bt,
+            overwrite=args.overwrite,
+        )
+    else:
+        model = get_benchmark_model_config(args.model)
+        common_configs = build_token_length_sweep(
+            kernel_name="cutedsl_fused_linear_cross_entropy_sm90",
+            probe_x=1024,
+            model=model,
+            setup_fn=setup_cutedsl_fused_linear_cross_entropy_sm90,
+            model_keys=["hidden_size", "vocab_size", "dtype"],
+            extra_configs={},
+            scale_dim="BT",
+            x_label="total tokens",
+            probe_provider="torch",
+            overwrite=args.overwrite,
+        )
+
+    providers = ["torch", "liger", "cutedsl-sm90"]
+    if chunked_linear_cross_entropy is not None:
+        providers.append("quack")
+    common_configs["kernel_providers"] = providers
+
+    run_benchmarks(
+        bench_test_fn=build_speed_bench_fn(setup_cutedsl_fused_linear_cross_entropy_sm90),
+        kernel_operation_modes=["forward", "full"],
+        metric_name="speed",
+        metric_unit="ms",
+        **common_configs,
+    )
+    run_benchmarks(
+        bench_test_fn=build_memory_bench_fn(setup_cutedsl_fused_linear_cross_entropy_sm90),
+        kernel_operation_modes=["full"],
+        metric_name="memory",
+        metric_unit="MB",
+        **common_configs,
+    )

--- a/benchmark/scripts/benchmark_cutile_fused_linear_cross_entropy_sm90.py
+++ b/benchmark/scripts/benchmark_cutile_fused_linear_cross_entropy_sm90.py
@@ -1,0 +1,124 @@
+import torch
+
+from benchmark_model_configs import MODEL_REGISTRY
+from benchmark_model_configs import build_model_config_sweep
+from benchmark_model_configs import build_token_length_sweep
+from benchmark_model_configs import get_benchmark_model_config
+from utils import SingleBenchmarkRunInput
+from utils import build_memory_bench_fn
+from utils import build_speed_bench_fn
+from utils import parse_benchmark_script_args
+from utils import run_benchmarks
+
+from liger_kernel.ops.cutile.ops.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyFunction
+from liger_kernel.utils import infer_device
+
+try:
+    from quack.linear_cross_entropy import chunked_linear_cross_entropy
+except ImportError:
+    chunked_linear_cross_entropy = None
+
+device = infer_device()
+
+
+class TorchLMHeadCE(torch.nn.Module):
+    def __init__(self, hidden_size, vocab_size, dtype):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.empty(vocab_size, hidden_size, dtype=dtype))
+        torch.nn.init.normal_(self.weight, std=hidden_size**-0.5)
+
+    def forward(self, x, target):
+        return torch.nn.functional.cross_entropy(torch.nn.functional.linear(x, self.weight), target)
+
+
+class CutileHopperLMHeadCE(TorchLMHeadCE):
+    def forward(self, x, target):
+        return LigerFusedLinearCrossEntropyFunction.apply(x, self.weight, target)[0]
+
+
+class QuackLMHeadCE(TorchLMHeadCE):
+    def __init__(self, hidden_size, vocab_size, dtype, tokens):
+        super().__init__(hidden_size, vocab_size, dtype)
+        self.tokens = tokens
+
+    def forward(self, x, target):
+        return chunked_linear_cross_entropy(x, self.weight, target, chunk_size=self.tokens)
+
+
+def setup_cutile_fused_linear_cross_entropy_sm90(input: SingleBenchmarkRunInput):
+    cfg = input.extra_benchmark_config
+    if isinstance(input.x, str):
+        model_cfg = MODEL_REGISTRY[input.x]
+        tokens = cfg["seq_len"] * cfg["bsz"]
+        vocab_size = model_cfg.vocab_size
+        hidden_size = model_cfg.hidden_size
+        dtype = model_cfg.dtype
+    else:
+        tokens = input.x
+        vocab_size = cfg["vocab_size"]
+        hidden_size = cfg["hidden_size"]
+        dtype = cfg["dtype"]
+
+    x = torch.randn(tokens, hidden_size, requires_grad=True, dtype=dtype, device=device)
+    target = torch.randint(vocab_size, (tokens,), dtype=torch.long, device=device)
+
+    if input.kernel_provider == "cutile-sm90":
+        module = CutileHopperLMHeadCE(hidden_size, vocab_size, dtype)
+    elif input.kernel_provider == "quack":
+        module = QuackLMHeadCE(hidden_size, vocab_size, dtype, tokens)
+    else:
+        module = TorchLMHeadCE(hidden_size, vocab_size, dtype)
+    module = module.to(device)
+    return x, lambda _: module(x, target)
+
+
+if __name__ == "__main__":
+    args = parse_benchmark_script_args()
+
+    if args.sweep_mode == "model_config":
+        common_configs = build_model_config_sweep(
+            kernel_name="cutile_fused_linear_cross_entropy_sm90",
+            setup_fn=setup_cutile_fused_linear_cross_entropy_sm90,
+            model_keys=["hidden_size", "vocab_size", "dtype"],
+            probe_provider="torch",
+            extra_configs={},
+            probe_dim="BT",
+            bt=args.bt,
+            overwrite=args.overwrite,
+        )
+    else:
+        model = get_benchmark_model_config(args.model)
+        common_configs = build_token_length_sweep(
+            kernel_name="cutile_fused_linear_cross_entropy_sm90",
+            probe_x=1024,
+            model=model,
+            setup_fn=setup_cutile_fused_linear_cross_entropy_sm90,
+            model_keys=["hidden_size", "vocab_size", "dtype"],
+            extra_configs={},
+            scale_dim="BT",
+            x_label="total tokens",
+            probe_provider="torch",
+            overwrite=args.overwrite,
+        )
+
+    providers = ["torch", "cutile-sm90"]
+    if chunked_linear_cross_entropy is not None:
+        providers.append("quack")
+    common_configs["kernel_providers"] = providers
+
+    run_benchmarks(
+        bench_test_fn=build_speed_bench_fn(setup_cutile_fused_linear_cross_entropy_sm90),
+        # Retained-graph backward is invalid because all fused providers update
+        # their saved precomputed gradients in place.
+        kernel_operation_modes=["forward", "full"],
+        metric_name="speed",
+        metric_unit="ms",
+        **common_configs,
+    )
+    run_benchmarks(
+        bench_test_fn=build_memory_bench_fn(setup_cutile_fused_linear_cross_entropy_sm90),
+        kernel_operation_modes=["full"],
+        metric_name="memory",
+        metric_unit="MB",
+        **common_configs,
+    )

--- a/benchmark/scripts/benchmark_fused_linear_cross_entropy.py
+++ b/benchmark/scripts/benchmark_fused_linear_cross_entropy.py
@@ -1,3 +1,5 @@
+import os
+
 import torch
 
 from benchmark_model_configs import MODEL_REGISTRY
@@ -76,6 +78,7 @@ def setup_fused_linear_cross_entropy(input: SingleBenchmarkRunInput):
 
 if __name__ == "__main__":
     args = parse_benchmark_script_args()
+    cutile_backend = os.environ.get("LIGER_KERNEL_IMPL", "").strip().lower() == "cutile"
 
     if args.sweep_mode == "model_config":
         common_configs = build_model_config_sweep(
@@ -109,11 +112,13 @@ if __name__ == "__main__":
             overwrite=args.overwrite,
         )
 
-    common_configs["kernel_providers"] = ["torch", "liger", "liger-fp32-accum"]
+    common_configs["kernel_providers"] = (
+        ["torch", "liger"] if cutile_backend else ["torch", "liger", "liger-fp32-accum"]
+    )
 
     run_benchmarks(
         bench_test_fn=build_speed_bench_fn(setup_fused_linear_cross_entropy),
-        kernel_operation_modes=["forward", "backward", "full"],
+        kernel_operation_modes=["forward", "full"] if cutile_backend else ["forward", "backward", "full"],
         metric_name="speed",
         metric_unit="ms",
         **common_configs,

--- a/benchmark/scripts/run_cutile_compare.py
+++ b/benchmark/scripts/run_cutile_compare.py
@@ -20,6 +20,7 @@ import sys
 
 CUTILE_ENABLED_KERNELS = [
     "cross_entropy",
+    "fused_linear_cross_entropy",
     "fused_linear_jsd",
     "geglu",
     "jsd",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def get_optional_dependencies():
         "cuda-tile[tileiras]",
     ]
     cutedsl_deps = [
-        "nvidia-cutlass-dsl>=4.5.2",
+        "nvidia-cutlass-dsl>=4.6.0",
     ]
     dev_deps = [
         "transformers>=4.52.0",

--- a/src/liger_kernel/ops/cutedsl/ops/__init__.py
+++ b/src/liger_kernel/ops/cutedsl/ops/__init__.py
@@ -15,6 +15,9 @@ from liger_kernel.ops.cutedsl.ops.cross_entropy import LigerCrossEntropyFunction
 from liger_kernel.ops.cutedsl.ops.cross_entropy import cross_entropy_backward
 from liger_kernel.ops.cutedsl.ops.cross_entropy import cross_entropy_forward
 from liger_kernel.ops.cutedsl.ops.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyFunction
+from liger_kernel.ops.cutedsl.ops.fused_linear_cross_entropy_sm90 import LigerFusedLinearCrossEntropySM90Function
+from liger_kernel.ops.cutedsl.ops.fused_linear_cross_entropy_sm90 import fused_linear_cross_entropy_forward_sm90
+from liger_kernel.ops.cutedsl.ops.fused_linear_cross_entropy_sm90 import liger_fused_linear_cross_entropy_sm90
 from liger_kernel.ops.cutedsl.ops.fused_scaled_cross_entropy_sm90 import LigerFusedScaledCrossEntropySM90Function
 from liger_kernel.ops.cutedsl.ops.fused_scaled_cross_entropy_sm90 import fused_scaled_cross_entropy_backward
 from liger_kernel.ops.cutedsl.ops.fused_scaled_cross_entropy_sm90 import fused_scaled_cross_entropy_forward
@@ -35,6 +38,9 @@ __all__ = [
     "cross_entropy_backward",
     "cross_entropy_forward",
     "LigerFusedLinearCrossEntropyFunction",
+    "LigerFusedLinearCrossEntropySM90Function",
+    "fused_linear_cross_entropy_forward_sm90",
+    "liger_fused_linear_cross_entropy_sm90",
     "LigerFusedScaledCrossEntropySM90Function",
     "fused_scaled_cross_entropy_backward",
     "fused_scaled_cross_entropy_forward",

--- a/src/liger_kernel/ops/cutedsl/ops/_fused_linear_cross_entropy_backward_sm90.py
+++ b/src/liger_kernel/ops/cutedsl/ops/_fused_linear_cross_entropy_backward_sm90.py
@@ -1,0 +1,105 @@
+"""Hopper (SM90) CuTe DSL fused-linear-cross-entropy **backward** GEMMs.
+
+The FLCE gradients follow the "gradient-in-forward" contract used by the Triton
+``LigerFusedLinearCrossEntropyFunction`` and by QuACK's
+``chunked_linear_cross_entropy``: the autograd *forward* has already produced
+
+    ``dZ[M, V] = (softmax(X @ W.T) - onehot(target)) * row_scale``
+
+(``row_scale`` folds the ``mean``/``sum`` reduction in), and this module turns
+that into the two parameter gradients with the shared WGMMA GEMM primitive
+:class:`~liger_kernel.ops.cutedsl.ops._fused_linear_cross_entropy_forward_sm90._TileGemmSM90`:
+
+    ``dX[M, H] = dZ[M, V] @ W[V, H]``      (A K-major over V, B MN-major over H)
+    ``dW[V, H] = dZ.T[V, M] @ X[M, H]``    (both operands MN-major)
+
+Both are expressed as ``C = A @ B.T`` by passing transposed *views* (never
+materialised transposes) of ``dZ``/``W``/``X`` and telling the loader which dim
+of each view is contiguous. The dX GEMM runs in autograd forward, while dW is
+deferred to autograd backward so its epilogue can apply the upstream scale.
+"""
+
+import cuda.bindings.driver as cuda
+import torch
+
+from liger_kernel.ops.cutedsl.ops._fused_linear_cross_entropy_forward_sm90 import tile_gemm
+
+
+def flce_dx(dz, weight, out_dtype=torch.bfloat16, output_scale=None):
+    """``dX[M, H] = dZ[M, V] @ W[V, H]``.
+
+    ``dz[M, V]`` is BF16 row-major (V contiguous).  ``weight[V, H]`` is BF16
+    row-major (H contiguous); its transpose view ``[H, V]`` is passed as the
+    MN-major B operand so ``C = A @ B.T = dZ @ W``.
+    """
+    with torch.cuda.device(dz.device):
+        m, v = dz.shape
+        h = weight.shape[1]
+        dx = torch.empty(m, h, device=dz.device, dtype=out_dtype)
+        weight_t = weight.transpose(0, 1)  # [H, V] view, H contiguous
+        stream = cuda.CUstream(torch.cuda.current_stream(dz.device).cuda_stream)
+        # A = dZ[M, V], K = V contiguous -> leading_dim 1
+        # B = W.T[H, V], H contiguous     -> leading_dim 0
+        tile_gemm(
+            dz,
+            weight_t,
+            dx,
+            a_leading=1,
+            b_leading=0,
+            stream=stream,
+            output_scale=output_scale,
+        )
+        return dx
+
+
+def flce_dw(dz, x, out_dtype=torch.bfloat16, output_scale=None):
+    """``dW[V, H] = dZ.T[V, M] @ X[M, H]``.
+
+    Both operands are MN-major transposed views: ``dZ.T[V, M]`` (V contiguous)
+    and ``X.T[H, M]`` (H contiguous), so ``C = A @ B.T = dZ.T @ X``.
+    """
+    import os
+
+    with torch.cuda.device(dz.device):
+        m, v = dz.shape
+        h = x.shape[1]
+        dw = torch.empty(v, h, device=dz.device, dtype=out_dtype)
+        dz_t = dz.transpose(0, 1)  # [V, M] view, V contiguous
+        x_t = x.transpose(0, 1)  # [H, M] view, H contiguous
+        stream = cuda.CUstream(torch.cuda.current_stream(dz.device).cuda_stream)
+        # A = dZ.T[V, M], V contiguous -> leading_dim 0
+        # B = X.T[H, M],  H contiguous -> leading_dim 0
+        # dW scheduling.  ``swap_grid=True`` transposes the launch grid so the GPU's
+        # x-fastest CTA order makes consecutive CTAs share the same A tile (an M-tile
+        # of dZ.T) across all N columns; that A tile is fetched from DRAM once and
+        # reused out of L2, and the 32 MB B operand stays L2-resident.  This static
+        # raster already delivers the QuACK-style L2 locality (77% L2 hit, 90.9%
+        # tensor-pipe active, 6.47 ms NCU on M=4096,H=4096,V=128256) at zero extra
+        # complexity.
+        #
+        # A fully persistent one-wave scheduler (``persistent=True`` -> the
+        # ``kernel_persistent`` path with a continuous TMA pipeline + async TMA-store
+        # epilogue) reaches an even better memory profile (81.8% L2 hit, 19% DRAM,
+        # waves=1 -- matching QuACK's) but is net *slower* (7.07 ms, 83% tensor): its
+        # shared-accumulator epilogue barriers block the single warp that also drives
+        # the TMA producer, so the tensor cores idle ~17% at every tile boundary.
+        # Beating the static raster from here needs a warp-specialized,
+        # double-buffered-accumulator epilogue (dedicate a warp-group to the store so
+        # the MMA WGs run the next tile uninterrupted); that path is left behind the
+        # ``FLCE_DW_PERSISTENT=1`` env toggle for future work.  Default: static raster.
+        persistent = os.environ.get("FLCE_DW_PERSISTENT", "0") != "0"
+        tile_gemm(
+            dz_t,
+            x_t,
+            dw,
+            a_leading=0,
+            b_leading=0,
+            stream=stream,
+            swap_grid=True,
+            output_scale=output_scale,
+            persistent=persistent,
+        )
+        return dw
+
+
+__all__ = ["flce_dx", "flce_dw"]

--- a/src/liger_kernel/ops/cutedsl/ops/_fused_linear_cross_entropy_backward_sm90.py
+++ b/src/liger_kernel/ops/cutedsl/ops/_fused_linear_cross_entropy_backward_sm90.py
@@ -69,7 +69,10 @@ def flce_dw(dz, x, out_dtype=torch.bfloat16, output_scale=None):
         stream = cuda.CUstream(torch.cuda.current_stream(dz.device).cuda_stream)
         # A = dZ.T[V, M], V contiguous -> leading_dim 0
         # B = X.T[H, M],  H contiguous -> leading_dim 0
-        # dW scheduling.  ``swap_grid=True`` transposes the launch grid so the GPU's
+        # dW scheduling. The default clustered persistent helper is selected inside
+        # ``tile_gemm`` and fuses ``output_scale`` into its TMA-store epilogue.
+        # ``FLCE_DW_CLUSTERED_PERSISTENT=0`` restores this static fallback.
+        # ``swap_grid=True`` transposes the fallback launch grid so the GPU's
         # x-fastest CTA order makes consecutive CTAs share the same A tile (an M-tile
         # of dZ.T) across all N columns; that A tile is fetched from DRAM once and
         # reused out of L2, and the 32 MB B operand stays L2-resident.  This static
@@ -77,7 +80,7 @@ def flce_dw(dz, x, out_dtype=torch.bfloat16, output_scale=None):
         # tensor-pipe active, 6.47 ms NCU on M=4096,H=4096,V=128256) at zero extra
         # complexity.
         #
-        # A fully persistent one-wave scheduler (``persistent=True`` -> the
+        # The older unclustered one-wave scheduler (``persistent=True`` -> the
         # ``kernel_persistent`` path with a continuous TMA pipeline + async TMA-store
         # epilogue) reaches an even better memory profile (81.8% L2 hit, 19% DRAM,
         # waves=1 -- matching QuACK's) but is net *slower* (7.07 ms, 83% tensor): its

--- a/src/liger_kernel/ops/cutedsl/ops/_fused_linear_cross_entropy_forward_sm90.py
+++ b/src/liger_kernel/ops/cutedsl/ops/_fused_linear_cross_entropy_forward_sm90.py
@@ -1,0 +1,1323 @@
+"""Hopper (SM90) CuTe DSL fused-linear-cross-entropy **forward** building blocks.
+
+This module owns two device kernels used by
+:mod:`liger_kernel.ops.cutedsl.ops.fused_linear_cross_entropy_sm90`:
+
+``_TileGemmSM90``
+    A warp-specialised WGMMA GEMM that computes ``C[M, N] = A[M, K] @ B[N, K].T``
+    with BF16 operands and an FP32 accumulator.  Each operand may be either
+    *K-major* (the contraction dim is contiguous, ``leading_dim`` points at it)
+    or *MN-major* (the M/N dim is contiguous).  A single tiled-MMA topology
+    (cooperative split-M over two WGMMA warp groups, ``M128 x N256 x K64``,
+    3 stages) drives all three logical GEMMs of the FLCE:
+
+    ==========  ==========================  ==============  ==============
+    GEMM        maths                        A layout        B layout
+    ==========  ==========================  ==============  ==============
+    logits      ``X[M,H] @ W[V,H].T``        K-major (H)     K-major (H)
+    dX          ``dZ[M,V] @ W[V,H]``         K-major (V)     MN-major (H)
+    dW          ``dZ.T[V,M] @ X[M,H]``       MN-major (V)    MN-major (H)
+    ==========  ==========================  ==============  ==============
+
+    The mainloop is the proven "warp-0-of-WG0 issues every TMA" software
+    pipeline: a single linear ``cp.async.bulk.tensor`` load stream feeds a
+    3-stage SMEM buffer, one WGMMA group stays in flight across each
+    release+refill, and the pipeline is drained exactly once per output tile.
+
+``_CrossEntropyClusterVector``
+    The preferred one-read CE path. Eight clustered CTAs cooperatively process
+    each row using aligned 128-bit copies, retain exponentials in registers, and
+    merge partition statistics through ordered deterministic DSMEM peer loads.
+    Shapes outside its bounded register/tail contract fall back to the original
+    two-kernel ``_CrossEntropyPartials`` + ``_CrossEntropyDZ`` implementation.
+    Both paths write ``dZ = (softmax(logits) - onehot(target)) * row_scale`` over
+    the BF16 logits in place.
+
+Only the pieces needed for a correct first functional FLCE are implemented:
+Hopper SM90, BF16 contiguous ``x[M, H]`` / ``w[V, H]``, int64 ``target[M]``.
+``H`` is padded up to ``TILE_N`` internally (a contraction-dim pad is exact);
+``M`` and ``V`` are guarded to be tile-aligned by the caller.
+"""
+
+from typing import Optional
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+
+from cutlass import BFloat16
+from cutlass import Float32
+from cutlass import Int32
+from cutlass import pipeline
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cutlass_dsl import T
+from cutlass.cutlass_dsl import dsl_user_op
+from cutlass.pipeline.helpers import pipeline_init_arrive
+from cutlass.pipeline.helpers import pipeline_init_wait
+from cutlass.utils import LayoutEnum
+from cutlass.utils import hopper_helpers
+
+from liger_kernel.ops.cutedsl.ops.utils import to_cute_tensor
+
+TILE_M = 128
+TILE_N = 256
+TILE_K = 64
+STAGES = 3
+NUM_MMA_WG = 2
+THREADS = NUM_MMA_WG * 128
+
+# Persistent dW epilogue: stage the FP32 accumulator into a small BF16 SMEM
+# buffer one 64-wide column sub-tile at a time and TMA-store it asynchronously,
+# double/quad-buffered, so the store overlaps the next tile's WGMMA mainloop
+# instead of draining the pipeline (the synchronous SMEM->GMEM epilogue idled
+# the tensor cores ~40% of the time under the one-CTA/SM persistent schedule).
+DW_STORE_TILE_N = 256
+DW_STORE_STAGES = 1
+DW_SUBTILES = TILE_N // DW_STORE_TILE_N
+DW_STORE_BARRIER_ID = 1
+
+
+WARPS_PER_CE_CTA = 8
+CE_THREADS = WARPS_PER_CE_CTA * 32
+CE_SCRATCH_VALUES = WARPS_PER_CE_CTA * 3 + 3
+CE_PARTITIONS = 8
+CE_VECTOR = 8
+CE_VECTOR_BITS = CE_VECTOR * 16
+CE_VECTOR_TILE = CE_THREADS * CE_VECTOR
+CE_VECTOR_VALUES_PER_THREAD = 64
+NEG_INF_F32 = -3.0e38
+LOG2_E = 1.4426950408889634
+LN2 = 0.6931471805599453
+
+
+@dsl_user_op
+def _map_dsmem_addr(local_ptr, peer_rank, *, loc=None, ip=None) -> Int32:
+    """Map a local SMEM pointer into a peer CTA's cluster-shared window."""
+    addr = llvm.ptrtoint(T.i32(), local_ptr.llvm_ptr, loc=loc, ip=ip)
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [addr, Int32(peer_rank).ir_value(loc=loc, ip=ip)],
+            "mapa.shared::cluster.u32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _dsmem_load_f32(addr, *, loc=None, ip=None) -> Float32:
+    """Load one FP32 value from a deterministic peer DSMEM address."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Int32(addr).ir_value(loc=loc, ip=ip)],
+            "ld.shared::cluster.f32 $0, [$1];",
+            "=f,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# WGMMA GEMM: C[M, N] = A[M, K] @ B[N, K].T
+# ---------------------------------------------------------------------------
+class _TileGemmSM90:
+    """BF16 WGMMA GEMM with a K-major/MN-major agnostic operand loader."""
+
+    def __init__(self, swap_grid=False, scale_output=False, persistent=False, num_sms=0):
+        self.swap_grid = swap_grid
+        self.scale_output = scale_output
+        # ``persistent`` launches exactly ``num_sms`` CTAs (one wave) and streams
+        # a flattened m-outer/n-inner tile schedule through a single continuous
+        # TMA software pipeline.  Used for the dW GEMM, whose 1 GB A operand
+        # (dZ.T[V, M]) otherwise thrashes L2 across ~121 scheduling waves.
+        self.persistent = persistent
+        self.num_sms = num_sms
+
+    @staticmethod
+    def _make_tma(tensor, smem_layout_staged, smem_tile):
+        smem_layout = cute.slice_(smem_layout_staged, (None, None, 0))
+        return cute.nvgpu.cpasync.make_tiled_tma_atom(
+            cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp(),
+            tensor,
+            smem_layout,
+            smem_tile,
+            num_multicast=1,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        c: cute.Tensor,
+        output_scale: Optional[cute.Tensor],
+        stream: cuda.CUstream,
+    ):
+        a_layout = LayoutEnum.from_tensor(a)
+        b_layout = LayoutEnum.from_tensor(b)
+        tile_shape = (TILE_M, TILE_N, TILE_K)
+        tiled_mma = hopper_helpers.make_trivial_tiled_mma(
+            BFloat16,
+            BFloat16,
+            a_layout.sm90_mma_major_mode(),
+            b_layout.sm90_mma_major_mode(),
+            Float32,
+            (NUM_MMA_WG, 1, 1),
+            (64, TILE_N),
+        )
+        a_smem_layout = hopper_helpers.make_smem_layout_a(a_layout, tile_shape, BFloat16, STAGES)
+        b_smem_layout = hopper_helpers.make_smem_layout_b(b_layout, tile_shape, BFloat16, STAGES)
+        tma_a, ta = self._make_tma(a, a_smem_layout, (TILE_M, TILE_K))
+        tma_b, tb = self._make_tma(b, b_smem_layout, (TILE_N, TILE_K))
+
+        m = a.shape[0]
+        n = b.shape[0]
+        grid_m = cute.ceil_div(m, TILE_M)
+        grid_n = cute.ceil_div(n, TILE_N)
+
+        if cutlass.const_expr(self.persistent):
+            # Persistent path: async TMA-store epilogue with a multi-stage BF16
+            # store buffer (sD) instead of the synchronous sC drain.
+            c_layout = LayoutEnum.from_tensor(c)
+            store_smem_layout = hopper_helpers.make_smem_layout_epi(
+                BFloat16, c_layout, (TILE_M, DW_STORE_TILE_N), DW_STORE_STAGES
+            )
+            tma_c_store, _tc = cute.nvgpu.cpasync.make_tiled_tma_atom(
+                cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp(),
+                c,
+                cute.slice_(store_smem_layout, (None, None, 0)),
+                (TILE_M, DW_STORE_TILE_N),
+            )
+
+            @cute.struct
+            class StoragePersistent:
+                pipe: cute.struct.MemRange[cutlass.Int64, STAGES * 2]
+                sA: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(a_smem_layout)], 1024]
+                sB: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(b_smem_layout)], 1024]
+                sD: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(store_smem_layout)], 1024]
+
+            self.storage_t = StoragePersistent
+            self.kernel_persistent(
+                tma_a,
+                ta,
+                tma_b,
+                tb,
+                c,
+                _tc,
+                output_scale,
+                tiled_mma,
+                a_smem_layout,
+                b_smem_layout,
+                tma_c_store,
+                store_smem_layout,
+            ).launch(
+                grid=(self.num_sms, 1, 1),
+                block=(THREADS, 1, 1),
+                stream=stream,
+            )
+            return
+
+        @cute.struct
+        class Storage:
+            pipe: cute.struct.MemRange[cutlass.Int64, STAGES * 2]
+            sA: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(a_smem_layout)], 1024]
+            sB: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(b_smem_layout)], 1024]
+            sC: cute.struct.Align[cute.struct.MemRange[BFloat16, TILE_M * (TILE_N + 8)], 1024]
+
+        # Plain row-major epilogue SMEM tile with a +8 column pad.  The pad makes
+        # consecutive rows land in different SMEM banks, so the strided WGMMA
+        # register -> (row, col) scatter is bank-conflict free.
+        c_smem_layout = cute.make_layout((TILE_M, TILE_N), stride=(TILE_N + 8, 1))
+        self.storage_t = Storage
+        grid = (grid_n, grid_m, 1) if self.swap_grid else (grid_m, grid_n, 1)
+        self.kernel(
+            tma_a,
+            ta,
+            tma_b,
+            tb,
+            c,
+            output_scale,
+            tiled_mma,
+            a_smem_layout,
+            b_smem_layout,
+            c_smem_layout,
+        ).launch(
+            grid=grid,
+            block=(THREADS, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        tma_a: cute.CopyAtom,
+        a: cute.Tensor,
+        tma_b: cute.CopyAtom,
+        b: cute.Tensor,
+        c: cute.Tensor,
+        output_scale: Optional[cute.Tensor],
+        tiled_mma: cute.TiledMma,
+        a_smem_layout: cute.ComposedLayout,
+        b_smem_layout: cute.ComposedLayout,
+        c_smem_layout: cute.Layout,
+    ):
+        tid, _, _ = cute.arch.thread_idx()
+        warp = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        warp_group = cute.arch.make_warp_uniform(tid // 128)
+        lane = tid % 32
+        local_warp = (tid % 128) // 32
+        block_x, block_y, _ = cute.arch.block_idx()
+        pid_m = block_y if self.swap_grid else block_x
+        pid_n = block_x if self.swap_grid else block_y
+
+        if warp == 0:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_a)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_b)
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.storage_t)
+        sA = storage.sA.get_tensor(a_smem_layout.outer, swizzle=a_smem_layout.inner)
+        sB = storage.sB.get_tensor(b_smem_layout.outer, swizzle=b_smem_layout.inner)
+        sC = storage.sC.get_tensor(c_smem_layout)
+
+        tile_shape = (TILE_M, TILE_N, TILE_K)
+        gA = cute.local_tile(a, cute.slice_(tile_shape, (None, 0, None)), (None, None, None))
+        gB = cute.local_tile(b, cute.slice_(tile_shape, (0, None, None)), (None, None, None))
+        tAsA, tAgA = cute.nvgpu.cpasync.tma_partition(
+            tma_a,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sA, 0, 2),
+            cute.group_modes(gA, 0, 2),
+        )
+        tBsB, tBgB = cute.nvgpu.cpasync.tma_partition(
+            tma_b,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sB, 0, 2),
+            cute.group_modes(gB, 0, 2),
+        )
+
+        tma_bytes = cute.size_in_bytes(BFloat16, cute.slice_(a_smem_layout, (None, None, 0))) + cute.size_in_bytes(
+            BFloat16, cute.slice_(b_smem_layout, (None, None, 0))
+        )
+
+        mainloop = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.pipe.data_ptr(),
+            num_stages=STAGES,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, NUM_MMA_WG * 4),
+            tx_count=tma_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+            defer_sync=True,
+        )
+        pipeline_init_arrive(cluster_shape_mn=(1, 1), is_relaxed=True)
+        pipeline_init_wait(cluster_shape_mn=(1, 1))
+
+        num_k_tiles = cute.size(gA, mode=[3])
+        num_k_blocks = TILE_K // 16
+
+        cute.arch.setmaxregister_increase(240)
+        mma_wg_layout = cute.make_layout(NUM_MMA_WG, stride=128)
+        thr_mma = tiled_mma.get_slice(mma_wg_layout(Int32(warp_group)))
+        tCrA = tiled_mma.make_fragment_A(thr_mma.partition_A(sA))
+        tCrB = tiled_mma.make_fragment_B(thr_mma.partition_B(sB))
+        accum = cute.make_rmem_tensor(thr_mma.partition_shape_C((TILE_M, TILE_N)), Float32)
+        n_accum = cute.size(accum)
+
+        tAgA_m = tAgA[(None, pid_m, None, 0)]
+        tBgB_n = tBgB[(None, pid_n, None, 0)]
+
+        load_index = Int32(0)
+        load_phase = Int32(1)
+        read_index = Int32(0)
+        read_phase = Int32(0)
+        rel_index = Int32(0)
+        rel_phase = Int32(0)
+        load_k = Int32(0)
+
+        # ---- prologue: STAGES loads on the single TMA warp ---------------
+        if warp == 0:
+            prologue = cutlass.min(Int32(STAGES), Int32(num_k_tiles))
+            for _ in range(prologue):
+                ps = pipeline.PipelineState(STAGES, Int32(0), load_index, load_phase)
+                mainloop.producer_acquire(ps)
+                bar = mainloop.producer_get_barrier(ps)
+                cute.copy(tma_a, tAgA_m[(None, load_k)], tAsA[(None, load_index)], tma_bar_ptr=bar, mcast_mask=0)
+                cute.copy(tma_b, tBgB_n[(None, load_k)], tBsB[(None, load_index)], tma_bar_ptr=bar)
+                mainloop.producer_commit(ps)
+                ps.advance()
+                load_index = ps.index
+                load_phase = ps.phase
+                load_k += 1
+
+        accum.fill(0.0)
+        tiled_mma.set(cute.nvgpu.warpgroup.Field.ACCUMULATE, True)
+
+        # ---- k == 0: no stage to release yet -----------------------------
+        rs = pipeline.PipelineState(STAGES, Int32(0), read_index, read_phase)
+        mainloop.consumer_wait(rs)
+        cute.nvgpu.warpgroup.fence()
+        for kb in cutlass.range_constexpr(num_k_blocks):
+            cute.gemm(tiled_mma, accum, tCrA[(None, None, kb, read_index)], tCrB[(None, None, kb, read_index)], accum)
+        cute.nvgpu.warpgroup.commit_group()
+        rs.advance()
+        read_index = rs.index
+        read_phase = rs.phase
+
+        # ---- steady state: release the previous stage, refill it ---------
+        for _ in range(1, num_k_tiles):
+            rs = pipeline.PipelineState(STAGES, Int32(0), read_index, read_phase)
+            mainloop.consumer_wait(rs)
+            cute.nvgpu.warpgroup.fence()
+            for kb in cutlass.range_constexpr(num_k_blocks):
+                cute.gemm(
+                    tiled_mma, accum, tCrA[(None, None, kb, read_index)], tCrB[(None, None, kb, read_index)], accum
+                )
+            cute.nvgpu.warpgroup.commit_group()
+            cute.nvgpu.warpgroup.wait_group(1)
+            rst = pipeline.PipelineState(STAGES, Int32(0), rel_index, rel_phase)
+            mainloop.consumer_release(rst)
+            rst.advance()
+            rel_index = rst.index
+            rel_phase = rst.phase
+            if warp == 0 and load_k < num_k_tiles:
+                ps = pipeline.PipelineState(STAGES, Int32(0), load_index, load_phase)
+                mainloop.producer_acquire(ps)
+                bar = mainloop.producer_get_barrier(ps)
+                cute.copy(tma_a, tAgA_m[(None, load_k)], tAsA[(None, load_index)], tma_bar_ptr=bar, mcast_mask=0)
+                cute.copy(tma_b, tBgB_n[(None, load_k)], tBsB[(None, load_index)], tma_bar_ptr=bar)
+                mainloop.producer_commit(ps)
+                ps.advance()
+                load_index = ps.index
+                load_phase = ps.phase
+                load_k += 1
+            rs.advance()
+            read_index = rs.index
+            read_phase = rs.phase
+
+        # ---- tile tail: the only full WGMMA drain ------------------------
+        cute.nvgpu.warpgroup.wait_group(0)
+        rst = pipeline.PipelineState(STAGES, Int32(0), rel_index, rel_phase)
+        mainloop.consumer_release(rst)
+        rst.advance()
+        rel_index = rst.index
+        rel_phase = rst.phase
+        if warp == 0:
+            ptail = pipeline.PipelineState(STAGES, Int32(0), load_index, load_phase)
+            mainloop.producer_tail(ptail)
+
+        # ---- epilogue: stage the FP32 WGMMA accumulator into plain SMEM via
+        # the validated register -> (row, col) map, then drain SMEM -> GMEM with
+        # fully coalesced stores.  The old path wrote each accumulator element
+        # straight to GMEM through the strided WGMMA map, so a warp's 32 lanes
+        # touched only a few columns per row (25% global store sector use);
+        # staging through SMEM lets adjacent lanes write adjacent columns of one
+        # row (100% sector use), which lifts the WGMMA tensor pipe from ~73% to
+        # ~91% (logits) / ~84% (dW) active on H200.
+        row_base = warp_group * 64 + local_warp * 16 + lane // 4
+        col_base = (lane % 4) * 2
+        c_dtype = c.element_type
+        scale = Float32(output_scale[0]) if cutlass.const_expr(self.scale_output) else Float32(1.0)
+        for i in cutlass.range_constexpr(n_accum):
+            row = row_base + ((i % 4) // 2) * 8
+            col = col_base + (i // 4) * 8 + (i % 2)
+            sC[row, col] = c_dtype(accum[i] * scale)
+        cute.arch.barrier()
+
+        gC = cute.local_tile(c, (TILE_M, TILE_N), (pid_m, pid_n))
+        # Element e = k * THREADS + tid: within any warp the 32 lanes cover 32
+        # consecutive columns of the same row, so every store is coalesced.
+        drain_iters = (TILE_M * TILE_N) // THREADS
+        for k in cutlass.range_constexpr(drain_iters):
+            e = k * THREADS + tid
+            row = e // TILE_N
+            col = e % TILE_N
+            gC[row, col] = sC[row, col]
+
+    @cute.kernel
+    def kernel_persistent(
+        self,
+        tma_a: cute.CopyAtom,
+        a: cute.Tensor,
+        tma_b: cute.CopyAtom,
+        b: cute.Tensor,
+        c: cute.Tensor,
+        c_store: cute.Tensor,
+        output_scale: Optional[cute.Tensor],
+        tiled_mma: cute.TiledMma,
+        a_smem_layout: cute.ComposedLayout,
+        b_smem_layout: cute.ComposedLayout,
+        tma_c_store: cute.CopyAtom,
+        store_smem_layout: cute.ComposedLayout,
+    ):
+        # Persistent one-wave scheduler for the dW GEMM.  ``num_sms`` CTAs are
+        # launched; CTA ``cid`` owns the flattened output tiles ``cid, cid +
+        # num_sms, cid + 2*num_sms, ...`` decoded m-outer / n-inner
+        # (``pid_m = lin // grid_n``, ``pid_n = lin % grid_n``).  Because the CTAs
+        # march the linear index in lockstep, every 132-tile window covers ~8 A
+        # rows x all N columns, so each 1 MB A tile is fetched from DRAM once and
+        # reused ``grid_n`` times out of L2 (and the whole B operand stays
+        # resident), collapsing the dW DRAM footprint that the multi-wave launch
+        # re-streamed 121 times.  The TMA load pipeline runs *continuously* across
+        # tile boundaries (ring index/phase carried; compute drained only at each
+        # epilogue), and the epilogue TMA-stores each 64-wide column sub-tile
+        # asynchronously so the store overlaps the next tile's WGMMA mainloop
+        # instead of stalling the tensor cores.
+        num_sms = cutlass.const_expr(self.num_sms)
+        tid, _, _ = cute.arch.thread_idx()
+        warp = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        warp_group = cute.arch.make_warp_uniform(tid // 128)
+        lane = tid % 32
+        local_warp = (tid % 128) // 32
+        block_x, _, _ = cute.arch.block_idx()
+        cta_id = Int32(block_x)
+
+        if warp == 0:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_a)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_b)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_c_store)
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.storage_t)
+        sA = storage.sA.get_tensor(a_smem_layout.outer, swizzle=a_smem_layout.inner)
+        sB = storage.sB.get_tensor(b_smem_layout.outer, swizzle=b_smem_layout.inner)
+        sD = storage.sD.get_tensor(store_smem_layout.outer, swizzle=store_smem_layout.inner)
+
+        tile_shape = (TILE_M, TILE_N, TILE_K)
+        gA = cute.local_tile(a, cute.slice_(tile_shape, (None, 0, None)), (None, None, None))
+        gB = cute.local_tile(b, cute.slice_(tile_shape, (0, None, None)), (None, None, None))
+        tAsA, tAgA = cute.nvgpu.cpasync.tma_partition(
+            tma_a,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sA, 0, 2),
+            cute.group_modes(gA, 0, 2),
+        )
+        tBsB, tBgB = cute.nvgpu.cpasync.tma_partition(
+            tma_b,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sB, 0, 2),
+            cute.group_modes(gB, 0, 2),
+        )
+        # Output tiled into (TILE_M, DW_STORE_TILE_N) sub-tiles for the TMA store.
+        # ``c_store`` is the store TMA's coord tensor (mirrors how the loads tile
+        # the load TMAs' coord tensors ``a``/``b`` rather than the raw operands).
+        gDW = cute.local_tile(c_store, (TILE_M, DW_STORE_TILE_N), (None, None))
+        tDsD, tDgD = cute.nvgpu.cpasync.tma_partition(
+            tma_c_store,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sD, 0, 2),
+            cute.group_modes(gDW, 0, 2),
+        )
+
+        tma_bytes = cute.size_in_bytes(BFloat16, cute.slice_(a_smem_layout, (None, None, 0))) + cute.size_in_bytes(
+            BFloat16, cute.slice_(b_smem_layout, (None, None, 0))
+        )
+
+        mainloop = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.pipe.data_ptr(),
+            num_stages=STAGES,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, NUM_MMA_WG * 4),
+            tx_count=tma_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+            defer_sync=True,
+        )
+        pipeline_init_arrive(cluster_shape_mn=(1, 1), is_relaxed=True)
+        pipeline_init_wait(cluster_shape_mn=(1, 1))
+
+        store_bar = pipeline.NamedBarrier(barrier_id=DW_STORE_BARRIER_ID, num_threads=THREADS)
+
+        num_k_tiles = cute.size(gA, mode=[3])
+        num_k_blocks = TILE_K // 16
+
+        cute.arch.setmaxregister_increase(240)
+        mma_wg_layout = cute.make_layout(NUM_MMA_WG, stride=128)
+        thr_mma = tiled_mma.get_slice(mma_wg_layout(Int32(warp_group)))
+        tCrA = tiled_mma.make_fragment_A(thr_mma.partition_A(sA))
+        tCrB = tiled_mma.make_fragment_B(thr_mma.partition_B(sB))
+        accum = cute.make_rmem_tensor(thr_mma.partition_shape_C((TILE_M, TILE_N)), Float32)
+
+        grid_m = cute.ceil_div(c.shape[0], TILE_M)
+        grid_n = cute.ceil_div(c.shape[1], TILE_N)
+        total_tiles = Int32(grid_m * grid_n)
+        num_tiles_for_cta = (total_tiles - cta_id + Int32(num_sms - 1)) // Int32(num_sms)
+        total_k = num_tiles_for_cta * Int32(num_k_tiles)
+
+        # Epilogue constants (tile-independent).
+        row_base = warp_group * 64 + local_warp * 16 + lane // 4
+        col_base = (lane % 4) * 2
+        c_dtype = c.element_type
+        scale = Float32(output_scale[0]) if cutlass.const_expr(self.scale_output) else Float32(1.0)
+        issuer = warp == 0
+        # Per-thread FP32 accumulator registers that map into one 64-wide column
+        # sub-tile: (TILE_M * DW_STORE_TILE_N) / THREADS.  For sub-tile ``sub``
+        # these are the contiguous chunk ``accum[sub_frag*sub : +sub_frag]``.
+        sub_frag = (TILE_M * DW_STORE_TILE_N) // THREADS
+
+        load_index = Int32(0)
+        load_phase = Int32(1)
+        read_index = Int32(0)
+        read_phase = Int32(0)
+        rel_index = Int32(0)
+        rel_phase = Int32(0)
+        gload = Int32(0)
+        gk_consumed = Int32(0)
+
+        # ---- one-time prologue: STAGES loads (decoded from the global k idx) --
+        if warp == 0:
+            prologue = cutlass.min(Int32(STAGES), total_k)
+            for _ in range(prologue):
+                gtile = gload // Int32(num_k_tiles)
+                gkk = gload % Int32(num_k_tiles)
+                glin = cta_id + gtile * Int32(num_sms)
+                gpm = glin // grid_n
+                gpn = glin % grid_n
+                ps = pipeline.PipelineState(STAGES, Int32(0), load_index, load_phase)
+                mainloop.producer_acquire(ps)
+                bar = mainloop.producer_get_barrier(ps)
+                cute.copy(
+                    tma_a,
+                    tAgA[(None, gpm, None, 0)][(None, gkk)],
+                    tAsA[(None, load_index)],
+                    tma_bar_ptr=bar,
+                    mcast_mask=0,
+                )
+                cute.copy(tma_b, tBgB[(None, gpn, None, 0)][(None, gkk)], tBsB[(None, load_index)], tma_bar_ptr=bar)
+                mainloop.producer_commit(ps)
+                ps.advance()
+                load_index = ps.index
+                load_phase = ps.phase
+                gload += 1
+
+        tiled_mma.set(cute.nvgpu.warpgroup.Field.ACCUMULATE, True)
+
+        # ---- persistent tile loop ---------------------------------------
+        tile_ord = Int32(0)
+        for _ in range(num_tiles_for_cta):
+            lin = cta_id + tile_ord * Int32(num_sms)
+            pid_m = lin // grid_n
+            pid_n = lin % grid_n
+            accum.fill(0.0)
+
+            for _ in range(num_k_tiles):
+                rs = pipeline.PipelineState(STAGES, Int32(0), read_index, read_phase)
+                mainloop.consumer_wait(rs)
+                cute.nvgpu.warpgroup.fence()
+                for kb in cutlass.range_constexpr(num_k_blocks):
+                    cute.gemm(
+                        tiled_mma, accum, tCrA[(None, None, kb, read_index)], tCrB[(None, None, kb, read_index)], accum
+                    )
+                cute.nvgpu.warpgroup.commit_group()
+                # Release the stage consumed on the previous global k step and
+                # refill it, keeping exactly one WGMMA group in flight.
+                if gk_consumed > 0:
+                    cute.nvgpu.warpgroup.wait_group(1)
+                    rst = pipeline.PipelineState(STAGES, Int32(0), rel_index, rel_phase)
+                    mainloop.consumer_release(rst)
+                    rst.advance()
+                    rel_index = rst.index
+                    rel_phase = rst.phase
+                    if warp == 0 and gload < total_k:
+                        gtile = gload // Int32(num_k_tiles)
+                        gkk = gload % Int32(num_k_tiles)
+                        glin = cta_id + gtile * Int32(num_sms)
+                        gpm = glin // grid_n
+                        gpn = glin % grid_n
+                        ps = pipeline.PipelineState(STAGES, Int32(0), load_index, load_phase)
+                        mainloop.producer_acquire(ps)
+                        bar = mainloop.producer_get_barrier(ps)
+                        cute.copy(
+                            tma_a,
+                            tAgA[(None, gpm, None, 0)][(None, gkk)],
+                            tAsA[(None, load_index)],
+                            tma_bar_ptr=bar,
+                            mcast_mask=0,
+                        )
+                        cute.copy(
+                            tma_b, tBgB[(None, gpn, None, 0)][(None, gkk)], tBsB[(None, load_index)], tma_bar_ptr=bar
+                        )
+                        mainloop.producer_commit(ps)
+                        ps.advance()
+                        load_index = ps.index
+                        load_phase = ps.phase
+                        gload += 1
+                rs.advance()
+                read_index = rs.index
+                read_phase = rs.phase
+                gk_consumed += 1
+
+            # ---- tile tail: drain the last WGMMA, then async TMA store -----
+            cute.nvgpu.warpgroup.wait_group(0)
+            for sub in cutlass.range_constexpr(DW_SUBTILES):
+                stage = sub % DW_STORE_STAGES
+                # Throttle to <= DW_STORE_STAGES outstanding stores so this sD
+                # stage is free to overwrite.
+                if issuer:
+                    cute.arch.cp_async_bulk_wait_group(DW_STORE_STAGES - 1, read=True)
+                store_bar.arrive_and_wait()
+                # Scatter this sub-tile's 64 columns of the FP32 accumulator into
+                # the BF16 store buffer using the validated register->(row, col)
+                # map (accum[sub_frag*sub : sub_frag*sub + sub_frag] == columns
+                # [DW_STORE_TILE_N*sub, +DW_STORE_TILE_N)).
+                for jj in cutlass.range_constexpr(sub_frag):
+                    row = row_base + ((jj % 4) // 2) * 8
+                    col = col_base + (jj // 4) * 8 + (jj % 2)
+                    sD[row, col, stage] = c_dtype(accum[sub_frag * sub + jj] * scale)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                store_bar.arrive_and_wait()
+                if issuer:
+                    cute.copy(
+                        tma_c_store,
+                        tDsD[(None, stage)],
+                        tDgD[(None, pid_m, pid_n * DW_SUBTILES + sub)],
+                    )
+                    cute.arch.cp_async_bulk_commit_group()
+            tile_ord += 1
+
+        # ---- final trailing release + single pipeline drain -------------
+        if gk_consumed > 0:
+            rst = pipeline.PipelineState(STAGES, Int32(0), rel_index, rel_phase)
+            mainloop.consumer_release(rst)
+            rst.advance()
+            rel_index = rst.index
+            rel_phase = rst.phase
+            if warp == 0:
+                ptail = pipeline.PipelineState(STAGES, Int32(0), load_index, load_phase)
+                mainloop.producer_tail(ptail)
+        # Drain every outstanding TMA store before the kernel exits.
+        if issuer:
+            cute.arch.cp_async_bulk_wait_group(0, read=True)
+        store_bar.arrive_and_wait()
+        if issuer:
+            cute.arch.cp_async_bulk_wait_group(0)
+
+
+# ---------------------------------------------------------------------------
+# Cross entropy + dZ formation (warp per row)
+# ---------------------------------------------------------------------------
+class _CrossEntropyPartials:
+    """Compute online-softmax state for one row/vocabulary partition per CTA."""
+
+    @cute.jit
+    def __call__(
+        self,
+        logits: cute.Tensor,
+        target: cute.Tensor,
+        partials: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        m = target.shape[0]
+        grid = (m, CE_PARTITIONS, 1)
+
+        @cute.struct
+        class Storage:
+            scratch: cute.struct.Align[
+                cute.struct.MemRange[Float32, CE_SCRATCH_VALUES],
+                16,
+            ]
+
+        self.storage_t = Storage
+        self.kernel(logits, target, partials).launch(
+            grid=grid,
+            block=(CE_THREADS, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        logits: cute.Tensor,
+        target: cute.Tensor,
+        partials: cute.Tensor,
+    ):
+        tid, _, _ = cute.arch.thread_idx()
+        row, partition, _ = cute.arch.block_idx()
+        lane = tid % 32
+        warp = tid // 32
+        m = target.shape[0]
+        v_size = logits.shape[1]
+
+        if row < m:
+            smem = cutlass.utils.SmemAllocator()
+            storage = smem.allocate(self.storage_t)
+            scratch = storage.scratch.get_tensor(cute.make_layout(CE_SCRATCH_VALUES))
+            tgt = Int32(target[row])
+            partition_size = cute.ceil_div(v_size, CE_PARTITIONS)
+            partition_start = partition * partition_size
+            partition_end = cutlass.min(partition_start + partition_size, v_size)
+
+            run_max = Float32(NEG_INF_F32)
+            run_sum = Float32(0.0)
+            tgt_logit = Float32(0.0)
+            v = partition_start + tid
+            while v < partition_end:
+                lg = Float32(logits[row, v])
+                new_max = cute.arch.fmax(run_max, lg)
+                run_sum = run_sum * cute.math.exp2((run_max - new_max) * LOG2_E, fastmath=True) + cute.math.exp2(
+                    (lg - new_max) * LOG2_E, fastmath=True
+                )
+                run_max = new_max
+                if v == tgt:
+                    tgt_logit = lg
+                v += CE_THREADS
+
+            warp_max = cute.arch.warp_reduction_max(run_max)
+            if lane == 0:
+                scratch[warp] = warp_max
+            cute.arch.sync_threads()
+
+            if warp == 0:
+                candidate_max = scratch[lane] if lane < WARPS_PER_CE_CTA else Float32(NEG_INF_F32)
+                block_max = cute.arch.warp_reduction_max(candidate_max)
+                if lane == 0:
+                    scratch[3 * WARPS_PER_CE_CTA] = block_max
+            cute.arch.sync_threads()
+
+            block_max = scratch[3 * WARPS_PER_CE_CTA]
+            local_sum = run_sum * cute.math.exp2(
+                (run_max - block_max) * LOG2_E,
+                fastmath=True,
+            )
+            warp_sum = cute.arch.warp_reduction_sum(local_sum)
+            if lane == 0:
+                scratch[WARPS_PER_CE_CTA + warp] = warp_sum
+            cute.arch.sync_threads()
+
+            warp_target = cute.arch.warp_reduction_sum(tgt_logit)
+            if lane == 0:
+                scratch[2 * WARPS_PER_CE_CTA + warp] = warp_target
+            cute.arch.sync_threads()
+
+            if warp == 0:
+                candidate_sum = scratch[WARPS_PER_CE_CTA + lane] if lane < WARPS_PER_CE_CTA else Float32(0.0)
+                candidate_target = scratch[2 * WARPS_PER_CE_CTA + lane] if lane < WARPS_PER_CE_CTA else Float32(0.0)
+                block_sum = cute.arch.warp_reduction_sum(candidate_sum)
+                block_target = cute.arch.warp_reduction_sum(candidate_target)
+                if lane == 0:
+                    partials[row, partition, 0] = block_max
+                    partials[row, partition, 1] = block_sum
+                    partials[row, partition, 2] = block_target
+
+
+class _CrossEntropyDZ:
+    """Merge partial softmax states and overwrite logits with scaled dZ."""
+
+    @cute.jit
+    def __call__(
+        self,
+        logits: cute.Tensor,
+        target: cute.Tensor,
+        partials: cute.Tensor,
+        nll: cute.Tensor,
+        dz: cute.Tensor,
+        row_scale: Float32,
+        ignore_index: Int32,
+        stream: cuda.CUstream,
+    ):
+        m = target.shape[0]
+        grid = (m, 1, 1)
+
+        @cute.struct
+        class Storage:
+            stats: cute.struct.Align[cute.struct.MemRange[Float32, 3], 16]
+
+        self.storage_t = Storage
+        self.kernel(logits, target, partials, nll, dz, row_scale, ignore_index).launch(
+            grid=grid,
+            block=(CE_THREADS, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        logits: cute.Tensor,
+        target: cute.Tensor,
+        partials: cute.Tensor,
+        nll: cute.Tensor,
+        dz: cute.Tensor,
+        row_scale: Float32,
+        ignore_index: Int32,
+    ):
+        tid, _, _ = cute.arch.thread_idx()
+        row, _, _ = cute.arch.block_idx()
+        lane = tid % 32
+        warp = tid // 32
+        m = target.shape[0]
+        v_size = logits.shape[1]
+
+        if row < m:
+            smem = cutlass.utils.SmemAllocator()
+            storage = smem.allocate(self.storage_t)
+            stats = storage.stats.get_tensor(cute.make_layout(3))
+            tgt = Int32(target[row])
+            ignore = tgt == ignore_index
+
+            if warp == 0:
+                partial_max = partials[row, lane, 0] if lane < CE_PARTITIONS else Float32(NEG_INF_F32)
+                block_max = cute.arch.warp_reduction_max(partial_max)
+                partial_sum = (
+                    partials[row, lane, 1]
+                    * cute.math.exp2(
+                        (partial_max - block_max) * LOG2_E,
+                        fastmath=True,
+                    )
+                    if lane < CE_PARTITIONS
+                    else Float32(0.0)
+                )
+                partial_target = partials[row, lane, 2] if lane < CE_PARTITIONS else Float32(0.0)
+                block_sum = cute.arch.warp_reduction_sum(partial_sum)
+                target_logit = cute.arch.warp_reduction_sum(partial_target)
+                if lane == 0:
+                    stats[0] = block_max
+                    stats[1] = block_sum
+                    stats[2] = target_logit
+                    lse = block_max + cute.math.log2(block_sum, fastmath=True) * LN2
+                    nll[row] = Float32(0.0) if ignore else lse - target_logit
+            cute.arch.sync_threads()
+
+            block_max = stats[0]
+            inv_sum = 1.0 / stats[1]
+            v = tid
+            while v < v_size:
+                lg = Float32(logits[row, v])
+                g = cute.math.exp2((lg - block_max) * LOG2_E, fastmath=True) * inv_sum
+                if v == tgt:
+                    g = g - 1.0
+                if ignore:
+                    g = Float32(0.0)
+                dz[row, v] = BFloat16(g * row_scale)
+                v += CE_THREADS
+
+
+class _CrossEntropyClusterVector:
+    """One-read cluster CE using aligned 128-bit CuTe G2R/R2G tiled copies."""
+
+    def __init__(self, partition_size):
+        vector_tiles = partition_size // CE_VECTOR_TILE
+        tail_values = partition_size - vector_tiles * CE_VECTOR_TILE
+        self.partition_size = partition_size
+        self.vector_tiles = vector_tiles
+        self.tail_threads = tail_values // CE_VECTOR
+
+    @cute.jit
+    def __call__(
+        self,
+        logits: cute.Tensor,
+        target: cute.Tensor,
+        nll: cute.Tensor,
+        row_scale: Float32,
+        ignore_index: Int32,
+        stream: cuda.CUstream,
+    ):
+        g2r_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyG2ROp(),
+            BFloat16,
+            num_bits_per_copy=CE_VECTOR_BITS,
+        )
+        r2g_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyR2GOp(),
+            BFloat16,
+            num_bits_per_copy=CE_VECTOR_BITS,
+        )
+        vector_copy_g2r = cute.make_tiled_copy_tv(
+            g2r_atom,
+            cute.make_layout((CE_THREADS, 1), stride=(1, CE_THREADS)),
+            cute.make_layout((1, CE_VECTOR), stride=(CE_VECTOR, 1)),
+        )
+        vector_copy_r2g = cute.make_tiled_copy_tv(
+            r2g_atom,
+            cute.make_layout((CE_THREADS, 1), stride=(1, CE_THREADS)),
+            cute.make_layout((1, CE_VECTOR), stride=(CE_VECTOR, 1)),
+        )
+
+        @cute.struct
+        class Storage:
+            scratch: cute.struct.Align[
+                cute.struct.MemRange[Float32, WARPS_PER_CE_CTA],
+                16,
+            ]
+            stats: cute.struct.Align[cute.struct.MemRange[Float32, 6], 16]
+
+        self.storage_t = Storage
+        self.kernel(
+            logits,
+            target,
+            nll,
+            row_scale,
+            ignore_index,
+            vector_copy_g2r,
+            vector_copy_r2g,
+        ).launch(
+            grid=(CE_PARTITIONS * target.shape[0], 1, 1),
+            block=(CE_THREADS, 1, 1),
+            cluster=(CE_PARTITIONS, 1, 1),
+            stream=stream,
+        )
+
+    @cute.jit
+    def _load_tail(
+        self,
+        g_partition: cute.Tensor,
+        vector_copy_g2r: cute.TiledCopy,
+        tid: Int32,
+        retained: cute.Tensor,
+    ):
+        g_tail_linear = cute.local_tile(
+            g_partition,
+            (CE_VECTOR_TILE,),
+            (self.vector_tiles,),
+        )
+        g_tail = cute.make_tensor(
+            g_tail_linear.iterator,
+            cute.make_layout((CE_THREADS, CE_VECTOR), stride=(CE_VECTOR, 1)),
+        )
+        tail_source = vector_copy_g2r.get_slice(tid).partition_S(g_tail)
+        tail_fragment = cute.make_rmem_tensor_like(tail_source, BFloat16)
+        cute.copy(vector_copy_g2r, tail_source, tail_fragment)
+        tail_values = tail_fragment.load().to(Float32)
+        for j in cutlass.range_constexpr(CE_VECTOR):
+            retained[self.vector_tiles * CE_VECTOR + j] = tail_values[j]
+
+    @cute.jit
+    def _store_tail(
+        self,
+        g_partition: cute.Tensor,
+        vector_copy_r2g: cute.TiledCopy,
+        tid: Int32,
+        retained: cute.Tensor,
+        inv_sum: Float32,
+        effective_scale: Float32,
+    ):
+        g_tail_linear = cute.local_tile(
+            g_partition,
+            (CE_VECTOR_TILE,),
+            (self.vector_tiles,),
+        )
+        g_tail = cute.make_tensor(
+            g_tail_linear.iterator,
+            cute.make_layout((CE_THREADS, CE_VECTOR), stride=(CE_VECTOR, 1)),
+        )
+        tail_destination = vector_copy_r2g.get_slice(tid).partition_D(g_tail)
+        tail_fragment = cute.make_rmem_tensor_like(tail_destination, BFloat16)
+        for j in cutlass.range_constexpr(CE_VECTOR):
+            tail_fragment[j] = BFloat16(retained[self.vector_tiles * CE_VECTOR + j] * inv_sum * effective_scale)
+        cute.copy(vector_copy_r2g, tail_fragment, tail_destination)
+
+    @cute.kernel
+    def kernel(
+        self,
+        logits: cute.Tensor,
+        target: cute.Tensor,
+        nll: cute.Tensor,
+        row_scale: Float32,
+        ignore_index: Int32,
+        vector_copy_g2r: cute.TiledCopy,
+        vector_copy_r2g: cute.TiledCopy,
+    ):
+        tid, _, _ = cute.arch.thread_idx()
+        block, _, _ = cute.arch.block_idx()
+        partition = block % CE_PARTITIONS
+        row = block // CE_PARTITIONS
+        lane = tid % 32
+        warp = tid // 32
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.storage_t)
+        scratch = storage.scratch.get_tensor(cute.make_layout(WARPS_PER_CE_CTA))
+        stats = storage.stats.get_tensor(cute.make_layout(6))
+
+        pipeline_init_arrive(cluster_shape_mn=(CE_PARTITIONS, 1), is_relaxed=True)
+        pipeline_init_wait(cluster_shape_mn=(CE_PARTITIONS, 1))
+
+        partition_start = partition * self.partition_size
+        partition_end = partition_start + self.partition_size
+        tgt = Int32(target[row])
+        ignore = tgt == ignore_index
+        effective_scale = Float32(0.0) if ignore else row_scale
+
+        g_row = logits[(row, None)]
+        g_partition = cute.local_tile(
+            g_row,
+            (self.partition_size,),
+            (partition,),
+        )
+        retained = cute.make_rmem_tensor((CE_VECTOR_VALUES_PER_THREAD,), Float32)
+        retained.fill(Float32(NEG_INF_F32))
+        thread_copy_g2r = vector_copy_g2r.get_slice(tid)
+
+        for tile in cutlass.range_constexpr(self.vector_tiles):
+            g_tile_linear = cute.local_tile(g_partition, (CE_VECTOR_TILE,), (tile,))
+            g_tile = cute.make_tensor(
+                g_tile_linear.iterator,
+                cute.make_layout((CE_THREADS, CE_VECTOR), stride=(CE_VECTOR, 1)),
+            )
+            source = thread_copy_g2r.partition_S(g_tile)
+            fragment = cute.make_rmem_tensor_like(source, BFloat16)
+            cute.copy(vector_copy_g2r, source, fragment)
+            values = fragment.load().to(Float32)
+            for j in cutlass.range_constexpr(CE_VECTOR):
+                retained[tile * CE_VECTOR + j] = values[j]
+
+        if tid < self.tail_threads:
+            self._load_tail(
+                g_partition,
+                vector_copy_g2r,
+                tid,
+                retained,
+            )
+
+        local_max = Float32(NEG_INF_F32)
+        for i in cutlass.range_constexpr(CE_VECTOR_VALUES_PER_THREAD):
+            local_max = cute.arch.fmax(local_max, retained[i])
+        warp_max = cute.arch.warp_reduction_max(local_max)
+        if lane == 0:
+            scratch[warp] = warp_max
+        cute.arch.sync_threads()
+        if warp == 0:
+            candidate = scratch[lane] if lane < WARPS_PER_CE_CTA else Float32(NEG_INF_F32)
+            block_max = cute.arch.warp_reduction_max(candidate)
+            if lane == 0:
+                stats[0] = block_max
+        cute.arch.sync_threads()
+
+        # Peers publish their maxima before deterministic DSMEM reads.
+        cute.arch.cluster_arrive()
+        cute.arch.cluster_wait()
+        if tid == 0:
+            cluster_max = Float32(NEG_INF_F32)
+            for peer in cutlass.range_constexpr(CE_PARTITIONS):
+                peer_stats = _map_dsmem_addr(storage.stats.data_ptr(), peer)
+                cluster_max = cute.arch.fmax(cluster_max, _dsmem_load_f32(peer_stats))
+            stats[3] = cluster_max
+        cute.arch.sync_threads()
+
+        cluster_max = stats[3]
+        local_sum = Float32(0.0)
+        for i in cutlass.range_constexpr(CE_VECTOR_VALUES_PER_THREAD):
+            exp_value = cute.math.exp2(
+                (retained[i] - cluster_max) * LOG2_E,
+                fastmath=True,
+            )
+            retained[i] = exp_value
+            local_sum += exp_value
+        warp_sum = cute.arch.warp_reduction_sum(local_sum)
+        if lane == 0:
+            scratch[warp] = warp_sum
+        cute.arch.sync_threads()
+        if warp == 0:
+            candidate = scratch[lane] if lane < WARPS_PER_CE_CTA else Float32(0.0)
+            block_sum = cute.arch.warp_reduction_sum(candidate)
+            if lane == 0:
+                stats[1] = block_sum
+        if tid == 0:
+            stats[2] = (
+                Float32(logits[row, tgt])
+                if tgt >= partition_start and tgt < partition_end and not ignore
+                else Float32(0.0)
+            )
+        cute.arch.sync_threads()
+
+        # Peers publish sums and target logits before the second DSMEM merge.
+        cute.arch.cluster_arrive()
+        cute.arch.cluster_wait()
+        if tid == 0:
+            cluster_sum = Float32(0.0)
+            target_logit = Float32(0.0)
+            for peer in cutlass.range_constexpr(CE_PARTITIONS):
+                peer_stats = _map_dsmem_addr(storage.stats.data_ptr(), peer)
+                cluster_sum += _dsmem_load_f32(peer_stats + 4)
+                target_logit += _dsmem_load_f32(peer_stats + 8)
+            stats[4] = cute.arch.rcp_approx(cluster_sum)
+            if partition == 0:
+                lse = cluster_max + cute.math.log2(cluster_sum, fastmath=True) * LN2
+                nll[row] = Float32(0.0) if ignore else lse - target_logit
+        cute.arch.sync_threads()
+
+        # Keep every DSMEM window alive until every peer has finished reading it.
+        cute.arch.cluster_arrive()
+        cute.arch.cluster_wait()
+
+        inv_sum = stats[4]
+        thread_copy_r2g = vector_copy_r2g.get_slice(tid)
+        for tile in cutlass.range_constexpr(self.vector_tiles):
+            g_tile_linear = cute.local_tile(g_partition, (CE_VECTOR_TILE,), (tile,))
+            g_tile = cute.make_tensor(
+                g_tile_linear.iterator,
+                cute.make_layout((CE_THREADS, CE_VECTOR), stride=(CE_VECTOR, 1)),
+            )
+            destination = thread_copy_r2g.partition_D(g_tile)
+            fragment = cute.make_rmem_tensor_like(destination, BFloat16)
+            for j in cutlass.range_constexpr(CE_VECTOR):
+                fragment[j] = BFloat16(retained[tile * CE_VECTOR + j] * inv_sum * effective_scale)
+            cute.copy(vector_copy_r2g, fragment, destination)
+
+        if tid < self.tail_threads:
+            self._store_tail(
+                g_partition,
+                vector_copy_r2g,
+                tid,
+                retained,
+                inv_sum,
+                effective_scale,
+            )
+
+        # Select exactly one thread after every vector store has completed.
+        cute.arch.sync_threads()
+        if (
+            not ignore
+            and tgt >= partition_start
+            and tgt < partition_end
+            and tid == (tgt - partition_start) % CE_THREADS
+        ):
+            logits[row, tgt] = BFloat16(Float32(logits[row, tgt]) - row_scale)
+
+
+# ---------------------------------------------------------------------------
+# compile caches (compile once per (shape, layout) signature)
+# ---------------------------------------------------------------------------
+_gemm_cache = {}
+_ce_partials_cache = {}
+_ce_dz_cache = {}
+_ce_cluster_vector_cache = {}
+
+
+def _gemm_key(a, b, c, swap_grid, scale_output, persistent):
+    return (
+        tuple(a.shape),
+        tuple(a.stride()),
+        a.dtype,
+        tuple(b.shape),
+        tuple(b.stride()),
+        b.dtype,
+        tuple(c.shape),
+        c.dtype,
+        swap_grid,
+        scale_output,
+        persistent,
+    )
+
+
+def tile_gemm(
+    a,
+    b,
+    c,
+    a_leading,
+    b_leading,
+    stream,
+    swap_grid=False,
+    output_scale=None,
+    persistent=False,
+):
+    """C[M,N] = A[M,K] @ B[N,K].T. ``*_leading`` names each operand's contiguous dim."""
+    a_c = to_cute_tensor(a.unsqueeze(-1), leading_dim=a_leading, assumed_align=16)
+    b_c = to_cute_tensor(b.unsqueeze(-1), leading_dim=b_leading, assumed_align=16)
+    c_c = to_cute_tensor(c, assumed_align=(2 if c.dtype == torch.bfloat16 else 4))
+    scale_c = to_cute_tensor(output_scale.reshape(1), assumed_align=4) if output_scale is not None else None
+    scale_output = output_scale is not None
+    num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count if persistent else 0
+    key = _gemm_key(a, b, c, swap_grid, scale_output, persistent)
+    compiled = _gemm_cache.get(key)
+    if compiled is None:
+        compiled = cute.compile(
+            _TileGemmSM90(
+                swap_grid=swap_grid,
+                scale_output=scale_output,
+                persistent=persistent,
+                num_sms=num_sms,
+            ),
+            a_c,
+            b_c,
+            c_c,
+            scale_c,
+            stream,
+        )
+        _gemm_cache[key] = compiled
+    compiled(a_c, b_c, c_c, scale_c, stream)
+
+
+def cross_entropy_dz(logits, target, nll, row_scale, ignore_index, stream):
+    """Fill ``nll[M]`` and overwrite ``logits`` in place with the scaled dZ."""
+    import os
+
+    partition_size = logits.shape[1] // CE_PARTITIONS
+    use_vector_cluster = (
+        os.environ.get("FLCE_CE_CLUSTER_VECTOR", "1") != "0"
+        and logits.shape[1] % CE_PARTITIONS == 0
+        and partition_size % CE_VECTOR == 0
+        and partition_size <= CE_THREADS * CE_VECTOR_VALUES_PER_THREAD
+    )
+    l_c = (
+        from_dlpack(logits.detach(), assumed_align=16)
+        if use_vector_cluster
+        else to_cute_tensor(logits, assumed_align=2)
+    )
+    t_c = to_cute_tensor(target, assumed_align=8)
+    n_c = to_cute_tensor(nll, assumed_align=4)
+    if use_vector_cluster:
+        key = (tuple(logits.shape), tuple(target.shape), row_scale, ignore_index)
+        compiled = _ce_cluster_vector_cache.get(key)
+        args = (
+            l_c,
+            t_c,
+            n_c,
+            Float32(row_scale),
+            Int32(ignore_index),
+            stream,
+        )
+        if compiled is None:
+            compiled = cute.compile(
+                _CrossEntropyClusterVector(partition_size),
+                *args,
+            )
+            _ce_cluster_vector_cache[key] = compiled
+        compiled(*args)
+        return
+
+    partials = torch.empty(
+        target.shape[0],
+        CE_PARTITIONS,
+        3,
+        device=logits.device,
+        dtype=torch.float32,
+    )
+    p_c = to_cute_tensor(partials, assumed_align=4)
+    key = (tuple(logits.shape), tuple(target.shape))
+    partials_compiled = _ce_partials_cache.get(key)
+    partials_args = (l_c, t_c, p_c, stream)
+    if partials_compiled is None:
+        partials_compiled = cute.compile(_CrossEntropyPartials(), *partials_args)
+        _ce_partials_cache[key] = partials_compiled
+    partials_compiled(*partials_args)
+
+    dz_compiled = _ce_dz_cache.get(key)
+    dz_args = (
+        l_c,
+        t_c,
+        p_c,
+        n_c,
+        l_c,
+        Float32(row_scale),
+        Int32(ignore_index),
+        stream,
+    )
+    if dz_compiled is None:
+        dz_compiled = cute.compile(_CrossEntropyDZ(), *dz_args)
+        _ce_dz_cache[key] = dz_compiled
+    dz_compiled(*dz_args)

--- a/src/liger_kernel/ops/cutedsl/ops/_fused_linear_cross_entropy_forward_sm90.py
+++ b/src/liger_kernel/ops/cutedsl/ops/_fused_linear_cross_entropy_forward_sm90.py
@@ -4,12 +4,13 @@ This module owns two device kernels used by
 :mod:`liger_kernel.ops.cutedsl.ops.fused_linear_cross_entropy_sm90`:
 
 ``_TileGemmSM90``
-    A warp-specialised WGMMA GEMM that computes ``C[M, N] = A[M, K] @ B[N, K].T``
-    with BF16 operands and an FP32 accumulator.  Each operand may be either
-    *K-major* (the contraction dim is contiguous, ``leading_dim`` points at it)
-    or *MN-major* (the M/N dim is contiguous).  A single tiled-MMA topology
-    (cooperative split-M over two WGMMA warp groups, ``M128 x N256 x K64``,
-    3 stages) drives all three logical GEMMs of the FLCE:
+    The static WGMMA fallback computes ``C[M, N] = A[M, K] @ B[N, K].T`` with
+    BF16 operands and an FP32 accumulator. Each operand may be either *K-major*
+    (the contraction dim is contiguous, ``leading_dim`` points at it) or
+    *MN-major* (the M/N dim is contiguous). Its cooperative split-M topology
+    (two WGMMA warp groups, ``M128 x N256 x K64``, 3 stages) drives dX and
+    remains available for logits/dW with ``FLCE_LOGITS_PERSISTENT=0`` /
+    ``FLCE_DW_CLUSTERED_PERSISTENT=0``:
 
     ==========  ==========================  ==============  ==============
     GEMM        maths                        A layout        B layout
@@ -19,7 +20,12 @@ This module owns two device kernels used by
     dW          ``dZ.T[V,M] @ X[M,H]``       MN-major (V)    MN-major (H)
     ==========  ==========================  ==============  ==============
 
-    The mainloop is the proven "warp-0-of-WG0 issues every TMA" software
+    The default logits and dW phases use :mod:`_sm90_persistent_gemm`: a
+    cluster-2, four-stage CUTLASS persistent template with one DMA and two WGMMA
+    warp groups plus a TMA-store epilogue. dW's scalar autograd scale is fused
+    into that epilogue.
+
+    The static mainloop is the proven "warp-0-of-WG0 issues every TMA" software
     pipeline: a single linear ``cp.async.bulk.tensor`` load stream feeds a
     3-stage SMEM buffer, one WGMMA group stays in flight across each
     release+refill, and the pipeline is drained exactly once per output tile.
@@ -1226,6 +1232,41 @@ def tile_gemm(
     persistent=False,
 ):
     """C[M,N] = A[M,K] @ B[N,K].T. ``*_leading`` names each operand's contiguous dim."""
+    import os
+
+    # Dispatch logits to the NVIDIA StaticPersistent WGMMA template for the
+    # logits GEMM (K-major A+B, no output scale, default grid orientation).
+    # The cluster-2 path raises tensor activity from 89.67% to 95.45% on H200.
+    # Set FLCE_LOGITS_PERSISTENT=0 to retain the original static fallback.
+    if (
+        os.environ.get("FLCE_LOGITS_PERSISTENT", "1") != "0"
+        and a_leading == 1
+        and b_leading == 1
+        and output_scale is None
+        and not swap_grid
+        and not persistent
+    ):
+        from liger_kernel.ops.cutedsl.ops._sm90_persistent_gemm import logits_persistent_gemm
+
+        logits_persistent_gemm(a, b, c, a_leading, b_leading, stream)
+        return
+
+    # The same persistent cluster improves dW while preserving its scalar
+    # autograd scale in the TMA epilogue. The old static raster remains
+    # available independently of the legacy FLCE_DW_PERSISTENT experiment.
+    if (
+        os.environ.get("FLCE_DW_CLUSTERED_PERSISTENT", "1") != "0"
+        and a_leading == 0
+        and b_leading == 0
+        and output_scale is not None
+        and swap_grid
+        and not persistent
+    ):
+        from liger_kernel.ops.cutedsl.ops._sm90_persistent_gemm import dw_persistent_gemm
+
+        dw_persistent_gemm(a, b, c, a_leading, b_leading, stream, output_scale)
+        return
+
     a_c = to_cute_tensor(a.unsqueeze(-1), leading_dim=a_leading, assumed_align=16)
     b_c = to_cute_tensor(b.unsqueeze(-1), leading_dim=b_leading, assumed_align=16)
     c_c = to_cute_tensor(c, assumed_align=(2 if c.dtype == torch.bfloat16 else 4))

--- a/src/liger_kernel/ops/cutedsl/ops/_sm90_persistent_gemm.py
+++ b/src/liger_kernel/ops/cutedsl/ops/_sm90_persistent_gemm.py
@@ -1,0 +1,921 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Derived from NVIDIA CUTLASS CuTeDSL examples:
+#   examples/python/CuTeDSL/cute/hopper/kernel/dense_gemm/dense_gemm_persistent.py
+
+"""CuTe DSL Hopper persistent GEMMs for FLCE.
+
+Vendors :class:`HopperWgmmaGemmPersistentKernel` from NVIDIA's CuTeDSL examples
+(BSD-3-Clause, see file header) and exposes persistent logits and dW entry
+points called by :func:`tile_gemm`. Set ``FLCE_LOGITS_PERSISTENT=0`` or
+``FLCE_DW_CLUSTERED_PERSISTENT=0`` to select the original static GEMMs.
+
+Measured topology (BF16, M×N×K = 4096×128256×4096, H200, one persistent wave):
+
+* CTA tile 128×256×64, cluster 1×2, swizzle 1, raster-along-M
+* 384 threads: 1 DMA warp-group (40 regs) + 2 MMA warp-groups (232 regs each)
+* Mainloop AB stages = 4 (``PipelineTmaAsync``); epilogue stages = 4 (``PipelineTmaStore``)
+* Epilogue sub-tile 128×32; ``StaticPersistentTileScheduler`` (one persistent wave)
+* Observed 95.45% tensor activity and 5.63 ms under matched NCU replay, versus
+  89.67% and 5.70 ms for the original static CuTe kernel.
+* Scaled dW reaches 95.04% tensor activity and 4.86 ms under matched NCU replay,
+  versus 88.73% and 5.15 ms for the original static CuTe kernel.
+"""
+
+import math
+
+from typing import Optional
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.hopper_helpers as sm90_utils
+import torch
+
+from cutlass.pipeline import pipeline_init_arrive
+from cutlass.pipeline import pipeline_init_wait
+
+from liger_kernel.ops.cutedsl.ops.utils import ensure_cuda_context
+from liger_kernel.ops.cutedsl.ops.utils import to_cute_tensor
+
+# Fixed tile configuration selected by the H200 parameter sweep.
+_TILE_SHAPE_MN = (128, 256)
+_CLUSTER_SHAPE_MN = (1, 2)
+_SWIZZLE_SIZE = 1
+_RASTER_ALONG_M = True
+
+
+class HopperWgmmaGemmPersistentKernel:
+    """Hopper (SM90) warp-specialised persistent WGMMA GEMM.
+
+    Computes C = A × B (batched, batch-count = 1) using three cooperating
+    components:
+
+    * ``PipelineTmaAsync`` mainloop — the single DMA warp-group (warp-group 0)
+      issues every TMA load; the two MMA warp-groups drain one pipeline stage
+      per WGMMA wave.
+    * ``PipelineTmaStore`` epilogue — register accumulator is scattered into an
+      SMEM sub-tile (128×32) and TMA-stored asynchronously, overlapping store
+      with the next tile's WGMMA mainloop.
+    * ``StaticPersistentTileScheduler`` — grid is one persistent wave; each CTA
+      streams through all of its assigned output tiles without re-launching.
+
+    Register budgets (load = 40, MMA = 232) match the measured H200 topology.
+
+    Derived from NVIDIA CUTLASS CuTeDSL examples (BSD-3-Clause).
+    """
+
+    def __init__(
+        self,
+        acc_dtype: type[cutlass.Numeric],
+        tile_shape_mn: tuple[int, int],
+        cluster_shape_mn: tuple[int, int],
+        swizzle_size: int,
+        raster_along_m: bool,
+        scale_output: bool = False,
+    ):
+        self.acc_dtype = acc_dtype
+        self.cluster_shape_mn = cluster_shape_mn
+        self.swizzle_size = swizzle_size
+        self.raster_along_m = raster_along_m
+        self.scale_output = scale_output
+        self.mma_inst_shape_mn = None
+        # K is resolved later in _setup_attributes.
+        self.tile_shape_mnk = (*tile_shape_mn, 1)
+        self.atom_layout_mnk = (2, 1, 1) if self.tile_shape_mnk[0] > 64 and self.tile_shape_mnk[1] > 128 else (1, 1, 1)
+        self.num_mcast_ctas_a = None
+        self.num_mcast_ctas_b = None
+        self.is_a_mcast = False
+        self.is_b_mcast = False
+        self.tiled_mma = None
+
+        self.occupancy = 1
+        self.num_dma_warp_groups = 1
+        self.num_mma_warp_groups = math.prod(self.atom_layout_mnk)
+        self.num_warps_per_warp_group = 4
+        self.num_threads_per_warp_group = self.num_warps_per_warp_group * 32
+        self.threads_per_cta = (self.num_dma_warp_groups + self.num_mma_warp_groups) * self.num_threads_per_warp_group
+        self.load_warp_id = 0
+        self.epi_store_warp_id = self.num_dma_warp_groups * self.num_warps_per_warp_group
+        # Register budgets matching the measured topology.
+        self.load_register_requirement = 40
+        self.mma_register_requirement = 232
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_90")
+
+        self.ab_stage = None
+        self.epi_stage = None
+
+        self.a_smem_layout_staged = None
+        self.b_smem_layout_staged = None
+        self.epi_smem_layout_staged = None
+        self.epi_tile = None
+
+        self.shared_storage = None
+        self.buffer_align_bytes = 1024
+
+        self.num_mma_threads = self.num_mma_warp_groups * self.num_threads_per_warp_group
+        self.epilog_sync_barrier = pipeline.NamedBarrier(barrier_id=1, num_threads=self.num_mma_threads)
+
+    def _setup_attributes(self):
+        """Configure tile/MMA/SMEM parameters from the traced input tensors."""
+        if self.tile_shape_mnk[0] not in [64, 128]:
+            raise ValueError("CTA tile shape M must be 64/128")
+        if self.tile_shape_mnk[1] not in [64, 128, 256]:
+            raise ValueError("CTA tile shape N must be 64/128/256")
+
+        self.tiled_mma = sm90_utils.make_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_layout.sm90_mma_major_mode(),
+            self.b_layout.sm90_mma_major_mode(),
+            self.acc_dtype,
+            self.atom_layout_mnk,
+            tiler_mn=(64, self.tile_shape_mnk[1]),
+        )
+        mma_inst_shape_k = cute.size(self.tiled_mma.shape_mnk, mode=[2])
+        mma_inst_tile_k = 4
+        self.tile_shape_mnk = (
+            self.tile_shape_mnk[0],
+            self.tile_shape_mnk[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+
+        self.cta_layout_mnk = cute.make_layout((*self.cluster_shape_mn, 1))
+        self.num_mcast_ctas_a = self.cluster_shape_mn[1]
+        self.num_mcast_ctas_b = self.cluster_shape_mn[0]
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+
+        is_cooperative = self.atom_layout_mnk == (2, 1, 1)
+        self.epi_tile = self._sm90_compute_tile_shape_or_override(
+            self.tile_shape_mnk, self.c_dtype, is_cooperative=is_cooperative
+        )
+
+        self.ab_stage, self.epi_stage = self._compute_stages(
+            self.tile_shape_mnk,
+            self.a_dtype,
+            self.b_dtype,
+            self.epi_tile,
+            self.c_dtype,
+            self.smem_capacity,
+            self.occupancy,
+        )
+
+        (
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.epi_smem_layout_staged,
+        ) = self._make_smem_layouts(
+            self.tile_shape_mnk,
+            self.epi_tile,
+            self.a_dtype,
+            self.a_layout,
+            self.b_dtype,
+            self.b_layout,
+            self.ab_stage,
+            self.c_dtype,
+            self.c_layout,
+            self.epi_stage,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        c: cute.Tensor,
+        output_scale: Optional[cute.Tensor],
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+    ):
+        # Derive element types and layout enums from the traced tensors.
+        self.a_dtype = a.element_type
+        self.b_dtype = b.element_type
+        self.c_dtype = c.element_type
+        self.a_layout = utils.LayoutEnum.from_tensor(a)
+        self.b_layout = utils.LayoutEnum.from_tensor(b)
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+
+        if cutlass.const_expr(self.a_dtype.width == 16 and self.a_dtype != self.b_dtype):
+            raise TypeError(f"Type mismatch: {self.a_dtype} != {self.b_dtype}")
+        if cutlass.const_expr(self.a_dtype.width != self.b_dtype.width):
+            raise TypeError(f"Type width mismatch: {self.a_dtype.width} != {self.b_dtype.width}")
+        if cutlass.const_expr(self.a_dtype.width != 16 and self.a_dtype.width != 8):
+            raise TypeError("a_dtype should be float16, float8, or int8")
+
+        self._setup_attributes()
+
+        tma_atom_a, tma_tensor_a = self._make_tma_atoms_and_tensors(
+            a,
+            self.a_smem_layout_staged,
+            (self.tile_shape_mnk[0], self.tile_shape_mnk[2]),
+            self.cluster_shape_mn[1],
+        )
+        tma_atom_b, tma_tensor_b = self._make_tma_atoms_and_tensors(
+            b,
+            self.b_smem_layout_staged,
+            (self.tile_shape_mnk[1], self.tile_shape_mnk[2]),
+            self.cluster_shape_mn[0],
+        )
+        tma_atom_c, tma_tensor_c = self._make_tma_store_atoms_and_tensors(
+            c,
+            self.epi_smem_layout_staged,
+            self.epi_tile,
+        )
+
+        tile_sched_params, grid = self._compute_grid(
+            c,
+            self.tile_shape_mnk,
+            self.cluster_shape_mn,
+            self.swizzle_size,
+            self.raster_along_m,
+            max_active_clusters,
+        )
+
+        @cute.struct
+        class SharedStorage:
+            mainloop_pipeline_array_ptr: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[self.a_dtype, cute.cosize(self.a_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(self.b_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.c_dtype,
+                    cute.cosize(self.epi_smem_layout_staged),
+                ],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        self.kernel(
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_c,
+            tma_tensor_c,
+            output_scale,
+            self.tiled_mma,
+            self.cta_layout_mnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.epi_smem_layout_staged,
+            tile_sched_params,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        output_scale: Optional[cute.Tensor],
+        tiled_mma: cute.TiledMma,
+        cta_layout_mnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        epi_smem_layout_staged: cute.ComposedLayout,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        # Prefetch TMA descriptors on warp 0.
+        if warp_idx == 0:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_a)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_b)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_c)
+
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        cluster_coord_mnk = cta_layout_mnk.get_flat_coord(cta_rank_in_cluster)
+
+        a_mcast_mask = cute.make_layout_image_mask(cta_layout_mnk, cluster_coord_mnk, mode=1)
+        b_mcast_mask = cute.make_layout_image_mask(cta_layout_mnk, cluster_coord_mnk, mode=0)
+        a_mcast_mask = a_mcast_mask if self.is_a_mcast else 0
+        b_mcast_mask = b_mcast_mask if self.is_b_mcast else 0
+
+        a_smem_layout = cute.slice_(a_smem_layout_staged, (None, None, 0))
+        b_smem_layout = cute.slice_(b_smem_layout_staged, (None, None, 0))
+        tma_copy_bytes = cute.size_in_bytes(self.a_dtype, a_smem_layout) + cute.size_in_bytes(
+            self.b_dtype, b_smem_layout
+        )
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        mainloop_pipeline_array_ptr = storage.mainloop_pipeline_array_ptr.data_ptr()
+
+        mainloop_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        mcast_size = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        consumer_arrive_cnt = mcast_size * self.num_mma_warp_groups * self.num_warps_per_warp_group
+        mainloop_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, consumer_arrive_cnt)
+
+        mainloop_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=mainloop_pipeline_array_ptr,
+            num_stages=self.ab_stage,
+            producer_group=mainloop_pipeline_producer_group,
+            consumer_group=mainloop_pipeline_consumer_group,
+            tx_count=tma_copy_bytes,
+            cta_layout_vmnk=cute.make_layout((1, *cta_layout_mnk.shape)),
+            defer_sync=True,
+        )
+
+        pipeline_init_arrive(cluster_shape_mn=self.cluster_shape_mn, is_relaxed=True)
+
+        sA = storage.sA.get_tensor(a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner)
+        sB = storage.sB.get_tensor(b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner)
+        sC = storage.sC.get_tensor(epi_smem_layout_staged.outer, swizzle=epi_smem_layout_staged.inner)
+
+        gA_mkl = cute.local_tile(
+            mA_mkl,
+            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+            (None, None, None),
+        )
+        gB_nkl = cute.local_tile(
+            mB_nkl,
+            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+            (None, None, None),
+        )
+        gC_mnl = cute.local_tile(
+            mC_mnl,
+            cute.slice_(self.tile_shape_mnk, (None, None, 0)),
+            (None, None, None),
+        )
+
+        # TMA load partitions for A (multicast along N cluster dimension).
+        a_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (0, None, 0)).shape)
+        a_cta_crd = cluster_coord_mnk[1]
+        tAsA, tAgA = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_a,
+            a_cta_crd,
+            a_cta_layout,
+            cute.group_modes(sA, 0, 2),
+            cute.group_modes(gA_mkl, 0, 2),
+        )
+
+        # TMA load partitions for B (multicast along M cluster dimension).
+        b_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (None, 0, 0)).shape)
+        b_cta_crd = cluster_coord_mnk[0]
+        tBsB, tBgB = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_b,
+            b_cta_crd,
+            b_cta_layout,
+            cute.group_modes(sB, 0, 2),
+            cute.group_modes(gB_nkl, 0, 2),
+        )
+
+        warp_group_idx = cute.arch.make_warp_uniform(tidx // self.num_threads_per_warp_group)
+        mma_warp_group_thread_layout = cute.make_layout(
+            self.num_mma_warp_groups, stride=self.num_threads_per_warp_group
+        )
+        thr_mma = tiled_mma.get_slice(mma_warp_group_thread_layout(warp_group_idx - self.num_dma_warp_groups))
+
+        tCsA = thr_mma.partition_A(sA)
+        tCsB = thr_mma.partition_B(sB)
+        tCrA = tiled_mma.make_fragment_A(tCsA)
+        tCrB = tiled_mma.make_fragment_B(tCsB)
+
+        tCgC = thr_mma.partition_C(gC_mnl)
+        acc_shape = tCgC.shape[:3]
+        accumulators = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+
+        k_tile_cnt = cute.size(gA_mkl, mode=[3])
+
+        pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
+
+        # Warp specialisation: DMA warp-group reduces to load_register_requirement.
+        is_dma_warp_group = warp_group_idx < self.num_dma_warp_groups
+        if is_dma_warp_group:
+            cute.arch.setmaxregister_decrease(self.load_register_requirement)
+
+        # ---- DMA warp-group: TMA loads driven by StaticPersistentTileScheduler ----
+        if warp_idx == self.load_warp_id:
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            mainloop_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.ab_stage)
+
+            while work_tile.is_valid_tile:
+                tile_coord_mnl = work_tile.tile_idx
+                tAgA_mkl = tAgA[(None, tile_coord_mnl[0], None, tile_coord_mnl[2])]
+                tBgB_nkl = tBgB[(None, tile_coord_mnl[1], None, tile_coord_mnl[2])]
+
+                mainloop_producer_state.reset_count()
+
+                for k_tile in range(k_tile_cnt):
+                    mainloop_pipeline.producer_acquire(mainloop_producer_state)
+                    tAgA_k = tAgA_mkl[(None, mainloop_producer_state.count)]
+                    tAsA_pipe = tAsA[(None, mainloop_producer_state.index)]
+                    tBgB_k = tBgB_nkl[(None, mainloop_producer_state.count)]
+                    tBsB_pipe = tBsB[(None, mainloop_producer_state.index)]
+
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_k,
+                        tAsA_pipe,
+                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(mainloop_producer_state),
+                        mcast_mask=a_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_k,
+                        tBsB_pipe,
+                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(mainloop_producer_state),
+                        mcast_mask=b_mcast_mask,
+                    )
+
+                    mainloop_pipeline.producer_commit(mainloop_producer_state)
+                    mainloop_producer_state.advance()
+
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            mainloop_pipeline.producer_tail(mainloop_producer_state)
+
+        # ---- MMA warp-groups: WGMMA + TMA-store epilogue ----
+        if not is_dma_warp_group:
+            cute.arch.setmaxregister_increase(self.mma_register_requirement)
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            mainloop_consumer_read_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.ab_stage
+            )
+            mainloop_consumer_release_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.ab_stage
+            )
+
+            num_k_blocks = cute.size(tCrA, mode=[2])
+
+            copy_atom_r2s = sm90_utils.sm90_get_smem_store_op(
+                self.c_layout,
+                elem_ty_d=self.c_dtype,
+                elem_ty_acc=self.acc_dtype,
+            )
+
+            copy_atom_C = cute.make_copy_atom(
+                cute.nvgpu.warp.StMatrix8x8x16bOp(
+                    self.c_layout.is_m_major_c(),
+                    4,
+                ),
+                self.c_dtype,
+            )
+
+            tiled_copy_C_Atom = cute.make_tiled_copy_C_atom(copy_atom_C, tiled_mma)
+
+            tiled_copy_r2s = cute.make_tiled_copy_S(
+                copy_atom_r2s,
+                tiled_copy_C_Atom,
+            )
+
+            thr_copy_r2s = tiled_copy_r2s.get_slice(tidx - self.num_dma_warp_groups * self.num_threads_per_warp_group)
+            tRS_sD = thr_copy_r2s.partition_D(sC)
+            tRS_rAcc = tiled_copy_r2s.retile(accumulators)
+
+            rD_shape = cute.shape(thr_copy_r2s.partition_S(sC))
+            tRS_rD_layout = cute.make_layout(rD_shape[:3])
+            tRS_rD = cute.make_rmem_tensor(tRS_rD_layout.shape, self.acc_dtype)
+            tRS_rD_out = cute.make_rmem_tensor(tRS_rD_layout.shape, self.c_dtype)
+            size_tRS_rD = cute.size(tRS_rD)
+
+            k_pipe_mmas = 1
+            prologue_mma_cnt = min(k_pipe_mmas, k_tile_cnt)
+
+            tma_store_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.num_mma_threads,
+            )
+            tma_store_pipeline = pipeline.PipelineTmaStore.create(
+                num_stages=self.epi_stage,
+                producer_group=tma_store_producer_group,
+            )
+            scale = cutlass.Float32(output_scale[0]) if cutlass.const_expr(self.scale_output) else cutlass.Float32(1.0)
+
+            while work_tile.is_valid_tile:
+                tile_coord_mnl = work_tile.tile_idx
+                gC_mnl_slice = gC_mnl[(None, None, *tile_coord_mnl)]
+
+                mainloop_consumer_read_state.reset_count()
+                mainloop_consumer_release_state.reset_count()
+                accumulators.fill(0.0)
+                tiled_mma.set(cute.nvgpu.warpgroup.Field.ACCUMULATE, True)
+                cute.nvgpu.warpgroup.fence()
+
+                # Prologue: issue first k_pipe_mmas WGMMAs before releasing any stage.
+                for k_tile in range(prologue_mma_cnt):
+                    mainloop_pipeline.consumer_wait(mainloop_consumer_read_state)
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_block_coord = (
+                            None,
+                            None,
+                            k_block_idx,
+                            mainloop_consumer_read_state.index,
+                        )
+                        cute.gemm(
+                            tiled_mma,
+                            accumulators,
+                            tCrA[k_block_coord],
+                            tCrB[k_block_coord],
+                            accumulators,
+                        )
+                    cute.nvgpu.warpgroup.commit_group()
+                    mainloop_consumer_read_state.advance()
+
+                # Steady state: release the previous stage; overlap with next WGMMA.
+                for k_tile in range(prologue_mma_cnt, k_tile_cnt):
+                    mainloop_pipeline.consumer_wait(mainloop_consumer_read_state)
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_block_coord = (
+                            None,
+                            None,
+                            k_block_idx,
+                            mainloop_consumer_read_state.index,
+                        )
+                        cute.gemm(
+                            tiled_mma,
+                            accumulators,
+                            tCrA[k_block_coord],
+                            tCrB[k_block_coord],
+                            accumulators,
+                        )
+                    cute.nvgpu.warpgroup.commit_group()
+                    cute.nvgpu.warpgroup.wait_group(k_pipe_mmas)
+                    mainloop_pipeline.consumer_release(mainloop_consumer_release_state)
+                    mainloop_consumer_release_state.advance()
+                    mainloop_consumer_read_state.advance()
+
+                # Drain remaining in-flight WGMMAs and release their pipeline stages.
+                cute.nvgpu.warpgroup.wait_group(0)
+                for k_tile in range(prologue_mma_cnt):
+                    mainloop_pipeline.consumer_release(mainloop_consumer_release_state)
+                    mainloop_consumer_release_state.advance()
+
+                # TMA-store epilogue: accumulator → SMEM sub-tile → GMEM.
+                tCgC_for_tma_partition = cute.zipped_divide(gC_mnl_slice, self.epi_tile)
+
+                bSG_sD, bSG_gD = cute.nvgpu.cpasync.tma_partition(
+                    tma_atom_c,
+                    0,
+                    cute.make_layout(1),
+                    cute.group_modes(sC, 0, 2),
+                    tCgC_for_tma_partition,
+                )
+
+                epi_tile_num = cute.size(tCgC_for_tma_partition, mode=[1])
+                epi_tile_shape = tCgC_for_tma_partition.shape[1]
+                epi_tile_layout = cute.make_layout(epi_tile_shape, stride=(epi_tile_shape[1], 1))
+
+                num_prev_epi_tiles = tile_sched.num_tiles_executed * epi_tile_num
+                for epi_idx in cutlass.range_constexpr(epi_tile_num):
+                    for epi_v in cutlass.range_constexpr(size_tRS_rD):
+                        tRS_rD[epi_v] = tRS_rAcc[epi_idx * size_tRS_rD + epi_v]
+
+                    acc_vec = tRS_rD.load()
+                    tRS_rD_out.store((acc_vec * scale).to(self.c_dtype))
+
+                    epi_buffer = (num_prev_epi_tiles + epi_idx) % cute.size(tRS_sD, mode=[3])
+                    cute.copy(
+                        tiled_copy_r2s,
+                        tRS_rD_out,
+                        tRS_sD[(None, None, None, epi_buffer)],
+                    )
+
+                    cute.arch.fence_proxy(
+                        "async.shared",
+                        space="cta",
+                    )
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                    gmem_coord = epi_tile_layout.get_hier_coord(epi_idx)
+                    if warp_idx == self.epi_store_warp_id:
+                        cute.copy(
+                            tma_atom_c,
+                            bSG_sD[(None, epi_buffer)],
+                            bSG_gD[(None, gmem_coord)],
+                        )
+                        tma_store_pipeline.producer_commit()
+                        tma_store_pipeline.producer_acquire()
+
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            tma_store_pipeline.producer_tail()
+
+    @staticmethod
+    def _compute_stages(
+        tile_shape_mnk: tuple[int, int, int],
+        a_dtype: type[cutlass.Numeric],
+        b_dtype: type[cutlass.Numeric],
+        epi_tile: tuple[int, int],
+        c_dtype: type[cutlass.Numeric],
+        smem_capacity: int,
+        occupancy: int,
+    ) -> tuple[int, int]:
+        """Compute AB-stage and epilogue-stage counts from SMEM capacity."""
+        a_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+        b_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+        ab_bytes_per_stage = cute.size(a_shape) * a_dtype.width // 8 + cute.size(b_shape) * b_dtype.width // 8
+        c_bytes_per_stage = cute.size(epi_tile) * c_dtype.width // 8
+        epi_stage = 4
+        epi_bytes = c_bytes_per_stage * epi_stage
+        mbar_helpers_bytes = 1024
+        ab_stage = (smem_capacity // occupancy - (mbar_helpers_bytes + epi_bytes)) // ab_bytes_per_stage
+        return ab_stage, epi_stage
+
+    @staticmethod
+    def _sm90_compute_tile_shape_or_override(
+        tile_shape_mnk: tuple[int, int, int],
+        element_type: type[cutlass.Numeric],
+        is_cooperative: bool = False,
+        epi_tile_override: Optional[tuple[int, int]] = None,
+    ) -> tuple[int, int]:
+        """Return the epilogue sub-tile shape (or the caller's override)."""
+        if epi_tile_override is not None:
+            return epi_tile_override
+        if is_cooperative:
+            tile_m = min(128, cute.size(tile_shape_mnk, mode=[0]))
+            tile_n = min(32, cute.size(tile_shape_mnk, mode=[1]))
+            return (tile_m, tile_n)
+        else:
+            n_perf = 64 if element_type.width == 8 else 32
+            tile_m = min(64, cute.size(tile_shape_mnk, mode=[0]))
+            tile_n = min(n_perf, cute.size(tile_shape_mnk, mode=[1]))
+            return (tile_m, tile_n)
+
+    @staticmethod
+    def _make_smem_layouts(
+        tile_shape_mnk: tuple[int, int, int],
+        epi_tile: tuple[int, int],
+        a_dtype: type[cutlass.Numeric],
+        a_layout: utils.LayoutEnum,
+        b_dtype: type[cutlass.Numeric],
+        b_layout: utils.LayoutEnum,
+        ab_stage: int,
+        c_dtype: type[cutlass.Numeric],
+        c_layout: utils.LayoutEnum,
+        epi_stage: int,
+    ) -> tuple[cute.ComposedLayout, cute.ComposedLayout, cute.ComposedLayout]:
+        """Build staged SMEM layouts for A, B, and the epilogue (C) buffer."""
+        a_smem_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+
+        a_is_k_major = a_layout.sm90_mma_major_mode() == cute.nvgpu.OperandMajorMode.K
+        b_is_k_major = b_layout.sm90_mma_major_mode() == cute.nvgpu.OperandMajorMode.K
+        a_major_mode_size = tile_shape_mnk[2 if a_is_k_major else 0]
+        a_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                a_layout,
+                a_dtype,
+                a_major_mode_size,
+            ),
+            a_dtype,
+        )
+        a_smem_layout_staged = cute.tile_to_shape(
+            a_smem_layout_atom,
+            cute.append(a_smem_shape, ab_stage),
+            order=(0, 1, 2) if a_is_k_major else (1, 0, 2),
+        )
+
+        b_smem_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+
+        b_major_mode_size = tile_shape_mnk[2 if b_is_k_major else 1]
+        b_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                b_layout,
+                b_dtype,
+                b_major_mode_size,
+            ),
+            b_dtype,
+        )
+        b_smem_layout_staged = cute.tile_to_shape(
+            b_smem_layout_atom,
+            cute.append(b_smem_shape, ab_stage),
+            order=(0, 1, 2) if b_is_k_major else (1, 0, 2),
+        )
+
+        c_smem_shape = epi_tile
+        c_major_mode_size = epi_tile[1] if c_layout.is_n_major_c() else epi_tile[0]
+        c_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(
+                c_layout,
+                c_dtype,
+                c_major_mode_size,
+            ),
+            c_dtype,
+        )
+        epi_smem_layout_staged = cute.tile_to_shape(
+            c_smem_layout_atom,
+            cute.append(c_smem_shape, epi_stage),
+            order=(1, 0, 2) if c_layout.is_m_major_c() else (0, 1, 2),
+        )
+
+        return a_smem_layout_staged, b_smem_layout_staged, epi_smem_layout_staged
+
+    @staticmethod
+    def _compute_grid(
+        c: cute.Tensor,
+        tile_shape_mnk: tuple[int, int, int],
+        cluster_shape_mn: tuple[int, int],
+        swizzle_size: int,
+        raster_along_m: bool,
+        max_active_clusters: cutlass.Constexpr,
+    ) -> tuple:
+        """Return ``(tile_sched_params, grid)`` for the persistent launch."""
+        c_shape = cute.slice_(tile_shape_mnk, (None, None, 0))
+        gc = cute.zipped_divide(c, tiler=c_shape)
+        num_ctas_mnl = gc[(0, (None, None, None))].shape
+        cluster_shape_mnl = (*cluster_shape_mn, 1)
+
+        tile_sched_params = utils.PersistentTileSchedulerParams(
+            num_ctas_mnl,
+            cluster_shape_mnl,
+            swizzle_size,
+            raster_along_m,
+        )
+        grid = utils.StaticPersistentTileScheduler.get_grid_shape(tile_sched_params, max_active_clusters)
+        return tile_sched_params, grid
+
+    @staticmethod
+    def _make_tma_store_atoms_and_tensors(
+        tensor_c: cute.Tensor,
+        epi_smem_layout_staged: cute.ComposedLayout,
+        epi_tile: tuple[int, int],
+    ) -> tuple:
+        """Create TMA atom + coord tensor for the epilogue S2G copy."""
+        epi_smem_layout = cute.slice_(epi_smem_layout_staged, (None, None, 0))
+        tma_atom_c, tma_tensor_c = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp(),
+            tensor_c,
+            epi_smem_layout,
+            epi_tile,
+        )
+        return tma_atom_c, tma_tensor_c
+
+    @staticmethod
+    def _make_tma_atoms_and_tensors(
+        tensor: cute.Tensor,
+        smem_layout_staged: cute.ComposedLayout,
+        smem_tile: tuple[int, int],
+        mcast_dim: int,
+    ) -> tuple:
+        """Create TMA atom + coord tensor for a G2S load (A or B operand)."""
+        op = (
+            cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp()
+            if mcast_dim == 1
+            else cute.nvgpu.cpasync.CopyBulkTensorTileG2SMulticastOp()
+        )
+        smem_layout = cute.slice_(smem_layout_staged, (None, None, 0))
+        tma_atom, tma_tensor = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            op,
+            tensor,
+            smem_layout,
+            smem_tile,
+            num_multicast=mcast_dim,
+        )
+        return tma_atom, tma_tensor
+
+
+# ---------------------------------------------------------------------------
+# Python-level compile cache and entry-point wrapper
+# ---------------------------------------------------------------------------
+
+# Per-device compile cache keyed on (shape, stride, dtype, device).
+# Multi-device is safe: device index is included in the key, and
+# max_active_clusters (device-specific) is captured during compilation.
+_persistent_gemm_cache: dict = {}
+
+
+def _persistent_gemm_key(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    c: torch.Tensor,
+    output_scale: Optional[torch.Tensor],
+) -> tuple:
+    return (
+        "_flce_persistent",
+        tuple(a.shape),
+        tuple(a.stride()),
+        a.dtype,
+        tuple(b.shape),
+        tuple(b.stride()),
+        b.dtype,
+        tuple(c.shape),
+        tuple(c.stride()),
+        c.dtype,
+        output_scale is not None,
+        output_scale.dtype if output_scale is not None else None,
+        a.device.index if a.device.type == "cuda" else -1,
+    )
+
+
+def _persistent_gemm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    c: torch.Tensor,
+    a_leading: int,
+    b_leading: int,
+    stream: cuda.CUstream,
+    output_scale: Optional[torch.Tensor] = None,
+) -> None:
+    """Run the fixed Hopper StaticPersistent WGMMA configuration."""
+    # Convert 2-D torch tensors to 3-D CuTe tensors [row, col, L=1].
+    a_c = to_cute_tensor(a.unsqueeze(-1), leading_dim=a_leading, assumed_align=16)
+    b_c = to_cute_tensor(b.unsqueeze(-1), leading_dim=b_leading, assumed_align=16)
+    # C output: N dimension (dim 1 of the 3-D view) is the leading/contiguous dim.
+    c_c = to_cute_tensor(c.unsqueeze(-1), leading_dim=1, assumed_align=16)
+    scale_c = to_cute_tensor(output_scale.reshape(1), assumed_align=4) if output_scale is not None else None
+    scale_output = output_scale is not None
+
+    key = _persistent_gemm_key(a, b, c, output_scale)
+    compiled = _persistent_gemm_cache.get(key)
+    if compiled is None:
+        with torch.cuda.device(a.device):
+            ensure_cuda_context()
+            max_active_clusters = cutlass.utils.HardwareInfo().get_max_active_clusters(
+                _CLUSTER_SHAPE_MN[0] * _CLUSTER_SHAPE_MN[1]
+            )
+        gemm_obj = HopperWgmmaGemmPersistentKernel(
+            acc_dtype=cutlass.Float32,
+            tile_shape_mn=_TILE_SHAPE_MN,
+            cluster_shape_mn=_CLUSTER_SHAPE_MN,
+            swizzle_size=_SWIZZLE_SIZE,
+            raster_along_m=_RASTER_ALONG_M,
+            scale_output=scale_output,
+        )
+        compiled = cute.compile(gemm_obj, a_c, b_c, c_c, scale_c, max_active_clusters, stream)
+        _persistent_gemm_cache[key] = compiled
+    compiled(a_c, b_c, c_c, scale_c, stream)
+
+
+def logits_persistent_gemm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    c: torch.Tensor,
+    a_leading: int,
+    b_leading: int,
+    stream: cuda.CUstream,
+) -> None:
+    """Compute unscaled FLCE logits with the persistent cluster."""
+    _persistent_gemm(a, b, c, a_leading, b_leading, stream)
+
+
+def dw_persistent_gemm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    c: torch.Tensor,
+    a_leading: int,
+    b_leading: int,
+    stream: cuda.CUstream,
+    output_scale: torch.Tensor,
+) -> None:
+    """Compute dW and fuse its scalar autograd scale into the TMA epilogue."""
+    _persistent_gemm(a, b, c, a_leading, b_leading, stream, output_scale)

--- a/src/liger_kernel/ops/cutedsl/ops/fused_linear_cross_entropy_sm90.py
+++ b/src/liger_kernel/ops/cutedsl/ops/fused_linear_cross_entropy_sm90.py
@@ -1,0 +1,268 @@
+"""Hopper (SM90) CuTe DSL **fused linear cross entropy**.
+
+This operator combines the classifier projection ``Z = X @ W.T``, softmax
+cross entropy, and input gradient in the autograd *forward*. The weight
+gradient is deferred to *backward* so its WGMMA epilogue can apply the upstream
+gradient without a separate full-tensor scale. It is a distinct implementation targeted at the Llama-scale shape
+``M=4096, H=4096, V=128256`` (BF16).
+
+Design (three logical GEMMs, "gradient-in-forward")
+---------------------------------------------------
+The forward runs, in order:
+
+1. **logits GEMM** ``logits[M, V] = X[M, H] @ W[V, H].T`` -- a WGMMA GEMM that
+   writes the raw BF16 logits to HBM exactly once (they are reused as the dZ
+   scratch, so no separate logits buffer survives).
+2. **CE + dZ** -- an eight-CTA one-read cluster kernel reads the logits with
+   aligned 128-bit copies, emits the per-token NLL ``nll[M]`` and overwrites the
+   logits *in place* with
+   ``dZ = (softmax(logits) - onehot(target)) * row_scale`` (BF16), where
+   ``row_scale`` folds the reduction (``1/N`` for ``mean``, ``1`` for ``sum``).
+   Unsupported vector-cluster shapes use the safe partitioned fallback.
+3. **dX GEMM** ``dX[M, H] = dZ @ W`` runs in forward. **dW GEMM**
+   ``dW[V, H] = dZ.T @ X`` runs in backward. Both use the same WGMMA primitive
+   on transposed operand *views*, and logits are never recomputed.
+
+The forward returns the reduced scalar loss and saves ``dX``, ``dZ``, and
+``X``. Backward scales ``dX`` and computes the scaled ``dW``.
+
+Supported semantics (deliberately narrow MVP)
+---------------------------------------------
+* Hopper (compute capability 9.0) only.
+* BF16 ``input[M, H]`` and ``weight[V, H]``, both contiguous; int64
+  ``target[M]``.
+* ``reduction`` in ``{"mean", "sum"}``; ``ignore_index`` honoured.
+* **No** bias, class weight, label smoothing, ``softcap``, ``lse_square_scale``
+  / z-loss, token-scaling or accuracy/metric outputs -- every one of these is
+  *rejected* with a clear error rather than silently ignored.
+
+Shape guards
+------------
+``H`` is padded up to ``TILE_N`` internally (a contraction-dim pad is exact and
+the padded gradient columns are sliced off).  ``M`` must be a multiple of
+``TILE_M`` (128) and ``V`` a multiple of ``TILE_N`` (256); both hold for the
+representative shape.  Other ``M``/``V`` are rejected -- ragged token/vocab
+tiling is left to a future version.
+
+Measured performance (H200, ``M=4096, H=4096, V=128256``, BF16, mean)
+---------------------------------------------------------------------
+Full forward+backward, interleaved CUDA-event medians (see
+``optimization/bench_flce_sm90.py``):
+
+* this kernel: ~18.06 ms hot median
+* QuACK 0.6.1 ``chunked_linear_cross_entropy``: ~17.33 ms hot median
+* Triton Liger FLCE: ~141 ms
+
+The CuTe DSL path is about 7.8x faster than the existing Triton path and remains
+about 4.2% slower than QuACK at this shape.
+"""
+
+import cuda.bindings.driver as cuda
+import torch
+
+from liger_kernel.ops.cutedsl.ops._fused_linear_cross_entropy_backward_sm90 import flce_dw
+from liger_kernel.ops.cutedsl.ops._fused_linear_cross_entropy_backward_sm90 import flce_dx
+from liger_kernel.ops.cutedsl.ops._fused_linear_cross_entropy_forward_sm90 import TILE_M
+from liger_kernel.ops.cutedsl.ops._fused_linear_cross_entropy_forward_sm90 import TILE_N
+from liger_kernel.ops.cutedsl.ops._fused_linear_cross_entropy_forward_sm90 import cross_entropy_dz
+from liger_kernel.ops.cutedsl.ops._fused_linear_cross_entropy_forward_sm90 import tile_gemm
+from liger_kernel.ops.cutedsl.ops.utils import ensure_cuda_context
+from liger_kernel.ops.utils import amp_custom_bwd
+from liger_kernel.ops.utils import amp_custom_fwd
+
+
+def _reject_unsupported(
+    bias, ce_weight, label_smoothing, softcap, lse_square_scale, use_token_scaling, return_z_loss, return_token_accuracy
+):
+    if bias is not None:
+        raise NotImplementedError("CuTe DSL FLCE (SM90) does not support bias")
+    if ce_weight is not None:
+        raise NotImplementedError("CuTe DSL FLCE (SM90) does not support class weights")
+    if label_smoothing:
+        raise NotImplementedError("CuTe DSL FLCE (SM90) does not support label smoothing")
+    if softcap is not None:
+        raise NotImplementedError("CuTe DSL FLCE (SM90) does not support logit softcapping")
+    if lse_square_scale:
+        raise NotImplementedError("CuTe DSL FLCE (SM90) does not support z-loss / lse_square_scale")
+    if use_token_scaling:
+        raise NotImplementedError("CuTe DSL FLCE (SM90) does not support token scaling")
+    if return_z_loss:
+        raise NotImplementedError("CuTe DSL FLCE (SM90) does not return z-loss")
+    if return_token_accuracy:
+        raise NotImplementedError("CuTe DSL FLCE (SM90) does not return token accuracy")
+
+
+def _validate(_input, weight, target, reduction):
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability(_input.device) != (9, 0):
+        raise RuntimeError("CuTe DSL FLCE requires a Hopper (compute capability 9.0) GPU")
+    if _input.dtype != torch.bfloat16 or weight.dtype != torch.bfloat16:
+        raise TypeError("CuTe DSL FLCE supports BF16 input and weight only")
+    if target.dtype != torch.int64:
+        raise TypeError("target must be an int64 tensor")
+    if _input.ndim != 2 or weight.ndim != 2 or target.ndim != 1:
+        raise ValueError("expected input[M, H], weight[V, H] and target[M]")
+    if _input.shape[0] != target.shape[0] or _input.shape[1] != weight.shape[1]:
+        raise ValueError(
+            f"input {tuple(_input.shape)}, weight {tuple(weight.shape)} and target "
+            f"{tuple(target.shape)} shapes are incompatible"
+        )
+    if reduction not in ("mean", "sum"):
+        raise ValueError(f"reduction must be 'mean' or 'sum', got {reduction!r}")
+    m = _input.shape[0]
+    v = weight.shape[0]
+    if m % TILE_M != 0:
+        raise NotImplementedError(f"CuTe DSL FLCE (MVP) requires M to be a multiple of {TILE_M}; got M={m}")
+    if v % TILE_N != 0:
+        raise NotImplementedError(f"CuTe DSL FLCE (MVP) requires V to be a multiple of {TILE_N}; got V={v}")
+
+
+def _pad_hidden(x, weight):
+    h = x.shape[1]
+    padded = (h + TILE_N - 1) // TILE_N * TILE_N
+    if padded == h:
+        return x.contiguous(), weight.contiguous(), h
+    x_p = torch.nn.functional.pad(x.contiguous(), (0, padded - h))
+    w_p = torch.nn.functional.pad(weight.contiguous(), (0, padded - h))
+    return x_p, w_p, h
+
+
+def fused_linear_cross_entropy_forward_sm90(
+    _input,
+    weight,
+    target,
+    ignore_index=-100,
+    reduction="mean",
+    defer_dw=False,
+):
+    """Run the three GEMMs + CE and return ``(loss, dx, dw)`` in caller dtypes.
+
+    ``dx`` / ``dw`` are the gradients of ``loss`` (reduction already folded in);
+    the autograd wrapper scales them by the scalar upstream gradient.
+    """
+    with torch.cuda.device(_input.device):
+        ensure_cuda_context()
+        x_pad, w_pad, hidden = _pad_hidden(_input, weight)
+        target = target.contiguous()
+        m, h_pad = x_pad.shape
+        v = w_pad.shape[0]
+
+        if reduction == "mean":
+            loss_scale = (target != ignore_index).sum().clamp_min(1).float().reciprocal()
+        else:
+            loss_scale = None
+
+        stream = cuda.CUstream(torch.cuda.current_stream(_input.device).cuda_stream)
+
+        # 1) logits = X @ W.T  (BF16, saved to HBM; reused in place as dZ)
+        logits = torch.empty(m, v, device=x_pad.device, dtype=torch.bfloat16)
+        tile_gemm(x_pad, w_pad, logits, a_leading=1, b_leading=1, stream=stream)
+
+        # 2) CE + dZ (overwrites `logits` in place)
+        nll = torch.empty(m, device=x_pad.device, dtype=torch.float32)
+        cross_entropy_dz(logits, target, nll, 1.0, ignore_index, stream)
+        dz = logits
+
+        # 3) dX = dZ @ W ; dW = dZ.T @ X
+        dx = flce_dx(
+            dz,
+            w_pad,
+            out_dtype=_input.dtype,
+            output_scale=loss_scale,
+        )
+        dx = dx[:, :hidden].contiguous()
+
+        loss = nll.sum()
+        if loss_scale is not None:
+            loss = loss * loss_scale
+        if defer_dw:
+            return loss, dx, dz, x_pad, loss_scale, hidden
+
+        dw = flce_dw(
+            dz,
+            x_pad,
+            out_dtype=weight.dtype,
+            output_scale=loss_scale,
+        )
+        dw = dw[:, :hidden].contiguous()
+        return loss, dx, dw
+
+
+class LigerFusedLinearCrossEntropySM90Function(torch.autograd.Function):
+    """``apply(input, weight, target, ignore_index=-100, reduction="mean")``.
+
+    Forward returns the scalar loss; backward scales the forward-computed input
+    gradient and computes the weight gradient.
+    """
+
+    @staticmethod
+    @amp_custom_fwd
+    def forward(
+        ctx,
+        _input,
+        weight,
+        target,
+        ignore_index=-100,
+        reduction="mean",
+        bias=None,
+        ce_weight=None,
+        label_smoothing=0.0,
+        softcap=None,
+        lse_square_scale=0.0,
+        use_token_scaling=False,
+        return_z_loss=False,
+        return_token_accuracy=False,
+    ):
+        _reject_unsupported(
+            bias,
+            ce_weight,
+            label_smoothing,
+            softcap,
+            lse_square_scale,
+            use_token_scaling,
+            return_z_loss,
+            return_token_accuracy,
+        )
+        _validate(_input, weight, target, reduction)
+        loss, dx, dz, x_padded, loss_scale, hidden = fused_linear_cross_entropy_forward_sm90(
+            _input,
+            weight,
+            target,
+            ignore_index=ignore_index,
+            reduction=reduction,
+            defer_dw=True,
+        )
+        saved_loss_scale = (
+            loss_scale if loss_scale is not None else torch.empty(0, device=_input.device, dtype=torch.float32)
+        )
+        ctx.save_for_backward(dx, dz, x_padded, saved_loss_scale)
+        ctx.has_loss_scale = loss_scale is not None
+        ctx.hidden = hidden
+        ctx.weight_dtype = weight.dtype
+        return loss
+
+    @staticmethod
+    @amp_custom_bwd
+    def backward(ctx, grad_output):
+        dx, dz, x_padded, loss_scale = ctx.saved_tensors
+        dx = dx * grad_output
+        output_scale = grad_output * loss_scale if ctx.has_loss_scale else grad_output
+        dw = flce_dw(
+            dz,
+            x_padded,
+            out_dtype=ctx.weight_dtype,
+            output_scale=output_scale,
+        )
+        dw = dw[:, : ctx.hidden].contiguous()
+        return dx, dw, None, None, None, None, None, None, None, None, None, None, None
+
+
+def liger_fused_linear_cross_entropy_sm90(_input, weight, target, ignore_index=-100, reduction="mean"):
+    """Functional entry point returning the reduced scalar loss."""
+    return LigerFusedLinearCrossEntropySM90Function.apply(_input, weight, target, ignore_index, reduction)
+
+
+__all__ = [
+    "LigerFusedLinearCrossEntropySM90Function",
+    "fused_linear_cross_entropy_forward_sm90",
+    "liger_fused_linear_cross_entropy_sm90",
+]

--- a/src/liger_kernel/ops/cutile/ops/__init__.py
+++ b/src/liger_kernel/ops/cutile/ops/__init__.py
@@ -15,6 +15,7 @@ except ImportError as exc:
 from liger_kernel.ops.cutile.ops.cross_entropy import LigerCrossEntropyFunction
 from liger_kernel.ops.cutile.ops.cross_entropy import cross_entropy_backward
 from liger_kernel.ops.cutile.ops.cross_entropy import cross_entropy_forward
+from liger_kernel.ops.cutile.ops.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyFunction
 from liger_kernel.ops.cutile.ops.fused_linear_jsd import LigerFusedLinearJSDFunction
 from liger_kernel.ops.cutile.ops.fused_linear_jsd import fused_linear_jsd_backward
 from liger_kernel.ops.cutile.ops.fused_linear_jsd import fused_linear_jsd_forward
@@ -45,6 +46,7 @@ __all__ = [
     "LigerCrossEntropyFunction",
     "cross_entropy_backward",
     "cross_entropy_forward",
+    "LigerFusedLinearCrossEntropyFunction",
     "LigerFusedLinearJSDFunction",
     "fused_linear_jsd_backward",
     "fused_linear_jsd_forward",

--- a/src/liger_kernel/ops/cutile/ops/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/ops/cutile/ops/fused_linear_cross_entropy.py
@@ -1,0 +1,468 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""Hopper-optimized cuTile fused linear cross entropy.
+
+The projection and input-gradient GEMMs use PyTorch's Hopper-tuned BLAS path.
+cuTile computes partitioned CE statistics, overwrites logits with dZ, and
+computes dW with an FP32-accumulating 128x256x64 MMA schedule.
+"""
+
+from typing import Optional
+
+import cuda.tile as ct
+import torch
+
+from liger_kernel.ops.cutile.ops.utils import _next_power_of_2
+from liger_kernel.ops.utils import amp_custom_bwd
+from liger_kernel.ops.utils import amp_custom_fwd
+
+ConstBool = ct.Constant[bool]
+ConstInt = ct.Constant[int]
+
+LOG2E = 1.4426950408889634
+DW_TILE_M = 128
+DW_TILE_N = 128
+DW_TILE_K = 64
+CE_BLOCK_SIZE = 2048
+LOGITS_STATS_BLOCK_SIZE = 4096
+MAX_STATS_BLOCK_SIZE = 1024
+
+
+@ct.kernel(num_worker_warps=ct.ByTarget(sm_90=8), opt_level=3)
+def _matmul_tn_kernel(
+    a,
+    b,
+    output,
+    grad_output,
+    TILE_M: ConstInt,
+    TILE_N: ConstInt,
+    TILE_K: ConstInt,
+):
+    """Compute ``output = (a.T @ b) * grad_output``."""
+    pid_m = ct.bid(0)
+    pid_n = ct.bid(1)
+    a_view = a.tiled_view((TILE_K, TILE_M), padding_mode=ct.PaddingMode.ZERO)
+    b_view = b.tiled_view((TILE_K, TILE_N), padding_mode=ct.PaddingMode.ZERO)
+    acc = ct.zeros((TILE_M, TILE_N), dtype=ct.float32)
+
+    for pid_k in range(a_view.num_tiles(0)):
+        a_tile = a_view.load((pid_k, pid_m), latency=10)
+        b_tile = b_view.load((pid_k, pid_n), latency=10)
+        acc = ct.mma(ct.transpose(a_tile), b_tile, acc)
+
+    scale = ct.astype(ct.gather(grad_output, (), check_bounds=False), ct.float32)
+    ct.store(output, (pid_m, pid_n), ct.astype(acc * scale, output.dtype), latency=1)
+
+
+@ct.kernel(num_worker_warps=ct.ByTarget(sm_90=8), opt_level=3)
+def _matmul_tn_n4_kernel(
+    a,
+    b,
+    output,
+    grad_output,
+    TILE_M: ConstInt,
+    TILE_N: ConstInt,
+    TILE_K: ConstInt,
+    LOAD_LATENCY: ConstInt,
+):
+    """Compute four adjacent dW column tiles while sharing each dZ load."""
+    pid_n = ct.bid(0) * 4
+    pid_m = ct.bid(1)
+    a_view = a.tiled_view((TILE_K, TILE_M), padding_mode=ct.PaddingMode.ZERO)
+    b_view = b.tiled_view((TILE_K, TILE_N), padding_mode=ct.PaddingMode.ZERO)
+    output_view = output.tiled_view((TILE_M, TILE_N), padding_mode=ct.PaddingMode.ZERO)
+    acc0 = ct.zeros((TILE_M, TILE_N), dtype=ct.float32)
+    acc1 = ct.zeros((TILE_M, TILE_N), dtype=ct.float32)
+    acc2 = ct.zeros((TILE_M, TILE_N), dtype=ct.float32)
+    acc3 = ct.zeros((TILE_M, TILE_N), dtype=ct.float32)
+
+    for pid_k in range(a_view.num_tiles(0)):
+        a_tile = ct.transpose(a_view.load((pid_k, pid_m), latency=LOAD_LATENCY))
+        acc0 = ct.mma(a_tile, b_view.load((pid_k, pid_n), latency=LOAD_LATENCY), acc0)
+        acc1 = ct.mma(a_tile, b_view.load((pid_k, pid_n + 1), latency=LOAD_LATENCY), acc1)
+        acc2 = ct.mma(a_tile, b_view.load((pid_k, pid_n + 2), latency=LOAD_LATENCY), acc2)
+        acc3 = ct.mma(a_tile, b_view.load((pid_k, pid_n + 3), latency=LOAD_LATENCY), acc3)
+
+    scale = ct.astype(ct.gather(grad_output, (), check_bounds=False), ct.float32)
+    output_view.store((pid_m, pid_n), ct.astype(acc0 * scale, output.dtype), latency=1)
+    output_view.store((pid_m, pid_n + 1), ct.astype(acc1 * scale, output.dtype), latency=1)
+    output_view.store((pid_m, pid_n + 2), ct.astype(acc2 * scale, output.dtype), latency=1)
+    output_view.store((pid_m, pid_n + 3), ct.astype(acc3 * scale, output.dtype), latency=1)
+
+
+@ct.kernel(occupancy=8)
+def _fused_cross_entropy_dz_kernel(
+    logits,
+    target,
+    loss,
+    loss_scale,
+    partial_max,
+    partial_sum,
+    completion_count,
+    vocab_size,
+    num_partitions,
+    ignore_index,
+    STATS_BLOCK_SIZE: ConstInt,
+    CE_BLOCK_SIZE: ConstInt,
+    PARTIALS_BLOCK_SIZE: ConstInt,
+    HAS_GRADIENTS: ConstBool,
+    REDUCTION_MEAN: ConstBool,
+):
+    program = ct.bid(0)
+    row = program // num_partitions
+    partition = program % num_partitions
+    label = ct.load(target, row, shape=())
+    stat_cols = ct.arange(STATS_BLOCK_SIZE, dtype=ct.int32) + partition * STATS_BLOCK_SIZE
+    values = ct.astype(
+        ct.gather(logits, (row, stat_cols), check_bounds=True, padding_value=-float("inf"), latency=4),
+        ct.float32,
+    )
+    block_max = ct.max(values, 0, keepdims=False)
+    block_sum = ct.sum(ct.exp2((values - block_max) * LOG2E, flush_to_zero=True), 0, keepdims=False)
+    ct.scatter(partial_max, (row, partition), block_max, check_bounds=False)
+    ct.scatter(partial_sum, (row, partition), block_sum, check_bounds=False)
+
+    completed = ct.atomic_add(
+        completion_count,
+        row,
+        1,
+        check_bounds=False,
+        memory_order=ct.MemoryOrder.ACQ_REL,
+        memory_scope=ct.MemoryScope.DEVICE,
+    )
+    if completed != num_partitions - 1:
+        return
+
+    if label == ignore_index:
+        if HAS_GRADIENTS:
+            for chunk in range((vocab_size + CE_BLOCK_SIZE - 1) // CE_BLOCK_SIZE):
+                cols = ct.arange(CE_BLOCK_SIZE, dtype=ct.int32) + chunk * CE_BLOCK_SIZE
+                ct.scatter(logits, (row, cols), ct.zeros((CE_BLOCK_SIZE,), dtype=logits.dtype), check_bounds=True)
+        ct.scatter(loss, row, ct.astype(0.0, loss.dtype))
+        return
+
+    partial_cols = ct.arange(PARTIALS_BLOCK_SIZE, dtype=ct.int32)
+    tile_max = ct.astype(
+        ct.gather(partial_max, (row, partial_cols), check_bounds=True, padding_value=-float("inf"), latency=2),
+        ct.float32,
+    )
+    tile_sum = ct.astype(
+        ct.gather(partial_sum, (row, partial_cols), check_bounds=True, padding_value=0.0, latency=2),
+        ct.float32,
+    )
+    valid_stats = ct.less(partial_cols, num_partitions)
+    tile_max = ct.where(valid_stats, tile_max, -float("inf"))
+    tile_sum = ct.where(valid_stats, tile_sum, 0.0)
+
+    max_value = ct.max(tile_max, 0, keepdims=False)
+    exp_sum = ct.sum(tile_sum * ct.exp2((tile_max - max_value) * LOG2E, flush_to_zero=True), 0, keepdims=False)
+    target_logit = ct.astype(ct.gather(logits, (row, label), check_bounds=False), ct.float32)
+    row_scale = 1.0
+    if REDUCTION_MEAN:
+        row_scale = ct.astype(ct.gather(loss_scale, (), check_bounds=False), ct.float32)
+    ct.scatter(loss, row, ct.astype((max_value + ct.log(exp_sum) - target_logit) * row_scale, loss.dtype))
+
+    if HAS_GRADIENTS:
+        inv_sum = 1.0 / exp_sum
+        for chunk in range((vocab_size + CE_BLOCK_SIZE - 1) // CE_BLOCK_SIZE):
+            cols = ct.arange(CE_BLOCK_SIZE, dtype=ct.int32) + chunk * CE_BLOCK_SIZE
+            logits_tile = ct.astype(
+                ct.gather(logits, (row, cols), check_bounds=True, padding_value=-float("inf"), latency=4),
+                ct.float32,
+            )
+            gradient = ct.exp2((logits_tile - max_value) * LOG2E, flush_to_zero=True) * inv_sum
+            gradient = ct.where(ct.equal(cols, label), gradient - 1.0, gradient)
+            ct.scatter(logits, (row, cols), ct.astype(gradient, logits.dtype), check_bounds=True)
+
+
+def _launch_matmul_tn(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    output: torch.Tensor,
+    grad_output: torch.Tensor,
+) -> None:
+    if output.shape[1] % 256 == 0:
+        _launch_cutile(
+            output.device,
+            (
+                output.shape[1] // 256,
+                (output.shape[0] + DW_TILE_M - 1) // DW_TILE_M,
+                1,
+            ),
+            _matmul_tn_n4_kernel,
+            (a, b, output, grad_output, DW_TILE_M, 64, DW_TILE_K, 5),
+        )
+        return
+
+    tile_n = min(256, _next_power_of_2(output.shape[1]))
+    _launch_cutile(
+        output.device,
+        (
+            (output.shape[0] + DW_TILE_M - 1) // DW_TILE_M,
+            (output.shape[1] + tile_n - 1) // tile_n,
+            1,
+        ),
+        _matmul_tn_kernel,
+        (a, b, output, grad_output, DW_TILE_M, tile_n, DW_TILE_K),
+    )
+
+
+def _launch_cutile(device: torch.device, grid, kernel, args) -> None:
+    with torch.cuda.device(device):
+        ct.launch(torch.cuda.current_stream(device), grid, kernel, args)
+
+
+def _reject_unsupported(
+    bias,
+    ce_weight,
+    lse_square_scale,
+    label_smoothing,
+    softcap,
+    return_z_loss,
+    accum_dtype,
+    use_token_scaling,
+    return_token_accuracy,
+    return_predicted_tokens,
+) -> None:
+    unsupported = {
+        "bias": bias is not None,
+        "class weights": ce_weight is not None,
+        "z-loss": bool(lse_square_scale),
+        "label smoothing": bool(label_smoothing),
+        "softcap": softcap is not None,
+        "return_z_loss": return_z_loss,
+        "accum_dtype": accum_dtype is not None,
+        "token scaling": use_token_scaling,
+        "return_token_accuracy": return_token_accuracy,
+        "return_predicted_tokens": return_predicted_tokens,
+    }
+    enabled = [name for name, value in unsupported.items() if value]
+    if enabled:
+        raise NotImplementedError(f"cuTile SM90 FLCE does not support: {', '.join(enabled)}")
+
+
+def _validate_inputs(
+    _input: torch.Tensor,
+    weight: torch.Tensor,
+    target: torch.Tensor,
+    reduction: str,
+) -> None:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability(_input.device) != (9, 0):
+        raise RuntimeError("cuTile FLCE requires a Hopper (compute capability 9.0) GPU")
+    if _input.dtype != torch.bfloat16 or weight.dtype != torch.bfloat16:
+        raise TypeError("cuTile FLCE supports BF16 input and weight only")
+    if target.dtype != torch.int64:
+        raise TypeError("target must be an int64 tensor")
+    if _input.ndim != 2 or weight.ndim != 2 or target.ndim != 1:
+        raise ValueError("expected input[M, H], weight[V, H], and target[M]")
+    if _input.shape[0] != target.shape[0] or _input.shape[1] != weight.shape[1]:
+        raise ValueError(
+            f"incompatible input {tuple(_input.shape)}, weight {tuple(weight.shape)}, and target {tuple(target.shape)}"
+        )
+    if reduction not in ("mean", "sum"):
+        raise ValueError(f"reduction must be 'mean' or 'sum', got {reduction!r}")
+    if _input.device != weight.device or _input.device != target.device:
+        raise ValueError("input, weight, and target must be on the same CUDA device")
+    if not _input.is_contiguous() or not weight.is_contiguous() or not target.is_contiguous():
+        raise ValueError("cuTile FLCE requires contiguous input, weight, and target tensors")
+    num_stats_partitions = (weight.shape[0] + LOGITS_STATS_BLOCK_SIZE - 1) // LOGITS_STATS_BLOCK_SIZE
+    if num_stats_partitions > MAX_STATS_BLOCK_SIZE:
+        raise NotImplementedError(
+            f"cuTile FLCE supports at most {MAX_STATS_BLOCK_SIZE * LOGITS_STATS_BLOCK_SIZE} vocabulary entries"
+        )
+
+
+def fused_linear_cross_entropy_forward(
+    _input,
+    weight,
+    target,
+    ce_weight=None,
+    bias=None,
+    ignore_index=-100,
+    lse_square_scale=0.0,
+    label_smoothing=0.0,
+    reduction="mean",
+    softcap=None,
+    return_z_loss=False,
+    accum_dtype=None,
+    use_token_scaling=False,
+    return_token_accuracy=False,
+    return_predicted_tokens=False,
+):
+    _reject_unsupported(
+        bias,
+        ce_weight,
+        lse_square_scale,
+        label_smoothing,
+        softcap,
+        return_z_loss,
+        accum_dtype,
+        use_token_scaling,
+        return_token_accuracy,
+        return_predicted_tokens,
+    )
+    _validate_inputs(_input, weight, target, reduction)
+
+    tokens, hidden_size = _input.shape
+    vocab_size = weight.shape[0]
+    num_vocab_tiles = (vocab_size + LOGITS_STATS_BLOCK_SIZE - 1) // LOGITS_STATS_BLOCK_SIZE
+    stats_block_size = _next_power_of_2(num_vocab_tiles)
+    needs_dz = _input.requires_grad or weight.requires_grad
+    logits = torch.empty((tokens, vocab_size), dtype=torch.bfloat16, device=_input.device)
+    loss_1d = torch.empty(tokens, dtype=torch.float32, device=_input.device)
+    partial_max = torch.empty((tokens, num_vocab_tiles), dtype=torch.float32, device=_input.device)
+    partial_sum = torch.empty_like(partial_max)
+    completion_count = torch.zeros(tokens, dtype=torch.int32, device=_input.device)
+    target_mask = target != ignore_index
+    valid_target = ~target_mask | ((target >= 0) & (target < vocab_size))
+    torch._assert_async(valid_target.all(), f"target values must be in [0, {vocab_size}) or equal ignore_index")
+    loss_scale = (
+        target_mask.sum().clamp_min(1).to(torch.float32).reciprocal()
+        if reduction == "mean"
+        else torch.empty((), dtype=torch.float32, device=_input.device)
+    )
+
+    torch.mm(_input, weight.t(), out=logits)
+    _launch_cutile(
+        logits.device,
+        (num_vocab_tiles * tokens, 1, 1),
+        _fused_cross_entropy_dz_kernel,
+        (
+            logits,
+            target,
+            loss_1d,
+            loss_scale,
+            partial_max,
+            partial_sum,
+            completion_count,
+            vocab_size,
+            num_vocab_tiles,
+            ignore_index,
+            LOGITS_STATS_BLOCK_SIZE,
+            CE_BLOCK_SIZE,
+            stats_block_size,
+            needs_dz,
+            reduction == "mean",
+        ),
+    )
+
+    grad_input = None
+    if _input.requires_grad:
+        grad_input = torch.empty((tokens, hidden_size), dtype=_input.dtype, device=_input.device)
+        torch.mm(logits, weight, out=grad_input)
+
+    loss = loss_1d.sum()
+    gradient_scale = loss_scale if reduction == "mean" else torch.ones((), dtype=torch.float32, device=_input.device)
+    return loss, grad_input, logits if weight.requires_grad else None, gradient_scale
+
+
+def fused_linear_cross_entropy_backward(
+    grad_output: torch.Tensor,
+    grad_input: Optional[torch.Tensor],
+    grad_logits: Optional[torch.Tensor],
+    _input: Optional[torch.Tensor],
+    gradient_scale: torch.Tensor,
+    weight_shape: torch.Size,
+    weight_dtype: torch.dtype,
+):
+    total_scale = grad_output * gradient_scale
+    if grad_input is not None:
+        grad_input = grad_input * total_scale
+
+    grad_weight = None
+    if grad_logits is not None:
+        grad_weight = torch.empty(weight_shape, dtype=weight_dtype, device=grad_logits.device)
+        _launch_matmul_tn(grad_logits, _input, grad_weight, total_scale)
+
+    return grad_input, grad_weight
+
+
+class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
+    @staticmethod
+    @amp_custom_fwd
+    def forward(
+        ctx,
+        _input,
+        weight,
+        target,
+        bias=None,
+        ce_weight=None,
+        ignore_index=-100,
+        lse_square_scale=0.0,
+        label_smoothing=0.0,
+        reduction="mean",
+        softcap=None,
+        return_z_loss=False,
+        accum_dtype=None,
+        use_token_scaling=False,
+        return_token_accuracy=False,
+        return_predicted_tokens=False,
+    ):
+        loss, grad_input, grad_logits, gradient_scale = fused_linear_cross_entropy_forward(
+            _input=_input,
+            weight=weight,
+            target=target,
+            ce_weight=ce_weight,
+            bias=bias,
+            ignore_index=ignore_index,
+            lse_square_scale=lse_square_scale,
+            label_smoothing=label_smoothing,
+            reduction=reduction,
+            softcap=softcap,
+            return_z_loss=return_z_loss,
+            accum_dtype=accum_dtype,
+            use_token_scaling=use_token_scaling,
+            return_token_accuracy=return_token_accuracy,
+            return_predicted_tokens=return_predicted_tokens,
+        )
+
+        ctx.save_for_backward(
+            grad_input,
+            grad_logits,
+            _input.detach() if weight.requires_grad else None,
+            gradient_scale,
+        )
+        ctx.weight_shape = weight.shape
+        ctx.weight_dtype = weight.dtype
+        return loss, None, None, None
+
+    @staticmethod
+    @amp_custom_bwd
+    def backward(ctx, grad_output, grad_output2, grad_output3, grad_output4):
+        del grad_output2, grad_output3, grad_output4
+        grad_input, grad_logits, _input, gradient_scale = ctx.saved_tensors
+        grad_input, grad_weight = fused_linear_cross_entropy_backward(
+            grad_output,
+            grad_input,
+            grad_logits,
+            _input,
+            gradient_scale,
+            ctx.weight_shape,
+            ctx.weight_dtype,
+        )
+        return (
+            grad_input,
+            grad_weight,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+__all__ = [
+    "LigerFusedLinearCrossEntropyFunction",
+    "fused_linear_cross_entropy_backward",
+    "fused_linear_cross_entropy_forward",
+]

--- a/test/transformers/test_cutedsl_fused_linear_cross_entropy_sm90.py
+++ b/test/transformers/test_cutedsl_fused_linear_cross_entropy_sm90.py
@@ -1,0 +1,129 @@
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (9, 0),
+    reason="CuTe DSL fused linear cross entropy requires Hopper (SM90)",
+)
+
+
+def _operator():
+    pytest.importorskip("cutlass")
+    from liger_kernel.ops.cutedsl.ops.fused_linear_cross_entropy_sm90 import LigerFusedLinearCrossEntropySM90Function
+
+    return LigerFusedLinearCrossEntropySM90Function
+
+
+def _reference(x, weight, target, ignore_index, reduction, grad_output):
+    x_ref = x.float().detach().requires_grad_()
+    weight_ref = weight.float().detach().requires_grad_()
+    loss = torch.nn.functional.cross_entropy(
+        x_ref @ weight_ref.T,
+        target,
+        ignore_index=ignore_index,
+        reduction=reduction,
+    )
+    loss.backward(grad_output)
+    return loss.detach(), x_ref.grad.detach(), weight_ref.grad.detach()
+
+
+def _relative_max_error(actual, expected):
+    return (actual.float() - expected.float()).abs().max() / expected.float().abs().max().clamp_min(1e-9)
+
+
+@pytest.mark.parametrize("shape", [(128, 256, 512), (256, 512, 768)])
+@pytest.mark.parametrize("reduction", ["mean", "sum"])
+@pytest.mark.parametrize("with_ignored_tokens", [False, True])
+def test_sm90_fused_linear_cross_entropy(shape, reduction, with_ignored_tokens):
+    torch.manual_seed(0)
+    tokens, hidden_size, vocab_size = shape
+    x = torch.randn(tokens, hidden_size, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(vocab_size, hidden_size, device="cuda", dtype=torch.bfloat16) * 0.05
+    target = torch.randint(vocab_size, (tokens,), device="cuda")
+    if with_ignored_tokens:
+        target[::17] = -100
+    grad_output = torch.tensor(0.75, device="cuda")
+
+    x_actual = x.detach().clone().requires_grad_()
+    weight_actual = weight.detach().clone().requires_grad_()
+    loss_actual = _operator().apply(
+        x_actual,
+        weight_actual,
+        target,
+        -100,
+        reduction,
+    )
+    loss_actual.backward(grad_output)
+
+    loss_expected, dx_expected, dw_expected = _reference(
+        x,
+        weight,
+        target,
+        -100,
+        reduction,
+        grad_output,
+    )
+
+    assert torch.allclose(loss_actual.float(), loss_expected, atol=5e-3, rtol=5e-3)
+    assert _relative_max_error(x_actual.grad, dx_expected) < 3e-2
+    assert _relative_max_error(weight_actual.grad, dw_expected) < 3e-2
+
+
+def test_sm90_fused_linear_cross_entropy_rejects_unsupported_shapes_and_dtypes():
+    function = _operator()
+    x = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(512, 256, device="cuda", dtype=torch.bfloat16)
+    target = torch.randint(512, (128,), device="cuda")
+
+    with pytest.raises(TypeError, match="BF16"):
+        function.apply(x.float(), weight.float(), target)
+    with pytest.raises(ValueError, match="reduction"):
+        function.apply(x, weight, target, -100, "none")
+    with pytest.raises(NotImplementedError, match="multiple of 128"):
+        function.apply(x[:127], weight, target[:127])
+    with pytest.raises(NotImplementedError, match="bias"):
+        function.apply(x, weight, target, -100, "mean", torch.zeros(512, device="cuda"))
+
+
+def test_sm90_fused_linear_cross_entropy_repeated_backward():
+    torch.manual_seed(1)
+    x = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    weight = torch.randn(512, 256, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    target = torch.randint(512, (128,), device="cuda")
+    loss = _operator().apply(x, weight, target)
+
+    first = torch.autograd.grad(loss, (x, weight), retain_graph=True)
+    second = torch.autograd.grad(loss, (x, weight), retain_graph=True)
+
+    assert torch.equal(first[0], second[0])
+    assert torch.equal(first[1], second[1])
+
+
+def test_sm90_fused_linear_cross_entropy_repeated_training_steps():
+    torch.manual_seed(2)
+    weight = torch.randn(512, 256, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+
+    for step in range(20):
+        x = torch.randn(128, 256, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        target = torch.randint(512, (128,), device="cuda")
+        if step % 3 == 0:
+            target[::17] = -100
+        _operator().apply(x, weight, target).backward()
+        torch.cuda.synchronize()
+        weight.grad = None
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two Hopper GPUs")
+def test_sm90_fused_linear_cross_entropy_noncurrent_cuda_device():
+    torch.cuda.set_device(0)
+    device = torch.device("cuda:1")
+    x = torch.randn(128, 256, device=device, dtype=torch.bfloat16, requires_grad=True)
+    weight = torch.randn(512, 256, device=device, dtype=torch.bfloat16, requires_grad=True)
+    target = torch.randint(512, (128,), device=device)
+
+    loss = _operator().apply(x, weight, target)
+    loss.backward()
+
+    assert loss.device == device
+    assert x.grad is not None
+    assert weight.grad is not None

--- a/test/transformers/test_cutile_backend.py
+++ b/test/transformers/test_cutile_backend.py
@@ -11,6 +11,7 @@ CUTILE_PREFIX = "liger_kernel.ops.cutile."
 # Transformer modules bind liger_kernel.ops.* at import time (geglu != GELUMul name).
 TRANSFORMER_MODULES = {
     "LigerCrossEntropyFunction": "liger_kernel.transformers.cross_entropy",
+    "LigerFusedLinearCrossEntropyFunction": "liger_kernel.transformers.fused_linear_cross_entropy",
     "LigerFusedLinearJSDFunction": "liger_kernel.transformers.fused_linear_jsd",
     "LigerGELUMulFunction": "liger_kernel.transformers.geglu",
     "LigerJSDFunction": "liger_kernel.transformers.jsd",

--- a/test/transformers/test_cutile_fused_linear_cross_entropy_sm90.py
+++ b/test/transformers/test_cutile_fused_linear_cross_entropy_sm90.py
@@ -1,0 +1,135 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+from test.utils import assert_verbose_allclose
+from test.utils import set_seed
+
+pytest.importorskip("cuda.tile")
+
+from liger_kernel.ops.cutile.ops.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyFunction
+
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="cuTile FLCE requires CUDA"),
+    pytest.mark.skipif(
+        not torch.cuda.is_available() or torch.cuda.get_device_capability() != (9, 0),
+        reason="cuTile FLCE requires Hopper",
+    ),
+]
+
+set_seed()
+
+
+def _reference(x, weight, target, ignore_index, reduction):
+    return F.cross_entropy(
+        F.linear(x, weight).float(),
+        target,
+        ignore_index=ignore_index,
+        reduction=reduction,
+    )
+
+
+@pytest.mark.parametrize("shape", [(128, 128, 256), (129, 96, 384), (32, 64, 8192)])
+@pytest.mark.parametrize("reduction", ["mean", "sum"])
+def test_correctness(shape, reduction):
+    tokens, hidden_size, vocab_size = shape
+    ignore_index = -100
+    upstream = torch.tensor(0.7, device="cuda")
+    x_data = torch.randn(tokens, hidden_size, device="cuda", dtype=torch.bfloat16)
+    weight_data = torch.randn(vocab_size, hidden_size, device="cuda", dtype=torch.bfloat16)
+    target = torch.randint(vocab_size, (tokens,), device="cuda")
+    target[: max(1, tokens // 8)] = ignore_index
+
+    x_ref = x_data.clone().requires_grad_(True)
+    weight_ref = weight_data.clone().requires_grad_(True)
+    loss_ref = _reference(x_ref, weight_ref, target, ignore_index, reduction)
+    loss_ref.backward(upstream)
+
+    x = x_data.clone().requires_grad_(True)
+    weight = weight_data.clone().requires_grad_(True)
+    loss, _, _, _ = LigerFusedLinearCrossEntropyFunction.apply(
+        x,
+        weight,
+        target,
+        None,
+        None,
+        ignore_index,
+        0.0,
+        0.0,
+        reduction,
+    )
+    loss.backward(upstream)
+
+    atol = 5e-3 if reduction == "mean" else 5e-2
+    rtol = 5e-2
+    assert_verbose_allclose(loss_ref, loss, atol=atol, rtol=rtol)
+    assert_verbose_allclose(x_ref.grad, x.grad, atol=atol, rtol=rtol)
+    assert_verbose_allclose(weight_ref.grad, weight.grad, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("requires_input_grad, requires_weight_grad", [(True, False), (False, True)])
+def test_independent_gradient_requirements(requires_input_grad, requires_weight_grad):
+    x = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16, requires_grad=requires_input_grad)
+    weight = torch.randn(256, 128, device="cuda", dtype=torch.bfloat16, requires_grad=requires_weight_grad)
+    target = torch.randint(256, (128,), device="cuda")
+
+    loss = LigerFusedLinearCrossEntropyFunction.apply(x, weight, target)[0]
+    loss.backward()
+
+    assert (x.grad is not None) == requires_input_grad
+    assert (weight.grad is not None) == requires_weight_grad
+
+
+def test_rejects_unsupported_features():
+    x = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    weight = torch.randn(256, 128, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    target = torch.randint(256, (128,), device="cuda")
+    bias = torch.zeros(256, device="cuda", dtype=torch.bfloat16)
+
+    with pytest.raises(NotImplementedError, match="bias"):
+        LigerFusedLinearCrossEntropyFunction.apply(x, weight, target, bias)
+
+
+def test_retained_backward_preserves_saved_gradient():
+    x = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    weight = torch.randn(256, 128, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    target = torch.randint(256, (128,), device="cuda")
+    upstream = torch.tensor(0.7, device="cuda")
+    loss = LigerFusedLinearCrossEntropyFunction.apply(x, weight, target)[0]
+
+    loss.backward(upstream, retain_graph=True)
+    first_x_grad = x.grad.clone()
+    first_weight_grad = weight.grad.clone()
+    x.grad = None
+    weight.grad = None
+    loss.backward(upstream, retain_graph=True)
+
+    assert_verbose_allclose(first_x_grad, x.grad, atol=0.0, rtol=0.0)
+    assert_verbose_allclose(first_weight_grad, weight.grad, atol=0.0, rtol=0.0)
+
+
+def test_large_token_grid():
+    tokens = 65536
+    x = torch.randn(tokens, 16, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(128, 16, device="cuda", dtype=torch.bfloat16)
+    target = torch.randint(128, (tokens,), device="cuda")
+
+    loss = LigerFusedLinearCrossEntropyFunction.apply(x, weight, target)[0]
+
+    assert torch.isfinite(loss)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two Hopper GPUs")
+def test_noncurrent_cuda_device():
+    torch.cuda.set_device(0)
+    device = torch.device("cuda:1")
+    x = torch.randn(128, 128, device=device, dtype=torch.bfloat16, requires_grad=True)
+    weight = torch.randn(256, 128, device=device, dtype=torch.bfloat16, requires_grad=True)
+    target = torch.randint(256, (128,), device=device)
+
+    loss = LigerFusedLinearCrossEntropyFunction.apply(x, weight, target)[0]
+    loss.backward()
+
+    assert torch.isfinite(loss)
+    assert x.grad is not None
+    assert weight.grad is not None


### PR DESCRIPTION
## Summary

Adds optimized Hopper (SM90) fused linear cross entropy implementations for both the CuTe DSL and cuTile backends, including the persistent GEMM optimization previously developed in #1369.

- **CuTe DSL SM90:** persistent BF16 WGMMA/TMA logits and scaled-dW GEMMs, static near-ceiling dX, and a vectorized one-read clustered CE+dZ kernel.
- **cuTile SM90:** Hopper-tuned BLAS logits/dX, partitioned cuTile CE+dZ, and an FP32-accumulating cuTile dW MMA kernel.
- Preserves the existing SM100 CuTe DSL FLCE API; the Hopper implementation is exposed explicitly as `LigerFusedLinearCrossEntropySM90Function`.
- Adds backend exports, cuTile routing, retained/repeated-backward coverage, non-current-device tests, and benchmark entry points.

## Implementation highlights

### CuTe DSL

- **Persistent logits and dW:** `M128 x N256 x K64`, cluster `(1,2)`, one dedicated DMA warp group, two WGMMA groups, four-stage TMA operand pipeline, and four-stage TMA-store epilogue.
- **Persistent one-wave scheduling:** 132 resident CTAs repeatedly claim output tiles instead of launching approximately 16K static CTAs over many hardware waves.
- **Cluster multicast:** logits multicast X across adjacent vocabulary tiles; dW multicasts dZ.T across adjacent hidden-dimension tiles.
- **Scaled dW epilogue:** applies the scalar autograd/reduction scale in FP32 before BF16 TMA stores.
- **Static dX:** retains the original `M128 x N256 x K64` S3 kernel because persistent and cuBLAS-shaped dX variants regressed end-to-end.
- **In-place CE+dZ:** aligned 128-bit copies, register-retained exponentials, deterministic DSMEM peer loads, and in-place logits-to-dZ conversion.
- Independent fallbacks: `FLCE_LOGITS_PERSISTENT=0`, `FLCE_DW_CLUSTERED_PERSISTENT=0`, and `FLCE_CE_CLUSTER_VECTOR=0`.

### cuTile

- Fused partition statistics, NLL, and in-place dZ formation.
- Device-scope atomic completion protocol for partition merging.
- Four-column-tile dW specialization that reuses dZ loads.
- Independent input/weight gradient requirements and retained-backward support.

## Benchmark plots

Latency plots show full eager forward+backward medians from 20 balanced-order
iterations. Memory plots show incremental peak allocated memory (median of
three synchronized runs).

### Token-length latency

![H200 token-length latency comparison](https://raw.githubusercontent.com/Celaena24/Liger-Kernel/ae4221df3189e115099ea965da0357b3c7d000f0/benchmark-assets/pr1356_token_latency.png)

### Token-length peak memory

![H200 token-length peak-memory comparison](https://raw.githubusercontent.com/Celaena24/Liger-Kernel/ae4221df3189e115099ea965da0357b3c7d000f0/benchmark-assets/pr1356_token_memory.png)

### Canonical-model latency

![H200 canonical-model latency comparison](https://raw.githubusercontent.com/Celaena24/Liger-Kernel/ae4221df3189e115099ea965da0357b3c7d000f0/benchmark-assets/pr1356_model_latency.png)

### Canonical-model peak memory

![H200 canonical-model peak-memory comparison](https://raw.githubusercontent.com/Celaena24/Liger-Kernel/ae4221df3189e115099ea965da0357b3c7d000f0/benchmark-assets/pr1356_model_memory.png)

## H200 benchmark results

BF16 full eager forward+backward. Medians use balanced provider order after three warmups. Lower latency is better. `CuTe vs cuTile = cuTile latency / CuTe latency`, so values above `1x` mean CuTe is faster.

### Paired optimization result at the target shape

`M=4096`, `H=4096`, `V=128256`, 40 paired balanced-order iterations:

| Cache | Original static CuTe | Persistent logits+dW | Improvement | Matched cuTile |
|---|---:|---:|---:|---:|
| hot | 19.083 ms | **18.340 ms** | **3.90%** | 18.794 ms |
| cold L2 | 19.226 ms | **18.523 ms** | **3.66%** | 19.111 ms |

Absolute latency depends on sustained-clock/provider ordering; the tables below are fresh four-provider sweeps collected with one consistent protocol.

### Token-length sweep

BF16, `H=4096`, `V=128256`, 20 balanced-order iterations.

#### Hot cache

| BT | CuTe DSL | **CuTe vs Triton** | cuTile | **cuTile vs Triton** | CuTe vs cuTile | QuACK | Triton |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 1,024 | 4.778 ms | **28.79x** | 4.775 ms | **28.81x** | 0.999x | 4.113 ms | 137.556 ms |
| 2,048 | 8.683 ms | **15.97x** | 8.773 ms | **15.80x** | 1.010x | 7.955 ms | 138.631 ms |
| 4,096 | 16.712 ms | **8.53x** | 17.210 ms | **8.28x** | 1.030x | 16.778 ms | 142.563 ms |
| 8,192 | 34.350 ms | **4.49x** | 35.559 ms | **4.33x** | 1.035x | 35.474 ms | 154.066 ms |
| 16,384 | 73.722 ms | **2.52x** | 74.060 ms | **2.50x** | 1.005x | 73.709 ms | 185.475 ms |

#### Cold L2

| BT | CuTe DSL | **CuTe vs Triton** | cuTile | **cuTile vs Triton** | CuTe vs cuTile | QuACK | Triton |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 1,024 | 4.648 ms | **29.61x** | 4.722 ms | **29.15x** | 1.016x | 4.074 ms | 137.638 ms |
| 2,048 | 8.564 ms | **16.15x** | 8.714 ms | **15.87x** | 1.018x | 7.954 ms | 138.286 ms |
| 4,096 | 16.615 ms | **8.56x** | 17.091 ms | **8.32x** | 1.029x | 16.669 ms | 142.245 ms |
| 8,192 | 34.559 ms | **4.46x** | 35.434 ms | **4.35x** | 1.025x | 35.080 ms | 154.007 ms |
| 16,384 | 74.933 ms | **2.47x** | 74.435 ms | **2.49x** | 0.993x | 73.767 ms | 184.990 ms |

### Canonical model sweep

BF16, `M=2048`, 20 balanced-order iterations.

#### Hot cache

| Model | H | V | CuTe DSL | **CuTe vs Triton** | cuTile | **cuTile vs Triton** | CuTe vs cuTile | QuACK | Triton |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| llama_2_7b | 4096 | 32000 | 2.392 ms | **4.20x** | 2.391 ms | **4.20x** | 0.999x | 2.130 ms | 10.050 ms |
| llama_3_8b | 4096 | 128256 | 8.720 ms | **15.92x** | 8.806 ms | **15.76x** | 1.010x | 7.963 ms | 138.824 ms |
| qwen2.5_7b | 3584 | 152064 | 9.992 ms | **14.35x** | 9.528 ms | **15.05x** | 0.954x | 9.144 ms | 143.391 ms |
| qwen2.5_14b | 5120 | 152064 | 13.691 ms | **7.63x** | 12.873 ms | **8.12x** | 0.940x | 12.496 ms | 104.493 ms |
| qwen2.5_72b | 8192 | 152064 | 19.733 ms | **8.48x** | 20.703 ms | **8.08x** | 1.049x | 20.199 ms | 167.350 ms |
| deepseek_v2_lite | 2048 | 102400 | 3.953 ms | **14.34x** | 3.925 ms | **14.44x** | 0.993x | 3.438 ms | 56.671 ms |
| deepseek_v3 | 7168 | 129280 | 15.001 ms | **8.65x** | 15.391 ms | **8.43x** | 1.026x | 14.681 ms | 129.745 ms |

#### Cold L2

| Model | H | V | CuTe DSL | **CuTe vs Triton** | cuTile | **cuTile vs Triton** | CuTe vs cuTile | QuACK | Triton |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| llama_2_7b | 4096 | 32000 | 2.358 ms | **4.24x** | 2.369 ms | **4.22x** | 1.004x | 2.112 ms | 9.989 ms |
| llama_3_8b | 4096 | 128256 | 8.571 ms | **16.12x** | 8.743 ms | **15.80x** | 1.020x | 7.955 ms | 138.144 ms |
| qwen2.5_7b | 3584 | 152064 | 9.892 ms | **14.48x** | 9.445 ms | **15.16x** | 0.955x | 9.154 ms | 143.186 ms |
| qwen2.5_14b | 5120 | 152064 | 13.553 ms | **7.70x** | 12.753 ms | **8.19x** | 0.941x | 12.432 ms | 104.395 ms |
| qwen2.5_72b | 8192 | 152064 | 19.610 ms | **8.53x** | 20.563 ms | **8.13x** | 1.049x | 19.892 ms | 167.231 ms |
| deepseek_v2_lite | 2048 | 102400 | 3.865 ms | **14.68x** | 3.881 ms | **14.62x** | 1.004x | 3.445 ms | 56.728 ms |
| deepseek_v3 | 7168 | 129280 | 14.962 ms | **8.66x** | 15.283 ms | **8.48x** | 1.021x | 14.753 ms | 129.568 ms |

The Qwen vocabulary (`V=152064`) intentionally exercises the safe partitioned CE fallback because its per-CTA cluster partition exceeds the one-read kernel's bounded register-retention limit.

### GEMMs versus cuBLAS

Target shape, hot cache:

| Phase | CuTe | cuBLAS | Gap |
|---|---:|---:|---:|
| logits | 6.318 ms | 6.313 ms | +0.08% |
| dX (unchanged static path) | 6.253 ms | 6.144 ms | +1.78% |
| dW | 6.423 ms | 6.422 ms | +0.02% |
| **total** | **18.994 ms** | **18.878 ms** | **+0.61%** |

Cold-L2 GEMM total is within 0.24% of cuBLAS.

## NCU diagnosis

| Phase | Metric | Static | Persistent |
|---|---|---:|---:|
| logits | tensor pipe active | 89.67% | **95.45%** |
| logits | long-scoreboard stalls | 9.39 | **3.16** |
| dW | tensor pipe active | 88.73% | **95.04%** |
| dW | long-scoreboard stalls | 10.88 | **3.37** |
| both | registers/thread | 240 | **168** |

## Correctness and test plan

- Focused CuTe Hopper FLCE suite: **12 passed**, including mean/sum, ignored tokens, retained backward, repeated training, and non-current-device coverage.
- cuTile mean/sum correctness, independent gradient requirements, retained backward, large token grids, and non-current-device coverage.
- cuTile backend routing through `LIGER_KERNEL_IMPL=cutile`.
- BF16 and FP32 upstream-scale cache variants checked directly.
- Compute Sanitizer memcheck and synccheck for the clustered CuTe CE.
- 200 synchronized full-shape CuTe forward/backward iterations.
- Focused Ruff check and format passed.

