### PR TITLE
Pin fp64 scalar kernel params to fp32 in remaining norm ops

### DIFF
--- a/src/liger_kernel/ops/fused_add_rms_norm.py
+++ b/src/liger_kernel/ops/fused_add_rms_norm.py
@@ -93,6 +93,10 @@ def _fused_add_rms_norm_forward_kernel(
     if casting_mode == _CASTING_MODE_NONE:
         eps = eps.to(S_row_dtype)
         offset = offset.to(S_row_dtype)
+    else:
+        # Force fp32 scalars: Inductor may use fp64 under torch.compile and tank throughput.
+        eps = eps.to(tl.float32)
+        offset = offset.to(tl.float32)
 
     mean_square = tl.sum(S_row * S_row, axis=0) / n_cols
     rstd = rsqrt(mean_square + eps)
@@ -168,7 +172,7 @@ def _fused_add_rms_norm_backward_kernel(
     dW_row = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
 
     W_row = tl.load(W_ptr + col_offsets, mask=mask, other=0.0)
-    W_row = W_row + offset
+    W_row = W_row + offset.to(tl.float32)
 
     for row_idx in range(row_start, row_end):
         dy_base = dY_ptr + row_idx * dY_row_stride

--- a/src/liger_kernel/ops/group_norm.py
+++ b/src/liger_kernel/ops/group_norm.py
@@ -75,7 +75,7 @@ def _group_norm_forward_kernel(
     variance = (squared_sum / hidden_size) - (m * m)
 
     # 1/std
-    rstd = rsqrt(variance + eps)
+    rstd = rsqrt(variance + eps.to(tl.float32))
 
     # Normalize — flat loop over full hidden_size (not per-channel)
     # This avoids the nested channel × per_channel_hidden loop where

--- a/src/liger_kernel/ops/layer_norm.py
+++ b/src/liger_kernel/ops/layer_norm.py
@@ -72,7 +72,7 @@ def _layer_norm_forward_kernel(
     # Apply mask to variance calculation to exclude contributions from masked elements
     X_centered_masked = tl.where(mask, X_centered, 0.0)
     var = tl.sum(X_centered_masked * X_centered_masked, axis=0) / n_cols
-    rstd = rsqrt(var + eps)
+    rstd = rsqrt(var + eps.to(tl.float32))
 
     # Store statistics (convert back to original dtype only once)
     tl.store(row_Mean_ptr, mean.to(X_row.dtype))

--- a/src/liger_kernel/ops/poly_norm.py
+++ b/src/liger_kernel/ops/poly_norm.py
@@ -69,6 +69,9 @@ def _poly_norm_forward_kernel(
     X_pow1 = X_row
 
     # Compute norm(x³): norm(u) = u * rsqrt(mean(u²) + eps)
+    # Force fp32 eps: Inductor may use fp64 under torch.compile and tank throughput.
+    eps = eps.to(tl.float32)
+
     mean_square_3 = tl.sum(X_pow3 * X_pow3, axis=0) / n_cols
     rstd_3 = rsqrt(mean_square_3 + eps)
     norm_x3 = X_pow3 * rstd_3


### PR DESCRIPTION
## Summary

Follow-up to #1350. The exact same non-`constexpr` Python `float` parameter bug, where Inductor specializes to **fp64**, forcing Triton to silently promote calculations (like `rsqrt`) to double precision, is fixed here across 4 remaining normalization operators:

| File | Scalar | Affected Sites |
| :--- | :--- | :--- |
| `fused_add_rms_norm.py` | `eps`, `offset` | forward `rsqrt(mean_square + eps)`, backward `W_row + offset` |
| `layer_norm.py` | `eps` | `rsqrt(var + eps)` |
| `group_norm.py` | `eps` | `rsqrt(variance + eps)` |
| `poly_norm.py` | `eps` | 3× `rsqrt(mean_square_N + eps)` |

## Details & Performance Impact

Severity is architecture-dependent, the bug is not: PTX is identical on H100 and B300, only the fp64 price differs (#1350's "roughly halving throughput" is H100-bound; B300 sees 4–6x, and SwiGLU hit 12.5x in #1330). So the evidence below
leads with instruction counts rather than wall clock.

| op | `.f64` before → after | compiled before → after | speedup | eager |
|---|---|---|---|---|
| `fused_add_rms_norm` | 212 → 3 | 0.2037 → 0.0335 ms | **6.1x** | unchanged |
| `poly_norm` | 192 → 1 | 0.2304 → 0.0367 ms | **6.3x** | unchanged |
| `layer_norm` | 100 → 1 | 0.1190 → 0.0272 ms | **4.4x** | unchanged |
| `group_norm` | 1540 → 1 | 0.1552 → 0.0986 ms | **1.6x** | unchanged |
| `rms_norm` (control) | 3 → 3 | 0.0146 → 0.0146 ms | 1.0x | unchanged |

> B300, bf16, per-kernel GPU time from the profiler. `rms_norm` is a control, which is already fixed, so it should be and is indeed unaffected.

## Shape sweep

Repeated at 5 shapes/op (4 for `group_norm`): **19/19 configs contaminated before, 19/19 clean after**, with compiled bandwidth restored to eager parity at every one.

| op | shapes | compiled BW before | after (eager parity) |
|---|---|---|---|
| `fused_add_rms_norm` | 2048², 8192×3072, 4096², 2048×8192, 16384×4096 | 500–680 GB/s | 3151–4748 GB/s |
| `layer_norm` | same 5 | 511–679 GB/s | 2333–3178 GB/s |
| `poly_norm` | same 5 | 273–365 GB/s | 1555–2451 GB/s |
| `group_norm` | (16,32,4096), (8,32,10240), (4,32,8192), (32,32,2048) | 50–222 GB/s | 71–293 GB/s |

> `group_norm`'s absolute bandwidth is low at all shapes for an unrelated reason; the fp64 penalty is still recovered at each. (put the details in comment)

Remaining follow-ups: the loss ops (`cross_entropy` `softcap`/`ls_eps`, `kl_div` `eps`, `tvd` `scale`, `grpo_loss`) and the Ascend backend copies under `ops/backends/_ascend/`, which take a different compiler path.

## Testing Done

* **Numeric Parity:** Eliminating the fp64 promotion closes the precision gap under compilation. `max|out_eager − out_compiled|` dropped from `1.6e-2 ~ 3.1e-2` down to exactly **0**.
* **Test Suite:** 140 passed, 10 xfailed (unit tests for all 4 ops + `rms_norm` pass identically on H100 and B300).

- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence