### PR TITLE
[cuTile] Add fused scaled cross entropy

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ loss = nll.sum() / (target != -100).sum().clamp_min(1)
 
 The implementations share this public contract but use different schedules:
 
-- **cuTile** (`LIGER_KERNEL_IMPL=cutile`) supports matching floating-point `input` and `weight` tensors on CUDA and a finite positive scalar `temperature`. Forward and backward bound the temporary logits workspace to 256 MiB. Backward reuses one workspace and writes `dX` and accumulates `dW` directly into their final tensors. `m_tiles_per_cluster` is accepted for API compatibility but does not change the cuTile schedule.
+- **cuTile** (`LIGER_KERNEL_IMPL=cutile`) supports matching floating-point `input` and `weight` tensors on CUDA and a finite positive scalar `temperature`. The portable temporary-logits budget is 256 MiB. Large FP16/BF16 Blackwell workloads (`M >= 4096`, `V >= 131072`) automatically use 512 MiB to improve GEMM utilization. Set `LIGER_CUTILE_SCALED_CE_WORKSPACE_MB` to another positive MiB value for workload-specific tuning; for example, 1024 can help large combined NLL-plus-entropy workloads but is not universally faster. Backward reuses one workspace and writes `dX` and accumulates `dW` directly into their final tensors. `m_tiles_per_cluster` is accepted for API compatibility but does not change the cuTile schedule.
 - **CuTe SM90** uses `LigerFusedScaledCrossEntropySM90Function` for BF16 inputs on Hopper. Forward never writes logits to HBM; `m_tiles_per_cluster=1` selects the fastest M-outer schedule and larger values select the M-fast schedule. Backward runs `dZ`, `dX`, and `dW` in one persistent cluster kernel with a reusable 1024-token `dZ` workspace.
 - **Fallback** uses a 512-token chunked PyTorch implementation adapted from Verl's fused PPO formulas when the default frontend cannot use the SM90 kernel.
 
@@ -244,6 +244,13 @@ H100 measurements for per-token NLL at `M=4096`, `H=4096`, `V=131072`, BF16:
 |---|---:|---:|---:|---:|
 | cuTile | 6.45 ms | 20.70 ms | 26.94 ms | 2.43 GiB |
 | CuTe SM90 | 7.26 ms | 19.81 ms | 27.74 ms | 2.43 GiB |
+
+B200 measurements for the same shape, using automatic cuTile workspace selection:
+
+| Implementation | Forward | Backward | Full | Peak full memory |
+|---|---:|---:|---:|---:|
+| cuTile | 2.97 ms | 8.35 ms | 11.36 ms | 2.64 GiB |
+| Torch | 5.24 ms | 7.15 ms | 12.85 ms | 7.22 GiB |
 
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -217,29 +217,11 @@ pip install "liger-kernel[cutedsl]"
 LIGER_KERNEL_IMPL=cutedsl python your_script.py
 ```
 
-It currently provides genuine `cutlass.cute` implementations of **RMSNorm**, **cross entropy**, and
-**fused scaled cross entropy** (`LigerFusedLinearScaledCrossEntropyFunction`). The frontend dispatches from the input
-device: Hopper compute capability 9.0 uses `LigerFusedScaledCrossEntropySM90Function`, while other devices and
-NVIDIA compute capabilities use a 512-token chunked PyTorch fallback adapted from Verl's fused linear PPO
-implementation. The scaled operator is an *additional* operator, not a replacement for the Triton
-`LigerFusedLinearCrossEntropyFunction`:
-it fuses `x @ weight.T` with the softmax, takes matching floating-point `input`/`weight` (BF16 on SM90) plus
-`ignore_index`, and returns
-the per-token negative log-likelihood `[M]` plus optional vocabulary entropy — reductions are composed in PyTorch. Backward
-therefore receives the per-token upstream gradient `[M]`, which is used verbatim as the row scale of
-`dZ`; a scalar `grad_output` is rejected rather than silently reduced. `temperature` defaults to
-`1.0` and applies the same `logits / temperature` semantics as Verl.
-Set `return_entropy=True` to additionally return differentiable per-token
-vocabulary entropy in the input dtype; its backward contribution follows Verl's PPO
-formula. Both NLL and entropy are zeroed for `ignore_index` rows.
-On SM90, `m_tiles_per_cluster` (>= 1, default `1`) selects the forward schedule: `1` uses the fastest M-outer self-TMA forward, values `> 1`
-use the M-fast forward with that many live M tiles per cluster. Backward executes `dZ`, `dX = dZ @ W`,
-and `dW = dZ.T @ X` inside one persistent cluster-2 CUDA kernel. Its device-side wave loop aliases
-phase-specific shared memory, uses W multicast for dX, transposed TMA for dW, and HBM atomics between
-waves. Backward uses a fixed reusable BF16 `dZ` workspace covering 1024 tokens; wave zero
-plain-stores BF16 `dW`, and later waves use Hopper BF16 TMA reduce-add. Ops without a CuTe DSL kernel
-transparently fall back to the default Triton kernel. Selecting the backend on a non-CUDA device, or
-without `nvidia-cutlass-dsl` installed, raises an error.
+It currently provides genuine `cutlass.cute` implementations of **RMSNorm**, **cross entropy**, and **fused scaled cross entropy**. Ops without a CuTe DSL kernel transparently fall back to the default Triton kernel.
+
+### Fused Scaled Cross Entropy
+
+`LigerFusedLinearScaledCrossEntropyFunction` is an additional per-token operator, not a replacement for the reduction-oriented Triton `LigerFusedLinearCrossEntropyFunction`. It takes `input[M, H]`, `weight[V, H]`, and `target[M]`, applies `logits / temperature`, and returns FP32 negative log-likelihood `[M]` plus optional differentiable vocabulary entropy `[M]` in the input dtype. Reductions remain in PyTorch, and rows whose target equals `ignore_index` contribute zero outputs and gradients.
 
 ```python
 from liger_kernel.ops import LigerFusedLinearScaledCrossEntropyFunction
@@ -249,6 +231,19 @@ nll, entropy = LigerFusedLinearScaledCrossEntropyFunction.apply(
 )  # [M], [M]
 loss = nll.sum() / (target != -100).sum().clamp_min(1)
 ```
+
+The implementations share this public contract but use different schedules:
+
+- **cuTile** (`LIGER_KERNEL_IMPL=cutile`) supports matching floating-point `input` and `weight` tensors on CUDA and a finite positive scalar `temperature`. Forward and backward bound the temporary logits workspace to 256 MiB. Backward reuses one workspace and writes `dX` and accumulates `dW` directly into their final tensors. `m_tiles_per_cluster` is accepted for API compatibility but does not change the cuTile schedule.
+- **CuTe SM90** uses `LigerFusedScaledCrossEntropySM90Function` for BF16 inputs on Hopper. Forward never writes logits to HBM; `m_tiles_per_cluster=1` selects the fastest M-outer schedule and larger values select the M-fast schedule. Backward runs `dZ`, `dX`, and `dW` in one persistent cluster kernel with a reusable 1024-token `dZ` workspace.
+- **Fallback** uses a 512-token chunked PyTorch implementation adapted from Verl's fused PPO formulas when the default frontend cannot use the SM90 kernel.
+
+H100 measurements for per-token NLL at `M=4096`, `H=4096`, `V=131072`, BF16:
+
+| Implementation | Forward | Backward | Full | Peak full memory |
+|---|---:|---:|---:|---:|
+| cuTile | 6.45 ms | 20.70 ms | 26.94 ms | 2.43 GiB |
+| CuTe SM90 | 7.26 ms | 19.81 ms | 27.74 ms | 2.43 GiB |
 
 
 ## Getting Started

--- a/benchmark/scripts/benchmark_fused_scaled_cross_entropy_sm90.py
+++ b/benchmark/scripts/benchmark_fused_scaled_cross_entropy_sm90.py
@@ -171,18 +171,19 @@ def setup_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput):
         raise ValueError(f"Unknown provider {provider!r}")
 
     layer = layer.to(device)
-    return x, lambda: layer(x, target), fixed_grad_output(total_tokens)
+    weight = layer.weight if hasattr(layer, "weight") else layer.linear.weight
+    return x, weight, lambda: layer(x, target), fixed_grad_output(total_tokens)
 
 
-def probe_forward_fn(x, fwd_fn, grad_output):
-    """Adapter for the shared memory-probing helpers (setup returns a 3-tuple)."""
+def probe_forward_fn(x, weight, fwd_fn, grad_output):
+    """Adapter for the shared memory-probing helpers (setup returns a 4-tuple)."""
     return fwd_fn()
 
 
 def bench_speed_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
     import triton
 
-    x, fwd_fn, grad_output = setup_fused_scaled_cross_entropy_sm90(input)
+    x, weight, fwd_fn, grad_output = setup_fused_scaled_cross_entropy_sm90(input)
     mode = input.kernel_operation_mode
 
     if mode == "forward":
@@ -199,12 +200,17 @@ def bench_speed_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput) 
     else:
         raise ValueError(f"Unsupported mode: {mode}")
 
-    ms_50, ms_20, ms_80 = triton.testing.do_bench(bench_fn, grad_to_none=[x], rep=10, quantiles=QUANTILES)
+    ms_50, ms_20, ms_80 = triton.testing.do_bench(
+        bench_fn,
+        grad_to_none=[x, weight],
+        rep=10,
+        quantiles=QUANTILES,
+    )
     return SingleBenchmarkRunOutput(y_20=ms_20, y_50=ms_50, y_80=ms_80)
 
 
 def bench_memory_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
-    x, fwd_fn, grad_output = setup_fused_scaled_cross_entropy_sm90(input)
+    x, weight, fwd_fn, grad_output = setup_fused_scaled_cross_entropy_sm90(input)
     mode = input.kernel_operation_mode
 
     if mode == "forward":
@@ -214,11 +220,13 @@ def bench_memory_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput)
 
         def bench_fn():
             x.grad = None
+            weight.grad = None
             y.backward(grad_output, retain_graph=True)
     elif mode == "full":
 
         def bench_fn():
             x.grad = None
+            weight.grad = None
             fwd_fn().backward(grad_output)
     else:
         raise ValueError(f"Unsupported mode: {mode}")

--- a/benchmark/scripts/benchmark_fused_scaled_cross_entropy_sm90.py
+++ b/benchmark/scripts/benchmark_fused_scaled_cross_entropy_sm90.py
@@ -15,13 +15,13 @@ Sweep parameters (all optional; defaults reproduce the previous behaviour)::
     --providers NAME [NAME ...]     explicit provider list
 
 Providers: ``torch``, ``liger`` (Triton FLCE, ``reduction="none"``),
-and ``cutedsl-sm90`` (fixed 1024-token wave-batched backward).
+``cutile``, and ``cutedsl-sm90`` (fixed 1024-token wave-batched backward).
 
 Example::
 
     python benchmark_fused_scaled_cross_entropy_sm90.py \\
         --tokens 4096 --hidden 4096 --vocab 131072 \\
-        --providers torch liger cutedsl-sm90
+        --providers torch liger cutile cutedsl-sm90
 """
 
 import argparse
@@ -53,6 +53,7 @@ REPRESENTATIVE_CONFIG = {
 }
 
 CUTEDSL_PREFIX = "cutedsl-sm90"
+CUTILE_PREFIX = "cutile"
 # Seed of the fixed per-token upstream gradient, so every provider and every
 # repetition sees byte-identical ``d(NLL)/d(loss)`` values.
 GRAD_SEED = 1234
@@ -110,6 +111,29 @@ class CuteDSLHopperLMHeadScaledCE(torch.nn.Module):
         )
 
 
+class CuTileLMHeadScaledCE(torch.nn.Module):
+    def __init__(self, hidden_size: int, vocab_size: int, dtype: torch.dtype, temperature: float = 1.0):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.empty(vocab_size, hidden_size, dtype=dtype))
+        self.temperature = temperature
+        torch.nn.init.normal_(self.weight, std=hidden_size**-0.5)
+
+    def forward(self, x, target):
+        from liger_kernel.ops.cutile.ops.fused_linear_scaled_cross_entropy import (
+            LigerFusedLinearScaledCrossEntropyFunction,
+        )
+
+        return LigerFusedLinearScaledCrossEntropyFunction.apply(
+            x,
+            self.weight,
+            target,
+            self.temperature,
+            -100,
+            1,
+            False,
+        )
+
+
 def fixed_grad_output(tokens: int) -> torch.Tensor:
     """The fixed ``[M]`` upstream gradient of the per-token NLL."""
     generator = torch.Generator(device=device).manual_seed(GRAD_SEED)
@@ -137,6 +161,8 @@ def setup_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput):
     provider = input.kernel_provider
     if provider == CUTEDSL_PREFIX:
         layer = CuteDSLHopperLMHeadScaledCE(hidden_size, vocab_size, dtype)
+    elif provider == CUTILE_PREFIX:
+        layer = CuTileLMHeadScaledCE(hidden_size, vocab_size, dtype)
     elif provider == "liger":
         layer = TritonLMHeadCE(hidden_size, vocab_size, dtype)
     elif provider == "torch":
@@ -219,10 +245,10 @@ def parse_sweep_args():
 def resolve_providers(sweep_args):
     if sweep_args.providers:
         for provider in sweep_args.providers:
-            if provider not in ("torch", "liger", CUTEDSL_PREFIX):
+            if provider not in ("torch", "liger", CUTILE_PREFIX, CUTEDSL_PREFIX):
                 raise ValueError(f"Unknown provider {provider!r}")
         return list(sweep_args.providers)
-    return ["torch", "liger", CUTEDSL_PREFIX]
+    return ["torch", "liger", CUTILE_PREFIX, CUTEDSL_PREFIX]
 
 
 if __name__ == "__main__":

--- a/src/liger_kernel/ops/cutile/ops/__init__.py
+++ b/src/liger_kernel/ops/cutile/ops/__init__.py
@@ -18,6 +18,7 @@ from liger_kernel.ops.cutile.ops.cross_entropy import cross_entropy_forward
 from liger_kernel.ops.cutile.ops.fused_linear_jsd import LigerFusedLinearJSDFunction
 from liger_kernel.ops.cutile.ops.fused_linear_jsd import fused_linear_jsd_backward
 from liger_kernel.ops.cutile.ops.fused_linear_jsd import fused_linear_jsd_forward
+from liger_kernel.ops.cutile.ops.fused_linear_scaled_cross_entropy import LigerFusedLinearScaledCrossEntropyFunction
 from liger_kernel.ops.cutile.ops.geglu import LigerGELUMulFunction
 from liger_kernel.ops.cutile.ops.geglu import geglu_backward
 from liger_kernel.ops.cutile.ops.geglu import geglu_forward
@@ -48,6 +49,7 @@ __all__ = [
     "LigerFusedLinearJSDFunction",
     "fused_linear_jsd_backward",
     "fused_linear_jsd_forward",
+    "LigerFusedLinearScaledCrossEntropyFunction",
     "LigerGELUMulFunction",
     "geglu_backward",
     "geglu_forward",

--- a/src/liger_kernel/ops/cutile/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cutile/ops/cross_entropy.py
@@ -9,17 +9,11 @@ from typing import Optional
 import cuda.tile as ct
 import torch
 
-from liger_kernel.ops.cutile.ops.utils import _next_power_of_2
+from liger_kernel.ops.cutile.ops.utils import LOG2E
+from liger_kernel.ops.cutile.ops.utils import _select_cross_entropy_block_size
 
 ConstFloat = ct.Constant[float]
 ConstInt = ct.Constant[int]
-
-MAX_FUSED_SIZE = 65536 // 2
-LOG2E = 1.4426950408889634
-
-
-def _select_cross_entropy_block_size(vocab_size: int) -> int:
-    return min(4096, min(MAX_FUSED_SIZE, _next_power_of_2(vocab_size)))
 
 
 @ct.kernel(occupancy=4)

--- a/src/liger_kernel/ops/cutile/ops/fused_linear_scaled_cross_entropy.py
+++ b/src/liger_kernel/ops/cutile/ops/fused_linear_scaled_cross_entropy.py
@@ -282,7 +282,13 @@ def fused_scaled_cross_entropy_backward(
     block_size = _select_cross_entropy_block_size(V)
 
     grad_input = torch.empty_like(_input) if _input.requires_grad else None
-    grad_weight = torch.zeros_like(weight) if weight.requires_grad else None
+    grad_weight = torch.empty_like(weight) if weight.requires_grad else None
+    grad_logits_workspace = torch.empty(
+        min(BT, chunk_size),
+        V,
+        dtype=_input.dtype,
+        device=_input.device,
+    )
     dummy_f32 = torch.empty(1, dtype=torch.float32, device=_input.device)
     dummy_input_dtype = torch.empty(1, dtype=_input.dtype, device=_input.device)
 
@@ -295,7 +301,8 @@ def fused_scaled_cross_entropy_backward(
     for start in range(0, BT, chunk_size):
         end = min(start + chunk_size, BT)
         input_chunk = _input[start:end]
-        grad_logits_chunk = (input_chunk @ weight.t()).contiguous()
+        grad_logits_chunk = grad_logits_workspace[: end - start]
+        torch.mm(input_chunk, weight.t(), out=grad_logits_chunk)
 
         ct.launch(
             torch.cuda.current_stream(),
@@ -318,9 +325,14 @@ def fused_scaled_cross_entropy_backward(
         )
 
         if grad_input is not None:
-            grad_input[start:end] = grad_logits_chunk @ weight
+            torch.mm(grad_logits_chunk, weight, out=grad_input[start:end])
         if grad_weight is not None:
-            grad_weight.add_(grad_logits_chunk.t() @ input_chunk)
+            if start == 0:
+                torch.mm(grad_logits_chunk.t(), input_chunk, out=grad_weight)
+            else:
+                # Accumulate the GEMM directly into grad_weight instead of
+                # materializing a full V x H temporary for every token chunk.
+                torch.addmm(grad_weight, grad_logits_chunk.t(), input_chunk, out=grad_weight)
 
     return grad_input, grad_weight
 

--- a/src/liger_kernel/ops/cutile/ops/fused_linear_scaled_cross_entropy.py
+++ b/src/liger_kernel/ops/cutile/ops/fused_linear_scaled_cross_entropy.py
@@ -21,7 +21,7 @@ def _validate_temperature(temperature):
         raise ValueError("temperature must be finite and > 0")
 
 
-def _validate_inputs(_input, weight, target, ignore_index):
+def _validate_input_metadata(_input, weight, target):
     if _input.ndim != 2 or weight.ndim != 2 or target.ndim != 1:
         raise ValueError("expected input[M,H], weight[V,H], and target[M]")
     if _input.shape[0] != target.shape[0] or _input.shape[1] != weight.shape[1]:
@@ -38,6 +38,9 @@ def _validate_inputs(_input, weight, target, ignore_index):
     if target.dtype != torch.int64:
         raise TypeError("target must be an int64 tensor")
 
+
+def _validate_inputs(_input, weight, target, ignore_index):
+    _validate_input_metadata(_input, weight, target)
     out_of_range = ((target < 0) | (target >= weight.shape[0])) & (target != ignore_index)
     if bool(out_of_range.any()):
         raise ValueError(
@@ -49,7 +52,16 @@ def _calculate_token_chunk_size(token_count, vocab_size, element_size):
     bytes_per_token = vocab_size * element_size
     max_tokens_per_chunk = max(1, _MAX_LOGITS_WORKSPACE_BYTES // bytes_per_token)
     power_of_two_chunk = _next_power_of_2(max_tokens_per_chunk + 1) // 2
-    return min(token_count, power_of_two_chunk)
+    if token_count <= power_of_two_chunk:
+        return token_count
+
+    minimum_chunks = (token_count + max_tokens_per_chunk - 1) // max_tokens_per_chunk
+    power_of_two_chunks = (token_count + power_of_two_chunk - 1) // power_of_two_chunk
+    power_of_two_tail = token_count - (power_of_two_chunks - 1) * power_of_two_chunk
+
+    if power_of_two_chunks > minimum_chunks or power_of_two_tail * 2 < power_of_two_chunk:
+        return (token_count + minimum_chunks - 1) // minimum_chunks
+    return power_of_two_chunk
 
 
 @ct.kernel(occupancy=4)
@@ -259,7 +271,7 @@ def fused_scaled_cross_entropy_backward(
     ``None`` for entropy-only backward; ``entropy`` and ``grad_entropy`` are
     needed only when entropy contributes to the gradient.
     """
-    _validate_inputs(_input, weight, target, ignore_index)
+    _validate_input_metadata(_input, weight, target)
     _validate_temperature(temperature)
     if grad_nll is None and grad_entropy is None:
         raise ValueError("at least one of grad_nll or grad_entropy must be provided")

--- a/src/liger_kernel/ops/cutile/ops/fused_linear_scaled_cross_entropy.py
+++ b/src/liger_kernel/ops/cutile/ops/fused_linear_scaled_cross_entropy.py
@@ -11,6 +11,8 @@ from liger_kernel.ops.cutile.ops.utils import _select_cross_entropy_block_size
 
 ConstInt = ct.Constant[int]
 
+_MAX_LOGITS_WORKSPACE_BYTES = 256 * 1024 * 1024
+
 
 def _validate_temperature(temperature):
     if isinstance(temperature, bool) or not isinstance(temperature, (int, float)):
@@ -41,6 +43,13 @@ def _validate_inputs(_input, weight, target, ignore_index):
         raise ValueError(
             f"target contains values outside [0, {weight.shape[0]}) that are not ignore_index={ignore_index}"
         )
+
+
+def _calculate_token_chunk_size(token_count, vocab_size, element_size):
+    bytes_per_token = vocab_size * element_size
+    max_tokens_per_chunk = max(1, _MAX_LOGITS_WORKSPACE_BYTES // bytes_per_token)
+    power_of_two_chunk = _next_power_of_2(max_tokens_per_chunk + 1) // 2
+    return min(token_count, power_of_two_chunk)
 
 
 @ct.kernel(occupancy=4)
@@ -133,10 +142,9 @@ def fused_scaled_cross_entropy_forward(
     if not isinstance(return_entropy, bool):
         raise TypeError("return_entropy must be a bool")
 
-    BT, H = _input.shape
+    BT = _input.shape[0]
     V = weight.shape[0]
-    inc_factor = (V + H - 1) // H
-    chunk_size = _next_power_of_2((BT + inc_factor - 1) // inc_factor)
+    chunk_size = _calculate_token_chunk_size(BT, V, _input.element_size())
     block_size = _select_cross_entropy_block_size(V)
 
     nll = torch.empty(BT, dtype=torch.float32, device=_input.device)
@@ -268,10 +276,9 @@ def fused_scaled_cross_entropy_backward(
                 f"got {tuple(entropy.shape)} and {tuple(grad_entropy.shape)}"
             )
 
-    BT, H = _input.shape
+    BT = _input.shape[0]
     V = weight.shape[0]
-    inc_factor = (V + H - 1) // H
-    chunk_size = _next_power_of_2((BT + inc_factor - 1) // inc_factor)
+    chunk_size = _calculate_token_chunk_size(BT, V, _input.element_size())
     block_size = _select_cross_entropy_block_size(V)
 
     grad_input = torch.empty_like(_input) if _input.requires_grad else None

--- a/src/liger_kernel/ops/cutile/ops/fused_linear_scaled_cross_entropy.py
+++ b/src/liger_kernel/ops/cutile/ops/fused_linear_scaled_cross_entropy.py
@@ -1,6 +1,7 @@
 """cuTile interface for fused linear scaled cross entropy."""
 
 import math
+import os
 
 import cuda.tile as ct
 import torch
@@ -8,10 +9,16 @@ import torch
 from liger_kernel.ops.cutile.ops.utils import LOG2E
 from liger_kernel.ops.cutile.ops.utils import _next_power_of_2
 from liger_kernel.ops.cutile.ops.utils import _select_cross_entropy_block_size
+from liger_kernel.utils import infer_device_arch
 
 ConstInt = ct.Constant[int]
 
-_MAX_LOGITS_WORKSPACE_BYTES = 256 * 1024 * 1024
+_MIB = 1024 * 1024
+_PORTABLE_LOGITS_WORKSPACE_BYTES = 256 * _MIB
+_BLACKWELL_LOGITS_WORKSPACE_BYTES = 512 * _MIB
+_BLACKWELL_MIN_TOKENS = 4096
+_BLACKWELL_MIN_VOCAB_SIZE = 131072
+_WORKSPACE_MB_ENV = "LIGER_CUTILE_SCALED_CE_WORKSPACE_MB"
 
 
 def _validate_temperature(temperature):
@@ -48,9 +55,35 @@ def _validate_inputs(_input, weight, target, ignore_index):
         )
 
 
-def _calculate_token_chunk_size(token_count, vocab_size, element_size):
+def _select_logits_workspace_bytes(device_id, token_count, vocab_size, element_size):
+    workspace_override = os.environ.get(_WORKSPACE_MB_ENV)
+    if workspace_override is not None:
+        try:
+            workspace_mb = int(workspace_override)
+        except ValueError as exc:
+            raise ValueError(f"{_WORKSPACE_MB_ENV} must be a positive integer, got {workspace_override!r}") from exc
+        if workspace_mb <= 0:
+            raise ValueError(f"{_WORKSPACE_MB_ENV} must be a positive integer, got {workspace_override!r}")
+        return workspace_mb * _MIB
+
+    if (
+        element_size == 2
+        and token_count >= _BLACKWELL_MIN_TOKENS
+        and vocab_size >= _BLACKWELL_MIN_VOCAB_SIZE
+        and infer_device_arch(device_id).startswith("blackwell")
+    ):
+        return _BLACKWELL_LOGITS_WORKSPACE_BYTES
+    return _PORTABLE_LOGITS_WORKSPACE_BYTES
+
+
+def _calculate_token_chunk_size(
+    token_count,
+    vocab_size,
+    element_size,
+    workspace_bytes=_PORTABLE_LOGITS_WORKSPACE_BYTES,
+):
     bytes_per_token = vocab_size * element_size
-    max_tokens_per_chunk = max(1, _MAX_LOGITS_WORKSPACE_BYTES // bytes_per_token)
+    max_tokens_per_chunk = max(1, workspace_bytes // bytes_per_token)
     power_of_two_chunk = _next_power_of_2(max_tokens_per_chunk + 1) // 2
     if token_count <= power_of_two_chunk:
         return token_count
@@ -156,7 +189,9 @@ def fused_scaled_cross_entropy_forward(
 
     BT = _input.shape[0]
     V = weight.shape[0]
-    chunk_size = _calculate_token_chunk_size(BT, V, _input.element_size())
+    device_id = _input.device.index if _input.device.index is not None else torch.cuda.current_device()
+    workspace_bytes = _select_logits_workspace_bytes(device_id, BT, V, _input.element_size())
+    chunk_size = _calculate_token_chunk_size(BT, V, _input.element_size(), workspace_bytes)
     block_size = _select_cross_entropy_block_size(V)
 
     nll = torch.empty(BT, dtype=torch.float32, device=_input.device)
@@ -290,7 +325,9 @@ def fused_scaled_cross_entropy_backward(
 
     BT = _input.shape[0]
     V = weight.shape[0]
-    chunk_size = _calculate_token_chunk_size(BT, V, _input.element_size())
+    device_id = _input.device.index if _input.device.index is not None else torch.cuda.current_device()
+    workspace_bytes = _select_logits_workspace_bytes(device_id, BT, V, _input.element_size())
+    chunk_size = _calculate_token_chunk_size(BT, V, _input.element_size(), workspace_bytes)
     block_size = _select_cross_entropy_block_size(V)
 
     grad_input = torch.empty_like(_input) if _input.requires_grad else None

--- a/src/liger_kernel/ops/cutile/ops/fused_linear_scaled_cross_entropy.py
+++ b/src/liger_kernel/ops/cutile/ops/fused_linear_scaled_cross_entropy.py
@@ -1,0 +1,231 @@
+"""cuTile interface for fused linear scaled cross entropy."""
+
+import math
+
+import cuda.tile as ct
+import torch
+
+from liger_kernel.ops.cutile.ops.utils import LOG2E
+from liger_kernel.ops.cutile.ops.utils import _next_power_of_2
+from liger_kernel.ops.cutile.ops.utils import _select_cross_entropy_block_size
+
+ConstInt = ct.Constant[int]
+
+
+def _validate_temperature(temperature):
+    if isinstance(temperature, bool) or not isinstance(temperature, (int, float)):
+        raise TypeError("temperature must be a real number")
+    if not math.isfinite(temperature) or temperature <= 0:
+        raise ValueError("temperature must be finite and > 0")
+
+
+def _validate_inputs(_input, weight, target, ignore_index):
+    if _input.ndim != 2 or weight.ndim != 2 or target.ndim != 1:
+        raise ValueError("expected input[M,H], weight[V,H], and target[M]")
+    if _input.shape[0] != target.shape[0] or _input.shape[1] != weight.shape[1]:
+        raise ValueError(
+            f"input {tuple(_input.shape)}, weight {tuple(weight.shape)} and target "
+            f"{tuple(target.shape)} shapes are incompatible"
+        )
+    if _input.shape[0] == 0 or _input.shape[1] == 0 or weight.shape[0] == 0:
+        raise ValueError("input, hidden, and vocabulary dimensions must be non-empty")
+    if _input.device != weight.device or _input.device != target.device:
+        raise ValueError("input, weight, and target must be on the same device")
+    if _input.dtype != weight.dtype or not torch.is_floating_point(_input):
+        raise TypeError("input and weight must have the same floating-point dtype")
+    if target.dtype != torch.int64:
+        raise TypeError("target must be an int64 tensor")
+
+    out_of_range = ((target < 0) | (target >= weight.shape[0])) & (target != ignore_index)
+    if bool(out_of_range.any()):
+        raise ValueError(
+            f"target contains values outside [0, {weight.shape[0]}) that are not ignore_index={ignore_index}"
+        )
+
+
+@ct.kernel(occupancy=4)
+def _fused_scaled_cross_entropy_forward_kernel_ct(
+    logits,
+    target,
+    nll,
+    entropy,
+    lse,
+    vocab_size,
+    inv_temperature,
+    ignore_index,
+    BLOCK_SIZE: ConstInt,
+    RETURN_ENTROPY: ConstInt,
+):
+    row_idx = ct.bid(0)
+    target_idx = ct.load(target, row_idx, shape=())
+
+    if target_idx == ignore_index:
+        ct.scatter(nll, row_idx, ct.astype(0.0, nll.dtype))
+        ct.scatter(lse, row_idx, ct.astype(0.0, lse.dtype))
+        if RETURN_ENTROPY:
+            ct.scatter(entropy, row_idx, ct.astype(0.0, entropy.dtype))
+        return
+
+    target_col = ct.astype(target_idx, ct.int32)
+    target_logit = ct.astype(
+        ct.gather(logits, (row_idx, target_col), check_bounds=False),
+        ct.float32,
+    )
+    target_logit *= inv_temperature
+
+    running_max = ct.float32(-math.inf)
+    running_sum = ct.float32(0.0)
+    running_weighted_sum = ct.float32(0.0)
+    num_chunks = (vocab_size + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    for chunk_idx in range(num_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), chunk_idx * BLOCK_SIZE)
+        in_bounds = ct.less(col_idx, vocab_size)
+        logits_chunk = ct.astype(
+            ct.gather(logits, (row_idx, col_idx), check_bounds=True, padding_value=-math.inf),
+            ct.float32,
+        )
+        logits_chunk *= inv_temperature
+
+        chunk_max = ct.max(logits_chunk, 0, keepdims=False)
+        exp_chunk = ct.exp2((logits_chunk - chunk_max) * LOG2E, flush_to_zero=True)
+        chunk_sum = ct.sum(exp_chunk, 0, keepdims=False)
+
+        new_max = ct.maximum(running_max, chunk_max)
+        previous_scale = ct.exp2((running_max - new_max) * LOG2E, flush_to_zero=True)
+        chunk_scale = ct.exp2((chunk_max - new_max) * LOG2E, flush_to_zero=True)
+
+        running_sum = running_sum * previous_scale + chunk_sum * chunk_scale
+        if RETURN_ENTROPY:
+            safe_logits_chunk = ct.where(in_bounds, logits_chunk, 0.0)
+            chunk_weighted_sum = ct.sum(exp_chunk * safe_logits_chunk, 0, keepdims=False)
+            running_weighted_sum = running_weighted_sum * previous_scale + chunk_weighted_sum * chunk_scale
+        running_max = new_max
+
+    logsumexp = running_max + ct.log(running_sum)
+
+    ct.scatter(nll, row_idx, ct.astype(logsumexp - target_logit, nll.dtype))
+    ct.scatter(lse, row_idx, ct.astype(logsumexp, lse.dtype))
+    if RETURN_ENTROPY:
+        entropy_value = logsumexp - running_weighted_sum / running_sum
+        ct.scatter(entropy, row_idx, ct.astype(entropy_value, entropy.dtype))
+
+
+def fused_scaled_cross_entropy_forward(
+    _input,
+    weight,
+    target,
+    temperature=1.0,
+    ignore_index=-100,
+    m_tiles_per_cluster=1,
+    return_entropy=False,
+):
+    """Compute per-token NLL and optional entropy in token chunks.
+
+    Returns ``(nll, entropy, lse, input, weight, hidden_size)``. The final
+    three values are retained by the autograd wrapper for backward.
+    """
+    _validate_inputs(_input, weight, target, ignore_index)
+    _validate_temperature(temperature)
+    if not isinstance(m_tiles_per_cluster, int) or isinstance(m_tiles_per_cluster, bool):
+        raise TypeError("m_tiles_per_cluster must be an int")
+    if m_tiles_per_cluster < 1:
+        raise ValueError("m_tiles_per_cluster must be >= 1")
+    if not isinstance(return_entropy, bool):
+        raise TypeError("return_entropy must be a bool")
+
+    BT, H = _input.shape
+    V = weight.shape[0]
+    inc_factor = (V + H - 1) // H
+    chunk_size = _next_power_of_2((BT + inc_factor - 1) // inc_factor)
+    block_size = _select_cross_entropy_block_size(V)
+
+    nll = torch.empty(BT, dtype=torch.float32, device=_input.device)
+    entropy = torch.empty(BT, dtype=_input.dtype, device=_input.device) if return_entropy else None
+    lse = torch.empty(BT, dtype=torch.float32, device=_input.device)
+    dummy_entropy = torch.empty(1, dtype=_input.dtype, device=_input.device)
+    target = target.contiguous()
+
+    for start in range(0, BT, chunk_size):
+        end = min(start + chunk_size, BT)
+        logits_chunk = (_input[start:end] @ weight.t()).contiguous()
+        entropy_arg = entropy[start:end] if return_entropy else dummy_entropy
+
+        ct.launch(
+            torch.cuda.current_stream(),
+            (end - start, 1, 1),
+            _fused_scaled_cross_entropy_forward_kernel_ct,
+            (
+                logits_chunk,
+                target[start:end],
+                nll[start:end],
+                entropy_arg,
+                lse[start:end],
+                int(V),
+                float(1.0 / temperature),
+                int(ignore_index),
+                int(block_size),
+                int(return_entropy),
+            ),
+        )
+
+    return nll, entropy, lse, _input, weight, H
+
+
+class _LigerFusedLinearScaledCrossEntropyCuTileFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, _input, weight, target, temperature, ignore_index, return_entropy):
+        ctx.set_materialize_grads(False)
+        nll, entropy, lse, saved_input, saved_weight, _ = fused_scaled_cross_entropy_forward(
+            _input,
+            weight,
+            target,
+            temperature,
+            ignore_index,
+            return_entropy=return_entropy,
+        )
+
+        saved_entropy = entropy if entropy is not None else _input.new_empty(0)
+        ctx.save_for_backward(saved_input, saved_weight, target, lse, saved_entropy)
+        ctx.temperature = temperature
+        ctx.ignore_index = ignore_index
+        ctx.return_entropy = return_entropy
+        return (nll, entropy) if return_entropy else nll
+
+    @staticmethod
+    def backward(ctx, grad_nll, grad_entropy=None):
+        raise NotImplementedError("cuTile fused linear scaled cross entropy backward is not implemented")
+
+
+class LigerFusedLinearScaledCrossEntropyFunction:
+    """Compute per-token scaled NLL and optional vocabulary entropy.
+
+    ``m_tiles_per_cluster`` is accepted for API compatibility but does not
+    change the cuTile schedule.
+    """
+
+    @staticmethod
+    def apply(
+        _input,
+        weight,
+        target,
+        temperature=1.0,
+        ignore_index=-100,
+        m_tiles_per_cluster=1,
+        return_entropy=False,
+    ):
+        if not isinstance(m_tiles_per_cluster, int) or isinstance(m_tiles_per_cluster, bool):
+            raise TypeError("m_tiles_per_cluster must be an int")
+        if m_tiles_per_cluster < 1:
+            raise ValueError("m_tiles_per_cluster must be >= 1")
+        if not isinstance(return_entropy, bool):
+            raise TypeError("return_entropy must be a bool")
+
+        return _LigerFusedLinearScaledCrossEntropyCuTileFunction.apply(
+            _input,
+            weight,
+            target,
+            temperature,
+            ignore_index,
+            return_entropy,
+        )

--- a/src/liger_kernel/ops/cutile/ops/fused_linear_scaled_cross_entropy.py
+++ b/src/liger_kernel/ops/cutile/ops/fused_linear_scaled_cross_entropy.py
@@ -122,8 +122,7 @@ def fused_scaled_cross_entropy_forward(
 ):
     """Compute per-token NLL and optional entropy in token chunks.
 
-    Returns ``(nll, entropy, lse, input, weight, hidden_size)``. The final
-    three values are retained by the autograd wrapper for backward.
+    Returns per-token NLL, optional entropy, and log-sum-exp.
     """
     _validate_inputs(_input, weight, target, ignore_index)
     _validate_temperature(temperature)
@@ -169,14 +168,161 @@ def fused_scaled_cross_entropy_forward(
             ),
         )
 
-    return nll, entropy, lse, _input, weight, H
+    return nll, entropy, lse
+
+
+@ct.kernel(occupancy=4)
+def _fused_scaled_cross_entropy_backward_kernel_ct(
+    logits,
+    target,
+    lse,
+    entropy,
+    grad_nll,
+    grad_entropy,
+    vocab_size,
+    inv_temperature,
+    ignore_index,
+    BLOCK_SIZE: ConstInt,
+    HAS_NLL_GRAD: ConstInt,
+    HAS_ENTROPY_GRAD: ConstInt,
+):
+    row_idx = ct.bid(0)
+    target_idx = ct.load(target, row_idx, shape=())
+    num_chunks = (vocab_size + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    if target_idx == ignore_index:
+        for chunk_idx in range(num_chunks):
+            col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), chunk_idx * BLOCK_SIZE)
+            zero_chunk = ct.full((BLOCK_SIZE,), 0.0, dtype=logits.dtype)
+            ct.scatter(logits, (row_idx, col_idx), zero_chunk, check_bounds=True)
+        return
+
+    target_col = ct.astype(target_idx, ct.int32)
+    row_lse = ct.astype(ct.load(lse, row_idx, shape=()), ct.float32)
+    row_grad_nll = ct.float32(0.0)
+    if HAS_NLL_GRAD:
+        row_grad_nll = ct.astype(ct.load(grad_nll, row_idx, shape=()), ct.float32)
+    row_entropy = ct.float32(0.0)
+    row_grad_entropy = ct.float32(0.0)
+    if HAS_ENTROPY_GRAD:
+        row_entropy = ct.astype(ct.load(entropy, row_idx, shape=()), ct.float32)
+        row_grad_entropy = ct.astype(ct.load(grad_entropy, row_idx, shape=()), ct.float32)
+
+    for chunk_idx in range(num_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), chunk_idx * BLOCK_SIZE)
+        raw_logits = ct.astype(
+            ct.gather(logits, (row_idx, col_idx), check_bounds=True, padding_value=-math.inf),
+            ct.float32,
+        )
+        scaled_logits = raw_logits * inv_temperature
+        probabilities = ct.exp(scaled_logits - row_lse)
+
+        grad_scaled_logits = probabilities * row_grad_nll
+        is_target = ct.equal(col_idx, target_col)
+        grad_scaled_logits = ct.where(is_target, grad_scaled_logits - row_grad_nll, grad_scaled_logits)
+        if HAS_ENTROPY_GRAD:
+            log_probabilities = scaled_logits - row_lse
+            grad_scaled_logits -= row_grad_entropy * probabilities * (log_probabilities + row_entropy)
+        grad_raw_logits = grad_scaled_logits * inv_temperature
+
+        ct.scatter(
+            logits,
+            (row_idx, col_idx),
+            ct.astype(grad_raw_logits, logits.dtype),
+            check_bounds=True,
+        )
+
+
+def fused_scaled_cross_entropy_backward(
+    grad_nll,
+    _input,
+    weight,
+    target,
+    lse,
+    temperature,
+    ignore_index,
+    *,
+    entropy=None,
+    grad_entropy=None,
+):
+    """Compute gradients for per-token NLL and optional entropy outputs.
+
+    Returns gradients for ``_input`` and ``weight``. ``grad_nll`` may be
+    ``None`` for entropy-only backward; ``entropy`` and ``grad_entropy`` are
+    needed only when entropy contributes to the gradient.
+    """
+    _validate_inputs(_input, weight, target, ignore_index)
+    _validate_temperature(temperature)
+    if grad_nll is None and grad_entropy is None:
+        raise ValueError("at least one of grad_nll or grad_entropy must be provided")
+    if grad_nll is not None and grad_nll.shape != target.shape:
+        raise ValueError(f"grad_nll must have shape {tuple(target.shape)}, got {tuple(grad_nll.shape)}")
+    if lse.shape != target.shape:
+        raise ValueError(f"lse must have shape {tuple(target.shape)}, got {tuple(lse.shape)}")
+    if grad_entropy is not None:
+        if entropy is None:
+            raise ValueError("entropy is required when grad_entropy is provided")
+        if entropy.shape != target.shape or grad_entropy.shape != target.shape:
+            raise ValueError(
+                f"entropy and grad_entropy must have shape {tuple(target.shape)}, "
+                f"got {tuple(entropy.shape)} and {tuple(grad_entropy.shape)}"
+            )
+
+    BT, H = _input.shape
+    V = weight.shape[0]
+    inc_factor = (V + H - 1) // H
+    chunk_size = _next_power_of_2((BT + inc_factor - 1) // inc_factor)
+    block_size = _select_cross_entropy_block_size(V)
+
+    grad_input = torch.empty_like(_input) if _input.requires_grad else None
+    grad_weight = torch.zeros_like(weight) if weight.requires_grad else None
+    dummy_f32 = torch.empty(1, dtype=torch.float32, device=_input.device)
+    dummy_input_dtype = torch.empty(1, dtype=_input.dtype, device=_input.device)
+
+    target = target.contiguous()
+    lse = lse.contiguous()
+    grad_nll = grad_nll.contiguous() if grad_nll is not None else None
+    entropy = entropy.contiguous() if entropy is not None else None
+    grad_entropy = grad_entropy.contiguous() if grad_entropy is not None else None
+
+    for start in range(0, BT, chunk_size):
+        end = min(start + chunk_size, BT)
+        input_chunk = _input[start:end]
+        grad_logits_chunk = (input_chunk @ weight.t()).contiguous()
+
+        ct.launch(
+            torch.cuda.current_stream(),
+            (end - start, 1, 1),
+            _fused_scaled_cross_entropy_backward_kernel_ct,
+            (
+                grad_logits_chunk,
+                target[start:end],
+                lse[start:end],
+                entropy[start:end] if entropy is not None else dummy_input_dtype,
+                grad_nll[start:end] if grad_nll is not None else dummy_f32,
+                grad_entropy[start:end] if grad_entropy is not None else dummy_input_dtype,
+                int(V),
+                float(1.0 / temperature),
+                int(ignore_index),
+                int(block_size),
+                int(grad_nll is not None),
+                int(grad_entropy is not None),
+            ),
+        )
+
+        if grad_input is not None:
+            grad_input[start:end] = grad_logits_chunk @ weight
+        if grad_weight is not None:
+            grad_weight.add_(grad_logits_chunk.t() @ input_chunk)
+
+    return grad_input, grad_weight
 
 
 class _LigerFusedLinearScaledCrossEntropyCuTileFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, _input, weight, target, temperature, ignore_index, return_entropy):
         ctx.set_materialize_grads(False)
-        nll, entropy, lse, saved_input, saved_weight, _ = fused_scaled_cross_entropy_forward(
+        nll, entropy, lse = fused_scaled_cross_entropy_forward(
             _input,
             weight,
             target,
@@ -186,7 +332,7 @@ class _LigerFusedLinearScaledCrossEntropyCuTileFunction(torch.autograd.Function)
         )
 
         saved_entropy = entropy if entropy is not None else _input.new_empty(0)
-        ctx.save_for_backward(saved_input, saved_weight, target, lse, saved_entropy)
+        ctx.save_for_backward(_input, weight, target, lse, saved_entropy)
         ctx.temperature = temperature
         ctx.ignore_index = ignore_index
         ctx.return_entropy = return_entropy
@@ -194,7 +340,19 @@ class _LigerFusedLinearScaledCrossEntropyCuTileFunction(torch.autograd.Function)
 
     @staticmethod
     def backward(ctx, grad_nll, grad_entropy=None):
-        raise NotImplementedError("cuTile fused linear scaled cross entropy backward is not implemented")
+        _input, weight, target, lse, entropy = ctx.saved_tensors
+        grad_input, grad_weight = fused_scaled_cross_entropy_backward(
+            grad_nll,
+            _input,
+            weight,
+            target,
+            lse,
+            ctx.temperature,
+            ctx.ignore_index,
+            entropy=entropy if ctx.return_entropy else None,
+            grad_entropy=grad_entropy,
+        )
+        return grad_input, grad_weight, None, None, None, None
 
 
 class LigerFusedLinearScaledCrossEntropyFunction:

--- a/src/liger_kernel/ops/cutile/ops/utils.py
+++ b/src/liger_kernel/ops/cutile/ops/utils.py
@@ -7,6 +7,8 @@ import cuda.tile as ct
 ConstBool = ct.Constant[bool]
 ConstInt = ct.Constant[int]
 
+LOG2E = 1.4426950408889634
+
 
 def _next_power_of_2(n: int):
     """Return the smallest power of 2 greater than or equal to n."""
@@ -19,6 +21,10 @@ def _next_power_of_2(n: int):
     n |= n >> 32
     n += 1
     return n
+
+
+def _select_cross_entropy_block_size(vocab_size: int) -> int:
+    return min(4096, _next_power_of_2(vocab_size))
 
 
 @ct.kernel(occupancy=1)

--- a/test/transformers/test_fused_linear_scaled_cross_entropy.py
+++ b/test/transformers/test_fused_linear_scaled_cross_entropy.py
@@ -198,7 +198,7 @@ def test_frontend_fallback_supports_entropy_only_backward():
     ("shape", "dtype", "atol", "rtol"),
     [
         ((17, 31, 257), torch.float32, 6e-5, 6e-5),
-        ((521, 64, 5003), torch.bfloat16, 8e-2, 5e-2),
+        ((1025, 64, 131072), torch.bfloat16, 8e-2, 5e-2),
     ],
     ids=["fp32-ragged", "bf16-multichunk"],
 )

--- a/test/transformers/test_fused_linear_scaled_cross_entropy.py
+++ b/test/transformers/test_fused_linear_scaled_cross_entropy.py
@@ -305,6 +305,59 @@ def test_cutile_token_chunk_size_balances_small_tails(token_count, vocab_size, e
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="cuTile requires CUDA")
 @pytest.mark.skipif(not _CUTILE_ENABLED, reason="requires LIGER_KERNEL_IMPL=cutile")
+@pytest.mark.parametrize(
+    ("architecture", "token_count", "vocab_size", "element_size", "expected_mb"),
+    [
+        ("hopper", 4096, 131072, 2, 256),
+        ("blackwell", 4096, 131072, 2, 512),
+        ("blackwell_ultra", 4096, 131072, 2, 512),
+        ("blackwell", 2048, 131072, 2, 256),
+        ("blackwell", 4096, 65536, 2, 256),
+        ("blackwell", 4096, 131072, 4, 256),
+    ],
+)
+def test_cutile_selects_workspace_by_architecture(
+    monkeypatch,
+    architecture,
+    token_count,
+    vocab_size,
+    element_size,
+    expected_mb,
+):
+    import liger_kernel.ops.cutile.ops.fused_linear_scaled_cross_entropy as scaled_ce
+
+    monkeypatch.delenv(scaled_ce._WORKSPACE_MB_ENV, raising=False)
+    monkeypatch.setattr(scaled_ce, "infer_device_arch", lambda _: architecture)
+
+    actual = scaled_ce._select_logits_workspace_bytes(0, token_count, vocab_size, element_size)
+    assert actual == expected_mb * scaled_ce._MIB
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="cuTile requires CUDA")
+@pytest.mark.skipif(not _CUTILE_ENABLED, reason="requires LIGER_KERNEL_IMPL=cutile")
+def test_cutile_workspace_override(monkeypatch):
+    import liger_kernel.ops.cutile.ops.fused_linear_scaled_cross_entropy as scaled_ce
+
+    monkeypatch.setenv(scaled_ce._WORKSPACE_MB_ENV, "1024")
+    workspace_bytes = scaled_ce._select_logits_workspace_bytes(0, 4096, 131072, 2)
+
+    assert workspace_bytes == 1024 * scaled_ce._MIB
+    assert scaled_ce._calculate_token_chunk_size(4096, 131072, 2, workspace_bytes) == 4096
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="cuTile requires CUDA")
+@pytest.mark.skipif(not _CUTILE_ENABLED, reason="requires LIGER_KERNEL_IMPL=cutile")
+@pytest.mark.parametrize("value", ["invalid", "0", "-1"])
+def test_cutile_rejects_invalid_workspace_override(monkeypatch, value):
+    import liger_kernel.ops.cutile.ops.fused_linear_scaled_cross_entropy as scaled_ce
+
+    monkeypatch.setenv(scaled_ce._WORKSPACE_MB_ENV, value)
+    with pytest.raises(ValueError, match=scaled_ce._WORKSPACE_MB_ENV):
+        scaled_ce._select_logits_workspace_bytes(0, 4096, 131072, 2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="cuTile requires CUDA")
+@pytest.mark.skipif(not _CUTILE_ENABLED, reason="requires LIGER_KERNEL_IMPL=cutile")
 def test_cutile_rejects_out_of_range_target():
     from liger_kernel.ops import LigerFusedLinearScaledCrossEntropyFunction
 

--- a/test/transformers/test_fused_linear_scaled_cross_entropy.py
+++ b/test/transformers/test_fused_linear_scaled_cross_entropy.py
@@ -1,4 +1,5 @@
 import importlib.util
+import os
 
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,6 +14,27 @@ _SPEC = importlib.util.spec_from_file_location("_fused_linear_scaled_cross_entro
 assert _SPEC is not None and _SPEC.loader is not None
 _FRONTEND = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_FRONTEND)
+
+_CUTILE_ENABLED = os.environ.get("LIGER_KERNEL_IMPL", "").strip().lower() == "cutile"
+
+
+def _reference_policy_stats(_input, weight, target, temperature, ignore_index):
+    logits = (_input @ weight.t()).float() / temperature
+    log_probs = logits.log_softmax(dim=-1)
+    probabilities = log_probs.exp()
+    valid = target != ignore_index
+    safe_target = target.masked_fill(~valid, 0)
+    nll = torch.where(
+        valid,
+        -log_probs.gather(-1, safe_target.unsqueeze(-1)).squeeze(-1),
+        torch.zeros_like(log_probs[:, 0]),
+    )
+    entropy = torch.where(
+        valid,
+        -(probabilities * log_probs).sum(dim=-1),
+        torch.zeros_like(log_probs[:, 0]),
+    ).to(_input.dtype)
+    return nll, entropy
 
 
 @pytest.mark.parametrize(
@@ -170,6 +192,100 @@ def test_frontend_fallback_supports_entropy_only_backward():
     assert weight.grad is not None
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="cuTile requires CUDA")
+@pytest.mark.skipif(not _CUTILE_ENABLED, reason="requires LIGER_KERNEL_IMPL=cutile")
+@pytest.mark.parametrize(
+    ("shape", "dtype", "atol", "rtol"),
+    [
+        ((17, 31, 257), torch.float32, 6e-5, 6e-5),
+        ((521, 64, 5003), torch.bfloat16, 8e-2, 5e-2),
+    ],
+    ids=["fp32-ragged", "bf16-multichunk"],
+)
+def test_cutile_matches_torch_forward_and_combined_backward(shape, dtype, atol, rtol):
+    if dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
+        pytest.skip("BF16 is not supported")
+
+    from liger_kernel.ops import LigerFusedLinearScaledCrossEntropyFunction
+
+    torch.manual_seed(42)
+    token_count, hidden_size, vocab_size = shape
+    temperature = 0.8
+    target = torch.randint(vocab_size, (token_count,), device="cuda", dtype=torch.int64)
+    target[::11] = -100
+    grad_nll = torch.randn(token_count, device="cuda", dtype=torch.float32)
+    grad_entropy = torch.randn(token_count, device="cuda", dtype=dtype)
+
+    actual_input = torch.randn(token_count, hidden_size, device="cuda", dtype=dtype, requires_grad=True)
+    actual_weight = torch.randn(vocab_size, hidden_size, device="cuda", dtype=dtype, requires_grad=True)
+    actual_nll, actual_entropy = LigerFusedLinearScaledCrossEntropyFunction.apply(
+        actual_input,
+        actual_weight,
+        target,
+        temperature,
+        -100,
+        3,
+        True,
+    )
+    torch.autograd.backward((actual_nll, actual_entropy), (grad_nll, grad_entropy))
+
+    expected_input = actual_input.detach().clone().requires_grad_(True)
+    expected_weight = actual_weight.detach().clone().requires_grad_(True)
+    expected_nll, expected_entropy = _reference_policy_stats(
+        expected_input,
+        expected_weight,
+        target,
+        temperature,
+        -100,
+    )
+    torch.autograd.backward((expected_nll, expected_entropy), (grad_nll, grad_entropy))
+
+    torch.testing.assert_close(actual_nll, expected_nll, atol=atol, rtol=rtol)
+    torch.testing.assert_close(actual_entropy, expected_entropy, atol=atol, rtol=rtol)
+    torch.testing.assert_close(actual_input.grad, expected_input.grad, atol=atol, rtol=rtol)
+    torch.testing.assert_close(actual_weight.grad, expected_weight.grad, atol=atol, rtol=rtol)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="cuTile requires CUDA")
+@pytest.mark.skipif(not _CUTILE_ENABLED, reason="requires LIGER_KERNEL_IMPL=cutile")
+@pytest.mark.parametrize("output", ["nll", "entropy"])
+def test_cutile_supports_single_output_backward(output):
+    from liger_kernel.ops import LigerFusedLinearScaledCrossEntropyFunction
+
+    torch.manual_seed(43)
+    token_count, hidden_size, vocab_size = 19, 33, 259
+    target = torch.randint(vocab_size, (token_count,), device="cuda", dtype=torch.int64)
+    target[::5] = -100
+    grad_output = torch.randn(token_count, device="cuda")
+
+    actual_input = torch.randn(token_count, hidden_size, device="cuda", requires_grad=True)
+    actual_weight = torch.randn(vocab_size, hidden_size, device="cuda", requires_grad=True)
+    actual_nll, actual_entropy = LigerFusedLinearScaledCrossEntropyFunction.apply(
+        actual_input,
+        actual_weight,
+        target,
+        1.2,
+        -100,
+        2,
+        True,
+    )
+    (actual_nll if output == "nll" else actual_entropy).backward(grad_output)
+
+    expected_input = actual_input.detach().clone().requires_grad_(True)
+    expected_weight = actual_weight.detach().clone().requires_grad_(True)
+    expected_nll, expected_entropy = _reference_policy_stats(
+        expected_input,
+        expected_weight,
+        target,
+        1.2,
+        -100,
+    )
+    (expected_nll if output == "nll" else expected_entropy).backward(grad_output)
+
+    torch.testing.assert_close(actual_input.grad, expected_input.grad, atol=6e-5, rtol=6e-5)
+    torch.testing.assert_close(actual_weight.grad, expected_weight.grad, atol=6e-5, rtol=6e-5)
+
+
 def test_frontend_is_exported_from_ops_root():
     try:
         import liger_kernel.ops as ops
@@ -178,6 +294,9 @@ def test_frontend_is_exported_from_ops_root():
             raise
         pytest.skip("root ops package requires Triton")
 
-    assert ops.LigerFusedLinearScaledCrossEntropyFunction.__module__ == (
-        "liger_kernel.ops.fused_linear_scaled_cross_entropy"
+    expected_module = (
+        "liger_kernel.ops.cutile.ops.fused_linear_scaled_cross_entropy"
+        if _CUTILE_ENABLED
+        else "liger_kernel.ops.fused_linear_scaled_cross_entropy"
     )
+    assert ops.LigerFusedLinearScaledCrossEntropyFunction.__module__ == expected_module

--- a/test/transformers/test_fused_linear_scaled_cross_entropy.py
+++ b/test/transformers/test_fused_linear_scaled_cross_entropy.py
@@ -286,6 +286,36 @@ def test_cutile_supports_single_output_backward(output):
     torch.testing.assert_close(actual_weight.grad, expected_weight.grad, atol=6e-5, rtol=6e-5)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="cuTile requires CUDA")
+@pytest.mark.skipif(not _CUTILE_ENABLED, reason="requires LIGER_KERNEL_IMPL=cutile")
+@pytest.mark.parametrize(
+    ("token_count", "vocab_size", "element_size", "expected"),
+    [
+        (4096, 131072, 2, 1024),
+        (1025, 131072, 2, 513),
+        (2500, 100000, 2, 1250),
+        (5000, 131072, 2, 1024),
+    ],
+)
+def test_cutile_token_chunk_size_balances_small_tails(token_count, vocab_size, element_size, expected):
+    from liger_kernel.ops.cutile.ops.fused_linear_scaled_cross_entropy import _calculate_token_chunk_size
+
+    assert _calculate_token_chunk_size(token_count, vocab_size, element_size) == expected
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="cuTile requires CUDA")
+@pytest.mark.skipif(not _CUTILE_ENABLED, reason="requires LIGER_KERNEL_IMPL=cutile")
+def test_cutile_rejects_out_of_range_target():
+    from liger_kernel.ops import LigerFusedLinearScaledCrossEntropyFunction
+
+    _input = torch.randn(2, 8, device="cuda")
+    weight = torch.randn(16, 8, device="cuda")
+    target = torch.tensor([0, 16], device="cuda", dtype=torch.int64)
+
+    with pytest.raises(ValueError, match=r"outside \[0, 16\)"):
+        LigerFusedLinearScaledCrossEntropyFunction.apply(_input, weight, target)
+
+
 def test_frontend_is_exported_from_ops_root():
     try:
         import liger_kernel.ops as ops

--- a/test/transformers/test_fused_linear_scaled_cross_entropy.py
+++ b/test/transformers/test_fused_linear_scaled_cross_entropy.py
@@ -18,25 +18,6 @@ _SPEC.loader.exec_module(_FRONTEND)
 _CUTILE_ENABLED = os.environ.get("LIGER_KERNEL_IMPL", "").strip().lower() == "cutile"
 
 
-def _reference_policy_stats(_input, weight, target, temperature, ignore_index):
-    logits = (_input @ weight.t()).float() / temperature
-    log_probs = logits.log_softmax(dim=-1)
-    probabilities = log_probs.exp()
-    valid = target != ignore_index
-    safe_target = target.masked_fill(~valid, 0)
-    nll = torch.where(
-        valid,
-        -log_probs.gather(-1, safe_target.unsqueeze(-1)).squeeze(-1),
-        torch.zeros_like(log_probs[:, 0]),
-    )
-    entropy = torch.where(
-        valid,
-        -(probabilities * log_probs).sum(dim=-1),
-        torch.zeros_like(log_probs[:, 0]),
-    ).to(_input.dtype)
-    return nll, entropy
-
-
 @pytest.mark.parametrize(
     ("device", "cuda_available", "hip_version"),
     [
@@ -202,11 +183,11 @@ def test_frontend_fallback_supports_entropy_only_backward():
     ],
     ids=["fp32-ragged", "bf16-multichunk"],
 )
-def test_cutile_matches_torch_forward_and_combined_backward(shape, dtype, atol, rtol):
+def test_cutile_matches_verl_fallback_forward_and_combined_backward(shape, dtype, atol, rtol):
     if dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
         pytest.skip("BF16 is not supported")
 
-    from liger_kernel.ops import LigerFusedLinearScaledCrossEntropyFunction
+    from liger_kernel.ops.cutile.ops.fused_linear_scaled_cross_entropy import LigerFusedLinearScaledCrossEntropyFunction
 
     torch.manual_seed(42)
     token_count, hidden_size, vocab_size = shape
@@ -216,8 +197,10 @@ def test_cutile_matches_torch_forward_and_combined_backward(shape, dtype, atol, 
     grad_nll = torch.randn(token_count, device="cuda", dtype=torch.float32)
     grad_entropy = torch.randn(token_count, device="cuda", dtype=dtype)
 
-    actual_input = torch.randn(token_count, hidden_size, device="cuda", dtype=dtype, requires_grad=True)
-    actual_weight = torch.randn(vocab_size, hidden_size, device="cuda", dtype=dtype, requires_grad=True)
+    actual_input = (torch.randn(token_count, hidden_size, device="cuda", dtype=dtype) * 0.25).requires_grad_(True)
+    actual_weight = (
+        torch.randn(vocab_size, hidden_size, device="cuda", dtype=dtype) / hidden_size**0.5
+    ).requires_grad_(True)
     actual_nll, actual_entropy = LigerFusedLinearScaledCrossEntropyFunction.apply(
         actual_input,
         actual_weight,
@@ -231,12 +214,13 @@ def test_cutile_matches_torch_forward_and_combined_backward(shape, dtype, atol, 
 
     expected_input = actual_input.detach().clone().requires_grad_(True)
     expected_weight = actual_weight.detach().clone().requires_grad_(True)
-    expected_nll, expected_entropy = _reference_policy_stats(
+    expected_nll, expected_entropy = _FRONTEND._FusedLinearPPOFallbackFunction.apply(
         expected_input,
         expected_weight,
         target,
         temperature,
         -100,
+        True,
     )
     torch.autograd.backward((expected_nll, expected_entropy), (grad_nll, grad_entropy))
 
@@ -250,7 +234,7 @@ def test_cutile_matches_torch_forward_and_combined_backward(shape, dtype, atol, 
 @pytest.mark.skipif(not _CUTILE_ENABLED, reason="requires LIGER_KERNEL_IMPL=cutile")
 @pytest.mark.parametrize("output", ["nll", "entropy"])
 def test_cutile_supports_single_output_backward(output):
-    from liger_kernel.ops import LigerFusedLinearScaledCrossEntropyFunction
+    from liger_kernel.ops.cutile.ops.fused_linear_scaled_cross_entropy import LigerFusedLinearScaledCrossEntropyFunction
 
     torch.manual_seed(43)
     token_count, hidden_size, vocab_size = 19, 33, 259
@@ -258,8 +242,8 @@ def test_cutile_supports_single_output_backward(output):
     target[::5] = -100
     grad_output = torch.randn(token_count, device="cuda")
 
-    actual_input = torch.randn(token_count, hidden_size, device="cuda", requires_grad=True)
-    actual_weight = torch.randn(vocab_size, hidden_size, device="cuda", requires_grad=True)
+    actual_input = (torch.randn(token_count, hidden_size, device="cuda") * 0.25).requires_grad_(True)
+    actual_weight = (torch.randn(vocab_size, hidden_size, device="cuda") / hidden_size**0.5).requires_grad_(True)
     actual_nll, actual_entropy = LigerFusedLinearScaledCrossEntropyFunction.apply(
         actual_input,
         actual_weight,
@@ -273,12 +257,13 @@ def test_cutile_supports_single_output_backward(output):
 
     expected_input = actual_input.detach().clone().requires_grad_(True)
     expected_weight = actual_weight.detach().clone().requires_grad_(True)
-    expected_nll, expected_entropy = _reference_policy_stats(
+    expected_nll, expected_entropy = _FRONTEND._FusedLinearPPOFallbackFunction.apply(
         expected_input,
         expected_weight,
         target,
         1.2,
         -100,
+        True,
     )
     (expected_nll if output == "nll" else expected_entropy).backward(grad_output)
 
@@ -359,7 +344,7 @@ def test_cutile_rejects_invalid_workspace_override(monkeypatch, value):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="cuTile requires CUDA")
 @pytest.mark.skipif(not _CUTILE_ENABLED, reason="requires LIGER_KERNEL_IMPL=cutile")
 def test_cutile_rejects_out_of_range_target():
-    from liger_kernel.ops import LigerFusedLinearScaledCrossEntropyFunction
+    from liger_kernel.ops.cutile.ops.fused_linear_scaled_cross_entropy import LigerFusedLinearScaledCrossEntropyFunction
 
     _input = torch.randn(2, 8, device="cuda")
     weight = torch.randn(16, 8, device="cuda")


### PR DESCRIPTION
## Summary

Adds a cuTile implementation of `LigerFusedLinearScaledCrossEntropyFunction`, matching the existing per-token scaled NLL and optional differentiable entropy contract.

**Compared with the VERL-derived PPO fallback on the combined NLL-plus-entropy workload, cuTile is 3.1x faster on H100 and 3.7x faster on B200 while reducing peak memory by 55% and 51%, respectively.**

| Hardware | Implementation | Forward | Backward | Full | Speedup vs VERL | Peak full memory | Memory saving vs VERL |
|---|---|---:|---:|---:|---:|---:|---:|
| H100 | **cuTile** | **6.24 ms** | **20.88 ms** | **26.15 ms** | **3.14x** | **2432 MiB** | **55%** |
| H100 | VERL-derived fallback | 22.36 ms | 59.40 ms | 82.03 ms | 1.00x | 5384 MiB | — |
| B200 | **cuTile** | **3.17 ms** | **9.18 ms** | **12.01 ms** | **3.68x** | **2640 MiB** | **51%** |
| B200 | VERL-derived fallback | 12.34 ms | 31.63 ms | 44.16 ms | 1.00x | 5336 MiB | — |

- registers the implementation behind `LIGER_KERNEL_IMPL=cutile`
- supports FP32, FP16, and BF16 matching `input`/`weight` dtypes, scalar positive temperature, ragged dimensions, and `ignore_index`
- bounds forward and backward logits workspaces to 256 MiB portably and automatically uses 512 MiB for large FP16/BF16 Blackwell workloads
- balances token chunks when power-of-two rounding would add a launch or leave a less-than-half-sized final chunk
- supports `LIGER_CUTILE_SCALED_CE_WORKSPACE_MB` for workload-specific workspace tuning
- recomputes logits chunk-by-chunk in backward, transforms them into `dZ` in place, writes `dX` directly, and accumulates `dW` directly with `mm`/`addmm` outputs to avoid full `V x H` temporaries
- tests the direct cuTile class against the independent VERL-derived fallback for combined, NLL-only, and entropy-only gradients
- adds the cuTile provider to the scaled-cross-entropy benchmark and fixes that benchmark to reset both input and weight gradients
- centralizes README documentation for the shared cuTile/CuTe/fallback public API

No open PR currently implements the same cuTile scaled-cross-entropy backend.

## Testing Done

- Hardware Type: NVIDIA H100 80GB HBM3 and NVIDIA B200
- [x] run `make test` to ensure correctness
  - equivalent command: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest --disable-warnings --ignore=test/convergence --ignore=test/cutedsl test/`
  - result: `4096 passed, 929 skipped, 14 xfailed`
- [x] run `make checkstyle` to ensure code style
  - result: repository-wide `ruff check .` and `ruff format --check .` passed
- [ ] run `make test-convergence` to ensure convergence
  - not applicable: this change adds an opt-in operator implementation and does not patch a model
- cuTile-targeted command: `LIGER_KERNEL_IMPL=cutile PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q test/transformers/test_fused_linear_scaled_cross_entropy.py test/transformers/test_cutile_backend.py`
  - result: `29 passed` on both H100 and B200

H100 BF16 benchmark at `M=4096`, `H=4096`, `V=131072`:

| Implementation | Forward | Backward | Full | Peak full memory |
|---|---:|---:|---:|---:|
| cuTile | 6.45 ms | 20.70 ms | 26.94 ms | 2.43 GiB |
| CuTe SM90 | 7.26 ms | 19.81 ms | 27.74 ms | 2.43 GiB |

B200 BF16 benchmark for the same shape, using automatic workspace selection:

| Implementation | Forward | Backward | Full | Peak full memory |
|---|---:|---:|---:|---:|
| cuTile | 2.97 ms | 8.35 ms | 11.36 ms | 2.64 GiB |
| Torch | 5.24 ms | 7.15 ms | 12.85 ms | 7.22 GiB |

AI assistance was used. The submitter reviewed the changed lines and ran the validation above.
