### PR TITLE
Pin fp64 scalar kernel params to fp32 in modulated_rms_norm and attn_res

### DIFF
--- a/src/liger_kernel/ops/attn_res.py
+++ b/src/liger_kernel/ops/attn_res.py
@@ -41,7 +41,7 @@ def _attn_res_fwd_kernel(
     n_blocks,  # N
     n_tokens,  # B*T
     D,  # hidden dim
-    eps,
+    eps: tl.constexpr,
     BLOCK_D: tl.constexpr,
     MAX_BLOCKS: tl.constexpr,
 ):

--- a/src/liger_kernel/ops/modulated_rms_norm.py
+++ b/src/liger_kernel/ops/modulated_rms_norm.py
@@ -86,6 +86,10 @@ def _modulated_rms_norm_forward_kernel(
     if casting_mode == _CASTING_MODE_NONE:
         eps = eps.to(X_row_dtype)
         offset = offset.to(X_row_dtype)
+    else:
+        # Force fp32 scalars: Inductor may use fp64 under torch.compile and tank throughput.
+        eps = eps.to(tl.float32)
+        offset = offset.to(tl.float32)
 
     mean_square = tl.sum(X_row * X_row, axis=0) / n_cols
     rstd = rsqrt(mean_square + eps)
@@ -134,7 +138,7 @@ def _modulated_rms_norm_backward_kernel(
     dShift_row_stride,
     n_rows,
     n_cols,
-    offset,
+    offset: tl.constexpr,
     rows_per_program,
     casting_mode: tl.constexpr,
     elementwise_affine: tl.constexpr,


### PR DESCRIPTION
## Summary
Continues the #1350 sweep, for `modulated_rms_norm` and `attn_res`: a Python `float` on a non-`constexpr` Triton param is fp32 in eager but fp64 under Inductor.

`modulated_rms_norm` has the same bug fixed in `rms_norm`, but the cast covers only one branch, and the backward has no casting-mode guard at all, so `offset` is fp64 in every mode.

## Details

B300, `4096 x 8192` bf16, per-kernel GPU time from the profiler.

| variant | `.f64` | compiled | speedup |
|---|---|---|---|
| `modulated_rms_norm` (llama) | 324 → 2 | 1.2305 → 0.1154 ms | **10.7x** |
| `modulated_rms_norm` (gemma) | 320 → 2 | 1.2063 → 0.1134 ms | **10.6x** |
| `modulated_rms_norm` (none) | 254 → 2 | 0.9439 → 0.1140 ms | **8.3x** |
| `attn_res` | 208 → 0 | 0.7955 → 0.4010 ms | **2.0x** |

Also a correctness fix: eager vs compiled diverged before (`max|d out|` 3.1e-2 llama, 1.2e-1 gemma), bit-identical after. Eager unchanged; `rms_norm` reads 1.0x on both arms as a control.

### Why the backward uses `constexpr`, not `.to(tl.float32)`

`.to()` on a scalar param breaks torch's Triton mutation analysis, which traces with a raw Python float (`AttributeError: 'float' object has no attribute 'to'`); torch then assumes every pointer arg is mutated. Harmless in `rms_norm`, but this kernel aliases `dShift` to `dScale` and takes `scale`, a leaf requiring grad, so it either raises `RuntimeError: a leaf Variable that requires grad is being used in an in-place operation` (llama) or silently returns a nondeterministic `dScale` (none):

| variant | `.f64` | comp-vs-comp | eager-vs-comp |
|---|---|---|---|
| baseline | 327 | 0.0000 | 0.2500 |
| forward `else:` only | 165 | 0.0000 | 0.0156 |
| backward `.to()` | 6 | **1.0000** | **15.1875** |
| forward + backward `constexpr` | 4 | 0.0000 | 0.0156 |

(`comp-vs-comp` = max gradient difference over four identical reruns.)
`constexpr` drops the fp64 param entirely; `offset`/`eps` take only a couple of values, so specializing is cheap. 

## Testing Done
- `test_modulated_rms_norm.py` + `test_attn_res.py`, plus `test_rms_norm.py` as
  an untouched control: **257 passed, 8 xfailed, 0 failed**. The xfails are all
  `test_dtensor_rms_norm`, marked `xfail` below 8 GPUs — pre-existing.
- `attn_res` backward accumulates with `tl.atomic_add`, so its gradients vary
  run to run regardless of this change: over 6 runs the eager spread is 0.5
  (rel 2.7e-4) on both `main` and this branch, with compiled in the same band.

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
