### PR TITLE
[Ascend] Fix missing accum_dtype param in fused_linear_jsd forward

### DIFF
--- a/src/liger_kernel/ops/backends/_ascend/ops/fused_linear_jsd.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/fused_linear_jsd.py
@@ -44,6 +44,7 @@ def fused_linear_jsd_forward(
     ignore_index,
     has_label,
     temperature,
+    accum_dtype=None,
 ):
     device = student_input.device
     dtype = student_input.dtype
@@ -202,6 +203,7 @@ class LigerFusedLinearJSDFunction(torch.autograd.Function):
         jsd_beta: float = 0.5,
         ignore_index: int = -100,
         temperature: float = 1.0,
+        accum_dtype: Optional[torch.dtype] = None,
     ):
         """
         Args:
@@ -236,6 +238,7 @@ class LigerFusedLinearJSDFunction(torch.autograd.Function):
             ignore_index,
             has_label,
             temperature,
+            accum_dtype,
         )
         # downcast to dtype and store for backward
         ctx.save_for_backward(
@@ -249,4 +252,4 @@ class LigerFusedLinearJSDFunction(torch.autograd.Function):
     def backward(ctx, grad_output):
         (grad_input, grad_weight) = ctx.saved_tensors
         grad_input, grad_weight = fused_linear_jsd_backward(grad_output, grad_input, grad_weight)
-        return (grad_input, grad_weight, None, None, None, None, None, None)
+        return (grad_input, grad_weight, None, None, None, None, None, None, None)


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
Fix `TypeError` in Ascend backend's `LigerFusedLinearJSDFunction.forward()` caused by a missing `accum_dtype` parameter.
When running the fused_linear_jsd test on Ascend NPU, the following error occurs:
TypeError: LigerFusedLinearJSDFunction.forward() takes from 5 to 9 positional arguments but 10 were given
Add the missing `accum_dtype: Optional[torch.dtype] = None` parameter in three locations within `backends/_ascend/ops/fused_linear_jsd.py`
<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
<img width="1413" height="425" alt="image" src="https://github.com/user-attachments/assets/51a379eb-050b-4620-ab73-2ba4a07617e5" />

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: Atlas 800I A2
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
