### PR TITLE
Fix single-token fused MoE auto dispatch

### DIFF
--- a/liger_cute_kernels/csrc/core/src/moe/moe.cu
+++ b/liger_cute_kernels/csrc/core/src/moe/moe.cu
@@ -1514,7 +1514,9 @@ void moe_fused_fwd_dispatch(const MoeFwdArgs& a, int* chosen_tile_m) {
 	// lookup picks rows recorded at comparable per-PE load.
 	const int n_pes = nvshmem_team_n_pes(a.team);
 	const int E_local = (n_pes > 0) ? std::max(1, num_experts / n_pes) : num_experts;
-	const int TKE = TK / E_local;
+	// The lookup operates in log space, so clamp the per-expert average to
+	// the smallest representable workload for tiny but valid token batches.
+	const int TKE = std::max(1, TK / E_local);
 	const int compute = moe_detect_compute_dispatch_key(a.device, "moe_fused_fwd_bf16_auto");
 
 	// ── Override path: LIGER_MOE_FORCE_CONFIG=TN1,TK1,S1,EC1,TN2,TK2,S2,EC2,ZB,CS,TM[,GemmTM]

--- a/liger_cute_kernels/csrc/core/src/moe/moe_bwd.cu
+++ b/liger_cute_kernels/csrc/core/src/moe/moe_bwd.cu
@@ -1674,7 +1674,8 @@ void moe_bwd_dispatch(const MoeBwdArgs& a, int fwd_tile_m) {
 	const int TK = T * top_k;
 	const int n_pes = nvshmem_team_n_pes(a.team);
 	const int E_local = (n_pes > 0) ? std::max(1, num_experts / n_pes) : num_experts;
-	const int TKE = TK / E_local;
+	// Keep backward lookup consistent with forward for tiny token batches.
+	const int TKE = std::max(1, TK / E_local);
 	const int compute = moe_detect_compute_dispatch_key(a.device, "moe_fused_bwd_bf16_auto");
 
 	if (const char* s = std::getenv("LIGER_MOE_BWD_FORCE_CONFIG")) {

--- a/liger_cute_kernels/test/test_moe_cuda_graph.py
+++ b/liger_cute_kernels/test/test_moe_cuda_graph.py
@@ -545,6 +545,125 @@ def _unaligned_fwd_bwd_worker(rank: int, world_size: int, init_file: str):
         _check_close(unaligned, padded)
 
 
+# ── forward + backward: single-token automatic dispatch ──────────────────────
+
+
+def _single_token_auto_dispatch_worker(
+    rank: int,
+    world_size: int,
+    init_file: str,
+):
+    _init(rank, world_size, init_file)
+    team = nvshmem.team_world()
+    tokens = 1 + rank * 7
+    hidden_dim = 512
+    intermediate_dim = 256
+    num_experts = 128
+    top_k = 8
+    experts_per_pe = num_experts // world_size
+    fwd_force = "128,64,4,64,128,64,4,64,4,3,128"
+    bwd_force = "2,128,64,4,128,256,64,2,32,64,64,2,128"
+
+    try:
+        tvm_ffi.moe_configure_symmetric(
+            max_tokens=64,
+            hidden_dim=hidden_dim,
+            max_num_experts=num_experts,
+            max_top_k=top_k,
+            num_pes=nvshmem.n_pes(),
+            num_hosts=1,
+            gpus_per_host=world_size,
+        )
+        torch.manual_seed(10_000 + rank)
+        X = torch.randn(tokens, hidden_dim, dtype=torch.bfloat16, device="cuda")
+        gate_W = torch.randn(num_experts, hidden_dim, dtype=torch.bfloat16, device="cuda")
+        all_B = torch.randn(
+            experts_per_pe,
+            intermediate_dim,
+            hidden_dim,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        all_C = torch.randn_like(all_B)
+        all_A = torch.randn(
+            experts_per_pe,
+            hidden_dim,
+            intermediate_dim,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        ei, ew = _route(X, gate_W, top_k)
+        dY = torch.randn_like(X)
+
+        def fwd():
+            return tvm_ffi.moe_fused_fwd_bf16(
+                X,
+                ei,
+                ew,
+                all_B,
+                all_C,
+                all_A,
+                num_experts=num_experts,
+                top_k=top_k,
+                team_handle=team,
+            )
+
+        def bwd(out):
+            return tvm_ffi.moe_fused_bwd_bf16(
+                dY,
+                out[2],
+                out[1],
+                out[4],
+                out[5],
+                out[3],
+                ei,
+                ew,
+                all_B,
+                all_C,
+                all_A,
+                num_experts=num_experts,
+                top_k=top_k,
+                team_handle=team,
+                fwd_tile_m=out[6],
+            )
+
+        os.environ["LIGER_MOE_FORCE_CONFIG"] = fwd_force
+        os.environ["LIGER_MOE_BWD_FORCE_CONFIG"] = bwd_force
+        forced_out = fwd()
+        forced_grads = bwd(forced_out)
+        torch.cuda.synchronize()
+        forced_cpu = [forced_out[0].detach().cpu().clone()]
+        forced_cpu.extend(tensor.detach().cpu().clone() for tensor in forced_grads)
+        tvm_ffi.moe_pop_fwd()
+
+        os.environ.pop("LIGER_MOE_FORCE_CONFIG")
+        os.environ.pop("LIGER_MOE_BWD_FORCE_CONFIG")
+        auto_out = fwd()
+        auto_grads = bwd(auto_out)
+        torch.cuda.synchronize()
+        auto_cpu = [auto_out[0].detach().cpu().clone()]
+        auto_cpu.extend(tensor.detach().cpu().clone() for tensor in auto_grads)
+        tvm_ffi.moe_pop_fwd()
+
+        dist.barrier()
+        nvshmem.finalize()
+        dist.destroy_process_group()
+    except BaseException:
+        try:
+            dist.destroy_process_group()
+        except Exception:
+            pass
+        raise
+
+    for name, auto, forced in zip(
+        ("Y", "dX", "dB", "dC", "dA", "dW"),
+        auto_cpu,
+        forced_cpu,
+    ):
+        assert torch.isfinite(auto).all(), f"{name} has non-finite values"
+        _check_close(auto, forced)
+
+
 # ── tests ─────────────────────────────────────────────────────────────────────
 
 
@@ -581,3 +700,14 @@ def test_moe_fwd_bwd_unaligned_tokens_match_padded():
     """Unaligned forward/backward must match zero-padded execution."""
 
     _run(_world_size(), _unaligned_fwd_bwd_worker)
+
+
+@pytest.mark.skipif(_NDEV < 2, reason="needs >=2 CUDA devices")
+def test_moe_fwd_bwd_single_token_auto_dispatch():
+    """Automatic dispatch supports a rank with one token.
+
+    The smallest rank has TKE=floor(T * top_k / experts_per_pe)=0 before
+    clamping. Its automatic forward and backward results must match known
+    compiled configurations while every rank participates in NVSHMEM.
+    """
+    _run(_world_size(), _single_token_auto_dispatch_worker)


### PR DESCRIPTION
## Summary

Liger fused MoE could deadlock for a valid one-token rank during automatic tuned-config selection.

Use case: Under inference scenario the single token can happen during tail inference over last few sample in the offline inference scenario.

Root cause:
For example, `top_k=8` and 16 local experts:

- [The dispatcher calculated `TKE=floor(T*top_k/E_local)`](https://github.com/linkedin/Liger-Kernel/blob/0f66f7eca4edcc3d3a599e8328a220ae9b386cbc/liger_cute_kernels/csrc/core/src/moe/moe.cu#L1505-L1518), producing `TKE=0` for `T=1`.
- [The tuned lookup evaluated `log(TKE)`](https://github.com/linkedin/Liger-Kernel/blob/0f66f7eca4edcc3d3a599e8328a220ae9b386cbc/liger_cute_kernels/csrc/core/src/moe/moe.cu#L1458-L1484). Runtime `TKE=0` therefore produced `lTKE=-inf`; every positive table entry had infinite distance, so `found` remained false.
- [The affected rank failed before launching the kernel](https://github.com/linkedin/Liger-Kernel/blob/0f66f7eca4edcc3d3a599e8328a220ae9b386cbc/liger_cute_kernels/csrc/core/src/moe/moe.cu#L1546-L1567), while peers waited at the [cross-PE barrier](https://github.com/linkedin/Liger-Kernel/blob/0f66f7eca4edcc3d3a599e8328a220ae9b386cbc/liger_cute_kernels/csrc/core/src/moe/moe.cu#L565-L580).

This change clamps the lookup-only forward and backward `TKE` values to one:

```cpp
const int TKE = std::max(1, TK / E_local);
```

Actual tokens, routing, communication, and computation are unchanged.

## Testing Done

- Hardware Type: NVIDIA H200 141 GB
- [ ] run `make test` to ensure correctness
  - 4,248 tests passed and 894 skipped.
  - Two tests initially failed because the pod imported an older installed `liger_cute_kernels.nvshmem` API; both passed when rerun against the current source package.
- [ ] run `make checkstyle` to ensure code style
  - Targeted Ruff lint and formatting checks passed for the changed Python test.
  - The full target reported pre-existing formatting drift in 13 unrelated files.
- [ ] run `make test-convergence` to ensure convergence
  - Not run; this native tuned-dispatch lookup change does not affect model convergence.
- [x] Added a real NCCL/NVSHMEM regression in the existing MoE CUDA test framework.
- [x] Automatic and forced forward/backward dispatch matched for ragged ranks with `T=[1,8,15,22,29,36,43,50]`.
- [x] Rebuilt the native SM90 library and ran a full no-padding DP8+EP8 reward replay: 2,048 requests, zero errors.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
