### PR TITLE
fix(cutedsl): preserve FP32 CE output precision

### DIFF
--- a/src/liger_kernel/ops/cutedsl/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cutedsl/ops/cross_entropy.py
@@ -687,6 +687,7 @@ def _launch_ce_fwd(
     pred_tok_out=None,
     inv_n_z=None,
     logical_vocab_size=None,
+    _split_fp32_features=True,
 ):
     assert x.stride(0) * x.element_size() % 16 == 0, (
         "cutedsl CE needs each row to start on a 16-byte boundary for vectorized loads; "
@@ -710,6 +711,57 @@ def _launch_ce_fwd(
     if not 0 < logical_vocab_size <= x.shape[-1]:
         raise ValueError(f"logical_vocab_size must be in [1, {x.shape[-1]}], got {logical_vocab_size}.")
     has_padding = logical_vocab_size != x.shape[-1]
+
+    # The combined FP32 gradient specializations for z-loss, softcap, and smoothing produce
+    # accurate gradients but reduced-precision public outputs with current CuTe DSL toolchains.
+    # Preserve those gradients while sourcing the outputs from the accurate no-gradient path.
+    if _split_fp32_features and x.dtype == torch.float32 and has_grad and (has_zloss or has_softcap or has_smoothing):
+        _launch_ce_fwd(
+            x=x,
+            y=y,
+            loss=loss,
+            inv_n_loss=inv_n_loss,
+            ignore_index=ignore_index,
+            has_grad=False,
+            lse_sq_scale=lse_sq_scale,
+            z_loss_out=z_loss_out,
+            return_z_loss=return_z_loss,
+            softcap=softcap,
+            label_smoothing=label_smoothing,
+            weight=weight,
+            weight_sum=weight_sum,
+            return_token_accuracy=return_token_accuracy,
+            return_predicted_tokens=return_predicted_tokens,
+            token_acc_out=token_acc_out,
+            pred_tok_out=pred_tok_out,
+            inv_n_z=inv_n_z,
+            logical_vocab_size=logical_vocab_size,
+            _split_fp32_features=False,
+        )
+        _launch_ce_fwd(
+            x=x,
+            y=y,
+            loss=torch.empty_like(loss),
+            inv_n_loss=inv_n_loss,
+            ignore_index=ignore_index,
+            has_grad=True,
+            lse_sq_scale=lse_sq_scale,
+            z_loss_out=None,
+            return_z_loss=False,
+            softcap=softcap,
+            label_smoothing=label_smoothing,
+            weight=weight,
+            weight_sum=weight_sum,
+            return_token_accuracy=False,
+            return_predicted_tokens=False,
+            token_acc_out=None,
+            pred_tok_out=None,
+            inv_n_z=inv_n_z,
+            logical_vocab_size=logical_vocab_size,
+            _split_fp32_features=False,
+        )
+        return
+
     softcap_val = float(softcap) if has_softcap else 0.0
     x_ct = to_cute_tensor(x)
     y_ct = to_cute_tensor(y, assumed_align=8)  # int64

--- a/src/liger_kernel/ops/cutedsl/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cutedsl/ops/cross_entropy.py
@@ -231,6 +231,17 @@ def _ce_fwd_kernel(
 
     # token_accuracy and predicted_tokens both reduce to the row's argmax column.
     NEED_ARGMAX = const_expr(RETURN_TOKEN_ACCURACY or RETURN_PREDICTED_TOKENS)
+    # CuTe DSL 4.6 can narrow these dynamic output stores to bf16 in feature-enabled
+    # FP32 training specializations. Rebuild explicitly typed pointers to keep them fp32.
+    if const_expr(mX.element_type.width == 32):
+        gLossFp32 = cute.make_tensor(
+            cute.make_ptr(Float32, mLoss.iterator.toint(), cute.AddressSpace.gmem, assumed_align=4),
+            cute.make_layout((mLoss.shape[0],)),
+        )
+        gZLossFp32 = cute.make_tensor(
+            cute.make_ptr(Float32, mZLoss.iterator.toint(), cute.AddressSpace.gmem, assumed_align=4),
+            cute.make_layout((mZLoss.shape[0],)),
+        )
 
     # Cross-warp reduction scratch (one (m, d)[, argmax][, scaled_x_sum] per warp), carved from
     # one smem pool sized for NUM_WARPS; the cp.async tile buffer comes from the same pool below.
@@ -477,9 +488,15 @@ def _ce_fwd_kernel(
         loss = Float32(0.0)
         zl = Float32(0.0)
     if tid == 0:
-        mLoss[row] = loss.to(mLoss.element_type)
+        if const_expr(mX.element_type.width == 32):
+            gLossFp32[row] = loss
+        else:
+            mLoss[row] = loss.to(mLoss.element_type)
         if const_expr(RETURN_Z_LOSS):
-            mZLoss[row] = zl.to(mZLoss.element_type)
+            if const_expr(mX.element_type.width == 32):
+                gZLossFp32[row] = zl
+            else:
+                mZLoss[row] = zl.to(mZLoss.element_type)
 
     # token_accuracy / predicted_tokens: ignored rows get 0.0 / -1 (matches Triton).
     # The ignored sentinel is folded in at fp32 (col_out) before the single int cast — the
@@ -687,7 +704,6 @@ def _launch_ce_fwd(
     pred_tok_out=None,
     inv_n_z=None,
     logical_vocab_size=None,
-    _split_fp32_features=True,
 ):
     assert x.stride(0) * x.element_size() % 16 == 0, (
         "cutedsl CE needs each row to start on a 16-byte boundary for vectorized loads; "
@@ -711,57 +727,6 @@ def _launch_ce_fwd(
     if not 0 < logical_vocab_size <= x.shape[-1]:
         raise ValueError(f"logical_vocab_size must be in [1, {x.shape[-1]}], got {logical_vocab_size}.")
     has_padding = logical_vocab_size != x.shape[-1]
-
-    # The combined FP32 gradient specializations for z-loss, softcap, and smoothing produce
-    # accurate gradients but reduced-precision public outputs with current CuTe DSL toolchains.
-    # Preserve those gradients while sourcing the outputs from the accurate no-gradient path.
-    if _split_fp32_features and x.dtype == torch.float32 and has_grad and (has_zloss or has_softcap or has_smoothing):
-        _launch_ce_fwd(
-            x=x,
-            y=y,
-            loss=loss,
-            inv_n_loss=inv_n_loss,
-            ignore_index=ignore_index,
-            has_grad=False,
-            lse_sq_scale=lse_sq_scale,
-            z_loss_out=z_loss_out,
-            return_z_loss=return_z_loss,
-            softcap=softcap,
-            label_smoothing=label_smoothing,
-            weight=weight,
-            weight_sum=weight_sum,
-            return_token_accuracy=return_token_accuracy,
-            return_predicted_tokens=return_predicted_tokens,
-            token_acc_out=token_acc_out,
-            pred_tok_out=pred_tok_out,
-            inv_n_z=inv_n_z,
-            logical_vocab_size=logical_vocab_size,
-            _split_fp32_features=False,
-        )
-        _launch_ce_fwd(
-            x=x,
-            y=y,
-            loss=torch.empty_like(loss),
-            inv_n_loss=inv_n_loss,
-            ignore_index=ignore_index,
-            has_grad=True,
-            lse_sq_scale=lse_sq_scale,
-            z_loss_out=None,
-            return_z_loss=False,
-            softcap=softcap,
-            label_smoothing=label_smoothing,
-            weight=weight,
-            weight_sum=weight_sum,
-            return_token_accuracy=False,
-            return_predicted_tokens=False,
-            token_acc_out=None,
-            pred_tok_out=None,
-            inv_n_z=inv_n_z,
-            logical_vocab_size=logical_vocab_size,
-            _split_fp32_features=False,
-        )
-        return
-
     softcap_val = float(softcap) if has_softcap else 0.0
     x_ct = to_cute_tensor(x)
     y_ct = to_cute_tensor(y, assumed_align=8)  # int64


### PR DESCRIPTION
## Summary
- force FP32 CE loss and z-loss stores through explicitly typed FP32 pointers
- prevent CuTe DSL 4.6 from narrowing feature-enabled FP32 training outputs to bf16
- preserve the existing single-kernel, in-place-gradient design

## Problem
With `nvidia-cutlass-dsl==4.6.0`, FP32 `HAS_GRAD` specializations that enable z-loss, softcap, or label smoothing store the public loss outputs at bf16 precision even though the CE math and gradients remain FP32-accurate. For example, the z-loss test produced `8.7725` instead of the Triton/PyTorch result `8.8014`; per-token values landed exactly on bf16 quantization points.

Rebuilding the loss and z-loss views with explicit `Float32` pointers keeps those stores FP32. FP16/BF16 paths retain their existing typed stores. This does not add launches, buffers, or API changes, and FLCE is unchanged.

## Validation
- `python -m pytest --confcutdir=test/cutedsl test/cutedsl/test_cross_entropy.py -q` — 158 passed, 1 environment-gated skip
- `LIGER_KERNEL_IMPL=cutedsl python -m pytest --confcutdir=test/cutedsl test/cutedsl/test_cross_entropy.py::test_liger_kernel_impl_cutedsl_selects_cutedsl_ce -q` — 1 passed
- `ruff check src/liger_kernel/ops/cutedsl/ops/cross_entropy.py`
- `ruff format --check src/liger_kernel/ops/cutedsl/ops/cross_entropy.py`