### PR TITLE
Support strided Liger MoE input weights

### DIFF
--- a/liger_cute_kernels/csrc/core/src/moe/mlp.cuh
+++ b/liger_cute_kernels/csrc/core/src/moe/mlp.cuh
@@ -61,8 +61,9 @@ using MlpFwdCtaBarrierT = CtaCounterBarrier<(Compute == 100 ? 10 : 9) * 32, kMlp
 struct MlpDims {
 	int hidden_dim;
 	int intermediate_dim;
-	int total_n_rows_1;     // experts_per_pe * intermediate_dim
+	int total_n_rows_1;     // physical rows spanned by the strided B/C views
 	int total_n_rows_2;     // experts_per_pe * hidden_dim
+	int expert_n_stride_1;  // B/C expert stride in TileN1 units
 	int num_n_tiles_1;      // intermediate_dim / TileN1
 	int num_n_tiles_2;      // ceildiv(hidden_dim/TileN2, NSub) — per-WG outer steps
 	int num_k_tiles_1;      // hidden_dim / TileK1
@@ -243,7 +244,7 @@ __device__ __forceinline__ void mlp_fused_fwd(
 				mlp1_fused_producer<Traits1>(
 					p1_pipe, p1_state,
 					smem.mlp1, tma_load_x, tma_load_b, tma_load_c,
-					x_mt, expert * dims.num_n_tiles_1,
+					x_mt, expert * dims.expert_n_stride_1,
 					num_tokens, dims.hidden_dim, dims.total_n_rows_1,
 					dims.num_n_tiles_1, dims.num_k_tiles_1, n_split, n_count);
 			}

--- a/liger_cute_kernels/csrc/core/src/moe/moe.cu
+++ b/liger_cute_kernels/csrc/core/src/moe/moe.cu
@@ -833,7 +833,20 @@ moe_fused_fwd_bf16(const MoeFwdArgs& a, int static_nsplit) {
 	// empty inner loops but still drive their TMA-load/store mbarriers so the
 	// pipeline stays balanced across the column.
 
-	int total_n_rows_1 = experts_per_pe * intermediate_dim;
+	LIGER_CHECK(a.weight_expert_stride >=
+			static_cast<int64_t>(intermediate_dim) * hidden_dim,
+		"weight expert stride (", a.weight_expert_stride,
+		") must cover at least one [I,D] expert matrix");
+	LIGER_CHECK(a.weight_expert_stride % hidden_dim == 0,
+		"weight expert stride (", a.weight_expert_stride,
+		") must contain complete hidden-dimension rows (D=", hidden_dim, ")");
+	int weight_expert_stride_rows =
+		static_cast<int>(a.weight_expert_stride / hidden_dim);
+	LIGER_CHECK(weight_expert_stride_rows % Traits1::TileN == 0,
+		"weight expert stride in rows (", weight_expert_stride_rows,
+		") must be divisible by MLP1 TileN (", Traits1::TileN, ")");
+	int total_n_rows_1 =
+		(experts_per_pe - 1) * weight_expert_stride_rows + intermediate_dim;
 	int total_n_rows_2 = experts_per_pe * hidden_dim;
 
 	int num_pes = nvshmem_team_n_pes(team);
@@ -934,6 +947,7 @@ moe_fused_fwd_bf16(const MoeFwdArgs& a, int static_nsplit) {
 	mlp_dims.intermediate_dim = intermediate_dim;
 	mlp_dims.total_n_rows_1   = total_n_rows_1;
 	mlp_dims.total_n_rows_2   = total_n_rows_2;
+	mlp_dims.expert_n_stride_1 = weight_expert_stride_rows / Traits1::TileN;
 	mlp_dims.num_n_tiles_1    = num_n_tiles_1;
 	mlp_dims.num_n_tiles_2    = num_n_tiles_2;
 	mlp_dims.num_k_tiles_1    = hidden_dim / Traits1::TileK;

--- a/liger_cute_kernels/csrc/core/src/moe/moe_launch.h
+++ b/liger_cute_kernels/csrc/core/src/moe/moe_launch.h
@@ -15,6 +15,8 @@
 
 #include <cuda_runtime.h>
 
+#include <cstdint>
+
 namespace liger {
 
 // Forward launcher inputs. bf16 payloads are carried as void* and reinterpret_cast
@@ -26,6 +28,7 @@ struct MoeFwdArgs {
 	const void* all_B;             // [epp, I, D] bf16
 	const void* all_C;             // [epp, I, D] bf16
 	const void* all_A;             // [epp, D, I] bf16
+	int64_t weight_expert_stride;  // all_B/all_C expert stride in bf16 elements
 	int num_tokens, hidden_dim, intermediate_dim, experts_per_pe;
 	int num_experts, top_k;
 	int team;                      // NVSHMEM team id (nvshmem_team_t == int)

--- a/liger_cute_kernels/csrc/core/src/moe/tune/tune_moe_fwd_bwd.cu
+++ b/liger_cute_kernels/csrc/core/src/moe/tune/tune_moe_fwd_bwd.cu
@@ -373,6 +373,7 @@ static bool run_pair_once(
 		fa.expert_indices = expert_indices.data_ptr<int>();
 		fa.expert_weights = expert_weights.data_ptr();
 		fa.all_B = all_B.data_ptr(); fa.all_C = all_C.data_ptr(); fa.all_A = all_A.data_ptr();
+		fa.weight_expert_stride = static_cast<int64_t>(Imid) * D;
 		fa.num_tokens = T; fa.hidden_dim = D; fa.intermediate_dim = Imid; fa.experts_per_pe = epp;
 		fa.num_experts = E; fa.top_k = K; fa.team = team; fa.stream = stream; fa.device = device;
 		fa.Y = Y.data_ptr();

--- a/liger_cute_kernels/liger_cute_kernels/tvm_ffi_bindings.cpp
+++ b/liger_cute_kernels/liger_cute_kernels/tvm_ffi_bindings.cpp
@@ -79,6 +79,20 @@ void RequireCudaTensor(ffi::TensorView tensor, int ndim, DLDataType dtype, const
   TVM_FFI_ICHECK_EQ(tensor.device().device_type, kDLCUDA) << name;
 }
 
+void RequireCudaMoeWeight(ffi::TensorView tensor, DLDataType dtype, const char* name) {
+  TVM_FFI_ICHECK_EQ(tensor.ndim(), 3) << name;
+  TVM_FFI_ICHECK_EQ(tensor.dtype(), dtype) << name;
+  TVM_FFI_ICHECK_EQ(tensor.device().device_type, kDLCUDA) << name;
+  TVM_FFI_ICHECK_EQ(tensor.stride(2), 1)
+      << name << " hidden dimension must be contiguous";
+  TVM_FFI_ICHECK_EQ(tensor.stride(1), tensor.size(2))
+      << name << " intermediate rows must be contiguous";
+  TVM_FFI_ICHECK_GE(tensor.stride(0), tensor.size(1) * tensor.size(2))
+      << name << " expert stride overlaps adjacent experts";
+  TVM_FFI_ICHECK_EQ(tensor.stride(0) % tensor.size(2), 0)
+      << name << " expert stride must contain complete hidden-dimension rows";
+}
+
 void RequireRank(ffi::TensorView tensor, int ndim, const char* name) {
   TVM_FFI_ICHECK_EQ(tensor.ndim(), ndim) << name;
   TVM_FFI_ICHECK(tensor.IsContiguous()) << name;
@@ -229,8 +243,8 @@ void moe_fused_fwd_bf16(
   RequireCudaTensor(X, 2, bf16, "X");
   RequireCudaTensor(expert_indices, 2, i32, "expert_indices");
   RequireCudaTensor(expert_weights, 2, bf16, "expert_weights");
-  RequireCudaTensor(all_B, 3, bf16, "all_B");
-  RequireCudaTensor(all_C, 3, bf16, "all_C");
+  RequireCudaMoeWeight(all_B, bf16, "all_B");
+  RequireCudaMoeWeight(all_C, bf16, "all_C");
   RequireCudaTensor(all_A, 3, bf16, "all_A");
   RequireCudaTensor(Y, 2, bf16, "Y");
   RequireCudaTensor(token_expert_slots, 1, i32, "token_expert_slots");
@@ -244,6 +258,14 @@ void moe_fused_fwd_bf16(
   const int64_t hidden_dim = X.size(1);
   const int64_t intermediate_dim = all_B.size(1);
   const int64_t experts_per_pe = all_B.size(0);
+  TVM_FFI_ICHECK_EQ(all_C.size(0), experts_per_pe);
+  TVM_FFI_ICHECK_EQ(all_C.size(1), intermediate_dim);
+  TVM_FFI_ICHECK_EQ(all_C.size(2), hidden_dim);
+  TVM_FFI_ICHECK_EQ(all_B.stride(0), all_C.stride(0))
+      << "all_B and all_C must use the same expert stride";
+  TVM_FFI_ICHECK_EQ(all_A.size(0), experts_per_pe);
+  TVM_FFI_ICHECK_EQ(all_A.size(1), hidden_dim);
+  TVM_FFI_ICHECK_EQ(all_A.size(2), intermediate_dim);
   TVM_FFI_ICHECK_EQ(hidden_dim, cfg.hidden_dim);
   TVM_FFI_ICHECK_EQ(num_experts, cfg.max_num_experts);
   TVM_FFI_ICHECK(top_k >= 1 && top_k <= cfg.max_top_k);
@@ -266,6 +288,7 @@ void moe_fused_fwd_bf16(
   args.all_B = all_B.data_ptr();
   args.all_C = all_C.data_ptr();
   args.all_A = all_A.data_ptr();
+  args.weight_expert_stride = all_B.stride(0);
   args.num_tokens = static_cast<int>(num_tokens);
   args.hidden_dim = static_cast<int>(hidden_dim);
   args.intermediate_dim = static_cast<int>(intermediate_dim);

--- a/liger_cute_kernels/liger_cute_kernels/tvm_ffi_bindings.cpp
+++ b/liger_cute_kernels/liger_cute_kernels/tvm_ffi_bindings.cpp
@@ -258,6 +258,8 @@ void moe_fused_fwd_bf16(
   const int64_t hidden_dim = X.size(1);
   const int64_t intermediate_dim = all_B.size(1);
   const int64_t experts_per_pe = all_B.size(0);
+  TVM_FFI_ICHECK_EQ(all_B.size(2), hidden_dim)
+      << "all_B hidden dimension must match X";
   TVM_FFI_ICHECK_EQ(all_C.size(0), experts_per_pe);
   TVM_FFI_ICHECK_EQ(all_C.size(1), intermediate_dim);
   TVM_FFI_ICHECK_EQ(all_C.size(2), hidden_dim);

--- a/liger_cute_kernels/test/test_moe_bindings.py
+++ b/liger_cute_kernels/test/test_moe_bindings.py
@@ -98,6 +98,50 @@ def test_fwd_rejects_wrong_dtype(tvm_ffi_module):
         )
 
 
+@pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA tensors")
+def test_fwd_rejects_mismatched_gate_hidden_dim(tvm_ffi_module):
+    tvm_ffi_module.moe_configure_symmetric(**_CFG)
+    T, D, E, K = 16, _CFG["hidden_dim"], _CFG["max_num_experts"], _CFG["max_top_k"]
+    experts_per_pe = E // _CFG["num_pes"]
+    intermediate_dim = 16
+    X = torch.zeros(T, D, dtype=torch.bfloat16, device="cuda")
+    expert_indices = torch.zeros(T, K, dtype=torch.int32, device="cuda")
+    expert_weights = torch.zeros(T, K, dtype=torch.bfloat16, device="cuda")
+    bad_B = torch.zeros(
+        experts_per_pe,
+        intermediate_dim,
+        D // 2,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    C = torch.zeros(
+        experts_per_pe,
+        intermediate_dim,
+        D,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    A = torch.zeros(
+        experts_per_pe,
+        D,
+        intermediate_dim,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    with pytest.raises(RuntimeError, match="all_B hidden dimension must match X"):
+        tvm_ffi_module.moe_fused_fwd_bf16(
+            X,
+            expert_indices,
+            expert_weights,
+            bad_B,
+            C,
+            A,
+            num_experts=E,
+            top_k=K,
+            team_handle=0,
+        )
+
+
 @pytest.mark.skip(
     reason="full fwd/bwd allocates symmetric memory; needs an initialized NVSHMEM "
     "runtime — bootstrap bindings not ported yet."

--- a/liger_cute_kernels/test/test_moe_cuda_graph.py
+++ b/liger_cute_kernels/test/test_moe_cuda_graph.py
@@ -258,6 +258,66 @@ def _fwd_graph_worker(rank: int, world_size: int, init_file: str):
         _check_close(Y, Y_ref)
 
 
+# ── forward: packed w13 strided views ─────────────────────────────────────────
+
+
+def _strided_fwd_worker(rank: int, world_size: int, init_file: str):
+    _init(rank, world_size, init_file)
+    team = nvshmem.team_world()
+    try:
+        _configure(world_size)
+        X, gate_W, all_B, all_C, all_A, ei, ew = _make_inputs(rank, world_size)
+        experts_per_pe = all_B.size(0)
+
+        packed_w13 = torch.stack((all_B, all_C), dim=1).reshape(experts_per_pe, 2 * _I, _D)
+        strided_B = packed_w13[:, :_I, :]
+        strided_C = packed_w13[:, _I:, :]
+        assert not strided_B.is_contiguous()
+        assert not strided_C.is_contiguous()
+        assert strided_B.stride() == (2 * _I * _D, _D, 1)
+        assert strided_C.stride() == strided_B.stride()
+
+        all_B_g = _gather_experts(all_B, dist.group.WORLD)
+        all_C_g = _gather_experts(all_C, dist.group.WORLD)
+        all_A_g = _gather_experts(all_A, dist.group.WORLD)
+        Y_ref = _torch_reference_moe(X, ei, ew, all_B_g, all_C_g, all_A_g, _K).cpu()
+
+        Y_contiguous = tvm_ffi.moe_fused_fwd_bf16(
+            X, ei, ew, all_B, all_C, all_A, num_experts=_E, top_k=_K, team_handle=team
+        )[0]
+        tvm_ffi.moe_pop_fwd()
+        torch.cuda.synchronize()
+        Y_contiguous = Y_contiguous.cpu()
+
+        Y_strided = tvm_ffi.moe_fused_fwd_bf16(
+            X,
+            ei,
+            ew,
+            strided_B,
+            strided_C,
+            all_A,
+            num_experts=_E,
+            top_k=_K,
+            team_handle=team,
+        )[0]
+        tvm_ffi.moe_pop_fwd()
+        torch.cuda.synchronize()
+        Y_strided = Y_strided.cpu()
+
+        dist.barrier()
+        nvshmem.finalize()
+        dist.destroy_process_group()
+    except BaseException:
+        try:
+            dist.destroy_process_group()
+        except Exception:
+            pass
+        raise
+
+    _check_close(Y_strided, Y_contiguous, mean_rel_tol=0.01)
+    _check_close(Y_strided, Y_ref)
+
+
 # ── forward + backward: two graphs ────────────────────────────────────────────
 
 
@@ -676,6 +736,12 @@ def test_moe_fwd_cuda_graph():
     (the second replay would corrupt the first's NVSHMEM writes otherwise).
     """
     _run(_world_size(), _fwd_graph_worker)
+
+
+@pytest.mark.skipif(_NDEV < 2, reason="needs >=2 CUDA devices")
+def test_moe_fwd_packed_w13_strided_views():
+    """Packed gate/up views avoid copies while matching contiguous weights."""
+    _run(_world_size(), _strided_fwd_worker)
 
 
 @pytest.mark.skipif(_NDEV < 2, reason="needs >=2 CUDA devices")

--- a/src/liger_kernel/ops/cute/ops/moe.py
+++ b/src/liger_kernel/ops/cute/ops/moe.py
@@ -75,6 +75,11 @@ class LigerExpertParallelFusedMoEFunction(torch.autograd.Function):
         top_k: int,
         pg: Optional["ProcessGroup"],
     ) -> torch.Tensor:
+        if not all_B.is_contiguous() or not all_C.is_contiguous():
+            raise ValueError(
+                "Strided MoE gate/up weights are supported only when gradients "
+                "are disabled; backward currently requires contiguous weights."
+            )
         team_handle = _resolve_team(pg)
 
         (
@@ -184,6 +189,11 @@ def moe_fused(
     used by fwd is popped immediately before returning; otherwise the
     intermediates stay alive on the autograd context until the matching
     ``backward`` consumes them and pops the stack there.
+
+    The no-grad path accepts gate/up views with contiguous inner dimensions and
+    a larger stride between experts, such as slices of packed ``w13`` storage.
+    The grad path currently requires contiguous gate/up tensors because the
+    backward kernel does not yet support an expert stride.
     """
     # Decide which path to take BEFORE entering the Function:
     # torch.is_grad_enabled() is forced to False inside

--- a/test/transformers/test_cute_moe_autograd.py
+++ b/test/transformers/test_cute_moe_autograd.py
@@ -206,14 +206,25 @@ def _autograd_worker(rank, world_size, init_file):
         all_A_g = _gather_experts(all_A_data, dist.group.WORLD)
         Y_ref = _torch_reference_moe(X_data, ei, ew, all_B_g, all_C_g, all_A_g, _K)
 
+        experts_per_pe = all_B_data.size(0)
+        packed_w13_data = torch.stack((all_B_data, all_C_data), dim=1).reshape(
+            experts_per_pe,
+            2 * _I,
+            _D,
+        )
+        strided_B_data = packed_w13_data[:, :_I, :]
+        strided_C_data = packed_w13_data[:, _I:, :]
+        assert not strided_B_data.is_contiguous()
+        assert not strided_C_data.is_contiguous()
+
         # ── No-grad fast path: must pop the symmetric stack immediately. ──
         with torch.no_grad():
             Y_ng = moe_fused(
                 X_data,
                 ei,
                 ew,
-                all_B_data,
-                all_C_data,
+                strided_B_data,
+                strided_C_data,
                 all_A_data,
                 num_experts=_E,
                 top_k=_K,
@@ -225,6 +236,24 @@ def _autograd_worker(rank, world_size, init_file):
 
         # The Function class is reachable via the ops module (sanity on the export).
         assert LigerExpertParallelFusedMoEFunction is not None
+
+        # Backward does not yet support expert-strided weights. Reject them
+        # before forward allocates symmetric intermediates.
+        packed_w13 = packed_w13_data.clone().detach().requires_grad_(True)
+        strided_B = packed_w13[:, :_I, :]
+        strided_C = packed_w13[:, _I:, :]
+        with pytest.raises(ValueError, match="gradients are disabled"):
+            moe_fused(
+                X_data.clone().detach().requires_grad_(True),
+                ei,
+                ew,
+                strided_B,
+                strided_C,
+                all_A_data.clone().detach().requires_grad_(True),
+                num_experts=_E,
+                top_k=_K,
+                pg=dist.group.WORLD,
+            )
 
         # ── Grad path: with-intermediates fwd, backward consumes + pops. ──
         X = X_data.clone().detach().requires_grad_(True)


### PR DESCRIPTION
## Summary
Support strided input weights for MOE. 

### Problems
Qwen-style MoE checkpoints store both input projections in one packed tensor:

```text
w13 shape: [experts, 2 * intermediate, hidden]

gate = w13[:, :intermediate, :]
up   = w13[:, intermediate:, :]
```

Each gate/up matrix is contiguous internally, but adjacent experts are
`2 * intermediate * hidden` elements apart. The current binding rejects these
views because the overall tensor is not contiguous. Serving integrations must
therefore call `.contiguous()` on both views. For Qwen3-235B, those retained
copies consume approximately 0.375 GiB per layer, or 35.25 GiB per GPU across
94 MoE layers, reducing KV-cache capacity and causing OOM at 90% memory
utilization.

Relaxing only the binding check would be incorrect. The old kernel
[defines `num_n_tiles_1` as `intermediate_dim / TileN`](https://github.com/linkedin/Liger-Kernel/blob/fb7352c8a384088eeabd1fba5650df82b5c4b861/liger_cute_kernels/csrc/core/src/moe/moe.cu#L829-L830)
and then
[uses `expert * dims.num_n_tiles_1` as the expert's starting weight tile](https://github.com/linkedin/Liger-Kernel/blob/fb7352c8a384088eeabd1fba5650df82b5c4b861/liger_cute_kernels/csrc/core/src/moe/mlp.cuh#L243-L248).
Together, these lines assume adjacent experts are separated by exactly
`intermediate / TileN` weight tiles:

```text
I=1536, TileN=128
useful tiles per expert = 1536 / 128 = 12

packed physical stride = 2 * 1536 / 128 = 24 tiles
```

For packed gate weights, physical tiles are:

```text
tiles  0-11: expert 0 gate
tiles 12-23: expert 0 up
tiles 24-35: expert 1 gate
```

Using the old `expert * 12` offset makes expert 1 gate computation read expert
0 up weights. The same issue causes the up descriptor to read the next expert's
gate weights. Outputs would therefore be silently corrupted.

This PR passes the actual expert stride from the tensor metadata and uses it
only to locate each expert's first tile. Each expert still computes exactly
`intermediate / TileN` useful tiles. For ordinary contiguous weights, the
physical stride equals the useful tile count, so existing behavior is unchanged.

## Notes

This PR supports expert-strided gate/up weights for forward no-grad inference.
The public `moe_fused` no-grad path calls the native forward directly and pops
its symmetric buffers immediately.

The grad-enabled path enters `LigerExpertParallelFusedMoEFunction.forward`,
which rejects non-contiguous gate/up tensors before resolving the NVSHMEM team
or launching native forward:

```python
if not all_B.is_contiguous() or not all_C.is_contiguous():
    raise ValueError(...)
```

## Testing Done

- Hardware Type: 8x NVIDIA H200
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
- [x] Local code review completed

Targeted validation:

- Built
  `liger_cute_kernels-0.1.0+cu130.torch2.11.0-cp312-cp312-linux_x86_64.whl`
  (`sha256: 22a12d6f8825b377f94f8b4a6c48a0350c2c488e2baa33bf569c8b2ce4ce3993`).
- Ran the complete fused-MoE CUDA graph test file on eight GPUs: 6 passed,
  including packed-view parity, forward/backward graphs, unaligned token tails,
  and single-token automatic dispatch.
- Verified the final review fixes:
  - mismatched gate hidden dimensions fail before TMA descriptor construction;
  - packed `w13` views match contiguous weights on eight GPUs; and
  - distributed autograd accepts strided no-grad inference, rejects strided
    grad mode before native allocation, and preserves the contiguous grad path.

- Integrated DP8+EP8 Qwen3-235B vLLM replay at 90% GPU memory completed 2,048
  requests with zero errors in 36.20 seconds, allocating 47.98 GiB of KV cache
  and 267,584 KV tokens per rank.

Native layout microbenchmark using identical weights, routes, tuned
configurations, and alternating execution order:

| Tokens per rank | Contiguous weights | Strided packed views | Difference |
|---:|---:|---:|---:|
| 512 | 1.615 ms | 1.623 ms | +0.5% |
| 4,096 | 4.000 ms | 4.005 ms | +0.1% |
| 16,384 | 12.301 ms | 12.210 ms | -0.7% |

The differences are within measurement noise; expert-strided TMA addressing
has no meaningful kernel latency penalty. Raw measurements:
`/shared/public/sharing/seeker_summary_rl/v07_test/liger_strided_weight_microbench_20260812_080042`.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
