### PR TITLE
Update CuTe DSL backend docs: op list and DSL version

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ pip install -e ".[dev]" --extra-index-url https://triton-ascend.osinfra.cn/pypi/
 - `transformers >= 4.x`: Required if you plan to use the transformers models patching APIs. The specific model you are working will dictate the minimum version of transformers.
 - `cuda-tile`: Required when enabling the optional cuTile backend on CUDA. Use this when your environment already provides CUDA Toolkit 13.1 or newer, or an existing tileiras compiler installation.
 - `cuda-tile[tileiras]`: Required when enabling the optional cuTile backend with the tileiras compiler installed directly into your Python environment.
-- `nvidia-cutlass-dsl >= 4.5.2`: Required when enabling the optional CuTe DSL backend on CUDA (the CUDA-only Python DSL shipped with NVIDIA CUTLASS, `import cutlass.cute`). Targets Hopper (SM90) and Blackwell (SM100/SM110).
+- `nvidia-cutlass-dsl >= 4.6.0`: Required when enabling the optional CuTe DSL backend on CUDA (the CUDA-only Python DSL shipped with NVIDIA CUTLASS, `import cutlass.cute`). Targets Hopper (SM90) and Blackwell (SM100/SM110).
 
 > **Note:**
 > Our kernels inherit the full spectrum of hardware compatibility offered by [Triton](https://github.com/triton-lang/triton).
@@ -217,7 +217,16 @@ pip install "liger-kernel[cutedsl]"
 LIGER_KERNEL_IMPL=cutedsl python your_script.py
 ```
 
-It currently provides genuine `cutlass.cute` implementations of **RMSNorm**, **cross entropy**, and **fused scaled cross entropy**. Ops without a CuTe DSL kernel transparently fall back to the default Triton kernel.
+It currently provides genuine `cutlass.cute` implementations of:
+
+- **RMSNorm**
+- **RoPE**
+- **SwiGLU**
+- **Cross entropy**
+- **Fused linear cross entropy** (with an SM90-specialized variant)
+- **Fused scaled cross entropy** (SM90)
+
+Ops without a CuTe DSL kernel transparently fall back to the default Triton kernel.
 
 ### Fused Scaled Cross Entropy
 


### PR DESCRIPTION
## Summary

Two doc fixes to the CuTe DSL backend section of `README.md`.

**1. Stale op list.** The "Enable CuTe DSL Backend" section claimed the backend provides `cutlass.cute` implementations of RMSNorm, cross entropy, and fused scaled cross entropy. It also ships **RoPE**, **SwiGLU**, and **fused linear cross entropy** — all exported from `src/liger_kernel/ops/cutedsl/ops/__init__.py`, all genuine `cutlass.cute` kernels (not fallbacks), and all covered by tests:

- `src/liger_kernel/ops/cutedsl/ops/rope.py` → `test/transformers/test_cutedsl_rope.py`
- `src/liger_kernel/ops/cutedsl/ops/swiglu.py` → `test/transformers/test_swiglu_cutedsl.py`
- `src/liger_kernel/ops/cutedsl/ops/fused_linear_cross_entropy.py` and `fused_linear_cross_entropy_sm90.py` → `test/cutedsl/test_fused_linear_cross_entropy.py`

Reformatted the list as bullets since it no longer fits comfortably inline.

**2. Version mismatch.** The Optional Dependencies section documented `nvidia-cutlass-dsl >= 4.5.2`, but the `cutedsl` extra in `setup.py:41` pins `nvidia-cutlass-dsl>=4.6.0`. Aligned the README to setup.py.

## Testing

Documentation-only change — no code paths touched.