### PR TITLE
Add FP32 accumulation option to fused scaled cross entropy

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,18 @@ The implementations share this public contract but use different schedules:
 - **CuTe SM90** uses `LigerFusedScaledCrossEntropySM90Function` for BF16 inputs on Hopper. Its sole forward uses the fixed cluster-M2 N160 fragment kernel, with a measured split-N lookup for profiled long-sequence shapes, and never writes logits to HBM; `m_tiles_per_cluster` remains accepted for API compatibility but does not change that schedule. Backward runs `dZ`, `dX`, and `dW` in one persistent cluster kernel with a reusable 1024-token `dZ` workspace.
 - **Fallback** uses a 512-token chunked PyTorch implementation adapted from Verl's fused PPO formulas when the default frontend cannot use the SM90 kernel.
 
+Backward sums `dW` across token chunks, so in a low-precision `weight` dtype the running sum is rounded once per chunk and the error compounds with the chunk count. The optional trailing `accum_dtype` argument keeps that accumulator in higher precision and casts back to `weight.dtype` at the end, at the cost of an extra `V x H` buffer:
+
+```python
+import torch
+
+nll, entropy = LigerFusedLinearScaledCrossEntropyFunction.apply(
+    x, weight, target, 1.0, -100, 1, True, torch.float32
+)
+```
+
+`accum_dtype` defaults to `None` (accumulate in the weight dtype). The cuTile and fallback implementations support it; the CuTe SM90 implementation accumulates `dW` inside a fused kernel and raises `NotImplementedError` if it is set.
+
 H100 BF16 forward medians from 60 interleaved samples per provider at
 `H=4096`, `V=131072`. Effective TFLOPS count the common projection work,
 `2*M*H*V`:

--- a/benchmark/scripts/benchmark_fused_scaled_cross_entropy_sm90.py
+++ b/benchmark/scripts/benchmark_fused_scaled_cross_entropy_sm90.py
@@ -16,6 +16,8 @@ Sweep parameters (all optional; defaults reproduce the previous behaviour)::
 
 Providers: ``torch``, ``liger`` (Triton FLCE, ``reduction="none"``),
 ``cutile``, and ``cutedsl-sm90`` (fixed 1024-token wave-batched backward).
+``cutile-accum-fp32`` is ``cutile`` with ``accum_dtype=torch.float32``, which
+keeps the chunked ``dW`` accumulation in FP32 at the cost of a ``V x H`` buffer.
 
 Example::
 
@@ -54,6 +56,7 @@ REPRESENTATIVE_CONFIG = {
 
 CUTEDSL_PREFIX = "cutedsl-sm90"
 CUTILE_PREFIX = "cutile"
+CUTILE_ACCUM_PREFIX = "cutile-accum-fp32"
 # Seed of the fixed per-token upstream gradient, so every provider and every
 # repetition sees byte-identical ``d(NLL)/d(loss)`` values.
 GRAD_SEED = 1234
@@ -112,10 +115,18 @@ class CuteDSLHopperLMHeadScaledCE(torch.nn.Module):
 
 
 class CuTileLMHeadScaledCE(torch.nn.Module):
-    def __init__(self, hidden_size: int, vocab_size: int, dtype: torch.dtype, temperature: float = 1.0):
+    def __init__(
+        self,
+        hidden_size: int,
+        vocab_size: int,
+        dtype: torch.dtype,
+        temperature: float = 1.0,
+        accum_dtype=None,
+    ):
         super().__init__()
         self.weight = torch.nn.Parameter(torch.empty(vocab_size, hidden_size, dtype=dtype))
         self.temperature = temperature
+        self.accum_dtype = accum_dtype
         torch.nn.init.normal_(self.weight, std=hidden_size**-0.5)
 
     def forward(self, x, target):
@@ -131,6 +142,7 @@ class CuTileLMHeadScaledCE(torch.nn.Module):
             -100,
             1,
             False,
+            self.accum_dtype,
         )
 
 
@@ -163,6 +175,8 @@ def setup_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput):
         layer = CuteDSLHopperLMHeadScaledCE(hidden_size, vocab_size, dtype)
     elif provider == CUTILE_PREFIX:
         layer = CuTileLMHeadScaledCE(hidden_size, vocab_size, dtype)
+    elif provider == CUTILE_ACCUM_PREFIX:
+        layer = CuTileLMHeadScaledCE(hidden_size, vocab_size, dtype, accum_dtype=torch.float32)
     elif provider == "liger":
         layer = TritonLMHeadCE(hidden_size, vocab_size, dtype)
     elif provider == "torch":
@@ -253,7 +267,7 @@ def parse_sweep_args():
 def resolve_providers(sweep_args):
     if sweep_args.providers:
         for provider in sweep_args.providers:
-            if provider not in ("torch", "liger", CUTILE_PREFIX, CUTEDSL_PREFIX):
+            if provider not in ("torch", "liger", CUTILE_PREFIX, CUTILE_ACCUM_PREFIX, CUTEDSL_PREFIX):
                 raise ValueError(f"Unknown provider {provider!r}")
         return list(sweep_args.providers)
     return ["torch", "liger", CUTILE_PREFIX, CUTEDSL_PREFIX]

--- a/src/liger_kernel/ops/cutile/ops/fused_linear_scaled_cross_entropy.py
+++ b/src/liger_kernel/ops/cutile/ops/fused_linear_scaled_cross_entropy.py
@@ -6,6 +6,8 @@ import os
 import cuda.tile as ct
 import torch
 
+from packaging.version import Version
+
 from liger_kernel.ops.cutile.ops.utils import LOG2E
 from liger_kernel.ops.cutile.ops.utils import _next_power_of_2
 from liger_kernel.ops.cutile.ops.utils import _select_cross_entropy_block_size
@@ -19,6 +21,8 @@ _BLACKWELL_LOGITS_WORKSPACE_BYTES = 512 * _MIB
 _BLACKWELL_MIN_TOKENS = 4096
 _BLACKWELL_MIN_VOCAB_SIZE = 131072
 _WORKSPACE_MB_ENV = "LIGER_CUTILE_SCALED_CE_WORKSPACE_MB"
+_TORCH_VERSION = Version(torch.__version__.split("+")[0])
+_ADDMM_SUPPORTS_OUT_DTYPE = _TORCH_VERSION >= Version("2.8.0")
 
 
 def _validate_temperature(temperature):
@@ -26,6 +30,15 @@ def _validate_temperature(temperature):
         raise TypeError("temperature must be a real number")
     if not math.isfinite(temperature) or temperature <= 0:
         raise ValueError("temperature must be finite and > 0")
+
+
+def _validate_accum_dtype(accum_dtype):
+    if accum_dtype is None:
+        return
+    if not isinstance(accum_dtype, torch.dtype):
+        raise TypeError("accum_dtype must be a torch.dtype or None")
+    if not accum_dtype.is_floating_point:
+        raise ValueError("accum_dtype must be a floating-point dtype")
 
 
 def _validate_input_metadata(_input, weight, target):
@@ -299,15 +312,23 @@ def fused_scaled_cross_entropy_backward(
     *,
     entropy=None,
     grad_entropy=None,
+    accum_dtype=None,
 ):
     """Compute gradients for per-token NLL and optional entropy outputs.
 
     Returns gradients for ``_input`` and ``weight``. ``grad_nll`` may be
     ``None`` for entropy-only backward; ``entropy`` and ``grad_entropy`` are
     needed only when entropy contributes to the gradient.
+
+    ``grad_weight`` is summed across token chunks, so with a low-precision
+    ``weight`` dtype the running sum is rounded once per chunk and the error
+    compounds with the chunk count. ``accum_dtype`` (e.g. ``torch.float32``)
+    keeps that accumulator in higher precision and casts back to
+    ``weight.dtype`` at the end, at the cost of an extra ``V x H`` buffer.
     """
     _validate_input_metadata(_input, weight, target)
     _validate_temperature(temperature)
+    _validate_accum_dtype(accum_dtype)
     if grad_nll is None and grad_entropy is None:
         raise ValueError("at least one of grad_nll or grad_entropy must be provided")
     if grad_nll is not None and grad_nll.shape != target.shape:
@@ -331,7 +352,15 @@ def fused_scaled_cross_entropy_backward(
     block_size = _select_cross_entropy_block_size(V)
 
     grad_input = torch.empty_like(_input) if _input.requires_grad else None
-    grad_weight = torch.empty_like(weight) if weight.requires_grad else None
+    if not weight.requires_grad:
+        grad_weight = None
+    elif accum_dtype is not None:
+        # A higher-precision accumulator has to start at zero because every chunk
+        # is folded in with addmm; the same-dtype path seeds itself from the first
+        # chunk's mm and can stay uninitialized.
+        grad_weight = torch.zeros_like(weight, dtype=accum_dtype)
+    else:
+        grad_weight = torch.empty_like(weight)
     grad_logits_workspace = torch.empty(
         min(BT, chunk_size),
         V,
@@ -376,19 +405,40 @@ def fused_scaled_cross_entropy_backward(
         if grad_input is not None:
             torch.mm(grad_logits_chunk, weight, out=grad_input[start:end])
         if grad_weight is not None:
-            if start == 0:
-                torch.mm(grad_logits_chunk.t(), input_chunk, out=grad_weight)
+            grad_logits_t = grad_logits_chunk.t()
+            if accum_dtype is not None:
+                if (
+                    _ADDMM_SUPPORTS_OUT_DTYPE
+                    and grad_weight.dtype == torch.float32
+                    and grad_logits_t.dtype in (torch.float16, torch.bfloat16)
+                    and grad_weight.device.type == "cuda"
+                    and torch.cuda.get_device_capability(grad_weight.device)[0] >= 8
+                ):
+                    torch.addmm(
+                        grad_weight,
+                        grad_logits_t,
+                        input_chunk,
+                        out_dtype=torch.float32,
+                        out=grad_weight,
+                    )
+                else:
+                    grad_weight += torch.mm(grad_logits_t, input_chunk).to(grad_weight.dtype)
+            elif start == 0:
+                torch.mm(grad_logits_t, input_chunk, out=grad_weight)
             else:
                 # Accumulate the GEMM directly into grad_weight instead of
                 # materializing a full V x H temporary for every token chunk.
-                torch.addmm(grad_weight, grad_logits_chunk.t(), input_chunk, out=grad_weight)
+                torch.addmm(grad_weight, grad_logits_t, input_chunk, out=grad_weight)
+
+    if grad_weight is not None and grad_weight.dtype != weight.dtype:
+        grad_weight = grad_weight.to(weight.dtype)
 
     return grad_input, grad_weight
 
 
 class _LigerFusedLinearScaledCrossEntropyCuTileFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, _input, weight, target, temperature, ignore_index, return_entropy):
+    def forward(ctx, _input, weight, target, temperature, ignore_index, return_entropy, accum_dtype=None):
         ctx.set_materialize_grads(False)
         nll, entropy, lse = fused_scaled_cross_entropy_forward(
             _input,
@@ -404,6 +454,7 @@ class _LigerFusedLinearScaledCrossEntropyCuTileFunction(torch.autograd.Function)
         ctx.temperature = temperature
         ctx.ignore_index = ignore_index
         ctx.return_entropy = return_entropy
+        ctx.accum_dtype = accum_dtype
         return (nll, entropy) if return_entropy else nll
 
     @staticmethod
@@ -419,8 +470,9 @@ class _LigerFusedLinearScaledCrossEntropyCuTileFunction(torch.autograd.Function)
             ctx.ignore_index,
             entropy=entropy if ctx.return_entropy else None,
             grad_entropy=grad_entropy,
+            accum_dtype=ctx.accum_dtype,
         )
-        return grad_input, grad_weight, None, None, None, None
+        return grad_input, grad_weight, None, None, None, None, None
 
 
 class LigerFusedLinearScaledCrossEntropyFunction:
@@ -428,6 +480,11 @@ class LigerFusedLinearScaledCrossEntropyFunction:
 
     ``m_tiles_per_cluster`` is accepted for API compatibility but does not
     change the cuTile schedule.
+
+    ``accum_dtype`` (torch.dtype): the dtype of the intermediate buffer used to
+    accumulate the weight gradient across token chunks. Recommended to set to a
+    higher precision, e.g. ``torch.float32``, if training is unstable with the
+    original dtype. Default: ``None``, accumulating in the weight dtype.
     """
 
     @staticmethod
@@ -439,6 +496,7 @@ class LigerFusedLinearScaledCrossEntropyFunction:
         ignore_index=-100,
         m_tiles_per_cluster=1,
         return_entropy=False,
+        accum_dtype=None,
     ):
         if not isinstance(m_tiles_per_cluster, int) or isinstance(m_tiles_per_cluster, bool):
             raise TypeError("m_tiles_per_cluster must be an int")
@@ -446,6 +504,7 @@ class LigerFusedLinearScaledCrossEntropyFunction:
             raise ValueError("m_tiles_per_cluster must be >= 1")
         if not isinstance(return_entropy, bool):
             raise TypeError("return_entropy must be a bool")
+        _validate_accum_dtype(accum_dtype)
 
         return _LigerFusedLinearScaledCrossEntropyCuTileFunction.apply(
             _input,
@@ -454,4 +513,5 @@ class LigerFusedLinearScaledCrossEntropyFunction:
             temperature,
             ignore_index,
             return_entropy,
+            accum_dtype,
         )

--- a/src/liger_kernel/ops/fused_linear_scaled_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_scaled_cross_entropy.py
@@ -23,6 +23,15 @@ def _validate_temperature(temperature):
         raise ValueError("temperature must be finite and > 0")
 
 
+def _validate_accum_dtype(accum_dtype):
+    if accum_dtype is None:
+        return
+    if not isinstance(accum_dtype, torch.dtype):
+        raise TypeError("accum_dtype must be a torch.dtype or None")
+    if not accum_dtype.is_floating_point:
+        raise ValueError("accum_dtype must be a floating-point dtype")
+
+
 def _validate_fallback_inputs(_input, weight, target, ignore_index):
     if _input.ndim != 2 or weight.ndim != 2 or target.ndim != 1:
         raise ValueError("expected input[M,H], weight[V,H], and target[M]")
@@ -95,10 +104,13 @@ def _fallback_backward_chunk(
 
 class _FusedLinearPPOFallbackFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, hidden_states, vocab_weights, input_ids, temperature, ignore_index, return_entropy):
+    def forward(
+        ctx, hidden_states, vocab_weights, input_ids, temperature, ignore_index, return_entropy, accum_dtype=None
+    ):
         ctx.set_materialize_grads(False)
         _validate_fallback_inputs(hidden_states, vocab_weights, input_ids, ignore_index)
         _validate_temperature(temperature)
+        _validate_accum_dtype(accum_dtype)
 
         valid = input_ids != ignore_index
         safe_input_ids = input_ids.masked_fill(~valid, 0)
@@ -121,13 +133,19 @@ class _FusedLinearPPOFallbackFunction(torch.autograd.Function):
 
         ctx.save_for_backward(hidden_states, vocab_weights, safe_input_ids, valid)
         ctx.temperature = temperature
+        ctx.accum_dtype = accum_dtype
         return (nll, entropy) if return_entropy else nll
 
     @staticmethod
     def backward(ctx, grad_nll, grad_entropy=None):
         hidden_states, vocab_weights, input_ids, valid = ctx.saved_tensors
         grad_hidden_states = torch.zeros_like(hidden_states) if ctx.needs_input_grad[0] else None
-        grad_vocab_weights = torch.zeros_like(vocab_weights) if ctx.needs_input_grad[1] else None
+        # The weight gradient is summed over every 512-token chunk, so in a
+        # low-precision dtype the running sum is rounded once per chunk.
+        grad_weight_dtype = ctx.accum_dtype if ctx.accum_dtype is not None else vocab_weights.dtype
+        grad_vocab_weights = (
+            torch.zeros_like(vocab_weights, dtype=grad_weight_dtype) if ctx.needs_input_grad[1] else None
+        )
 
         for start in range(0, hidden_states.shape[0], _FALLBACK_CHUNK_SIZE):
             end = min(start + _FALLBACK_CHUNK_SIZE, hidden_states.shape[0])
@@ -143,9 +161,12 @@ class _FusedLinearPPOFallbackFunction(torch.autograd.Function):
             if grad_hidden_states is not None:
                 grad_hidden_states[start:end].add_(chunk_grad_hidden)
             if grad_vocab_weights is not None:
-                grad_vocab_weights.add_(chunk_grad_weight)
+                grad_vocab_weights.add_(chunk_grad_weight.to(grad_weight_dtype))
 
-        return grad_hidden_states, grad_vocab_weights, None, None, None, None
+        if grad_vocab_weights is not None and grad_vocab_weights.dtype != vocab_weights.dtype:
+            grad_vocab_weights = grad_vocab_weights.to(vocab_weights.dtype)
+
+        return grad_hidden_states, grad_vocab_weights, None, None, None, None, None
 
 
 def _resolve_implementation(device):
@@ -159,7 +180,14 @@ def _resolve_implementation(device):
 
 
 class LigerFusedLinearScaledCrossEntropyFunction:
-    """Dispatch fused scaled cross entropy to the implementation for ``input.device``."""
+    """Dispatch fused scaled cross entropy to the implementation for ``input.device``.
+
+    ``accum_dtype`` (torch.dtype): the dtype of the intermediate buffer used to
+    accumulate the weight gradient across token chunks. Recommended to set to a
+    higher precision, e.g. ``torch.float32``, if training is unstable with the
+    original dtype. Default: ``None``, accumulating in the weight dtype. Not
+    supported by the SM90 implementation, which accumulates inside a fused kernel.
+    """
 
     @staticmethod
     def apply(
@@ -170,6 +198,7 @@ class LigerFusedLinearScaledCrossEntropyFunction:
         ignore_index=-100,
         m_tiles_per_cluster=1,
         return_entropy=False,
+        accum_dtype=None,
     ):
         if not isinstance(m_tiles_per_cluster, int) or isinstance(m_tiles_per_cluster, bool):
             raise TypeError("m_tiles_per_cluster must be an int")
@@ -177,6 +206,7 @@ class LigerFusedLinearScaledCrossEntropyFunction:
             raise ValueError("m_tiles_per_cluster must be >= 1")
         if not isinstance(return_entropy, bool):
             raise TypeError("return_entropy must be a bool")
+        _validate_accum_dtype(accum_dtype)
 
         implementation = _resolve_implementation(_input.device)
         if implementation is _FusedLinearPPOFallbackFunction:
@@ -187,6 +217,12 @@ class LigerFusedLinearScaledCrossEntropyFunction:
                 temperature,
                 ignore_index,
                 return_entropy,
+                accum_dtype,
+            )
+        if accum_dtype is not None:
+            raise NotImplementedError(
+                "accum_dtype is not supported by the SM90 fused scaled cross entropy "
+                "implementation, which accumulates the weight gradient inside a fused kernel"
             )
         return implementation.apply(
             _input,

--- a/test/transformers/test_fused_linear_scaled_cross_entropy.py
+++ b/test/transformers/test_fused_linear_scaled_cross_entropy.py
@@ -92,6 +92,49 @@ def test_frontend_dispatches_sm90_and_forwards_arguments(monkeypatch):
     assert calls == [(_input, weight, target, 0.7, -1, 3, True)]
 
 
+def test_frontend_rejects_accum_dtype_for_sm90(monkeypatch):
+    device = torch.device("cuda:3")
+    _input = SimpleNamespace(device=device)
+
+    class StubSM90Function:
+        @staticmethod
+        def apply(*args):
+            pytest.fail("SM90 must not be invoked when accum_dtype is requested")
+
+    monkeypatch.setattr(_FRONTEND.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(_FRONTEND.torch.version, "hip", None)
+    monkeypatch.setattr(_FRONTEND.torch.cuda, "get_device_capability", lambda actual: (9, 0))
+    monkeypatch.setattr(_FRONTEND, "_load_sm90_function", lambda: StubSM90Function)
+
+    with pytest.raises(NotImplementedError, match="accum_dtype"):
+        _FRONTEND.LigerFusedLinearScaledCrossEntropyFunction.apply(
+            _input,
+            object(),
+            object(),
+            0.7,
+            -1,
+            3,
+            True,
+            torch.float32,
+        )
+
+
+@pytest.mark.parametrize(
+    ("accum_dtype", "error"),
+    [("float32", TypeError), (torch.int32, ValueError)],
+    ids=["not-a-dtype", "integer-dtype"],
+)
+def test_frontend_rejects_invalid_accum_dtype(accum_dtype, error):
+    _input = torch.randn(4, 8, requires_grad=True)
+    weight = torch.randn(16, 8, requires_grad=True)
+    target = torch.arange(4)
+
+    with pytest.raises(error, match="accum_dtype"):
+        _FRONTEND.LigerFusedLinearScaledCrossEntropyFunction.apply(
+            _input, weight, target, 1.0, -100, 1, False, accum_dtype
+        )
+
+
 def test_frontend_fallback_matches_torch_with_entropy_and_ignored_rows():
     torch.manual_seed(42)
     token_count, hidden_size, vocab_size = 521, 7, 13
@@ -173,8 +216,51 @@ def test_frontend_fallback_supports_entropy_only_backward():
     assert weight.grad is not None
 
 
+def _fallback_bf16_weight_grad(accum_dtype):
+    """Run the bf16 fallback over many token chunks and return (grad, fp64 reference)."""
+    torch.manual_seed(7)
+    # 32 chunks of _FALLBACK_CHUNK_SIZE, so the running grad_weight sum is rounded
+    # 32 times when it is accumulated in the weight dtype.
+    token_count = _FRONTEND._FALLBACK_CHUNK_SIZE * 32
+    hidden_size, vocab_size, temperature = 8, 32, 0.9
+    target = torch.randint(vocab_size, (token_count,), dtype=torch.long)
+    grad_nll = torch.rand(token_count)
+
+    _input = (torch.randn(token_count, hidden_size) * 0.25).bfloat16().requires_grad_(True)
+    weight = (torch.randn(vocab_size, hidden_size) / hidden_size**0.5).bfloat16().requires_grad_(True)
+    nll = _FRONTEND.LigerFusedLinearScaledCrossEntropyFunction.apply(
+        _input, weight, target, temperature, -100, 1, False, accum_dtype
+    )
+    nll.backward(grad_nll)
+
+    ref_input = _input.detach().double().requires_grad_(True)
+    ref_weight = weight.detach().double().requires_grad_(True)
+    ref_logits = (ref_input @ ref_weight.t()) / temperature
+    ref_nll = -ref_logits.log_softmax(dim=-1).gather(-1, target.unsqueeze(-1)).squeeze(-1)
+    ref_nll.backward(grad_nll.double())
+
+    return weight.grad, ref_weight.grad
+
+
+def test_frontend_fallback_accum_dtype_keeps_weight_grad_dtype():
+    grad, _ = _fallback_bf16_weight_grad(torch.float32)
+
+    assert grad.dtype == torch.bfloat16
+
+
+def test_frontend_fallback_accum_dtype_reduces_multi_chunk_weight_grad_error():
+    default_grad, reference = _fallback_bf16_weight_grad(None)
+    accum_grad, _ = _fallback_bf16_weight_grad(torch.float32)
+
+    default_error = (default_grad.double() - reference).abs().sum()
+    accum_error = (accum_grad.double() - reference).abs().sum()
+
+    assert accum_error < default_error
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="cuTile requires CUDA")
 @pytest.mark.skipif(not _CUTILE_ENABLED, reason="requires LIGER_KERNEL_IMPL=cutile")
+@pytest.mark.parametrize("accum_dtype", [None, torch.float32], ids=["accumNone", "accumfp32"])
 @pytest.mark.parametrize(
     ("shape", "dtype", "atol", "rtol"),
     [
@@ -183,7 +269,7 @@ def test_frontend_fallback_supports_entropy_only_backward():
     ],
     ids=["fp32-ragged", "bf16-multichunk"],
 )
-def test_cutile_matches_verl_fallback_forward_and_combined_backward(shape, dtype, atol, rtol):
+def test_cutile_matches_verl_fallback_forward_and_combined_backward(shape, dtype, atol, rtol, accum_dtype):
     if dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
         pytest.skip("BF16 is not supported")
 
@@ -209,6 +295,7 @@ def test_cutile_matches_verl_fallback_forward_and_combined_backward(shape, dtype
         -100,
         3,
         True,
+        accum_dtype,
     )
     torch.autograd.backward((actual_nll, actual_entropy), (grad_nll, grad_entropy))
 
@@ -228,6 +315,56 @@ def test_cutile_matches_verl_fallback_forward_and_combined_backward(shape, dtype
     torch.testing.assert_close(actual_entropy, expected_entropy, atol=atol, rtol=rtol)
     torch.testing.assert_close(actual_input.grad, expected_input.grad, atol=atol, rtol=rtol)
     torch.testing.assert_close(actual_weight.grad, expected_weight.grad, atol=atol, rtol=rtol)
+    assert actual_weight.grad.dtype == dtype
+
+
+def _cutile_bf16_weight_grad(accum_dtype):
+    """Run the bf16 cuTile backward over 32 token chunks, returning (grad, fp64 reference)."""
+    from liger_kernel.ops.cutile.ops.fused_linear_scaled_cross_entropy import LigerFusedLinearScaledCrossEntropyFunction
+
+    torch.manual_seed(7)
+    # A 1 MiB workspace caps the chunk at 256 tokens for this vocabulary, so the
+    # running grad_weight sum is rounded 32 times when accumulated in bf16.
+    token_count, hidden_size, vocab_size, temperature = 8192, 32, 2048, 0.9
+    target = torch.randint(vocab_size, (token_count,), device="cuda", dtype=torch.int64)
+    grad_nll = torch.rand(token_count, device="cuda", dtype=torch.float32)
+
+    _input = (torch.randn(token_count, hidden_size, device="cuda") * 0.25).bfloat16().requires_grad_(True)
+    weight = (torch.randn(vocab_size, hidden_size, device="cuda") / hidden_size**0.5).bfloat16().requires_grad_(True)
+    nll = LigerFusedLinearScaledCrossEntropyFunction.apply(
+        _input, weight, target, temperature, -100, 1, False, accum_dtype
+    )
+    nll.backward(grad_nll)
+
+    ref_input = _input.detach().double().requires_grad_(True)
+    ref_weight = weight.detach().double().requires_grad_(True)
+    ref_logits = (ref_input @ ref_weight.t()) / temperature
+    ref_nll = -ref_logits.log_softmax(dim=-1).gather(-1, target.unsqueeze(-1)).squeeze(-1)
+    ref_nll.backward(grad_nll.double())
+
+    return weight.grad, ref_weight.grad
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="cuTile requires CUDA")
+@pytest.mark.skipif(not _CUTILE_ENABLED, reason="requires LIGER_KERNEL_IMPL=cutile")
+def test_cutile_accum_dtype_reduces_multi_chunk_weight_grad_error(monkeypatch):
+    if not torch.cuda.is_bf16_supported():
+        pytest.skip("BF16 is not supported")
+
+    from liger_kernel.ops.cutile.ops.fused_linear_scaled_cross_entropy import _WORKSPACE_MB_ENV
+
+    monkeypatch.setenv(_WORKSPACE_MB_ENV, "1")
+
+    default_grad, reference = _cutile_bf16_weight_grad(None)
+    accum_grad, _ = _cutile_bf16_weight_grad(torch.float32)
+
+    assert default_grad.dtype == torch.bfloat16
+    assert accum_grad.dtype == torch.bfloat16
+
+    default_error = (default_grad.double() - reference).abs().sum()
+    accum_error = (accum_grad.double() - reference).abs().sum()
+
+    assert accum_error < default_error
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="cuTile requires CUDA")


### PR DESCRIPTION
## Summary
- Add an optional `accum_dtype` to fused scaled cross entropy so chunked weight gradients can accumulate in FP32 before casting back to the parameter dtype.
- Support the option in the cuTile implementation and PyTorch fallback while preserving the existing default behavior; reject it explicitly for the fused CuTe SM90 path.
- Add correctness coverage, a `cutile-accum-fp32` benchmark provider, and usage documentation.

## Details
BF16 `grad_weight` was previously rounded after every token chunk because the running accumulator inherited `weight.dtype`. With `accum_dtype=torch.float32`, supported CUDA systems use `torch.addmm(..., out_dtype=torch.float32)` to avoid that chunk-boundary precision loss. The tradeoff is an additional `V x H` FP32 buffer.

On an NVIDIA B200 at `M=8192, H=4096, V=131072`, FP32 accumulation added 0.7% full-pass latency and 2048 MB peak memory. A chunk-count sweep showed the gradient error improvement growing from 1.34x at 16 chunks to 7.31x at 1024 chunks.

## Testing Done
- Hardware Type: NVIDIA B200
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
- [x] Local code review completed
- [x] Ran `test/transformers/test_fused_linear_scaled_cross_entropy.py` with `LIGER_KERNEL_IMPL=cutile` on B200: 36 passed
- [x] Ran targeted `ruff check` and `ruff format --check` on all changed Python files
- [x] Benchmarked `cutile` versus `cutile-accum-fp32` on B200 for speed, memory, and precision

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
