### PR TITLE
[CUDA] Add cuTile RMSNorm and optimize CuTe DSL RMSNorm

### DIFF
--- a/benchmark/scripts/run_cutile_compare.py
+++ b/benchmark/scripts/run_cutile_compare.py
@@ -25,6 +25,7 @@ CUTILE_ENABLED_KERNELS = [
     "geglu",
     "jsd",
     "layer_norm",
+    "rms_norm",
 ]
 
 

--- a/src/liger_kernel/ops/cutedsl/ops/rms_norm.py
+++ b/src/liger_kernel/ops/cutedsl/ops/rms_norm.py
@@ -70,6 +70,7 @@ _FORCE_NO_FAST = bool(int(os.environ.get("LIGER_RMS_FORCE_NO_FAST") or 0))
 _FORCE_SPLIT_BWD = bool(int(os.environ.get("LIGER_RMS_FORCE_SPLIT_BWD") or 0))
 _AUTOTUNE_FILE = os.environ.get("LIGER_RMS_AUTOTUNE_FILE") or None
 _FUSED_STRIP_MULT = int(os.environ.get("LIGER_RMS_FUSED_STRIP_MULT") or 0)
+_DW_REDUCTION_POLICY = os.environ.get("LIGER_RMS_DW_REDUCTION", "auto")
 # A/B switches for the two halves of the Blackwell fast path (see below).
 _FORCE_NO_FFI = bool(int(os.environ.get("LIGER_RMS_FORCE_NO_FFI") or 0))
 _FORCE_NO_PACKED = bool(int(os.environ.get("LIGER_RMS_FORCE_NO_PACKED") or 0))
@@ -160,6 +161,26 @@ def _is_blackwell(device=None) -> bool:
         return False
 
 
+def _is_hopper(device=None) -> bool:
+    """Whether ``device`` is an SM90 Hopper GPU."""
+    try:
+        if not torch.cuda.is_available():
+            return False
+        if isinstance(device, torch.device):
+            device_id = device.index if device.index is not None else torch.cuda.current_device()
+        elif device is None:
+            device_id = torch.cuda.current_device()
+        else:
+            device_id = device
+        is_hopper = _hopper_cache.get(device_id)
+        if is_hopper is None:
+            is_hopper = torch.cuda.get_device_capability(device_id) == (9, 0)
+            _hopper_cache[device_id] = is_hopper
+        return is_hopper
+    except Exception:  # pragma: no cover - no CUDA / bad device
+        return False
+
+
 def _use_packed_math(device, n_cols: int, vec: int) -> bool:
     """Whether to compile the packed-f32x2 fused backward for this launch.
 
@@ -197,6 +218,7 @@ def _use_ffi() -> bool:
 
 # Compiled TVM-FFI callables, keyed on everything the specialization bakes.
 _ffi_compile_cache: dict = {}
+_hopper_cache: dict[int, bool] = {}
 
 
 def _ffi_fake(dtype: torch.dtype, shape, divisibility: int):
@@ -389,6 +411,26 @@ def _warp_reduce_sum(val: Float32) -> Float32:
 
 
 @cute.jit
+def _cta_reduce_sum_one_barrier(
+    val: Float32,
+    sm_warp: cute.Tensor,
+    lane: Int32,
+    warp: Int32,
+    slot: Int32,
+    NUM_WARPS: cutlass.Constexpr,
+) -> Float32:
+    """Reduce warp partials with one CTA barrier and ping-pong scratch."""
+    val = _warp_reduce_sum(val)
+    if lane == 0:
+        sm_warp[slot, warp] = val
+    cute.arch.barrier()
+    result = Float32(0.0)
+    for warp_idx in cutlass.range_constexpr(NUM_WARPS):
+        result = result + sm_warp[slot, warp_idx]
+    return result
+
+
+@cute.jit
 def _cta_reduce_sum_warp0(
     val: Float32,
     sm_warp: cute.Tensor,
@@ -397,20 +439,15 @@ def _cta_reduce_sum_warp0(
     warp: Int32,
     NUM_WARPS: cutlass.Constexpr,
 ) -> Float32:
-    """Reduce warp partials with warp 0 and broadcast one shared scalar.
-
-    Only warp 0 reads the partials. This avoids the scalar fallback's shared-load
-    loop in every thread while retaining a simple, reusable CTA
-    reduction for the vector forward and backward paths.
-    """
+    """Reduce with warp 0 and broadcast through a second CTA barrier."""
     val = _warp_reduce_sum(val)
     if lane == 0:
-        sm_warp[warp] = val
+        sm_warp[0, warp] = val
     cute.arch.barrier()
     warp0_val = Float32(0.0)
     if warp == 0:
         if lane < NUM_WARPS:
-            warp0_val = sm_warp[lane]
+            warp0_val = sm_warp[0, lane]
         warp0_val = _warp_reduce_sum(warp0_val)
         if lane == 0:
             sm_result[0] = warp0_val
@@ -510,8 +547,11 @@ def _rms_norm_fwd_vector_kernel(
     row, _, _ = cute.arch.block_idx()
 
     smem = cutlass.utils.SmemAllocator()
-    sm_warp = smem.allocate_tensor(Float32, cute.make_layout(NUM_WARPS), byte_alignment=4)
-    sm_result = smem.allocate_tensor(Float32, cute.make_layout(1), byte_alignment=4)
+    sm_warp = smem.allocate_tensor(
+        Float32,
+        cute.make_layout((2, NUM_WARPS), stride=(NUM_WARPS, 1)),
+        byte_alignment=4,
+    )
 
     # Slicing a dynamic tensor loses its static alignment.  The host validates the
     # 16-byte base/row alignment before selecting this kernel, so reconstruct the
@@ -542,7 +582,7 @@ def _rms_norm_fwd_vector_kernel(
             x_ssa = x_frags[None, ct].load().to(Float32)
             partial = partial + (x_ssa * x_ssa).reduce(cute.ReductionOp.ADD, Float32(0.0), 0)
 
-    total = _cta_reduce_sum_warp0(partial, sm_warp, sm_result, lane, warp, NUM_WARPS)
+    total = _cta_reduce_sum_one_barrier(partial, sm_warp, lane, warp, Int32(0), NUM_WARPS)
     rstd = cute.math.rsqrt(total / Float32(N_COLS) + eps)
     if tid == 0:
         mRSTD[row] = rstd.to(mRSTD.element_type)
@@ -673,7 +713,10 @@ def _rms_norm_bwd_dw_kernel(
         # llama rounds x*rstd to the input dtype before accumulating (Triton parity).
         if const_expr(CASTING_MODE == _CASTING_MODE_LLAMA):
             xhat = xhat.to(mX.element_type).to(Float32)
-        acc = acc + dyf * xhat
+        dw_update = dyf * xhat
+        if const_expr(CASTING_MODE == _CASTING_MODE_LLAMA):
+            dw_update = dw_update.to(mX.element_type).to(Float32)
+        acc = acc + dw_update
     if c < n_cols:
         mdW[strip, None][c] = acc.to(mdW.element_type)
 
@@ -711,7 +754,11 @@ def _rms_norm_bwd_fused_vector_kernel(
     n_vec = N_COLS // VEC
 
     smem = cutlass.utils.SmemAllocator()
-    sm_warp = smem.allocate_tensor(Float32, cute.make_layout(NUM_WARPS), byte_alignment=4)
+    sm_warp = smem.allocate_tensor(
+        Float32,
+        cute.make_layout((2, NUM_WARPS), stride=(NUM_WARPS, 1)),
+        byte_alignment=4,
+    )
     sm_result = smem.allocate_tensor(Float32, cute.make_layout(1), byte_alignment=4)
 
     # W and dW are persistent row vectors, matching Triton's per-program state.
@@ -735,32 +782,30 @@ def _rms_norm_bwd_fused_vector_kernel(
     # Triton assigns one contiguous ceil-divided row range to each SM program.
     rows_per_strip = (n_rows + num_strips - 1) // num_strips
     row_start = strip * rows_per_strip
+    row_linear_offset = row_start * N_COLS
     for i in cutlass.range(0, rows_per_strip):
         r = row_start + i
         r_valid = r < n_rows
-        # Constructing a row view is pointer arithmetic even when no copy follows.
-        # Clamp the inactive final iteration to row 0 to keep that pointer in bounds.
-        r_safe = Int32(0)
+        row_linear_safe = Int32(0)
         if r_valid:
-            r_safe = r
+            row_linear_safe = row_linear_offset
         rstd = Float32(0.0)
         if r_valid:
             rstd = mRSTD[r].to(Float32)
 
-        # Rebuild row views with the host-validated alignment for vector copies.
-        x_row = mX[r_safe, None]
-        dy_row = mdY[r_safe, None]
-        dx_row = mdX[r_safe, None]
+        x_row_ptr = mX.iterator + row_linear_safe
+        dy_row_ptr = mdY.iterator + row_linear_safe
+        dx_row_ptr = mdX.iterator + row_linear_safe
         gX = cute.make_tensor(
-            cute.make_ptr(mX.element_type, x_row.iterator.toint(), cute.AddressSpace.gmem, assumed_align=16),
+            cute.make_ptr(mX.element_type, x_row_ptr.toint(), cute.AddressSpace.gmem, assumed_align=16),
             cute.make_layout((N_COLS,)),
         )
         gdY = cute.make_tensor(
-            cute.make_ptr(mdY.element_type, dy_row.iterator.toint(), cute.AddressSpace.gmem, assumed_align=16),
+            cute.make_ptr(mdY.element_type, dy_row_ptr.toint(), cute.AddressSpace.gmem, assumed_align=16),
             cute.make_layout((N_COLS,)),
         )
         gdX = cute.make_tensor(
-            cute.make_ptr(mdX.element_type, dx_row.iterator.toint(), cute.AddressSpace.gmem, assumed_align=16),
+            cute.make_ptr(mdX.element_type, dx_row_ptr.toint(), cute.AddressSpace.gmem, assumed_align=16),
             cute.make_layout((N_COLS,)),
         )
         gXv = cute.tiled_divide(gX, (VEC,))
@@ -802,7 +847,10 @@ def _rms_norm_bwd_fused_vector_kernel(
                     ).reduce(cute.ReductionOp.ADD, Float32(0.0), 0)
         if const_expr(PACKED_MATH):
             dot = dot0 + dot1
-        dot_total = _cta_reduce_sum_warp0(dot, sm_warp, sm_result, lane, warp, NUM_WARPS)
+        if const_expr(mX.element_type.width == 32 and N_COLS > 2048):
+            dot_total = _cta_reduce_sum_warp0(dot, sm_warp, sm_result, lane, warp, NUM_WARPS)
+        else:
+            dot_total = _cta_reduce_sum_one_barrier(dot, sm_warp, lane, warp, Int32(i % 2), NUM_WARPS)
         coef = (Float32(0.0) - rstd * rstd * dot_total) / Float32(N_COLS)
 
         # Reuse the original register fragments for dX and dW.
@@ -832,7 +880,12 @@ def _rms_norm_bwd_fused_vector_kernel(
                         if const_expr(CASTING_MODE == _CASTING_MODE_LLAMA):
                             h0 = h0.to(mX.element_type).to(Float32)
                             h1 = h1.to(mX.element_type).to(Float32)
-                        a0, a1 = carch.fma_packed_f32x2((dy0, dy1), (h0, h1), (ar[i], ar[i + 1]))
+                            p0, p1 = carch.mul_packed_f32x2((dy0, dy1), (h0, h1))
+                            p0 = p0.to(mX.element_type).to(Float32)
+                            p1 = p1.to(mX.element_type).to(Float32)
+                            a0, a1 = carch.add_packed_f32x2((ar[i], ar[i + 1]), (p0, p1))
+                        else:
+                            a0, a1 = carch.fma_packed_f32x2((dy0, dy1), (h0, h1), (ar[i], ar[i + 1]))
                         ar[i] = a0
                         ar[i + 1] = a1
                     cute.autovec_copy(dx_frag, gdXv[None, vec_idx])
@@ -845,7 +898,11 @@ def _rms_norm_bwd_fused_vector_kernel(
                     xhat = xf * rstd
                     if const_expr(CASTING_MODE == _CASTING_MODE_LLAMA):
                         xhat = xhat.to(mX.element_type).to(Float32)
-                    dw_acc[None, ct].store(dw_acc[None, ct].load() + dyf * xhat)
+                    dw_update = dyf * xhat
+                    if const_expr(CASTING_MODE == _CASTING_MODE_LLAMA):
+                        dw_update = dw_update.to(mX.element_type).to(Float32)
+                    dw_acc[None, ct].store(dw_acc[None, ct].load() + dw_update)
+        row_linear_offset = row_linear_offset + N_COLS
 
     # Emit this strip's dW partials; the host sums the num_strips partial rows.
     dw_row = mdW[strip, None]
@@ -883,7 +940,7 @@ def _rms_norm_fwd_vector_host(
     stream: cuda.CUstream = None,
 ):
     n_rows = mX.shape[0]
-    smem_bytes = (((NUM_WARPS + 1) * 4 + 15) // 16) * 16
+    smem_bytes = (((2 * NUM_WARPS + 1) * 4 + 15) // 16) * 16
     _rms_norm_fwd_vector_kernel(
         mX,
         mW,
@@ -1022,7 +1079,7 @@ def _rms_norm_bwd_fused_host(
 # which is what lets PyTorch tensors be handed straight to it. ``eps`` / ``offset``
 # stay runtime scalars so a change of either does not force a recompile.
 def _make_fwd_vector_ffi(casting_mode, elementwise_affine, n_cols, vec, num_vec_tiles, num_warps, num_threads):
-    smem_bytes = (((num_warps + 1) * 4 + 15) // 16) * 16
+    smem_bytes = (((2 * num_warps + 1) * 4 + 15) // 16) * 16
 
     @cute.jit
     def fwd(
@@ -1059,7 +1116,7 @@ def _make_fwd_vector_ffi(casting_mode, elementwise_affine, n_cols, vec, num_vec_
 
 
 def _make_bwd_fused_ffi(casting_mode, n_cols, vec, num_vec_tiles, num_threads, num_warps, packed):
-    smem_bytes = (((num_warps + 1) * 4 + 15) // 16) * 16
+    smem_bytes = (((2 * num_warps + 1) * 4 + 15) // 16) * 16
 
     @cute.jit
     def bwd(
@@ -1244,7 +1301,7 @@ def _launch_fwd_vector(X, W, Y, RSTD, eps, offset, casting_mode, elementwise_aff
     """
     n_cols_ = X.shape[1]
     if _use_ffi():
-        num_warps = fwd_warp_count(n_cols_, vec)
+        num_warps = fwd_warp_count(n_cols_, vec, X.shape[0], _is_hopper(X.device))
         num_threads = 32 * num_warps
         fn = _get_fwd_vector_ffi(
             X.dtype,
@@ -1275,7 +1332,7 @@ def _launch_fwd_vector(X, W, Y, RSTD, eps, offset, casting_mode, elementwise_aff
     rstd_ct = to_cute_tensor(RSTD, assumed_align=4)
     w_ct = _to_cute_cached(W, assumed_align=16) if elementwise_affine else rstd_ct
     n_cols = X.shape[1]
-    num_warps = fwd_warp_count(n_cols, vec)
+    num_warps = fwd_warp_count(n_cols, vec, X.shape[0], _is_hopper(X.device))
     num_threads = 32 * num_warps
     num_vec_tiles = (n_cols // vec + num_threads - 1) // num_threads
     # Optionally bucket n_cols in the compile key to reduce cold-compile churn.
@@ -1452,7 +1509,7 @@ def _launch_bwd_fused(
     dw_ct = _to_cute_cached(dW_partial, assumed_align=16)  # fp32 (num_strips, n_cols)
     n_cols = X.shape[1]
     num_threads = 32 * num_warps
-    smem_bytes = (((num_warps + 1) * 4 + 15) // 16) * 16
+    smem_bytes = (((2 * num_warps + 1) * 4 + 15) // 16) * 16
 
     # The width and thread geometry size the register layouts and reduction
     # scratch, so every value is baked into the compiled specialization.
@@ -1708,7 +1765,19 @@ def rms_norm_backward(dY, X, W, RSTD, offset, casting_mode, BLOCK_SIZE, num_warp
         _launch_bwd_dw(dY, X, RSTD, dW_partial, rows_per_strip, casting_mode)
         _launch_bwd_dx(dY, X, W, RSTD, dX, offset, casting_mode, elementwise_affine)
 
-    dW = dW_partial.sum(dim=0).to(W.dtype)
+    # The 32-warp epilogue needs at least four partials per warp; keep the
+    # established torch reduction for smaller or non-Hopper auto-dispatches.
+    use_custom_dw_reduction = _DW_REDUCTION_POLICY == "custom" or (
+        _DW_REDUCTION_POLICY == "auto" and num_strips >= 128 and _is_hopper(W.device)
+    )
+    if use_custom_dw_reduction:
+        from liger_kernel.ops.cutedsl.ops.rms_norm_dw_reduce import reduce_dw_partials
+
+        dW = reduce_dw_partials(dW_partial, W.dtype)
+    elif _DW_REDUCTION_POLICY in ("auto", "torch"):
+        dW = dW_partial.sum(dim=0).to(W.dtype)
+    else:
+        raise ValueError(f"Invalid LIGER_RMS_DW_REDUCTION policy: {_DW_REDUCTION_POLICY}")
     return dX.view(*shape), dW
 
 

--- a/src/liger_kernel/ops/cutedsl/ops/rms_norm.py
+++ b/src/liger_kernel/ops/cutedsl/ops/rms_norm.py
@@ -172,11 +172,7 @@ def _is_hopper(device=None) -> bool:
             device_id = torch.cuda.current_device()
         else:
             device_id = device
-        is_hopper = _hopper_cache.get(device_id)
-        if is_hopper is None:
-            is_hopper = torch.cuda.get_device_capability(device_id) == (9, 0)
-            _hopper_cache[device_id] = is_hopper
-        return is_hopper
+        return infer_device_arch(device_id) == "hopper"
     except Exception:  # pragma: no cover - no CUDA / bad device
         return False
 
@@ -218,7 +214,6 @@ def _use_ffi() -> bool:
 
 # Compiled TVM-FFI callables, keyed on everything the specialization bakes.
 _ffi_compile_cache: dict = {}
-_hopper_cache: dict[int, bool] = {}
 
 
 def _ffi_fake(dtype: torch.dtype, shape, divisibility: int):

--- a/src/liger_kernel/ops/cutedsl/ops/rms_norm_dw_reduce.py
+++ b/src/liger_kernel/ops/cutedsl/ops/rms_norm_dw_reduce.py
@@ -1,0 +1,140 @@
+"""Parallel final partial-dW reduction for CuTeDSL RMSNorm backward."""
+
+import os
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+
+from cutlass import Float32
+
+from liger_kernel.ops.cutedsl.ops.rms_norm import _compile_cache
+from liger_kernel.ops.cutedsl.ops.rms_norm import _cute_stream
+from liger_kernel.ops.cutedsl.ops.rms_norm import _to_cute_cached
+from liger_kernel.ops.cutedsl.ops.utils import to_cute_tensor
+
+_THREADS = 32
+_REDUCTION_WARPS = int(os.environ.get("LIGER_RMS_DW_REDUCTION_WARPS") or 32)
+
+
+@cute.kernel
+def _reduce_dw_partials_kernel(
+    mdW: cute.Tensor,
+    mdWOut: cute.Tensor,
+):
+    """One warp reduces one contiguous 32-column tile over every strip."""
+    tid, _, _ = cute.arch.thread_idx()
+    column_block, _, _ = cute.arch.block_idx()
+    column = column_block * _THREADS + tid
+    n_strips = mdW.shape[0]
+    n_cols = mdW.shape[1]
+
+    accumulator = Float32(0.0)
+    if column < n_cols:
+        for strip in cutlass.range(0, n_strips):
+            accumulator = accumulator + mdW[strip, column].to(Float32)
+        mdWOut[column] = accumulator.to(mdWOut.element_type)
+
+
+@cute.kernel
+def _reduce_dw_partials_parallel_kernel(
+    mdW: cute.Tensor,
+    mdWOut: cute.Tensor,
+    NUM_WARPS: cutlass.Constexpr,
+):
+    """Split each column's strip reduction across multiple warps."""
+    tid, _, _ = cute.arch.thread_idx()
+    lane = tid % _THREADS
+    warp = tid // _THREADS
+    column_block, _, _ = cute.arch.block_idx()
+    column = column_block * _THREADS + lane
+    n_strips = mdW.shape[0]
+    n_cols = mdW.shape[1]
+
+    accumulator = Float32(0.0)
+    num_iterations = (n_strips + NUM_WARPS - 1) // NUM_WARPS
+    if column < n_cols:
+        for iteration in cutlass.range(0, num_iterations):
+            strip = iteration * NUM_WARPS + warp
+            if strip < n_strips:
+                accumulator = accumulator + mdW[strip, column].to(Float32)
+
+    smem = cutlass.utils.SmemAllocator()
+    partials = smem.allocate_tensor(
+        Float32,
+        cute.make_layout((NUM_WARPS, _THREADS), stride=(_THREADS, 1)),
+        byte_alignment=16,
+    )
+    partials[warp, lane] = accumulator
+    cute.arch.barrier()
+
+    if warp == 0 and column < n_cols:
+        total = Float32(0.0)
+        for source_warp in cutlass.range_constexpr(NUM_WARPS):
+            total = total + partials[source_warp, lane]
+        mdWOut[column] = total.to(mdWOut.element_type)
+
+
+@cute.jit
+def _reduce_dw_partials_host(
+    mdW: cute.Tensor,
+    mdWOut: cute.Tensor,
+    stream: cuda.CUstream = None,
+):
+    _reduce_dw_partials_kernel(mdW, mdWOut).launch(
+        grid=[cute.ceil_div(mdW.shape[1], _THREADS), 1, 1],
+        block=[_THREADS, 1, 1],
+        stream=stream,
+    )
+
+
+@cute.jit
+def _reduce_dw_partials_parallel_host(
+    mdW: cute.Tensor,
+    mdWOut: cute.Tensor,
+    NUM_WARPS: cutlass.Constexpr,
+    stream: cuda.CUstream = None,
+):
+    _reduce_dw_partials_parallel_kernel(mdW, mdWOut, NUM_WARPS).launch(
+        grid=[cute.ceil_div(mdW.shape[1], _THREADS), 1, 1],
+        block=[_THREADS * NUM_WARPS, 1, 1],
+        smem=NUM_WARPS * _THREADS * 4,
+        stream=stream,
+    )
+
+
+def reduce_dw_partials(dW_partial: torch.Tensor, output_dtype: torch.dtype) -> torch.Tensor:
+    """Reduce FP32 strip partials and fuse the final output-dtype conversion."""
+    if _REDUCTION_WARPS not in (1, 2, 4, 8, 16, 32):
+        raise ValueError(f"LIGER_RMS_DW_REDUCTION_WARPS must be one of 1, 2, 4, 8, 16, or 32, got {_REDUCTION_WARPS}")
+    output = torch.empty(dW_partial.shape[1], dtype=output_dtype, device=dW_partial.device)
+    partial_ct = _to_cute_cached(dW_partial, assumed_align=16)
+    output_ct = to_cute_tensor(output, assumed_align=16)
+    key = (
+        "rms_norm_dw_reduce",
+        dW_partial.shape[0],
+        dW_partial.shape[1],
+        dW_partial.dtype,
+        output.dtype,
+        _REDUCTION_WARPS,
+    )
+    stream = _cute_stream()
+    if key not in _compile_cache:
+        if _REDUCTION_WARPS == 1:
+            _compile_cache[key] = cute.compile(
+                _reduce_dw_partials_host,
+                partial_ct,
+                output_ct,
+                stream,
+            )
+        else:
+            _compile_cache[key] = cute.compile(
+                _reduce_dw_partials_parallel_host,
+                partial_ct,
+                output_ct,
+                _REDUCTION_WARPS,
+                stream,
+            )
+    _compile_cache[key](partial_ct, output_ct, stream)
+    return output

--- a/src/liger_kernel/ops/cutedsl/ops/rms_norm_fastpath.py
+++ b/src/liger_kernel/ops/cutedsl/ops/rms_norm_fastpath.py
@@ -18,17 +18,16 @@ def backward_warp_count(n_cols: int) -> int:
     return 4
 
 
-def fwd_warp_count(n_cols: int, vec: int) -> int:
-    """Width-aware warp count for the vector forward kernel.
+def fwd_warp_count(n_cols: int, vec: int, n_rows: int | None = None, sm90: bool = False) -> int:
+    """Choose forward warps from width and, on SM90, available row parallelism."""
+    n_vectors = n_cols // vec
+    if not sm90 or n_rows is None:
+        return 8 if n_vectors >= 512 else 4
 
-    ``vec`` is the number of elements per 16-byte load, so ``n_cols // vec`` is the
-    number of vectors in a row. Wide rows (>= 512 vectors, e.g. bf16 hidden >= 4096)
-    profit from 8 warps: spreading the row over twice the threads halves the
-    register-resident vector tiles per thread, which lifts occupancy from ~55% to
-    ~88% and hides the DRAM-load latency that bounds this memory-bound kernel
-    (measured 4-7% faster at bf16 hidden 4096/8192, and faster still on tall inputs).
-    Narrow rows keep 4 warps: 8 warps would leave half the CTA idle (fewer vectors
-    than threads) and make the cross-warp reduction the bottleneck (up to ~30% slower
-    at bf16 hidden 1024/2048).
-    """
-    return 8 if (n_cols // vec) >= 512 else 4
+    if n_rows < 2048:
+        return 4 if n_vectors <= 128 else 8
+    if n_rows >= 4096 and n_cols <= 1024:
+        return 2
+    if n_rows >= 8192 and n_vectors <= 256:
+        return 2
+    return 4 if n_vectors <= 512 else 8

--- a/src/liger_kernel/ops/cutile/ops/__init__.py
+++ b/src/liger_kernel/ops/cutile/ops/__init__.py
@@ -36,6 +36,9 @@ from liger_kernel.ops.cutile.ops.layer_norm import layer_norm_forward
 from liger_kernel.ops.cutile.ops.llama4_rope import LigerLlama4RopeFunction
 from liger_kernel.ops.cutile.ops.multi_token_attention import LigerMultiTokenAttentionFunction
 from liger_kernel.ops.cutile.ops.qwen2vl_mrope import LigerQwen2VLMRopeFunction
+from liger_kernel.ops.cutile.ops.rms_norm import LigerRMSNormFunction
+from liger_kernel.ops.cutile.ops.rms_norm import rms_norm_backward
+from liger_kernel.ops.cutile.ops.rms_norm import rms_norm_forward
 from liger_kernel.ops.cutile.ops.rope import LigerRopeFunction
 from liger_kernel.ops.cutile.ops.rope import rope_backward
 from liger_kernel.ops.cutile.ops.rope import rope_forward
@@ -68,6 +71,9 @@ __all__ = [
     "LigerLlama4RopeFunction",
     "LigerMultiTokenAttentionFunction",
     "LigerQwen2VLMRopeFunction",
+    "LigerRMSNormFunction",
+    "rms_norm_backward",
+    "rms_norm_forward",
     "LigerRopeFunction",
     "rope_backward",
     "rope_forward",

--- a/src/liger_kernel/ops/cutile/ops/rms_norm.py
+++ b/src/liger_kernel/ops/cutile/ops/rms_norm.py
@@ -1,0 +1,382 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""Register-resident RMSNorm forward and persistent fused backward for cuTile."""
+
+import math
+import os
+
+import cuda.tile as ct
+import torch
+
+from liger_kernel.ops.cutile.ops.utils import _next_power_of_2
+from liger_kernel.ops.utils import ensure_contiguous
+
+ConstBool = ct.Constant[bool]
+ConstFloat = ct.Constant[float]
+ConstInt = ct.Constant[int]
+
+_CASTING_MODE_NONE = -1
+_CASTING_MODE_LLAMA = 0
+_CASTING_MODE_GEMMA = 1
+
+_STR_TO_CASTING_MODE = {
+    "llama": _CASTING_MODE_LLAMA,
+    "gemma": _CASTING_MODE_GEMMA,
+    "none": _CASTING_MODE_NONE,
+}
+
+_DW_REDUCTION_POLICY = os.environ.get("LIGER_RMS_DW_REDUCTION", "auto")
+_DW_REDUCTION_TILE_SIZE = int(os.environ.get("LIGER_RMS_DW_REDUCTION_TILE_SIZE") or 32)
+_DW_REDUCTION_ROW_TILE_SIZE = int(os.environ.get("LIGER_RMS_DW_REDUCTION_ROW_TILE_SIZE") or 32)
+
+
+def _calculate_settings(n_cols):
+    block_size = _next_power_of_2(n_cols)
+    if block_size > 65536:
+        raise RuntimeError(f"Hidden dimension {n_cols} exceeds maximum supported size of 65536.")
+    return block_size
+
+
+@ct.kernel(occupancy=1)
+def _rms_norm_fwd_kernel_ct(
+    x,
+    weight,
+    y,
+    rstd_out,
+    n_cols: ConstInt,
+    eps: ConstFloat,
+    offset: ConstFloat,
+    casting_mode: ConstInt,
+    elementwise_affine: ConstBool,
+    block_size: ConstInt,
+    aligned: ConstBool,
+):
+    """One block per row; retain X across its reduction and output phases."""
+    row = ct.bid(0)
+    columns = ct.arange(block_size, dtype=ct.int32)
+    check_bounds = not aligned
+
+    x_input = ct.gather(x, (row, columns), check_bounds=check_bounds, padding_value=0.0, latency=4)
+    x_float = ct.astype(x_input, ct.float32)
+    sum_square = ct.sum(x_float * x_float, 0, keepdims=False)
+    reciprocal_rms = ct.rsqrt(sum_square / n_cols + eps)
+    ct.scatter(rstd_out, row, reciprocal_rms)
+
+    normalized = x_float * reciprocal_rms
+    if casting_mode == _CASTING_MODE_LLAMA:
+        normalized = ct.astype(ct.astype(normalized, x.dtype), ct.float32)
+    if elementwise_affine:
+        weight_tile = ct.astype(
+            ct.gather(weight, columns, check_bounds=check_bounds, padding_value=0.0, latency=3),
+            ct.float32,
+        )
+        normalized = normalized * (weight_tile + offset)
+    ct.scatter(y, (row, columns), ct.astype(normalized, y.dtype), check_bounds=check_bounds)
+
+
+@ct.kernel(occupancy=1)
+def _rms_norm_bwd_dx_kernel_ct(
+    x,
+    dy,
+    weight,
+    rstd,
+    dx,
+    n_cols: ConstInt,
+    offset: ConstFloat,
+    casting_mode: ConstInt,
+    elementwise_affine: ConstBool,
+    block_size: ConstInt,
+    aligned: ConstBool,
+):
+    """One block per row for the non-affine or dX-only backward path."""
+    row = ct.bid(0)
+    columns = ct.arange(block_size, dtype=ct.int32)
+    check_bounds = not aligned
+
+    x_tile = ct.astype(
+        ct.gather(x, (row, columns), check_bounds=check_bounds, padding_value=0.0, latency=4),
+        ct.float32,
+    )
+    dy_tile = ct.astype(
+        ct.gather(dy, (row, columns), check_bounds=check_bounds, padding_value=0.0, latency=4),
+        ct.float32,
+    )
+    reciprocal_rms = ct.astype(ct.load(rstd, row, shape=(), latency=3), ct.float32)
+    m = dy_tile
+    if elementwise_affine:
+        weight_tile = ct.astype(
+            ct.gather(weight, columns, check_bounds=check_bounds, padding_value=0.0, latency=3),
+            ct.float32,
+        )
+        m = dy_tile * (weight_tile + offset)
+
+    dot = ct.sum(m * x_tile, 0, keepdims=False)
+    coefficient = -(reciprocal_rms * reciprocal_rms * dot) / n_cols
+    dx_tile = reciprocal_rms * (m + coefficient * x_tile)
+    ct.scatter(dx, (row, columns), ct.astype(dx_tile, dx.dtype), check_bounds=check_bounds)
+
+
+@ct.kernel(occupancy=1)
+def _rms_norm_bwd_combined_kernel_ct(
+    x,
+    dy,
+    weight,
+    rstd,
+    dx,
+    dw_partial,
+    n_rows: ConstInt,
+    n_cols: ConstInt,
+    rows_per_program: ConstInt,
+    offset: ConstFloat,
+    casting_mode: ConstInt,
+    block_size: ConstInt,
+    aligned: ConstBool,
+):
+    """Persistent fused dX+dW; retain W and FP32 dW accumulators across rows."""
+    program = ct.bid(0)
+    columns = ct.arange(block_size, dtype=ct.int32)
+    check_bounds = not aligned
+
+    weight_tile = ct.astype(
+        ct.gather(weight, columns, check_bounds=check_bounds, padding_value=0.0, latency=3),
+        ct.float32,
+    )
+    dw_accumulator = ct.full((block_size,), 0.0, dtype=ct.float32)
+
+    for row_offset in range(rows_per_program):
+        row = program * rows_per_program + row_offset
+        if row < n_rows:
+            x_input = ct.gather(x, (row, columns), check_bounds=check_bounds, padding_value=0.0, latency=4)
+            dy_input = ct.gather(dy, (row, columns), check_bounds=check_bounds, padding_value=0.0, latency=4)
+            x_tile = ct.astype(x_input, ct.float32)
+            dy_tile = ct.astype(dy_input, ct.float32)
+            reciprocal_rms = ct.astype(ct.load(rstd, row, shape=(), latency=3), ct.float32)
+
+            m = dy_tile * (weight_tile + offset)
+            dot = ct.sum(m * x_tile, 0, keepdims=False)
+            coefficient = -(reciprocal_rms * reciprocal_rms * dot) / n_cols
+            dx_tile = reciprocal_rms * (m + coefficient * x_tile)
+            ct.scatter(dx, (row, columns), ct.astype(dx_tile, dx.dtype), check_bounds=check_bounds)
+
+            normalized = x_tile * reciprocal_rms
+            if casting_mode == _CASTING_MODE_LLAMA:
+                normalized = ct.astype(ct.astype(normalized, x.dtype), ct.float32)
+            dw_accumulator = dw_accumulator + dy_tile * normalized
+
+    ct.scatter(dw_partial, (program, columns), dw_accumulator, check_bounds=check_bounds)
+
+
+@ct.kernel(occupancy=1)
+def _rms_norm_dw_reduce_kernel_ct(
+    dw_partial,
+    dw,
+    num_programs: ConstInt,
+    n_cols: ConstInt,
+    tile_size: ConstInt,
+    row_tile_size: ConstInt,
+    aligned: ConstBool,
+):
+    """Reduce FP32 dW partials and cast once to the output dtype."""
+    column_tile = ct.bid(0)
+    columns = column_tile * tile_size + ct.arange(tile_size, dtype=ct.int32)
+    check_bounds = not aligned
+    accumulator = ct.full((tile_size,), 0.0, dtype=ct.float32)
+
+    num_row_tiles = (num_programs + row_tile_size - 1) // row_tile_size
+    for row_tile in range(num_row_tiles):
+        partials = ct.load(
+            dw_partial,
+            index=(row_tile, column_tile),
+            shape=(row_tile_size, tile_size),
+            padding_mode=ct.PaddingMode.ZERO,
+            latency=4,
+        )
+        accumulator += ct.sum(partials, 0, keepdims=False)
+
+    ct.scatter(dw, columns, ct.astype(accumulator, dw.dtype), check_bounds=check_bounds)
+
+
+def rms_norm_forward(X, W, eps, offset, casting_mode, row_mode):
+    del row_mode
+    if not isinstance(casting_mode, int):
+        if casting_mode not in _STR_TO_CASTING_MODE:
+            raise ValueError(f"Invalid casting mode: {casting_mode}")
+        casting_mode = _STR_TO_CASTING_MODE[casting_mode]
+    elif casting_mode not in _STR_TO_CASTING_MODE.values():
+        raise ValueError(f"Invalid casting mode: {casting_mode}")
+
+    shape = X.shape
+    hidden_size = shape[-1]
+    x_2d = X.contiguous().view(-1, hidden_size)
+    n_rows, n_cols = x_2d.shape
+    block_size = _calculate_settings(n_cols)
+    aligned = n_cols == block_size
+    elementwise_affine = W is not None
+    if elementwise_affine:
+        if W.shape != (n_cols,):
+            raise ValueError(f"expected weight shape {(n_cols,)}, got {tuple(W.shape)}")
+        weight = W.contiguous()
+
+    y = torch.empty_like(x_2d)
+    reciprocal_rms = torch.empty(n_rows, dtype=torch.float32, device=X.device)
+    weight_arg = weight if elementwise_affine else reciprocal_rms
+    ct.launch(
+        torch.cuda.current_stream(),
+        (n_rows, 1, 1),
+        _rms_norm_fwd_kernel_ct,
+        (
+            x_2d,
+            weight_arg,
+            y,
+            reciprocal_rms,
+            int(n_cols),
+            float(eps),
+            float(offset),
+            int(casting_mode),
+            bool(elementwise_affine),
+            int(block_size),
+            bool(aligned),
+        ),
+    )
+    return y.view(*shape), x_2d, reciprocal_rms, block_size, None, casting_mode
+
+
+def rms_norm_backward(dY, X, W, RSTD, offset, casting_mode, BLOCK_SIZE, num_warps, in_place, row_mode):
+    del num_warps, row_mode
+    shape = dY.shape
+    hidden_size = shape[-1]
+    dy_2d = dY.contiguous().view(-1, hidden_size)
+    x_2d = X.contiguous().view(-1, hidden_size)
+    n_rows, n_cols = dy_2d.shape
+    block_size = _calculate_settings(n_cols) if BLOCK_SIZE is None else BLOCK_SIZE
+    aligned = n_cols == block_size
+    elementwise_affine = W is not None
+    dx = dy_2d if in_place else torch.empty_like(dy_2d)
+
+    if not elementwise_affine:
+        ct.launch(
+            torch.cuda.current_stream(),
+            (n_rows, 1, 1),
+            _rms_norm_bwd_dx_kernel_ct,
+            (
+                x_2d,
+                dy_2d,
+                RSTD.contiguous(),
+                RSTD.contiguous(),
+                dx,
+                int(n_cols),
+                float(offset),
+                int(casting_mode),
+                False,
+                int(block_size),
+                bool(aligned),
+            ),
+        )
+        return dx.view(*shape), None
+
+    weight = W.contiguous()
+    sm_count = torch.cuda.get_device_properties(X.device).multi_processor_count
+    strip_multiplier = 2 if n_rows >= 16 * sm_count else 1
+    num_programs = max(1, min(n_rows, strip_multiplier * sm_count))
+    rows_per_program = math.ceil(n_rows / num_programs)
+    dw_partial = torch.empty((num_programs, n_cols), dtype=torch.float32, device=W.device)
+
+    ct.launch(
+        torch.cuda.current_stream(),
+        (num_programs, 1, 1),
+        _rms_norm_bwd_combined_kernel_ct,
+        (
+            x_2d,
+            dy_2d,
+            weight,
+            RSTD.contiguous(),
+            dx,
+            dw_partial,
+            int(n_rows),
+            int(n_cols),
+            int(rows_per_program),
+            float(offset),
+            int(casting_mode),
+            int(block_size),
+            bool(aligned),
+        ),
+    )
+    if _DW_REDUCTION_POLICY in ("auto", "custom"):
+        tile_size = _DW_REDUCTION_TILE_SIZE
+        if tile_size <= 0 or tile_size & (tile_size - 1):
+            raise ValueError(f"LIGER_RMS_DW_REDUCTION_TILE_SIZE must be a positive power of two, got {tile_size}")
+        row_tile_size = _DW_REDUCTION_ROW_TILE_SIZE
+        if row_tile_size <= 0 or row_tile_size & (row_tile_size - 1):
+            raise ValueError(
+                f"LIGER_RMS_DW_REDUCTION_ROW_TILE_SIZE must be a positive power of two, got {row_tile_size}"
+            )
+        dw = torch.empty_like(weight)
+        ct.launch(
+            torch.cuda.current_stream(),
+            (math.ceil(n_cols / tile_size), 1, 1),
+            _rms_norm_dw_reduce_kernel_ct,
+            (
+                dw_partial,
+                dw,
+                int(num_programs),
+                int(n_cols),
+                int(tile_size),
+                int(row_tile_size),
+                bool(n_cols % tile_size == 0),
+            ),
+        )
+    elif _DW_REDUCTION_POLICY == "torch":
+        dw = dw_partial.sum(dim=0).to(W.dtype)
+    else:
+        raise ValueError(f"Invalid LIGER_RMS_DW_REDUCTION policy: {_DW_REDUCTION_POLICY}")
+    return dx.view(*shape), dw
+
+
+class LigerRMSNormFunction(torch.autograd.Function):
+    @staticmethod
+    @ensure_contiguous
+    def forward(ctx, X, W, eps, offset=0.0, casting_mode="llama", in_place=True, row_mode=None):
+        Y, X, RSTD, BLOCK_SIZE, num_warps, casting_mode = rms_norm_forward(
+            X,
+            W,
+            eps,
+            offset,
+            casting_mode,
+            row_mode,
+        )
+        ctx.offset = offset
+        ctx.casting_mode = casting_mode
+        ctx.in_place = in_place
+        ctx.row_mode = row_mode
+        ctx.BLOCK_SIZE = BLOCK_SIZE
+        ctx.num_warps = num_warps
+        ctx.elementwise_affine = W is not None
+        if W is None:
+            ctx.save_for_backward(X, RSTD)
+        else:
+            ctx.save_for_backward(X, W, RSTD)
+        return Y
+
+    @staticmethod
+    @ensure_contiguous
+    def backward(ctx, dY):
+        if ctx.elementwise_affine:
+            X, W, RSTD = ctx.saved_tensors
+        else:
+            X, RSTD = ctx.saved_tensors
+            W = None
+        dX, dW = rms_norm_backward(
+            dY,
+            X,
+            W,
+            RSTD,
+            ctx.offset,
+            ctx.casting_mode,
+            ctx.BLOCK_SIZE,
+            ctx.num_warps,
+            ctx.in_place,
+            ctx.row_mode,
+        )
+        return dX, dW, None, None, None, None, None

--- a/src/liger_kernel/ops/cutile/ops/rms_norm.py
+++ b/src/liger_kernel/ops/cutile/ops/rms_norm.py
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-#
-# SPDX-License-Identifier: MIT
-
 """Register-resident RMSNorm forward and persistent fused backward for cuTile."""
 
 import math

--- a/test/transformers/test_cutedsl_rms_norm_fastpath.py
+++ b/test/transformers/test_cutedsl_rms_norm_fastpath.py
@@ -13,6 +13,7 @@ _helpers = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_helpers)
 fast_path_vector_width = _helpers.fast_path_vector_width
 backward_warp_count = _helpers.backward_warp_count
+fwd_warp_count = _helpers.fwd_warp_count
 
 
 def test_fast_path_vector_width_uses_largest_participating_element():
@@ -40,3 +41,26 @@ def test_fast_path_vector_width_rejects_non_vectorizable_size():
 )
 def test_backward_warp_count(n_cols, expected):
     assert backward_warp_count(n_cols) == expected
+
+
+@pytest.mark.parametrize(
+    ("n_rows", "n_cols", "vec", "expected"),
+    [
+        (1024, 1024, 8, 4),
+        (1024, 2048, 8, 8),
+        (2048, 1024, 8, 4),
+        (2048, 4096, 8, 4),
+        (4096, 1024, 4, 2),
+        (4096, 2048, 8, 4),
+        (8192, 2048, 8, 2),
+        (8192, 2048, 4, 4),
+        (8192, 4096, 4, 8),
+    ],
+)
+def test_hopper_forward_warp_count_uses_row_parallelism(n_rows, n_cols, vec, expected):
+    assert fwd_warp_count(n_cols, vec, n_rows, sm90=True) == expected
+
+
+def test_forward_warp_count_preserves_width_policy_off_hopper():
+    assert fwd_warp_count(2048, 8, 8192, sm90=False) == 4
+    assert fwd_warp_count(4096, 8, 8192, sm90=False) == 8

--- a/test/transformers/test_cutile_backend.py
+++ b/test/transformers/test_cutile_backend.py
@@ -16,6 +16,7 @@ TRANSFORMER_MODULES = {
     "LigerGELUMulFunction": "liger_kernel.transformers.geglu",
     "LigerJSDFunction": "liger_kernel.transformers.jsd",
     "LigerLayerNormFunction": "liger_kernel.transformers.layer_norm",
+    "LigerRMSNormFunction": "liger_kernel.transformers.rms_norm",
 }
 
 pytestmark = [

--- a/test/transformers/test_cutile_rms_norm.py
+++ b/test/transformers/test_cutile_rms_norm.py
@@ -2,6 +2,67 @@ import importlib.util
 
 import pytest
 import torch
+import torch.nn as nn
+
+from test.utils import assert_verbose_allclose
+from test.utils import supports_bfloat16
+
+
+class BaseRMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6, elementwise_affine=True):
+        super().__init__()
+        self.elementwise_affine = elementwise_affine
+        if elementwise_affine:
+            self.weight = nn.Parameter(torch.ones(hidden_size))
+        else:
+            self.register_parameter("weight", None)
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        input_dtype = hidden_states.dtype
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        if self.elementwise_affine:
+            return self.weight * hidden_states.to(input_dtype)
+        return hidden_states.to(input_dtype)
+
+
+class LlamaRMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6, elementwise_affine=True):
+        super().__init__()
+        self.elementwise_affine = elementwise_affine
+        if elementwise_affine:
+            self.weight = nn.Parameter(torch.ones(hidden_size))
+        else:
+            self.register_parameter("weight", None)
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        if self.elementwise_affine:
+            return self.weight * hidden_states.to(input_dtype)
+        return hidden_states.to(input_dtype)
+
+
+class GemmaRMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6, elementwise_affine=True):
+        super().__init__()
+        self.eps = eps
+        self.elementwise_affine = elementwise_affine
+        if elementwise_affine:
+            self.weight = nn.Parameter(torch.ones(hidden_size))
+        else:
+            self.register_parameter("weight", None)
+
+    def forward(self, hidden_states):
+        output = hidden_states.float()
+        output = output * torch.rsqrt(output.pow(2).mean(-1, keepdim=True) + self.eps)
+        if self.elementwise_affine:
+            output = output * (1.0 + self.weight.float())
+        return output.type_as(hidden_states)
 
 
 def _has_cuda_tile():
@@ -22,76 +83,72 @@ pytestmark = [
     pytest.mark.skipif(not _CUDA_TILE_AVAILABLE, reason="cuda-tile is not installed"),
 ]
 
-_TOLERANCES = {
-    torch.bfloat16: (1e-1, 3e-2),
-    torch.float32: (3e-4, 2e-5),
-}
 
-
-def _run_cutile(x, weight, grad_output, casting_mode, in_place):
-    x_local = x.clone().detach().requires_grad_(True)
-    weight_local = None if weight is None else weight.clone().detach().requires_grad_(True)
-    output = CuTileRMSNormFunction.apply(x_local, weight_local, 1e-6, 0.0, casting_mode, in_place, None)
-    output.backward(grad_output.clone())
-    weight_grad = None if weight_local is None else weight_local.grad
-    return output, x_local.grad, weight_grad
-
-
-def _run_reference(x, weight, grad_output, casting_mode):
-    x_local = x.clone().detach().requires_grad_(True)
-    weight_local = None if weight is None else weight.clone().detach().requires_grad_(True)
-    x_float = x_local.float()
-    reciprocal_rms = torch.rsqrt(x_float.square().mean(dim=-1, keepdim=True) + 1e-6)
-    normalized = x_float * reciprocal_rms
-    if casting_mode == "llama":
-        normalized = normalized.to(x_local.dtype)
-    if weight_local is not None:
-        normalized = normalized.float() * weight_local.float()
-    output = normalized.to(x_local.dtype)
-    output.backward(grad_output.clone())
-    weight_grad = None if weight_local is None else weight_local.grad
-    return output, x_local.grad, weight_grad
-
-
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-@pytest.mark.parametrize("hidden_size", [1000, 8192])
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
+@pytest.mark.parametrize(
+    "bs, sl, hd",
+    [
+        (2, 128, 512),
+        (5, 123, 123),
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype, atol, rtol",
+    [
+        (torch.float32, 1e-4, 1e-6),
+        pytest.param(
+            torch.bfloat16,
+            2e-1,
+            2e-2,
+            marks=pytest.mark.skipif(not supports_bfloat16(), reason="bfloat16 not supported on this GPU"),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "reference, offset, casting_mode",
+    [
+        (LlamaRMSNorm, 0.0, "llama"),
+        (GemmaRMSNorm, 1.0, "gemma"),
+        (BaseRMSNorm, 0.0, "none"),
+    ],
+)
+@pytest.mark.parametrize("in_place", [True, False])
 @pytest.mark.parametrize("elementwise_affine", [True, False])
-def test_cutile_rms_norm_parity(dtype, hidden_size, elementwise_affine):
-    torch.manual_seed(42)
-    x = torch.randn(257, hidden_size, device="cuda", dtype=dtype)
-    weight = torch.randn(hidden_size, device="cuda", dtype=dtype) if elementwise_affine else None
-    grad_output = torch.randn_like(x)
+def test_cutile_rms_norm_correctness(
+    bs,
+    sl,
+    hd,
+    dtype,
+    atol,
+    rtol,
+    reference,
+    offset,
+    casting_mode,
+    in_place,
+    elementwise_affine,
+):
+    tensor = torch.randn(bs, sl, hd, device="cuda", dtype=dtype)
+    reference_input = tensor.clone().requires_grad_(True)
+    cutile_input = tensor.clone().requires_grad_(True)
+    grad_output = torch.randn_like(tensor)
 
-    cutile = _run_cutile(x, weight, grad_output, "llama", False)
-    reference = _run_reference(x, weight, grad_output, "llama")
-    atol, rtol = _TOLERANCES[dtype]
-    for actual, expected in zip(cutile, reference):
-        if actual is None:
-            assert expected is None
-        else:
-            torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+    reference_rms = reference(hidden_size=hd, elementwise_affine=elementwise_affine).cuda().to(dtype)
+    reference_output = reference_rms(reference_input)
+    reference_output.backward(grad_output)
 
+    cutile_weight = reference_rms.weight.detach().clone().requires_grad_(True) if elementwise_affine else None
+    cutile_output = CuTileRMSNormFunction.apply(
+        cutile_input,
+        cutile_weight,
+        1e-6,
+        offset,
+        casting_mode,
+        in_place,
+        None,
+    )
+    cutile_output.backward(grad_output.clone())
 
-@pytest.mark.parametrize("casting_mode", ["gemma", "none"])
-def test_cutile_rms_norm_casting_modes(casting_mode):
-    torch.manual_seed(7)
-    x = torch.randn(129, 1024, device="cuda", dtype=torch.bfloat16)
-    weight = torch.randn(1024, device="cuda", dtype=torch.bfloat16)
-    grad_output = torch.randn_like(x)
-
-    cutile = _run_cutile(x, weight, grad_output, casting_mode, False)
-    reference = _run_reference(x, weight, grad_output, casting_mode)
-    for actual, expected in zip(cutile, reference):
-        torch.testing.assert_close(actual, expected, atol=2e-1, rtol=3e-2)
-
-
-def test_cutile_rms_norm_in_place_backward():
-    torch.manual_seed(11)
-    x = torch.randn(131, 1024, device="cuda", dtype=torch.bfloat16)
-    weight = torch.randn(1024, device="cuda", dtype=torch.bfloat16)
-    grad_output = torch.randn_like(x)
-
-    cutile = _run_cutile(x, weight, grad_output, "llama", True)
-    reference = _run_reference(x, weight, grad_output, "llama")
-    for actual, expected in zip(cutile, reference):
-        torch.testing.assert_close(actual, expected, atol=6e-2, rtol=3e-2)
+    assert_verbose_allclose(reference_output, cutile_output, atol=atol, rtol=rtol)
+    assert_verbose_allclose(reference_input.grad, cutile_input.grad, atol=atol, rtol=rtol, max_print=20)
+    if elementwise_affine:
+        assert_verbose_allclose(reference_rms.weight.grad, cutile_weight.grad, atol=atol, rtol=rtol)

--- a/test/transformers/test_cutile_rms_norm.py
+++ b/test/transformers/test_cutile_rms_norm.py
@@ -1,0 +1,97 @@
+import importlib.util
+
+import pytest
+import torch
+
+
+def _has_cuda_tile():
+    try:
+        return importlib.util.find_spec("cuda.tile") is not None
+    except ModuleNotFoundError:
+        return False
+
+
+_CUDA_TILE_AVAILABLE = _has_cuda_tile()
+if _CUDA_TILE_AVAILABLE:
+    from liger_kernel.ops.cutile.ops.rms_norm import LigerRMSNormFunction as CuTileRMSNormFunction
+else:
+    CuTileRMSNormFunction = None
+
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="cuTile RMSNorm requires CUDA"),
+    pytest.mark.skipif(not _CUDA_TILE_AVAILABLE, reason="cuda-tile is not installed"),
+]
+
+_TOLERANCES = {
+    torch.bfloat16: (1e-1, 3e-2),
+    torch.float32: (3e-4, 2e-5),
+}
+
+
+def _run_cutile(x, weight, grad_output, casting_mode, in_place):
+    x_local = x.clone().detach().requires_grad_(True)
+    weight_local = None if weight is None else weight.clone().detach().requires_grad_(True)
+    output = CuTileRMSNormFunction.apply(x_local, weight_local, 1e-6, 0.0, casting_mode, in_place, None)
+    output.backward(grad_output.clone())
+    weight_grad = None if weight_local is None else weight_local.grad
+    return output, x_local.grad, weight_grad
+
+
+def _run_reference(x, weight, grad_output, casting_mode):
+    x_local = x.clone().detach().requires_grad_(True)
+    weight_local = None if weight is None else weight.clone().detach().requires_grad_(True)
+    x_float = x_local.float()
+    reciprocal_rms = torch.rsqrt(x_float.square().mean(dim=-1, keepdim=True) + 1e-6)
+    normalized = x_float * reciprocal_rms
+    if casting_mode == "llama":
+        normalized = normalized.to(x_local.dtype)
+    if weight_local is not None:
+        normalized = normalized.float() * weight_local.float()
+    output = normalized.to(x_local.dtype)
+    output.backward(grad_output.clone())
+    weight_grad = None if weight_local is None else weight_local.grad
+    return output, x_local.grad, weight_grad
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("hidden_size", [1000, 8192])
+@pytest.mark.parametrize("elementwise_affine", [True, False])
+def test_cutile_rms_norm_parity(dtype, hidden_size, elementwise_affine):
+    torch.manual_seed(42)
+    x = torch.randn(257, hidden_size, device="cuda", dtype=dtype)
+    weight = torch.randn(hidden_size, device="cuda", dtype=dtype) if elementwise_affine else None
+    grad_output = torch.randn_like(x)
+
+    cutile = _run_cutile(x, weight, grad_output, "llama", False)
+    reference = _run_reference(x, weight, grad_output, "llama")
+    atol, rtol = _TOLERANCES[dtype]
+    for actual, expected in zip(cutile, reference):
+        if actual is None:
+            assert expected is None
+        else:
+            torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("casting_mode", ["gemma", "none"])
+def test_cutile_rms_norm_casting_modes(casting_mode):
+    torch.manual_seed(7)
+    x = torch.randn(129, 1024, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(1024, device="cuda", dtype=torch.bfloat16)
+    grad_output = torch.randn_like(x)
+
+    cutile = _run_cutile(x, weight, grad_output, casting_mode, False)
+    reference = _run_reference(x, weight, grad_output, casting_mode)
+    for actual, expected in zip(cutile, reference):
+        torch.testing.assert_close(actual, expected, atol=2e-1, rtol=3e-2)
+
+
+def test_cutile_rms_norm_in_place_backward():
+    torch.manual_seed(11)
+    x = torch.randn(131, 1024, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(1024, device="cuda", dtype=torch.bfloat16)
+    grad_output = torch.randn_like(x)
+
+    cutile = _run_cutile(x, weight, grad_output, "llama", True)
+    reference = _run_reference(x, weight, grad_output, "llama")
+    for actual, expected in zip(cutile, reference):
+        torch.testing.assert_close(actual, expected, atol=6e-2, rtol=3e-2)


### PR DESCRIPTION
## Summary

Adds a native cuTile RMSNorm backend and optimizes the existing CuTe DSL RMSNorm path on Hopper.

- Adds register-resident cuTile forward and persistent fused dX+dW backward kernels.
- Gives both cuTile and CuTe DSL fused partial-dW reduction/cast epilogues for a fair comparison.
- Reduces CuTe DSL's per-row synchronization with safe ping-pong shared-memory scratch.
- Adds SM90 row-aware forward warp dispatch and a 32-warp parallel dW epilogue.
- Preserves the existing non-Hopper CuTe DSL policy and small-workload torch reduction fallback.

Across sequence lengths 1K-8K on H100, CuTe DSL is faster than the optimized cuTile implementation for all measured H=1024/2048 backward cases and all BF16 H=4096 backward cases.

## Details

### cuTile RMSNorm

The new cuTile implementation supports the existing RMSNorm contract:

- `llama`, `gemma`, and `none` casting modes
- optional affine weights and offsets
- in-place or out-of-place backward
- register-resident forward inputs
- persistent combined dX+dW backward
- fused 32x32 FP32 partial-dW reduction and output-dtype conversion

It is exported through `LIGER_KERNEL_IMPL=cutile` and registered with the existing backend comparison driver.

### CuTe DSL optimizations

1. **One-barrier reductions:** warp partials use ping-pong shared scratch, removing the second CTA barrier without racing scratch reuse. Wide FP32 rows retain the original two-barrier path where it benchmarks faster.
2. **SM90 forward dispatch:** warp count now considers both row width and available row parallelism. Non-SM90 devices retain the previous width-only policy.
3. **Parallel dW epilogue:** 32 warps split the strip dimension, merge once through shared memory, and fuse the final cast. Auto dispatch uses this path only on SM90 with at least 128 strips.
4. **BF16 gradient parity:** dW products round consistently with the existing Triton/PyTorch behavior before FP32 accumulation.

## Benchmark Results

Measured on one NVIDIA H100 80GB HBM3 (SM90). Each value is median device latency in microseconds from CUDA Graph replay with 100 warmup and 500 measured repetitions. `Tokens` is the flattened row count (batch x sequence length; batch=1 here). Lower is better.

Geometric-mean CuTe DSL speedup over cuTile across sequence lengths 1024/2048/4096/8192:

| Hidden | Dtype | Forward | Backward | Full |
|---:|---|---:|---:|---:|
| 1024 | BF16 | +1.6% | +6.0% | +5.4% |
| 1024 | FP32 | +2.0% | +5.3% | +5.4% |
| 2048 | BF16 | +2.7% | +4.3% | +4.3% |
| 2048 | FP32 | +2.7% | +4.7% | +4.5% |
| 4096 | BF16 | +3.4% | +3.4% | +3.6% |
| 4096 | FP32 | +3.8% | -2.3% | +0.1% |

### H=1024, BF16

| Tokens | Forward CuTeDSL | Forward CuTile | Forward Triton | Backward CuTeDSL | Backward CuTile | Backward Triton | Full CuTeDSL | Full CuTile | Full Triton |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1024 | 7.12 | 6.93 | 7.30 | 16.10 | 16.31 | 21.36 | 18.95 | 18.88 | 24.03 |
| 2048 | 8.66 | 8.81 | 8.89 | 23.02 | 24.75 | 28.60 | 26.28 | 28.12 | 32.27 |
| 4096 | 11.52 | 12.20 | 12.14 | 26.33 | 28.64 | 43.49 | 33.06 | 35.94 | 50.13 |
| 8192 | 17.66 | 17.96 | 17.82 | 44.05 | 47.02 | 73.22 | 57.12 | 60.82 | 87.03 |

### H=1024, FP32

| Tokens | Forward CuTeDSL | Forward CuTile | Forward Triton | Backward CuTeDSL | Backward CuTile | Backward Triton | Full CuTeDSL | Full CuTile | Full Triton |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1024 | 8.32 | 8.57 | 8.43 | 17.47 | 18.53 | 21.27 | 21.43 | 22.95 | 25.07 |
| 2048 | 10.81 | 10.72 | 10.79 | 26.57 | 28.54 | 30.95 | 32.76 | 35.04 | 37.01 |
| 4096 | 16.91 | 17.43 | 17.30 | 34.69 | 36.17 | 51.54 | 47.29 | 49.35 | 64.85 |
| 8192 | 27.68 | 28.40 | 28.46 | 56.43 | 58.38 | 90.18 | 80.21 | 82.68 | 114.87 |

### H=2048, BF16

| Tokens | Forward CuTeDSL | Forward CuTile | Forward Triton | Backward CuTeDSL | Backward CuTile | Backward Triton | Full CuTeDSL | Full CuTile | Full Triton |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1024 | 8.43 | 8.25 | 8.59 | 18.28 | 18.61 | 23.80 | 22.32 | 22.49 | 27.64 |
| 2048 | 10.84 | 11.91 | 12.22 | 27.88 | 29.55 | 33.99 | 34.39 | 37.14 | 41.21 |
| 4096 | 17.59 | 17.80 | 18.04 | 35.60 | 37.45 | 55.20 | 48.74 | 50.88 | 69.23 |
| 8192 | 28.79 | 29.36 | 29.36 | 58.15 | 60.62 | 95.37 | 82.40 | 85.79 | 120.71 |

### H=2048, FP32

| Tokens | Forward CuTeDSL | Forward CuTile | Forward Triton | Backward CuTeDSL | Backward CuTile | Backward Triton | Full CuTeDSL | Full CuTile | Full Triton |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1024 | 10.73 | 10.78 | 10.79 | 22.34 | 23.78 | 26.93 | 28.54 | 30.17 | 32.50 |
| 2048 | 16.40 | 17.44 | 17.35 | 35.97 | 38.09 | 42.39 | 48.28 | 51.53 | 55.47 |
| 4096 | 27.66 | 28.36 | 28.61 | 48.11 | 49.97 | 72.15 | 71.98 | 74.46 | 96.44 |
| 8192 | 49.50 | 50.32 | 50.51 | 83.68 | 85.83 | 127.86 | 129.73 | 132.37 | 174.73 |

### H=4096, BF16

| Tokens | Forward CuTeDSL | Forward CuTile | Forward Triton | Backward CuTeDSL | Backward CuTile | Backward Triton | Full CuTeDSL | Full CuTile | Full Triton |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1024 | 10.68 | 11.96 | 12.27 | 24.43 | 24.87 | 30.20 | 30.30 | 31.68 | 37.21 |
| 2048 | 18.04 | 17.83 | 17.93 | 38.34 | 40.08 | 46.51 | 52.04 | 54.05 | 60.34 |
| 4096 | 28.35 | 29.06 | 28.91 | 50.49 | 52.36 | 76.80 | 75.20 | 77.51 | 102.17 |
| 8192 | 50.79 | 51.27 | 51.04 | 86.16 | 89.17 | 134.44 | 132.94 | 136.80 | 181.73 |

### H=4096, FP32

| Tokens | Forward CuTeDSL | Forward CuTile | Forward Triton | Backward CuTeDSL | Backward CuTile | Backward Triton | Full CuTeDSL | Full CuTile | Full Triton |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1024 | 16.19 | 17.65 | 17.48 | 31.80 | 30.43 | 38.63 | 44.07 | 44.38 | 51.76 |
| 2048 | 27.64 | 28.54 | 28.52 | 51.42 | 48.92 | 63.21 | 75.00 | 73.86 | 87.81 |
| 4096 | 49.48 | 50.45 | 50.50 | 81.20 | 81.46 | 110.71 | 127.24 | 128.46 | 157.26 |
| 8192 | 93.30 | 94.42 | 94.46 | 149.11 | 148.99 | 204.68 | 238.88 | 239.99 | 295.53 |

## Testing Done

- CuTe DSL backend suite: 97 passed
- cuTile canonical reference matrix: 48 passed
- Canonical RMSNorm suite with each backend: 64 passed, 8 expected DTensor xfails
- SM90 forward-dispatch policy tests: 19 passed
- Large-shape CuTe DSL/Triton parity: BF16 and FP32 at M=8192, H=1024/2048/4096
- `make checkstyle`

- Hardware Type: NVIDIA H100 80GB HBM3
- [ ] run `make test` to ensure correctness (targeted RMSNorm suites run instead)
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
