### PR TITLE
[Bug] FLCE Triton Fallback

### DIFF
--- a/src/liger_kernel/ops/cutedsl/ops/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/ops/cutedsl/ops/fused_linear_cross_entropy.py
@@ -1,3 +1,5 @@
+import functools
+import logging
 import operator
 
 import cutlass
@@ -11,6 +13,8 @@ from liger_kernel.ops.utils import amp_custom_bwd
 from liger_kernel.ops.utils import amp_custom_fwd
 from liger_kernel.ops.utils import compare_version
 from liger_kernel.utils import infer_device_arch
+
+logger = logging.getLogger(__name__)
 
 _SUPPORTS_OUT_DTYPE = compare_version("torch", operator.ge, "2.8.0")
 _FORWARD_GRAD_MIN_CHUNK = 512
@@ -226,6 +230,28 @@ def _native_sm100_supported(tensor):
     return infer_device_arch(device_id) == "blackwell" and torch.cuda.get_device_capability(tensor.device) == (10, 0)
 
 
+def _native_unsupported_reason(_input, reduction):
+    """Why the native SM100 path cannot serve this call, or None if it can."""
+    if not _native_sm100_supported(_input):
+        return "requires exact SM100 hardware"
+    if _input.dtype not in (torch.bfloat16, torch.float16):
+        return f"requires FP16/BF16 input and weight (got {_input.dtype})"
+    if reduction not in ("mean", "sum"):
+        return f"requires mean/sum reduction (got {reduction!r})"
+    return None
+
+
+@functools.lru_cache(maxsize=None)
+def _warn_triton_fallback_once(reason):
+    """One warning per distinct reason, so a training loop logs it once, not per step."""
+    logger.warning(
+        "LIGER_KERNEL_IMPL=cutedsl was requested, but the native CuTe DSL fused linear "
+        "cross entropy %s. Falling back to the Triton kernel for this op; results are "
+        "unchanged but you are not on the CuTe DSL path.",
+        reason,
+    )
+
+
 class _FlceState:
     def save_for_backward(self, *tensors):
         self.saved_tensors = tensors
@@ -253,11 +279,8 @@ def fused_linear_cross_entropy_forward(
     _validate_inputs(_input, weight, target, bias, ce_weight, reduction, ignore_index)
     needs_grad = _input.requires_grad or weight.requires_grad or (bias is not None and bias.requires_grad)
 
-    if (
-        not _native_sm100_supported(_input)
-        or _input.dtype not in (torch.bfloat16, torch.float16)
-        or reduction not in ("mean", "sum")
-    ):
+    # Direct calls error here; fallback is in LigerFusedLinearCrossEntropyFunction before autograd.
+    if _native_unsupported_reason(_input, reduction) is not None:
         raise RuntimeError(
             "Native CuTe DSL FLCE requires exact SM100 hardware, FP16/BF16 input and weight, and mean/sum reduction."
         )
@@ -360,7 +383,7 @@ def fused_linear_cross_entropy_backward(ctx, grad_output):
     return grads
 
 
-class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
+class _NativeFusedLinearCrossEntropyFunction(torch.autograd.Function):
     @staticmethod
     @amp_custom_fwd
     def forward(
@@ -409,3 +432,62 @@ class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
     @amp_custom_bwd
     def backward(ctx, grad_output, grad_output2=None, grad_output3=None, grad_output4=None):
         return fused_linear_cross_entropy_backward(ctx, grad_output)
+
+
+class LigerFusedLinearCrossEntropyFunction:
+    """Dispatch: use native CuTe DSL if supported, else fall back to Triton.
+
+    Not a torch.autograd.Function — must dispatch before autograd, since calling Triton inside would skip graph recording. 
+    Keeps the .apply API; signature matches both backends.
+    """
+
+    @staticmethod
+    def apply(
+        _input,
+        weight,
+        target,
+        bias=None,
+        ce_weight=None,
+        ignore_index=-100,
+        lse_square_scale=0.0,
+        label_smoothing=0.0,
+        reduction="mean",
+        softcap=None,
+        return_z_loss=False,
+        accum_dtype=None,
+        use_token_scaling=False,
+        return_token_accuracy=False,
+        return_predicted_tokens=False,
+    ):
+        args = (
+            _input,
+            weight,
+            target,
+            bias,
+            ce_weight,
+            ignore_index,
+            lse_square_scale,
+            label_smoothing,
+            reduction,
+            softcap,
+            return_z_loss,
+            accum_dtype,
+            use_token_scaling,
+            return_token_accuracy,
+            return_predicted_tokens,
+        )
+
+        # Validate inputs before dispatch; consistent with native path.
+        _validate_inputs(_input, weight, target, bias, ce_weight, reduction, ignore_index)
+
+        reason = _native_unsupported_reason(_input, reduction)
+        if reason is None:
+            return _NativeFusedLinearCrossEntropyFunction.apply(*args)
+
+        # Lazy import: only load fallback if needed.
+        from liger_kernel.ops.fused_linear_cross_entropy import (
+            LigerFusedLinearCrossEntropyFunction as _TritonFusedLinearCrossEntropyFunction,
+        )
+
+        _warn_triton_fallback_once(reason)
+        return _TritonFusedLinearCrossEntropyFunction.apply(*args)

--- a/src/liger_kernel/ops/cutedsl/ops/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/ops/cutedsl/ops/fused_linear_cross_entropy.py
@@ -437,7 +437,7 @@ class _NativeFusedLinearCrossEntropyFunction(torch.autograd.Function):
 class LigerFusedLinearCrossEntropyFunction:
     """Dispatch: use native CuTe DSL if supported, else fall back to Triton.
 
-    Not a torch.autograd.Function — must dispatch before autograd, since calling Triton inside would skip graph recording. 
+    Not a torch.autograd.Function — must dispatch before autograd, since calling Triton inside would skip graph recording.
     Keeps the .apply API; signature matches both backends.
     """
 

--- a/test/cutedsl/test_fused_linear_cross_entropy.py
+++ b/test/cutedsl/test_fused_linear_cross_entropy.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import subprocess
 import sys
@@ -1024,11 +1025,101 @@ def test_flce_target_negative_non_ignore_raises():
         _run_or_skip(lambda: _apply(_cutedsl_flce(), _input, weight, target))
 
 
+# =============================================================================
+# Triton fallback for capability misses
+#
+# The native path only covers SM100 + FP16/BF16 + mean/sum. Anything outside that is a
+# *capability* miss, not a user error, so the dispatcher routes to Triton instead of
+# raising. Each test below forces one miss, makes a native dispatch impossible to
+# overlook, and then checks the result still matches Triton exactly.
+# =============================================================================
+def _flce_module():
+    """The cutedsl FLCE module itself, or skip when CUTLASS is not installed."""
+    try:
+        import liger_kernel.ops.cutedsl.ops.fused_linear_cross_entropy as flce
+    except ImportError as exc:
+        pytest.skip(f"cutedsl backend not importable (cutlass.cute missing?): {exc}")
+    return flce
+
+
+def _fwd_bwd(fn, _input, weight, target, **opts):
+    """Forward + backward on private clones, so both backends see identical inputs."""
+    x = _input.detach().clone().requires_grad_(True)
+    w = weight.detach().clone().requires_grad_(True)
+    loss = _apply(fn, x, w, target, **opts)[0]
+    loss.sum().backward()
+    return loss.detach(), x.grad, w.grad
+
+
+def _assert_falls_back_to_triton(monkeypatch, caplog, *, dtype=torch.bfloat16, reduction="mean", force_sm90=False):
+    flce = _flce_module()
+    _input, weight, target = _basic_args(dtype=dtype)
+
+    if force_sm90:
+        monkeypatch.setattr(flce, "_native_sm100_supported", lambda _: False)
+
+    # Choosing the native path here is exactly the bug under test; a numeric-only
+    # assertion would pass either way on real SM100 hardware, so make it explicit.
+    def _native_must_not_run(*args, **kwargs):
+        raise AssertionError("dispatcher chose the native SM100 path; expected the Triton fallback")
+
+    monkeypatch.setattr(flce._NativeFusedLinearCrossEntropyFunction, "apply", staticmethod(_native_must_not_run))
+    flce._warn_triton_fallback_once.cache_clear()
+
+    with caplog.at_level(logging.WARNING, logger=flce.__name__):
+        got = _fwd_bwd(_cutedsl_flce(), _input, weight, target, reduction=reduction)
+    want = _fwd_bwd(_triton_flce(), _input, weight, target, reduction=reduction)
+
+    # Both sides ran the same Triton kernel, so this is equality, not approximation.
+    for tensor_got, tensor_want, what in zip(got, want, ("loss", "grad_input", "grad_weight")):
+        torch.testing.assert_close(tensor_got, tensor_want, rtol=0, atol=0, msg=f"{what} mismatch vs Triton")
+
+    assert any("Falling back to the Triton kernel" in record.getMessage() for record in caplog.records), (
+        "the fallback must announce itself, so a user who opted into cutedsl is not "
+        "left believing they are on the accelerated path"
+    )
+
+
 @cuda_required
-def test_flce_reduction_none_is_rejected():
+def test_flce_falls_back_to_triton_on_non_sm100(monkeypatch, caplog):
+    _assert_falls_back_to_triton(monkeypatch, caplog, force_sm90=True)
+
+
+@cuda_required
+def test_flce_falls_back_to_triton_for_fp32(monkeypatch, caplog):
+    _assert_falls_back_to_triton(monkeypatch, caplog, dtype=torch.float32)
+
+
+@cuda_required
+def test_flce_falls_back_to_triton_for_reduction_none(monkeypatch, caplog):
+    _assert_falls_back_to_triton(monkeypatch, caplog, reduction="none")
+
+
+@sm100_required
+def test_flce_uses_native_path_when_supported(monkeypatch):
+    """Ensures supported calls use the native path instead of always falling back."""
+    flce = _flce_module()
+    called = []
+    native_apply = flce._NativeFusedLinearCrossEntropyFunction.apply
+
+    def _spy(*args, **kwargs):
+        called.append(True)
+        return native_apply(*args, **kwargs)
+
+    monkeypatch.setattr(flce._NativeFusedLinearCrossEntropyFunction, "apply", staticmethod(_spy))
+    _input, weight, target = _basic_args(dtype=torch.bfloat16)
+    _apply(_cutedsl_flce(), _input, weight, target)
+    assert called, "SM100 + bf16 + mean is fully supported; the native path must be used"
+
+
+@cuda_required
+def test_flce_native_forward_still_raises_on_capability_miss(monkeypatch):
+    """The low-level entry point keeps failing loudly; only the dispatcher degrades."""
+    flce = _flce_module()
+    monkeypatch.setattr(flce, "_native_sm100_supported", lambda _: False)
     _input, weight, target = _basic_args()
-    with pytest.raises(RuntimeError, match="mean/sum reduction"):
-        _apply(_cutedsl_flce(), _input, weight, target, reduction="none")
+    with pytest.raises(RuntimeError, match="exact SM100"):
+        flce.fused_linear_cross_entropy_forward(_input, weight, target)
 
 
 @cuda_required
@@ -1117,23 +1208,6 @@ def test_flce_native_support_requires_exact_sm100(monkeypatch):
     assert seen == [tensor.device]
 
 
-@cuda_required
-def test_flce_native_function_rejects_fp32_inputs():
-    _input, weight, target = _basic_args(dtype=torch.float32)
-    with pytest.raises(RuntimeError, match="FP16/BF16"):
-        _apply(_cutedsl_flce(), _input, weight, target)
-
-
-@cuda_required
-def test_flce_native_function_rejects_non_sm100(monkeypatch):
-    import liger_kernel.ops.cutedsl.ops.fused_linear_cross_entropy as flce
-
-    monkeypatch.setattr(flce, "_native_sm100_supported", lambda _: False)
-    _input, weight, target = _basic_args()
-    with pytest.raises(RuntimeError, match="exact SM100"):
-        _apply(_cutedsl_flce(), _input, weight, target)
-
-
 def test_flce_native_gemm_guards_noncurrent_device(monkeypatch):
     try:
         import liger_kernel.ops.cutedsl.ops._sm100_gemm as gemm
@@ -1201,3 +1275,59 @@ def test_liger_kernel_impl_cutedsl_selects_cutedsl_flce():
     if proc.returncode == 77:
         pytest.skip(proc.stderr.strip() or "cutedsl FLCE not wired yet")
     assert proc.returncode == 0, f"cutedsl FLCE dispatch check failed:\n{proc.stderr}"
+
+
+def _cutedsl_installed():
+    try:
+        import cutlass.cute  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.skipif(not _cutedsl_installed(), reason="cutedsl backend not installed")
+def test_cutedsl_flce_integration_does_not_raise_on_capability_miss():
+    """End-to-end regression: ensures a capability miss in FLCE falls back instead of raising.
+
+    Tests real dispatch by requiring a new interpreter. Uses FP32 (which is unsupported on all GPUs)
+    as the trigger, so the test never quietly passes on any hardware.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    pythonpath = os.pathsep.join([str(repo_root / "src"), str(repo_root), os.environ.get("PYTHONPATH", "")])
+    env = {**os.environ, "LIGER_KERNEL_IMPL": "cutedsl", "PYTHONPATH": pythonpath}
+    script = textwrap.dedent(
+        """
+        import sys
+        import torch
+
+        from liger_kernel.ops import LigerFusedLinearCrossEntropyFunction
+        from liger_kernel.transformers.functional import liger_fused_linear_cross_entropy
+
+        expected = "liger_kernel.ops.cutedsl.ops.fused_linear_cross_entropy"
+        mod = LigerFusedLinearCrossEntropyFunction.__module__
+        if mod != expected:
+            print(f"cutedsl FLCE not selected (module={mod}); skipping", file=sys.stderr)
+            sys.exit(77)
+
+        torch.manual_seed(0)
+        BT, H, V = 8, 16, 128
+        x = torch.randn(BT, H, device="cuda", dtype=torch.float32, requires_grad=True)
+        w = torch.randn(V, H, device="cuda", dtype=torch.float32, requires_grad=True)
+        target = torch.randint(0, V, (BT,), device="cuda")
+
+        loss = liger_fused_linear_cross_entropy(x, w, target)
+        loss.backward()
+
+        assert torch.isfinite(loss), loss
+        assert x.grad is not None and torch.isfinite(x.grad).all()
+        assert w.grad is not None and torch.isfinite(w.grad).all()
+        """
+    )
+    proc = subprocess.run([sys.executable, "-c", script], env=env, cwd=repo_root, capture_output=True, text=True)
+    if proc.returncode == 77:
+        pytest.skip(proc.stderr.strip() or "cutedsl FLCE not selected")
+    assert proc.returncode == 0, (
+        "FLCE must fall back to Triton instead of raising when the native CuTe DSL path "
+        f"cannot serve the call:\n{proc.stderr}"
+    )


### PR DESCRIPTION
## Summary
The CuTe DSL backend's `LigerFusedLinearCrossEntropyFunction` currently raises a hard `RuntimeError` on capability misses (e.g., non-SM100 hardware, FP32, or unsupported reductions) instead of falling back to Triton. This breaks fused-linear-cross-entropy training across all models when using the `cutedsl` backend on non-SM100 hardware (reproducible on H100 via `LIGER_KERNEL_IMPL=cutedsl python -m pytest test/convergence/bf16/test_mini_models.py -k "mini_llama3 or mini_qwen2"`).

This PR makes capability misses fall back to the Triton kernel with a one-time warning. Found while validating #1390 against both backends, not specific to any model. The README already sets this expectation for ops with no CuTe DSL kernel, this PR extends it to an op that has one which declines the current hardware.

## Details

### Dispatch Implementation
- `LigerFusedLinearCrossEntropyFunction` is now a thin dispatcher rather than a `torch.autograd.Function`. The original autograd logic is renamed to `_NativeFusedLinearCrossEntropyFunction`.
- Call choice must occur before autograd records the node. Running Triton's `.apply` inside an autograd `forward()` would execute outside the graph and silently drop gradients.
- Call sites and `__module__` assertions remain unchanged.
- Validation executes before dispatch to guarantee uniform error messages across different GPU architectures.
- Low-level entry point `fused_linear_cross_entropy_forward` still raises on misses; only the dispatcher degrades.


## Testing Done
Validated across **H100 (SM90)** and **B200 (SM100)** to ensure both fallback and native execution paths work properly.

| Test Suite | H100 (SM90) | B200 (SM100) |
| :--- | :---: | :---: |
| `test/cutedsl` FLCE + convergence (`mini_llama3`, `mini_qwen2`, `muse_glimmer`) | 26 PASSED | 26 PASSED |
| Full `test/cutedsl/test_fused_linear_cross_entropy.py` (incl. `@sm100_required`) | — | 240 PASSED |

### Test Changes
- 3 tests now asset Triton fallback instead of a hard raise (`test_flce_falls_back_to_triton_on_non_sm100`, `..._for_fp32`, `..._for_reduction_none`).
- `test_flce_uses_native_path_when_supported` (`@sm100_required`) to prevent accidental permanent fallback.
- `test_flce_native_forward_still_raises_on_capability_miss` to check the low-level entry point.
- `test_cutedsl_flce_integration_does_not_raise_on_capability_miss` to verify the end-to-end integration path via a subprocess.

- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence
