### PR TITLE
Fix JSD underflow for low-probability vocabulary entries

### DIFF
--- a/src/liger_kernel/ops/backends/_ascend/ops/jsd.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/jsd.py
@@ -74,24 +74,21 @@ def _jsd_kernel(
                     loss = X_prob * (X - Y)
                     dX = loss + X_prob
                 else:
-                    max_val = tl.maximum(tl.max(X, axis=0), tl.max(Y, axis=0))
+                    max_val = tl.maximum(X, Y)
                     X_shifted = X - max_val
                     Y_shifted = Y - max_val
 
-                    # Pre-compute exp(max_val) since it's used twice
-                    exp_max = tl.exp(max_val)
+                    # Compute log(M) before rescaling to probability space. Computing M
+                    # directly can underflow to zero for low-probability vocabulary blocks.
+                    M_shifted = beta * tl.exp(Y_shifted) + (1 - beta) * tl.exp(X_shifted)
+                    log_M = max_val + tl.log(M_shifted)
 
-                    # Compute exp terms with compensation
-                    Q = tl.exp(X_shifted) * exp_max  # = exp(X)
-                    P = tl.exp(Y_shifted) * exp_max  # = exp(Y)
-
-                    # Pre-compute common terms
+                    Q = tl.exp(X)
+                    P = tl.exp(Y)
                     beta_P = beta * P
                     one_minus_beta_Q = (1 - beta) * Q
-                    M = beta_P + one_minus_beta_Q
-                    log_M = tl.log(M)
 
-                    loss = beta_P * Y + one_minus_beta_Q * X - M * log_M
+                    loss = beta_P * (Y - log_M) + one_minus_beta_Q * (X - log_M)
                     dX = one_minus_beta_Q * (X - log_M)
 
                 # Pre-compute scaling factor

--- a/src/liger_kernel/ops/cutile/ops/jsd.py
+++ b/src/liger_kernel/ops/cutile/ops/jsd.py
@@ -69,17 +69,16 @@ def jsd_kernel_ct(
             loss_tile = x_prob * (x_f32 - y_f32)
             dx_tile = loss_tile + x_prob
         else:
-            x_max = ct.max(x_f32, 0, keepdims=True)
-            y_max = ct.max(y_f32, 0, keepdims=True)
-            max_val = ct.maximum(x_max, y_max)
-            exp_max = ct.exp(max_val)
-            q_prob = ct.exp(x_f32 - max_val) * exp_max
-            p_prob = ct.exp(y_f32 - max_val) * exp_max
+            max_val = ct.maximum(x_f32, y_f32)
+            x_shifted = x_f32 - max_val
+            y_shifted = y_f32 - max_val
+            m_shifted = beta * ct.exp(y_shifted) + (1.0 - beta) * ct.exp(x_shifted)
+            log_m = max_val + ct.log(m_shifted)
+            q_prob = ct.exp(x_f32)
+            p_prob = ct.exp(y_f32)
             beta_p = beta * p_prob
             one_minus_beta_q = (1.0 - beta) * q_prob
-            m_prob = beta_p + one_minus_beta_q
-            log_m = ct.log(m_prob)
-            loss_tile = beta_p * y_f32 + one_minus_beta_q * x_f32 - m_prob * log_m
+            loss_tile = beta_p * (y_f32 - log_m) + one_minus_beta_q * (x_f32 - log_m)
             dx_tile = one_minus_beta_q * (x_f32 - log_m)
 
         loss_tile = loss_tile * inv_n_non_ignore

--- a/src/liger_kernel/ops/jsd.py
+++ b/src/liger_kernel/ops/jsd.py
@@ -64,24 +64,21 @@ def _jsd_kernel(
             loss = X_prob * (X - Y)
             dX = loss + X_prob
         else:
-            max_val = tl.maximum(tl.max(X, axis=0), tl.max(Y, axis=0))
+            max_val = tl.maximum(X, Y)
             X_shifted = X - max_val
             Y_shifted = Y - max_val
 
-            # Pre-compute exp(max_val) since it's used twice
-            exp_max = tl.exp(max_val)
+            # Compute log(M) before rescaling to probability space. Computing M
+            # directly can underflow to zero for low-probability vocabulary blocks.
+            M_shifted = beta * tl.exp(Y_shifted) + (1 - beta) * tl.exp(X_shifted)
+            log_M = max_val + tl.log(M_shifted)
 
-            # Compute exp terms with compensation
-            Q = tl.exp(X_shifted) * exp_max  # = exp(X)
-            P = tl.exp(Y_shifted) * exp_max  # = exp(Y)
-
-            # Pre-compute common terms
+            Q = tl.exp(X)
+            P = tl.exp(Y)
             beta_P = beta * P
             one_minus_beta_Q = (1 - beta) * Q
-            M = beta_P + one_minus_beta_Q
-            log_M = tl.log(M)  # No need to compensate as M is already in original scale
 
-            loss = beta_P * Y + one_minus_beta_Q * X - M * log_M
+            loss = beta_P * (Y - log_M) + one_minus_beta_Q * (X - log_M)
             dX = one_minus_beta_Q * (X - log_M)
 
         # Pre-compute scaling factor

--- a/test/transformers/test_fused_linear_jsd.py
+++ b/test/transformers/test_fused_linear_jsd.py
@@ -75,6 +75,36 @@ class LigerLMHeadJSD(torch.nn.Module):
         )
 
 
+def test_low_probability_vocab_block_is_finite():
+    H = 4
+    V = 32769
+    torch_model = TorchLMHeadJSD(H=H, V=V, dtype=torch.float32, device=device)
+    liger_model = LigerLMHeadJSD(H=H, V=V, dtype=torch.float32, device=device)
+
+    torch_model.student_lin.weight.data.fill_(-120.0)
+    torch_model.student_lin.weight.data[0].zero_()
+    torch_model.teacher_lin.weight.data.fill_(-121.0)
+    torch_model.teacher_lin.weight.data[0].zero_()
+    liger_model.load_state_dict(torch_model.state_dict())
+
+    student_input = torch.zeros(1, H // 2, device=device)
+    student_input[:, 0] = 1.0
+    torch_input = student_input.detach().clone().requires_grad_(True)
+    liger_input = student_input.detach().clone().requires_grad_(True)
+    teacher_input = torch.zeros(1, H, device=device)
+    teacher_input[:, 0] = 1.0
+
+    torch_output = torch_model(torch_input, teacher_input)
+    liger_output = liger_model(liger_input, teacher_input)
+    torch_output.backward()
+    liger_output.backward()
+
+    assert torch.isfinite(liger_output)
+    assert torch.isfinite(liger_input.grad).all()
+    assert_verbose_allclose(torch_output, liger_output, atol=1e-7, rtol=1e-6)
+    assert_verbose_allclose(torch_input.grad, liger_input.grad, atol=1e-7, rtol=1e-6)
+
+
 #############################################################################
 # Test the correctness of the fused linear JSD
 #############################################################################

--- a/test/transformers/test_jsd.py
+++ b/test/transformers/test_jsd.py
@@ -1,3 +1,5 @@
+import math
+
 from typing import Optional
 
 import pytest
@@ -75,10 +77,8 @@ class JSD(torch.nn.Module):
                 log_p.view(-1, log_p.size(-1)),
                 log_q.view(-1, log_q.size(-1)),
             )
-            m = torch.lerp(torch.exp(log_q), torch.exp(log_p), self.beta)
-            loss = self.beta * self.kl(torch.log(m), log_p).sum(dim=-1) + (1 - self.beta) * self.kl(
-                torch.log(m), log_q
-            ).sum(dim=-1)
+            log_m = torch.logaddexp(log_p + math.log(self.beta), log_q + math.log1p(-self.beta))
+            loss = self.beta * self.kl(log_m, log_p).sum(dim=-1) + (1 - self.beta) * self.kl(log_m, log_q).sum(dim=-1)
 
         if label is not None:
             loss = torch.where(label != self.ignore_index, loss, 0.0)
@@ -350,3 +350,24 @@ def test_correctness_with_all_indices_ignored(
 
     output2.backward()
     assert_verbose_allclose(torch.zeros_like(x2.grad), x2.grad, atol=atol, rtol=rtol)
+
+
+def test_low_probability_vocab_block_is_finite():
+    vocab_size = 65537
+    logits = torch.full((1, vocab_size), -120.0, device=device)
+    logits[:, 0] = 0.0
+
+    input = logits.log_softmax(dim=-1)
+    target = logits.sub(1.0).log_softmax(dim=-1)
+    torch_input = input.detach().clone().requires_grad_(True)
+    liger_input = input.detach().clone().requires_grad_(True)
+
+    torch_output = JSD()(torch_input, target)
+    liger_output = LigerJSD()(liger_input, target)
+    torch_output.backward()
+    liger_output.backward()
+
+    assert torch.isfinite(liger_output)
+    assert torch.isfinite(liger_input.grad).all()
+    assert_verbose_allclose(torch_output, liger_output, atol=1e-7, rtol=1e-6)
+    assert_verbose_allclose(torch_input.grad, liger_input.grad, atol=1e-7, rtol=1e-6)


### PR DESCRIPTION
## Summary

Fix NaNs in generalized JSD when both student and teacher probabilities underflow to zero in FP32.

The previous implementation constructed the mixture distribution in probability space. For log probabilities around `-104` or lower, both probabilities could underflow to zero, resulting in `log(0)` and NaN loss terms.

This change:
- computes `log(M)` using an element-wise log-sum-exp formulation
- evaluates the loss as weighted KL terms to avoid `0 * -inf`
- applies the fix consistently to the Triton, Ascend, and cuTile backends
- updates the PyTorch reference to use the equivalent stable formulation `torch.logaddexp`
- adds standalone and fused-linear regression tests

Both new regression tests return NaN on `main` and pass with this change.

## Testing Done

Hardware Type: A100
- [x] run `make test` to ensure correctness (18 unrelated chunked GRPO LUSPO failures)
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence (does not exercise JSD)

Ascend and cuTile received the equivalent backend change but were not runtime-tested as I don't have the hardware.