### PR TITLE
B300: fuse scaled cross entropy with bounded Triton workspace

### DIFF
--- a/benchmark/scripts/benchmark_fused_scaled_cross_entropy_sm90.py
+++ b/benchmark/scripts/benchmark_fused_scaled_cross_entropy_sm90.py
@@ -4,7 +4,7 @@ The measured operation returns the **per-token NLL** ``[M]`` (never a mean or a
 sum), so the backward is driven by a *fixed* per-token gradient vector ``[M]``
 -- the same vector for every provider, every repetition and every operation
 mode -- instead of the shared harness' fresh ``randn_like`` draw.  That keeps
-the three providers numerically comparable and keeps the gradient allocation
+the providers numerically comparable and keeps the gradient allocation
 out of the timed region.
 
 Sweep parameters (all optional; defaults reproduce the previous behaviour)::
@@ -15,13 +15,15 @@ Sweep parameters (all optional; defaults reproduce the previous behaviour)::
     --providers NAME [NAME ...]     explicit provider list
 
 Providers: ``torch``, ``liger`` (Triton FLCE, ``reduction="none"``),
-``cutile``, and ``cutedsl-sm90`` (fixed 1024-token wave-batched backward).
+``scaled-default`` (the device-dispatching scaled-CE frontend),
+``scaled-fallback`` (its exact PyTorch fallback), ``cutile``, and
+``cutedsl-sm90`` (fixed 1024-token wave-batched backward).
 
 Example::
 
     python benchmark_fused_scaled_cross_entropy_sm90.py \\
         --tokens 4096 --hidden 4096 --vocab 131072 \\
-        --providers torch liger cutile cutedsl-sm90
+        --providers scaled-fallback scaled-default cutile
 """
 
 import argparse
@@ -40,7 +42,6 @@ from utils import _test_memory
 from utils import parse_benchmark_script_args
 from utils import run_benchmarks
 
-from liger_kernel.ops.cutedsl.ops.fused_scaled_cross_entropy_sm90 import LigerFusedScaledCrossEntropySM90Function
 from liger_kernel.transformers.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyLoss
 from liger_kernel.utils import infer_device
 
@@ -54,6 +55,8 @@ REPRESENTATIVE_CONFIG = {
 
 CUTEDSL_PREFIX = "cutedsl-sm90"
 CUTILE_PREFIX = "cutile"
+SCALED_DEFAULT_PREFIX = "scaled-default"
+SCALED_FALLBACK_PREFIX = "scaled-fallback"
 # Seed of the fixed per-token upstream gradient, so every provider and every
 # repetition sees byte-identical ``d(NLL)/d(loss)`` values.
 GRAD_SEED = 1234
@@ -101,6 +104,10 @@ class CuteDSLHopperLMHeadScaledCE(torch.nn.Module):
         torch.nn.init.normal_(self.weight, std=hidden_size**-0.5)
 
     def forward(self, x, target):
+        from liger_kernel.ops.cutedsl.ops.fused_scaled_cross_entropy_sm90 import (
+            LigerFusedScaledCrossEntropySM90Function,
+        )
+
         return LigerFusedScaledCrossEntropySM90Function.apply(
             x,
             self.weight,
@@ -134,6 +141,51 @@ class CuTileLMHeadScaledCE(torch.nn.Module):
         )
 
 
+class DefaultLMHeadScaledCE(torch.nn.Module):
+    """Device-dispatching scaled CE frontend used by public callers."""
+
+    def __init__(self, hidden_size: int, vocab_size: int, dtype: torch.dtype, temperature: float = 1.0):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.empty(vocab_size, hidden_size, dtype=dtype))
+        self.temperature = temperature
+        torch.nn.init.normal_(self.weight, std=hidden_size**-0.5)
+
+    def forward(self, x, target):
+        from liger_kernel.ops.fused_linear_scaled_cross_entropy import LigerFusedLinearScaledCrossEntropyFunction
+
+        return LigerFusedLinearScaledCrossEntropyFunction.apply(
+            x,
+            self.weight,
+            target,
+            self.temperature,
+            -100,
+            1,
+            False,
+        )
+
+
+class FallbackLMHeadScaledCE(torch.nn.Module):
+    """Exact 512-token PyTorch fallback behind the scaled CE frontend."""
+
+    def __init__(self, hidden_size: int, vocab_size: int, dtype: torch.dtype, temperature: float = 1.0):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.empty(vocab_size, hidden_size, dtype=dtype))
+        self.temperature = temperature
+        torch.nn.init.normal_(self.weight, std=hidden_size**-0.5)
+
+    def forward(self, x, target):
+        from liger_kernel.ops.fused_linear_scaled_cross_entropy import _FusedLinearPPOFallbackFunction
+
+        return _FusedLinearPPOFallbackFunction.apply(
+            x,
+            self.weight,
+            target,
+            self.temperature,
+            -100,
+            False,
+        )
+
+
 def fixed_grad_output(tokens: int) -> torch.Tensor:
     """The fixed ``[M]`` upstream gradient of the per-token NLL."""
     generator = torch.Generator(device=device).manual_seed(GRAD_SEED)
@@ -163,6 +215,10 @@ def setup_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput):
         layer = CuteDSLHopperLMHeadScaledCE(hidden_size, vocab_size, dtype)
     elif provider == CUTILE_PREFIX:
         layer = CuTileLMHeadScaledCE(hidden_size, vocab_size, dtype)
+    elif provider == SCALED_DEFAULT_PREFIX:
+        layer = DefaultLMHeadScaledCE(hidden_size, vocab_size, dtype)
+    elif provider == SCALED_FALLBACK_PREFIX:
+        layer = FallbackLMHeadScaledCE(hidden_size, vocab_size, dtype)
     elif provider == "liger":
         layer = TritonLMHeadCE(hidden_size, vocab_size, dtype)
     elif provider == "torch":
@@ -253,7 +309,14 @@ def parse_sweep_args():
 def resolve_providers(sweep_args):
     if sweep_args.providers:
         for provider in sweep_args.providers:
-            if provider not in ("torch", "liger", CUTILE_PREFIX, CUTEDSL_PREFIX):
+            if provider not in (
+                "torch",
+                "liger",
+                CUTILE_PREFIX,
+                CUTEDSL_PREFIX,
+                SCALED_DEFAULT_PREFIX,
+                SCALED_FALLBACK_PREFIX,
+            ):
                 raise ValueError(f"Unknown provider {provider!r}")
         return list(sweep_args.providers)
     return ["torch", "liger", CUTILE_PREFIX, CUTEDSL_PREFIX]

--- a/benchmark/scripts/benchmark_fused_scaled_cross_entropy_sm90.py
+++ b/benchmark/scripts/benchmark_fused_scaled_cross_entropy_sm90.py
@@ -13,6 +13,7 @@ Sweep parameters (all optional; defaults reproduce the previous behaviour)::
     --hidden H                      hidden size
     --vocab V                       vocabulary size
     --providers NAME [NAME ...]     explicit provider list
+    --return-entropy                benchmark NLL and entropy together
 
 Providers: ``torch``, ``liger`` (Triton FLCE, ``reduction="none"``),
 ``scaled-default`` (the device-dispatching scaled-CE frontend),
@@ -23,7 +24,7 @@ Example::
 
     python benchmark_fused_scaled_cross_entropy_sm90.py \\
         --tokens 4096 --hidden 4096 --vocab 131072 \\
-        --providers scaled-fallback scaled-default cutile
+        --providers scaled-fallback scaled-default --return-entropy
 """
 
 import argparse
@@ -60,6 +61,7 @@ SCALED_FALLBACK_PREFIX = "scaled-fallback"
 # Seed of the fixed per-token upstream gradient, so every provider and every
 # repetition sees byte-identical ``d(NLL)/d(loss)`` values.
 GRAD_SEED = 1234
+ENTROPY_GRAD_SEED = 1235
 
 
 class TorchLMHeadCE(torch.nn.Module):
@@ -144,10 +146,18 @@ class CuTileLMHeadScaledCE(torch.nn.Module):
 class DefaultLMHeadScaledCE(torch.nn.Module):
     """Device-dispatching scaled CE frontend used by public callers."""
 
-    def __init__(self, hidden_size: int, vocab_size: int, dtype: torch.dtype, temperature: float = 1.0):
+    def __init__(
+        self,
+        hidden_size: int,
+        vocab_size: int,
+        dtype: torch.dtype,
+        temperature: float = 1.0,
+        return_entropy: bool = False,
+    ):
         super().__init__()
         self.weight = torch.nn.Parameter(torch.empty(vocab_size, hidden_size, dtype=dtype))
         self.temperature = temperature
+        self.return_entropy = return_entropy
         torch.nn.init.normal_(self.weight, std=hidden_size**-0.5)
 
     def forward(self, x, target):
@@ -160,17 +170,25 @@ class DefaultLMHeadScaledCE(torch.nn.Module):
             self.temperature,
             -100,
             1,
-            False,
+            self.return_entropy,
         )
 
 
 class FallbackLMHeadScaledCE(torch.nn.Module):
     """Exact 512-token PyTorch fallback behind the scaled CE frontend."""
 
-    def __init__(self, hidden_size: int, vocab_size: int, dtype: torch.dtype, temperature: float = 1.0):
+    def __init__(
+        self,
+        hidden_size: int,
+        vocab_size: int,
+        dtype: torch.dtype,
+        temperature: float = 1.0,
+        return_entropy: bool = False,
+    ):
         super().__init__()
         self.weight = torch.nn.Parameter(torch.empty(vocab_size, hidden_size, dtype=dtype))
         self.temperature = temperature
+        self.return_entropy = return_entropy
         torch.nn.init.normal_(self.weight, std=hidden_size**-0.5)
 
     def forward(self, x, target):
@@ -182,18 +200,29 @@ class FallbackLMHeadScaledCE(torch.nn.Module):
             target,
             self.temperature,
             -100,
-            False,
+            self.return_entropy,
         )
 
 
-def fixed_grad_output(tokens: int) -> torch.Tensor:
-    """The fixed ``[M]`` upstream gradient of the per-token NLL."""
+def fixed_grad_outputs(tokens: int, dtype: torch.dtype, return_entropy: bool) -> tuple[torch.Tensor, ...]:
+    """Fixed independent upstream gradients for the per-token outputs."""
     generator = torch.Generator(device=device).manual_seed(GRAD_SEED)
-    return torch.rand(tokens, generator=generator, device=device, dtype=torch.float32) + 0.25
+    grad_nll = torch.rand(tokens, generator=generator, device=device, dtype=torch.float32) + 0.25
+    if not return_entropy:
+        return (grad_nll,)
+    entropy_generator = torch.Generator(device=device).manual_seed(ENTROPY_GRAD_SEED)
+    grad_entropy = torch.rand(tokens, generator=entropy_generator, device=device, dtype=dtype) - 0.5
+    return grad_nll, grad_entropy
+
+
+def backward_outputs(outputs, grad_outputs, retain_graph=False):
+    """Backpropagate either the NLL tensor or the NLL/entropy tuple."""
+    outputs = (outputs,) if isinstance(outputs, torch.Tensor) else outputs
+    torch.autograd.backward(outputs, grad_outputs, retain_graph=retain_graph)
 
 
 def setup_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput):
-    """Return ``(x, forward_fn, grad_output)`` for one benchmark point."""
+    """Return ``(x, forward_fn, grad_outputs)`` for one benchmark point."""
     cfg = input.extra_benchmark_config
     if isinstance(input.x, str):
         model_cfg = MODEL_REGISTRY[input.x]
@@ -206,6 +235,7 @@ def setup_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput):
         hidden_size = cfg["hidden_size"]
         vocab_size = cfg["vocab_size"]
         dtype = cfg["dtype"]
+    return_entropy = cfg.get("return_entropy", False)
 
     x = torch.randn(total_tokens, hidden_size, requires_grad=True, dtype=dtype, device=device)
     target = torch.randint(vocab_size, (total_tokens,), dtype=torch.long, device=device)
@@ -216,9 +246,9 @@ def setup_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput):
     elif provider == CUTILE_PREFIX:
         layer = CuTileLMHeadScaledCE(hidden_size, vocab_size, dtype)
     elif provider == SCALED_DEFAULT_PREFIX:
-        layer = DefaultLMHeadScaledCE(hidden_size, vocab_size, dtype)
+        layer = DefaultLMHeadScaledCE(hidden_size, vocab_size, dtype, return_entropy=return_entropy)
     elif provider == SCALED_FALLBACK_PREFIX:
-        layer = FallbackLMHeadScaledCE(hidden_size, vocab_size, dtype)
+        layer = FallbackLMHeadScaledCE(hidden_size, vocab_size, dtype, return_entropy=return_entropy)
     elif provider == "liger":
         layer = TritonLMHeadCE(hidden_size, vocab_size, dtype)
     elif provider == "torch":
@@ -228,10 +258,10 @@ def setup_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput):
 
     layer = layer.to(device)
     weight = layer.weight if hasattr(layer, "weight") else layer.linear.weight
-    return x, weight, lambda: layer(x, target), fixed_grad_output(total_tokens)
+    return x, weight, lambda: layer(x, target), fixed_grad_outputs(total_tokens, dtype, return_entropy)
 
 
-def probe_forward_fn(x, weight, fwd_fn, grad_output):
+def probe_forward_fn(x, weight, fwd_fn, grad_outputs):
     """Adapter for the shared memory-probing helpers (setup returns a 4-tuple)."""
     return fwd_fn()
 
@@ -239,7 +269,7 @@ def probe_forward_fn(x, weight, fwd_fn, grad_output):
 def bench_speed_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
     import triton
 
-    x, weight, fwd_fn, grad_output = setup_fused_scaled_cross_entropy_sm90(input)
+    x, weight, fwd_fn, grad_outputs = setup_fused_scaled_cross_entropy_sm90(input)
     mode = input.kernel_operation_mode
 
     if mode == "forward":
@@ -248,11 +278,11 @@ def bench_speed_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput) 
         y = fwd_fn()
 
         def bench_fn():
-            y.backward(grad_output, retain_graph=True)
+            backward_outputs(y, grad_outputs, retain_graph=True)
     elif mode == "full":
 
         def bench_fn():
-            fwd_fn().backward(grad_output)
+            backward_outputs(fwd_fn(), grad_outputs)
     else:
         raise ValueError(f"Unsupported mode: {mode}")
 
@@ -266,7 +296,7 @@ def bench_speed_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput) 
 
 
 def bench_memory_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput) -> SingleBenchmarkRunOutput:
-    x, weight, fwd_fn, grad_output = setup_fused_scaled_cross_entropy_sm90(input)
+    x, weight, fwd_fn, grad_outputs = setup_fused_scaled_cross_entropy_sm90(input)
     mode = input.kernel_operation_mode
 
     if mode == "forward":
@@ -277,13 +307,13 @@ def bench_memory_fused_scaled_cross_entropy_sm90(input: SingleBenchmarkRunInput)
         def bench_fn():
             x.grad = None
             weight.grad = None
-            y.backward(grad_output, retain_graph=True)
+            backward_outputs(y, grad_outputs, retain_graph=True)
     elif mode == "full":
 
         def bench_fn():
             x.grad = None
             weight.grad = None
-            fwd_fn().backward(grad_output)
+            backward_outputs(fwd_fn(), grad_outputs)
     else:
         raise ValueError(f"Unsupported mode: {mode}")
 
@@ -298,6 +328,11 @@ def parse_sweep_args():
     parser.add_argument("--hidden", type=int, default=None, help="Hidden size (H).")
     parser.add_argument("--vocab", type=int, default=None, help="Vocabulary size (V).")
     parser.add_argument("--providers", type=str, nargs="+", default=None, help="Explicit provider list.")
+    parser.add_argument(
+        "--return-entropy",
+        action="store_true",
+        help="Benchmark scaled NLL and differentiable entropy together (scaled providers only).",
+    )
     if any(flag in ("-h", "--help") for flag in sys.argv[1:]):
         parser.print_help()
         print()
@@ -307,8 +342,11 @@ def parse_sweep_args():
 
 
 def resolve_providers(sweep_args):
-    if sweep_args.providers:
-        for provider in sweep_args.providers:
+    providers = list(sweep_args.providers) if sweep_args.providers else None
+    if sweep_args.return_entropy and providers is None:
+        providers = [SCALED_FALLBACK_PREFIX, SCALED_DEFAULT_PREFIX]
+    if providers:
+        for provider in providers:
             if provider not in (
                 "torch",
                 "liger",
@@ -318,7 +356,11 @@ def resolve_providers(sweep_args):
                 SCALED_FALLBACK_PREFIX,
             ):
                 raise ValueError(f"Unknown provider {provider!r}")
-        return list(sweep_args.providers)
+        if sweep_args.return_entropy:
+            unsupported = [p for p in providers if p not in (SCALED_DEFAULT_PREFIX, SCALED_FALLBACK_PREFIX)]
+            if unsupported:
+                raise ValueError(f"--return-entropy only supports scaled providers, got {unsupported}")
+        return providers
     return ["torch", "liger", CUTILE_PREFIX, CUTEDSL_PREFIX]
 
 
@@ -367,6 +409,9 @@ if __name__ == "__main__":
             common_configs["extra_benchmark_configs"].append(shape)
 
     common_configs["kernel_providers"] = resolve_providers(sweep_args)
+    if sweep_args.return_entropy:
+        for config in common_configs["extra_benchmark_configs"]:
+            config["return_entropy"] = True
 
     run_benchmarks(
         bench_test_fn=bench_speed_fused_scaled_cross_entropy_sm90,

--- a/src/liger_kernel/ops/fused_linear_scaled_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_scaled_cross_entropy.py
@@ -3,11 +3,129 @@
 import math
 
 import torch
+import triton
+import triton.language as tl
+
+from liger_kernel.ops.utils import device_context
+from liger_kernel.utils import infer_device_arch
 
 # The fallback formulas and 512-token chunking are adapted from Verl's
 # Apache-2.0 FusedLinearForPPOFunction:
 # https://github.com/verl-project/verl/blob/main/verl/utils/experimental/torch_functional.py
 _FALLBACK_CHUNK_SIZE = 512
+_MIB = 1024 * 1024
+_SM103_LOGITS_WORKSPACE_BYTES = 512 * _MIB
+_SM103_BLOCK_SIZE = 8192
+_SM103_NUM_WARPS = 8
+_LOG2_E = tl.constexpr(1.4426950408889634)
+
+
+@triton.jit
+def _scaled_cross_entropy_forward_kernel(
+    logits,
+    target,
+    nll,
+    entropy,
+    lse,
+    logits_row_stride: tl.constexpr,
+    vocab_size,
+    inv_temperature: tl.constexpr,
+    ignore_index: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    RETURN_ENTROPY: tl.constexpr,
+):
+    row = tl.program_id(0)
+    row_logits = logits + row * logits_row_stride
+    target_idx = tl.load(target + row)
+    valid = target_idx != ignore_index
+    safe_target = tl.where(valid, target_idx, 0)
+    target_logit = tl.load(row_logits + safe_target).to(tl.float32) * inv_temperature
+
+    running_max = -float("inf")
+    running_sum = 0.0
+    running_weighted_sum = 0.0
+    offsets = tl.arange(0, BLOCK_SIZE)
+    for start in range(0, vocab_size, BLOCK_SIZE):
+        cols = start + offsets
+        mask = cols < vocab_size
+        values = tl.load(row_logits + cols, mask=mask, other=-float("inf")).to(tl.float32)
+        values *= inv_temperature
+        block_max = tl.max(values, axis=0)
+        block_exp = tl.exp2((values - block_max) * _LOG2_E)
+        block_sum = tl.sum(block_exp, axis=0)
+        new_max = tl.maximum(running_max, block_max)
+        previous_scale = tl.exp2((running_max - new_max) * _LOG2_E)
+        block_scale = tl.exp2((block_max - new_max) * _LOG2_E)
+        running_sum = running_sum * previous_scale + block_sum * block_scale
+        if RETURN_ENTROPY:
+            safe_values = tl.where(mask, values, 0.0)
+            block_weighted_sum = tl.sum(block_exp * safe_values, axis=0)
+            running_weighted_sum = running_weighted_sum * previous_scale + block_weighted_sum * block_scale
+        running_max = new_max
+
+    row_lse = running_max + tl.log(running_sum)
+    tl.store(nll + row, tl.where(valid, row_lse - target_logit, 0.0))
+    tl.store(lse + row, tl.where(valid, row_lse, 0.0))
+    if RETURN_ENTROPY:
+        row_entropy = row_lse - running_weighted_sum / running_sum
+        tl.store(entropy + row, tl.where(valid, row_entropy, 0.0))
+
+
+@triton.jit
+def _scaled_cross_entropy_backward_kernel(
+    logits,
+    target,
+    lse,
+    entropy,
+    grad_nll,
+    grad_entropy,
+    logits_row_stride: tl.constexpr,
+    vocab_size,
+    inv_temperature: tl.constexpr,
+    ignore_index: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    HAS_NLL_GRAD: tl.constexpr,
+    HAS_ENTROPY_GRAD: tl.constexpr,
+):
+    row = tl.program_id(0)
+    row_logits = logits + row * logits_row_stride
+    target_idx = tl.load(target + row)
+    valid = target_idx != ignore_index
+    safe_target = tl.where(valid, target_idx, 0)
+    row_lse = tl.load(lse + row)
+
+    row_grad_nll = 0.0
+    if HAS_NLL_GRAD:
+        row_grad_nll = tl.load(grad_nll + row).to(tl.float32)
+    row_entropy = 0.0
+    row_grad_entropy = 0.0
+    if HAS_ENTROPY_GRAD:
+        row_entropy = tl.load(entropy + row).to(tl.float32)
+        row_grad_entropy = tl.load(grad_entropy + row).to(tl.float32)
+
+    offsets = tl.arange(0, BLOCK_SIZE)
+    for start in range(0, vocab_size, BLOCK_SIZE):
+        cols = start + offsets
+        mask = cols < vocab_size
+        raw_logits = tl.load(row_logits + cols, mask=mask, other=0.0).to(tl.float32)
+        scaled_logits = raw_logits * inv_temperature
+        probabilities = tl.exp2((scaled_logits - row_lse) * _LOG2_E)
+
+        grad_scaled_logits = probabilities * row_grad_nll
+        grad_scaled_logits = tl.where(cols == safe_target, grad_scaled_logits - row_grad_nll, grad_scaled_logits)
+        if HAS_ENTROPY_GRAD:
+            log_probabilities = scaled_logits - row_lse
+            grad_scaled_logits -= row_grad_entropy * probabilities * (log_probabilities + row_entropy)
+        grad_raw_logits = tl.where(valid & mask, grad_scaled_logits * inv_temperature, 0.0)
+        tl.store(row_logits + cols, grad_raw_logits, mask=mask)
+
+
+def _calculate_sm103_token_chunk_size(token_count, vocab_size, element_size):
+    max_tokens_per_chunk = max(1, _SM103_LOGITS_WORKSPACE_BYTES // (vocab_size * element_size))
+    if token_count <= max_tokens_per_chunk:
+        return token_count
+    minimum_chunks = (token_count + max_tokens_per_chunk - 1) // max_tokens_per_chunk
+    return (token_count + minimum_chunks - 1) // minimum_chunks
 
 
 def _load_sm90_function():
@@ -148,13 +266,180 @@ class _FusedLinearPPOFallbackFunction(torch.autograd.Function):
         return grad_hidden_states, grad_vocab_weights, None, None, None, None
 
 
-def _resolve_implementation(device):
+def _sm103_forward(hidden_states, vocab_weights, input_ids, temperature, ignore_index, return_entropy):
+    token_count = hidden_states.shape[0]
+    vocab_size = vocab_weights.shape[0]
+    chunk_size = _calculate_sm103_token_chunk_size(
+        token_count,
+        vocab_size,
+        hidden_states.element_size(),
+    )
+    nll = torch.empty(token_count, dtype=torch.float32, device=hidden_states.device)
+    entropy = hidden_states.new_empty(token_count) if return_entropy else None
+    lse = torch.empty(token_count, dtype=torch.float32, device=hidden_states.device)
+    logits_workspace = torch.empty(
+        min(token_count, chunk_size),
+        vocab_size,
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+    dummy_entropy = hidden_states.new_empty(1)
+
+    with device_context(hidden_states.device):
+        for start in range(0, token_count, chunk_size):
+            end = min(start + chunk_size, token_count)
+            logits_chunk = logits_workspace[: end - start]
+            torch.mm(hidden_states[start:end], vocab_weights.t(), out=logits_chunk)
+            _scaled_cross_entropy_forward_kernel[(end - start,)](
+                logits_chunk,
+                input_ids[start:end],
+                nll[start:end],
+                entropy[start:end] if entropy is not None else dummy_entropy,
+                lse[start:end],
+                logits_chunk.stride(0),
+                vocab_size,
+                1.0 / temperature,
+                ignore_index,
+                BLOCK_SIZE=_SM103_BLOCK_SIZE,
+                RETURN_ENTROPY=return_entropy,
+                num_warps=_SM103_NUM_WARPS,
+            )
+
+    return nll, entropy, lse
+
+
+def _sm103_backward(
+    grad_nll,
+    grad_entropy,
+    hidden_states,
+    vocab_weights,
+    input_ids,
+    lse,
+    entropy,
+    temperature,
+    ignore_index,
+    needs_input_grad,
+    needs_weight_grad,
+):
+    token_count = hidden_states.shape[0]
+    vocab_size = vocab_weights.shape[0]
+    chunk_size = _calculate_sm103_token_chunk_size(
+        token_count,
+        vocab_size,
+        hidden_states.element_size(),
+    )
+    logits_workspace = torch.empty(
+        min(token_count, chunk_size),
+        vocab_size,
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+    grad_hidden_states = torch.empty_like(hidden_states) if needs_input_grad else None
+    grad_vocab_weights = torch.empty_like(vocab_weights) if needs_weight_grad else None
+    dummy_f32 = torch.empty(1, dtype=torch.float32, device=hidden_states.device)
+    dummy_input_dtype = hidden_states.new_empty(1)
+
+    grad_nll = grad_nll.contiguous() if grad_nll is not None else None
+    grad_entropy = grad_entropy.contiguous() if grad_entropy is not None else None
+
+    with device_context(hidden_states.device):
+        for start in range(0, token_count, chunk_size):
+            end = min(start + chunk_size, token_count)
+            hidden_chunk = hidden_states[start:end]
+            grad_logits_chunk = logits_workspace[: end - start]
+            torch.mm(hidden_chunk, vocab_weights.t(), out=grad_logits_chunk)
+            _scaled_cross_entropy_backward_kernel[(end - start,)](
+                grad_logits_chunk,
+                input_ids[start:end],
+                lse[start:end],
+                entropy[start:end] if entropy is not None else dummy_input_dtype,
+                grad_nll[start:end] if grad_nll is not None else dummy_f32,
+                grad_entropy[start:end] if grad_entropy is not None else dummy_input_dtype,
+                grad_logits_chunk.stride(0),
+                vocab_size,
+                1.0 / temperature,
+                ignore_index,
+                BLOCK_SIZE=_SM103_BLOCK_SIZE,
+                HAS_NLL_GRAD=grad_nll is not None,
+                HAS_ENTROPY_GRAD=grad_entropy is not None,
+                num_warps=_SM103_NUM_WARPS,
+            )
+
+            if grad_hidden_states is not None:
+                torch.mm(grad_logits_chunk, vocab_weights, out=grad_hidden_states[start:end])
+            if grad_vocab_weights is not None:
+                if start == 0:
+                    torch.mm(grad_logits_chunk.t(), hidden_chunk, out=grad_vocab_weights)
+                else:
+                    torch.addmm(
+                        grad_vocab_weights,
+                        grad_logits_chunk.t(),
+                        hidden_chunk,
+                        out=grad_vocab_weights,
+                    )
+
+    return grad_hidden_states, grad_vocab_weights
+
+
+class _FusedLinearScaledCrossEntropySM103Function(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, hidden_states, vocab_weights, input_ids, temperature, ignore_index, return_entropy):
+        ctx.set_materialize_grads(False)
+        _validate_fallback_inputs(hidden_states, vocab_weights, input_ids, ignore_index)
+        _validate_temperature(temperature)
+
+        input_ids = input_ids.contiguous()
+        nll, entropy, lse = _sm103_forward(
+            hidden_states,
+            vocab_weights,
+            input_ids,
+            temperature,
+            ignore_index,
+            return_entropy,
+        )
+        saved_entropy = entropy if entropy is not None else hidden_states.new_empty(0)
+        ctx.save_for_backward(hidden_states, vocab_weights, input_ids, lse, saved_entropy)
+        ctx.temperature = temperature
+        ctx.ignore_index = ignore_index
+        ctx.return_entropy = return_entropy
+        return (nll, entropy) if return_entropy else nll
+
+    @staticmethod
+    def backward(ctx, grad_nll, grad_entropy=None):
+        hidden_states, vocab_weights, input_ids, lse, entropy = ctx.saved_tensors
+        grad_hidden_states, grad_vocab_weights = _sm103_backward(
+            grad_nll,
+            grad_entropy,
+            hidden_states,
+            vocab_weights,
+            input_ids,
+            lse,
+            entropy if ctx.return_entropy else None,
+            ctx.temperature,
+            ctx.ignore_index,
+            ctx.needs_input_grad[0],
+            ctx.needs_input_grad[1],
+        )
+        return grad_hidden_states, grad_vocab_weights, None, None, None, None
+
+
+def _device_id(device):
+    return device.index if device.index is not None else torch.cuda.current_device()
+
+
+def _resolve_implementation(device, dtype=None):
     if device.type != "cuda" or not torch.cuda.is_available() or torch.version.hip is not None:
         return _FusedLinearPPOFallbackFunction
 
     capability = torch.cuda.get_device_capability(device)
     if capability == (9, 0):
         return _load_sm90_function()
+    if (
+        capability == (10, 3)
+        and dtype in (torch.float16, torch.bfloat16, torch.float32)
+        and infer_device_arch(_device_id(device)) == "blackwell_ultra"
+    ):
+        return _FusedLinearScaledCrossEntropySM103Function
     return _FusedLinearPPOFallbackFunction
 
 
@@ -178,8 +463,8 @@ class LigerFusedLinearScaledCrossEntropyFunction:
         if not isinstance(return_entropy, bool):
             raise TypeError("return_entropy must be a bool")
 
-        implementation = _resolve_implementation(_input.device)
-        if implementation is _FusedLinearPPOFallbackFunction:
+        implementation = _resolve_implementation(_input.device, _input.dtype)
+        if implementation in (_FusedLinearPPOFallbackFunction, _FusedLinearScaledCrossEntropySM103Function):
             return implementation.apply(
                 _input,
                 weight,

--- a/test/transformers/test_fused_linear_scaled_cross_entropy.py
+++ b/test/transformers/test_fused_linear_scaled_cross_entropy.py
@@ -353,6 +353,67 @@ def test_sm103_matches_fp32_reference(dtype, shape, temperature, gradient_mode):
         torch.testing.assert_close(actual_grad.float(), expected_grad.float(), atol=atol, rtol=rtol)
 
 
+def test_sm103_multichunk_ragged_tail_matches_fp32_reference(monkeypatch):
+    _require_sm103()
+    if not torch.cuda.is_bf16_supported():
+        pytest.skip("BF16 is not supported")
+
+    token_count, hidden_size, vocab_size = 7, 33, 257
+    dtype = torch.bfloat16
+    temperature = 0.8
+    generator = torch.Generator(device="cuda").manual_seed(49)
+    hidden_data = torch.randn(token_count, hidden_size, device="cuda", dtype=dtype, generator=generator) * 0.25
+    weight_data = (
+        torch.randn(vocab_size, hidden_size, device="cuda", dtype=dtype, generator=generator) / hidden_size**0.5
+    )
+    target = torch.randint(vocab_size, (token_count,), device="cuda", generator=generator)
+    target[::4] = -100
+    grad_nll = torch.randn(token_count, device="cuda", dtype=torch.float32, generator=generator)
+    grad_entropy = torch.randn(token_count, device="cuda", dtype=dtype, generator=generator)
+
+    workspace_bytes = 3 * vocab_size * hidden_data.element_size()
+    monkeypatch.setattr(_FRONTEND, "_SM103_LOGITS_WORKSPACE_BYTES", workspace_bytes)
+    assert _FRONTEND._calculate_sm103_token_chunk_size(token_count, vocab_size, hidden_data.element_size()) == 3
+
+    actual_hidden = hidden_data.clone().requires_grad_(True)
+    actual_weight = weight_data.clone().requires_grad_(True)
+    actual_nll, actual_entropy = _FRONTEND.LigerFusedLinearScaledCrossEntropyFunction.apply(
+        actual_hidden,
+        actual_weight,
+        target,
+        temperature,
+        -100,
+        1,
+        True,
+    )
+    actual_grads = torch.autograd.grad(
+        (actual_nll, actual_entropy),
+        (actual_hidden, actual_weight),
+        (grad_nll, grad_entropy),
+    )
+
+    expected_hidden = hidden_data.float().requires_grad_(True)
+    expected_weight = weight_data.float().requires_grad_(True)
+    expected_nll, expected_entropy = _scaled_ce_reference(
+        expected_hidden,
+        expected_weight,
+        target,
+        temperature,
+        True,
+    )
+    expected_grads = torch.autograd.grad(
+        (expected_nll, expected_entropy),
+        (expected_hidden, expected_weight),
+        (grad_nll, grad_entropy.float()),
+    )
+
+    atol, rtol = 8e-2, 5e-2
+    torch.testing.assert_close(actual_nll, expected_nll, atol=atol, rtol=rtol)
+    torch.testing.assert_close(actual_entropy.float(), expected_entropy, atol=atol, rtol=rtol)
+    for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+        torch.testing.assert_close(actual_grad.float(), expected_grad, atol=atol, rtol=rtol)
+
+
 def test_sm103_noncontiguous_inputs_partial_grads_repeated_backward_and_context(monkeypatch):
     _require_sm103()
     generator = torch.Generator(device="cuda").manual_seed(47)

--- a/test/transformers/test_fused_linear_scaled_cross_entropy.py
+++ b/test/transformers/test_fused_linear_scaled_cross_entropy.py
@@ -63,7 +63,7 @@ def test_frontend_uses_fallback_for_unsupported_nvidia_compute_capability(monkey
 
 def test_frontend_dispatches_sm90_and_forwards_arguments(monkeypatch):
     device = torch.device("cuda:3")
-    _input = SimpleNamespace(device=device)
+    _input = SimpleNamespace(device=device, dtype=torch.bfloat16)
     weight = object()
     target = object()
     calls = []

--- a/test/transformers/test_fused_linear_scaled_cross_entropy.py
+++ b/test/transformers/test_fused_linear_scaled_cross_entropy.py
@@ -1,6 +1,7 @@
 import importlib.util
 import os
 
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -92,6 +93,79 @@ def test_frontend_dispatches_sm90_and_forwards_arguments(monkeypatch):
     assert calls == [(_input, weight, target, 0.7, -1, 3, True)]
 
 
+def test_frontend_dispatches_sm103_from_nondefault_input_device(monkeypatch):
+    device = torch.device("cuda:7")
+    seen_capability = []
+    seen_arch = []
+
+    monkeypatch.setattr(_FRONTEND.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(_FRONTEND.torch.version, "hip", None)
+    monkeypatch.setattr(
+        _FRONTEND.torch.cuda,
+        "get_device_capability",
+        lambda actual: seen_capability.append(actual) or (10, 3),
+    )
+    monkeypatch.setattr(
+        _FRONTEND,
+        "infer_device_arch",
+        lambda device_id: seen_arch.append(device_id) or "blackwell_ultra",
+    )
+
+    assert (
+        _FRONTEND._resolve_implementation(device, torch.bfloat16)
+        is _FRONTEND._FusedLinearScaledCrossEntropySM103Function
+    )
+    assert seen_capability == [device]
+    assert seen_arch == [7]
+
+
+@pytest.mark.parametrize(
+    ("capability", "architecture"),
+    [
+        ((10, 0), "blackwell"),
+        ((12, 0), "blackwell_consumer"),
+        ((10, 3), "cuda"),
+    ],
+)
+def test_frontend_keeps_non_sm103_devices_on_existing_paths(monkeypatch, capability, architecture):
+    monkeypatch.setattr(_FRONTEND.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(_FRONTEND.torch.version, "hip", None)
+    monkeypatch.setattr(_FRONTEND.torch.cuda, "get_device_capability", lambda _: capability)
+    monkeypatch.setattr(_FRONTEND, "infer_device_arch", lambda _: architecture)
+
+    assert _FRONTEND._resolve_implementation(torch.device("cuda:2")) is _FRONTEND._FusedLinearPPOFallbackFunction
+
+
+def test_frontend_keeps_unsupported_dtype_on_fallback(monkeypatch):
+    monkeypatch.setattr(_FRONTEND.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(_FRONTEND.torch.version, "hip", None)
+    monkeypatch.setattr(_FRONTEND.torch.cuda, "get_device_capability", lambda _: (10, 3))
+    monkeypatch.setattr(
+        _FRONTEND,
+        "infer_device_arch",
+        lambda _: pytest.fail("architecture lookup is unnecessary for an unsupported dtype"),
+    )
+
+    assert (
+        _FRONTEND._resolve_implementation(torch.device("cuda:2"), torch.float64)
+        is _FRONTEND._FusedLinearPPOFallbackFunction
+    )
+
+
+@pytest.mark.parametrize(
+    ("token_count", "vocab_size", "element_size", "expected"),
+    [
+        (1, 131072, 2, 1),
+        (2048, 131072, 2, 2048),
+        (4096, 131072, 2, 2048),
+        (4097, 131072, 2, 1366),
+        (4096, 65536, 4, 2048),
+    ],
+)
+def test_sm103_token_chunk_size_is_bounded_and_balanced(token_count, vocab_size, element_size, expected):
+    assert _FRONTEND._calculate_sm103_token_chunk_size(token_count, vocab_size, element_size) == expected
+
+
 def test_frontend_fallback_matches_torch_with_entropy_and_ignored_rows():
     torch.manual_seed(42)
     token_count, hidden_size, vocab_size = 521, 7, 13
@@ -171,6 +245,202 @@ def test_frontend_fallback_supports_entropy_only_backward():
 
     assert _input.grad is not None
     assert weight.grad is not None
+
+
+def _require_sm103():
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    device_id = torch.cuda.current_device()
+    if torch.cuda.get_device_capability(device_id) != (10, 3):
+        pytest.skip("requires SM103")
+
+
+def _scaled_ce_reference(hidden, weight, target, temperature, return_entropy):
+    logits = hidden.float() @ weight.float().t()
+    logits /= temperature
+    valid = target != -100
+    safe_target = target.masked_fill(~valid, 0)
+    log_probs = logits.log_softmax(dim=-1)
+    nll = torch.where(
+        valid,
+        -log_probs.gather(-1, safe_target.unsqueeze(-1)).squeeze(-1),
+        torch.zeros_like(log_probs[:, 0]),
+    )
+    if not return_entropy:
+        return nll
+    entropy = torch.where(
+        valid,
+        -(log_probs.exp() * log_probs).sum(dim=-1),
+        torch.zeros_like(log_probs[:, 0]),
+    ).to(hidden.dtype)
+    return nll, entropy
+
+
+@pytest.mark.parametrize(
+    ("dtype", "shape", "temperature"),
+    [
+        (torch.float32, (17, 31, 257), 0.5),
+        (torch.float16, (7, 33, 32769), 1.0),
+        (torch.bfloat16, (16, 64, 4096), 0.8),
+        (torch.bfloat16, (2, 16, 131072), 1.7),
+    ],
+    ids=["fp32-ragged", "fp16-wide-ragged", "bf16-power-of-two", "bf16-large-vocab"],
+)
+@pytest.mark.parametrize("gradient_mode", ["nll", "entropy", "mixed"])
+def test_sm103_matches_fp32_reference(dtype, shape, temperature, gradient_mode):
+    _require_sm103()
+    if dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
+        pytest.skip("BF16 is not supported")
+
+    token_count, hidden_size, vocab_size = shape
+    generator = torch.Generator(device="cuda").manual_seed(token_count + vocab_size)
+    hidden_data = torch.randn(token_count, hidden_size, device="cuda", dtype=dtype, generator=generator) * 0.25
+    weight_data = (
+        torch.randn(vocab_size, hidden_size, device="cuda", dtype=dtype, generator=generator) / hidden_size**0.5
+    )
+    target = torch.randint(vocab_size, (token_count,), device="cuda", generator=generator)
+    target[::5] = -100
+    grad_nll = torch.randn(token_count, device="cuda", dtype=torch.float32, generator=generator)
+    grad_entropy = torch.randn(token_count, device="cuda", dtype=dtype, generator=generator)
+    return_entropy = gradient_mode != "nll"
+
+    actual_hidden = hidden_data.clone().requires_grad_(True)
+    actual_weight = weight_data.clone().requires_grad_(True)
+    actual = _FRONTEND.LigerFusedLinearScaledCrossEntropyFunction.apply(
+        actual_hidden,
+        actual_weight,
+        target,
+        temperature,
+        -100,
+        1,
+        return_entropy,
+    )
+    if gradient_mode == "nll":
+        actual_outputs = (actual,)
+        actual_grad_outputs = (grad_nll,)
+    elif gradient_mode == "entropy":
+        actual_outputs = (actual[1],)
+        actual_grad_outputs = (grad_entropy,)
+    else:
+        actual_outputs = actual
+        actual_grad_outputs = (grad_nll, grad_entropy)
+    actual_grads = torch.autograd.grad(actual_outputs, (actual_hidden, actual_weight), actual_grad_outputs)
+
+    expected_hidden = hidden_data.float().requires_grad_(True)
+    expected_weight = weight_data.float().requires_grad_(True)
+    expected = _scaled_ce_reference(expected_hidden, expected_weight, target, temperature, return_entropy)
+    if gradient_mode == "nll":
+        expected_outputs = (expected,)
+        expected_grad_outputs = (grad_nll,)
+    elif gradient_mode == "entropy":
+        expected_outputs = (expected[1],)
+        expected_grad_outputs = (grad_entropy.float(),)
+    else:
+        expected_outputs = expected
+        expected_grad_outputs = (grad_nll, grad_entropy.float())
+    expected_grads = torch.autograd.grad(expected_outputs, (expected_hidden, expected_weight), expected_grad_outputs)
+
+    atol, rtol = {
+        torch.float32: (6e-5, 6e-5),
+        torch.float16: (3e-2, 3e-2),
+        torch.bfloat16: (8e-2, 5e-2),
+    }[dtype]
+    actual_all_outputs = actual if return_entropy else (actual,)
+    expected_all_outputs = expected if return_entropy else (expected,)
+    for actual_output, expected_output in zip(actual_all_outputs, expected_all_outputs):
+        torch.testing.assert_close(actual_output.float(), expected_output.float(), atol=atol, rtol=rtol)
+    for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+        torch.testing.assert_close(actual_grad.float(), expected_grad.float(), atol=atol, rtol=rtol)
+
+
+def test_sm103_noncontiguous_inputs_partial_grads_repeated_backward_and_context(monkeypatch):
+    _require_sm103()
+    generator = torch.Generator(device="cuda").manual_seed(47)
+    hidden_base = torch.randn(11, 66, device="cuda", dtype=torch.bfloat16, generator=generator)
+    weight_base = torch.randn(259, 66, device="cuda", dtype=torch.bfloat16, generator=generator)
+    hidden = hidden_base[:, ::2].requires_grad_(True)
+    weight = weight_base[:, ::2]
+    target = torch.randint(259, (22,), device="cuda", generator=generator)[::2]
+    grad = torch.randn(22, device="cuda", dtype=torch.float32, generator=generator)[::2]
+    hidden_before = hidden.detach().clone()
+    weight_before = weight.detach().clone()
+    seen_devices = []
+    real_device_context = _FRONTEND.device_context
+
+    @contextmanager
+    def recording_device_context(device):
+        seen_devices.append(torch.device(device))
+        with real_device_context(device):
+            yield
+
+    monkeypatch.setattr(_FRONTEND, "device_context", recording_device_context)
+    output = _FRONTEND.LigerFusedLinearScaledCrossEntropyFunction.apply(hidden, weight, target, 1.0, -100, 1, False)
+    first_grad = torch.autograd.grad(output, hidden, grad, retain_graph=True)[0]
+    second_grad = torch.autograd.grad(output, hidden, grad)[0]
+
+    assert not hidden.is_contiguous()
+    assert not weight.is_contiguous()
+    assert not target.is_contiguous()
+    assert not grad.is_contiguous()
+    assert output.shape == target.shape
+    assert output.dtype == torch.float32
+    torch.testing.assert_close(first_grad, second_grad, atol=0, rtol=0)
+    torch.testing.assert_close(hidden, hidden_before, atol=0, rtol=0)
+    torch.testing.assert_close(weight, weight_before, atol=0, rtol=0)
+    assert seen_devices == [hidden.device, hidden.device, hidden.device]
+
+
+def test_sm103_all_ignored_rows_return_zero_outputs_and_gradients():
+    _require_sm103()
+    hidden = torch.randn(5, 17, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    weight = torch.randn(513, 17, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    target = torch.full((5,), -100, device="cuda", dtype=torch.int64)
+
+    nll, entropy = _FRONTEND.LigerFusedLinearScaledCrossEntropyFunction.apply(
+        hidden,
+        weight,
+        target,
+        1.0,
+        -100,
+        1,
+        True,
+    )
+    torch.autograd.backward((nll, entropy), (torch.randn_like(nll), torch.randn_like(entropy)))
+
+    assert torch.count_nonzero(nll) == 0
+    assert torch.count_nonzero(entropy) == 0
+    assert torch.count_nonzero(hidden.grad) == 0
+    assert torch.count_nonzero(weight.grad) == 0
+
+
+def test_sm103_weight_only_gradient_and_compiled_forward_match_eager():
+    _require_sm103()
+    from liger_kernel.ops.fused_linear_scaled_cross_entropy import LigerFusedLinearScaledCrossEntropyFunction
+
+    generator = torch.Generator(device="cuda").manual_seed(48)
+    hidden = torch.randn(13, 35, device="cuda", dtype=torch.bfloat16, generator=generator)
+    weight = torch.randn(1023, 35, device="cuda", dtype=torch.bfloat16, generator=generator).requires_grad_(True)
+    target = torch.randint(1023, (13,), device="cuda", generator=generator)
+    grad = torch.randn(13, device="cuda", dtype=torch.float32, generator=generator)
+
+    def forward(input_, weight_, labels):
+        return LigerFusedLinearScaledCrossEntropyFunction.apply(
+            input_,
+            weight_,
+            labels,
+            0.8,
+            -100,
+            1,
+            False,
+        )
+
+    eager = forward(hidden, weight, target)
+    eager_grad = torch.autograd.grad(eager, weight, grad, retain_graph=True)[0]
+    compiled = torch.compile(forward)(hidden, weight, target)
+    compiled_grad = torch.autograd.grad(compiled, weight, grad)[0]
+
+    torch.testing.assert_close(compiled, eager, atol=0, rtol=0)
+    torch.testing.assert_close(compiled_grad, eager_grad, atol=0, rtol=0)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="cuTile requires CUDA")

--- a/test/transformers/test_fused_linear_scaled_cross_entropy.py
+++ b/test/transformers/test_fused_linear_scaled_cross_entropy.py
@@ -247,12 +247,31 @@ def test_frontend_fallback_supports_entropy_only_backward():
     assert weight.grad is not None
 
 
-def _require_sm103():
+def _force_sm103_candidate(monkeypatch):
+    """Exercise the generic SM103 candidate on any NVIDIA CUDA GPU.
+
+    As in #1271, CI forces this test-only dispatch because the Triton kernels and
+    ``torch.mm`` calls use no SM103-only instructions. Production dispatch remains
+    restricted to exact SM103 Blackwell Ultra devices.
+    """
     if not torch.cuda.is_available():
-        pytest.skip("requires CUDA")
-    device_id = torch.cuda.current_device()
-    if torch.cuda.get_device_capability(device_id) != (10, 3):
-        pytest.skip("requires SM103")
+        pytest.skip("requires NVIDIA CUDA")
+    if torch.version.hip is not None:
+        pytest.skip("requires NVIDIA CUDA")
+
+    import liger_kernel.ops.fused_linear_scaled_cross_entropy as canonical_frontend
+
+    monkeypatch.setattr(
+        _FRONTEND,
+        "_resolve_implementation",
+        lambda _device, _dtype=None: _FRONTEND._FusedLinearScaledCrossEntropySM103Function,
+    )
+    monkeypatch.setattr(
+        canonical_frontend,
+        "_resolve_implementation",
+        lambda _device, _dtype=None: canonical_frontend._FusedLinearScaledCrossEntropySM103Function,
+    )
+    return canonical_frontend
 
 
 def _scaled_ce_reference(hidden, weight, target, temperature, return_entropy):
@@ -287,8 +306,8 @@ def _scaled_ce_reference(hidden, weight, target, temperature, return_entropy):
     ids=["fp32-ragged", "fp16-wide-ragged", "bf16-power-of-two", "bf16-large-vocab"],
 )
 @pytest.mark.parametrize("gradient_mode", ["nll", "entropy", "mixed"])
-def test_sm103_matches_fp32_reference(dtype, shape, temperature, gradient_mode):
-    _require_sm103()
+def test_sm103_matches_fp32_reference(monkeypatch, dtype, shape, temperature, gradient_mode):
+    _force_sm103_candidate(monkeypatch)
     if dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
         pytest.skip("BF16 is not supported")
 
@@ -354,7 +373,7 @@ def test_sm103_matches_fp32_reference(dtype, shape, temperature, gradient_mode):
 
 
 def test_sm103_multichunk_ragged_tail_matches_fp32_reference(monkeypatch):
-    _require_sm103()
+    _force_sm103_candidate(monkeypatch)
     if not torch.cuda.is_bf16_supported():
         pytest.skip("BF16 is not supported")
 
@@ -415,7 +434,7 @@ def test_sm103_multichunk_ragged_tail_matches_fp32_reference(monkeypatch):
 
 
 def test_sm103_noncontiguous_inputs_partial_grads_repeated_backward_and_context(monkeypatch):
-    _require_sm103()
+    _force_sm103_candidate(monkeypatch)
     generator = torch.Generator(device="cuda").manual_seed(47)
     hidden_base = torch.randn(11, 66, device="cuda", dtype=torch.bfloat16, generator=generator)
     weight_base = torch.randn(259, 66, device="cuda", dtype=torch.bfloat16, generator=generator)
@@ -451,8 +470,8 @@ def test_sm103_noncontiguous_inputs_partial_grads_repeated_backward_and_context(
     assert seen_devices == [hidden.device, hidden.device, hidden.device]
 
 
-def test_sm103_all_ignored_rows_return_zero_outputs_and_gradients():
-    _require_sm103()
+def test_sm103_all_ignored_rows_return_zero_outputs_and_gradients(monkeypatch):
+    _force_sm103_candidate(monkeypatch)
     hidden = torch.randn(5, 17, device="cuda", dtype=torch.bfloat16, requires_grad=True)
     weight = torch.randn(513, 17, device="cuda", dtype=torch.bfloat16, requires_grad=True)
     target = torch.full((5,), -100, device="cuda", dtype=torch.int64)
@@ -474,9 +493,9 @@ def test_sm103_all_ignored_rows_return_zero_outputs_and_gradients():
     assert torch.count_nonzero(weight.grad) == 0
 
 
-def test_sm103_weight_only_gradient_and_compiled_forward_match_eager():
-    _require_sm103()
-    from liger_kernel.ops.fused_linear_scaled_cross_entropy import LigerFusedLinearScaledCrossEntropyFunction
+def test_sm103_weight_only_gradient_and_compiled_forward_match_eager(monkeypatch):
+    canonical_frontend = _force_sm103_candidate(monkeypatch)
+    fused_scaled_ce = canonical_frontend.LigerFusedLinearScaledCrossEntropyFunction
 
     generator = torch.Generator(device="cuda").manual_seed(48)
     hidden = torch.randn(13, 35, device="cuda", dtype=torch.bfloat16, generator=generator)
@@ -485,7 +504,7 @@ def test_sm103_weight_only_gradient_and_compiled_forward_match_eager():
     grad = torch.randn(13, device="cuda", dtype=torch.float32, generator=generator)
 
     def forward(input_, weight_, labels):
-        return LigerFusedLinearScaledCrossEntropyFunction.apply(
+        return fused_scaled_ce.apply(
             input_,
             weight_,
             labels,


### PR DESCRIPTION
## Summary

The default fused scaled cross-entropy frontend currently routes exact SM103 to its 512-token PyTorch fallback. That path repeatedly materializes full-vocabulary FP32 probabilities, log probabilities, entropy intermediates, and gradients.

This change adds an exact-SM103 Triton path that uses one bounded 512 MiB low-precision logits/dlogits workspace:

- forward projects one token chunk at a time and uses a fused online max/sum/weighted-sum row reduction to emit FP32 NLL/LSE plus optional input-dtype entropy;
- backward recomputes the projection once, overwrites the same workspace with dlogits using arbitrary signed NLL/entropy upstream gradients, then uses PyTorch GEMMs for dX/dW;
- dispatch resolves compute capability and `blackwell_ultra` from the actual input device, and runs the complete path in that device context;
- SM90 CuTe DSL, opt-in cuTile, non-SM103 CUDA, ROCm, and CPU behavior remain unchanged.

The fixed production schedule is `BLOCK_SIZE=8192`, `num_warps=8`. The workspace policy was selected from the predeclared 256/512/1024 MiB sweep.

This PR addresses [fork issue #20](https://github.com/heiheiha798/Liger-Kernel/issues/20). The original engineering record remains in [fork draft PR #21](https://github.com/heiheiha798/Liger-Kernel/pull/21).

## Details

### Scope

- `src/liger_kernel/ops/fused_linear_scaled_cross_entropy.py`
- `test/transformers/test_fused_linear_scaled_cross_entropy.py`
- `benchmark/scripts/benchmark_fused_scaled_cross_entropy_sm90.py`

The benchmark extension adds `scaled-default` and `scaled-fallback` providers with identical per-token semantics and fixed independent NLL/entropy upstream gradients. NLL-only remains the default; `--return-entropy` reproduces the combined workload. No benchmark data is committed.

### B300 Profile

Environment: NVIDIA B300 SXM6 AC, SM103/CC 10.3, driver 580.126.09, CUDA 13.0, PyTorch 2.13.0+cu130, Triton 3.7.1.

The clean baseline gate in Slurm job 5117 compared the public fallback with opt-in cuTile and optimized PyTorch at BF16 `H=4096`, `V=131072`, `M={2048,4096,8192,16384}`, entropy off/on. Public full-pass geomeans were:

- fallback / cuTile: **3.179x** (minimum 2.593x)
- fallback / PyTorch: **2.236x** (minimum 2.027x)

The baseline timeline showed the repeated full-vocabulary eager chain. Exact-head profiling in job 5139 at BF16 `M=8192,H=4096,V=128256`, entropy enabled, reduced device events from 2,132 / 164.85 ms aggregate to 66 / 39.81 ms aggregate. The candidate uses four forward and four backward Triton row kernels, matching four 2048-token workspace chunks.

NCU for those candidate kernels:

| Kernel | Aggregate duration | Registers/thread | Achieved occupancy | DRAM read/write | SM throughput | Local spills |
|---|---:|---:|---:|---:|---:|---:|
| forward (4 launches) | 1.015 ms | 80 | 35.21% | 2101.8 / 14.3 MiB | 66.79% | 0 |
| backward (4 launches) | 1.202 ms | 42 | 54.46% | 2101.9 / 1864.6 MiB | 73.43% | 0 |

### Exact-Source Performance

Slurm job 5129 ran clean detached baseline `7c454f488ea522bdf408991543af922685ecebb1` and kernel candidate `95ebb42044507a6aec4ef36bd59f7c27f9b0650c` in fresh processes on the same B300 allocation. Providers alternated for seven rounds with identical immutable inputs and signed upstream gradients; compilation was excluded. Values below are paired-round median direct-full latency. Later commits change only tests and the tracked reproduction CLI, not the measured kernel source.

#### Token sweep: BF16, H=4096, V=128256, entropy enabled

| Tokens | Baseline ms | Candidate ms | Speedup | Baseline MiB | Candidate MiB | Memory ratio |
|---:|---:|---:|---:|---:|---:|---:|
| 1024 | 10.783 | 2.871 | 3.755x | 4150.0 | 1260.5 | 3.292x |
| 2048 | 21.127 | 5.105 | 4.137x | 4158.0 | 1520.0 | 2.736x |
| 4096 | 41.889 | 11.310 | 3.710x | 4173.3 | 1536.0 | 2.717x |
| 8192 | 83.450 | 24.856 | 3.356x | 4205.4 | 1568.1 | 2.682x |
| 16384 | 167.227 | 49.924 | 3.350x | 4270.2 | 1632.2 | 2.616x |
| 32768 | 334.385 | 97.563 | 3.427x | 4398.5 | 1760.3 | 2.499x |
| 65536 | 668.602 | 205.885 | 3.248x | 4654.9 | 2016.6 | 2.308x |

#### Vocab sweep: BF16, M=8192, H=4096, entropy enabled

| Vocab | Baseline ms | Candidate ms | Speedup | Baseline MiB | Candidate MiB | Memory ratio |
|---:|---:|---:|---:|---:|---:|---:|
| 32000 | 22.745 | 5.328 | 4.269x | 1104.1 | 814.1 | 1.356x |
| 102400 | 67.119 | 19.626 | 3.420x | 3372.1 | 1264.1 | 2.668x |
| 128256 | 83.450 | 24.856 | 3.356x | 4205.4 | 1568.1 | 2.682x |
| 152064 | 99.085 | 32.728 | 3.026x | 4976.6 | 1728.1 | 2.880x |
| 201088 | 129.309 | 41.295 | 3.133x | 6555.5 | 2086.1 | 3.142x |
| 262144 | 166.829 | 52.457 | 3.183x | 8520.1 | 2624.1 | 3.247x |

Across all primary points:

- forward geomean: **4.050x token**, **4.048x vocab**;
- backward geomean: **3.542x token**, **3.343x vocab**;
- direct-full geomean: **3.558x token**, **3.379x vocab**;
- minimum measured control ratio: **1.328x**; no declared point regressed.

## Testing Done

- Hardware Type: NVIDIA B300 SXM6 AC
- [ ] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence

Final head `8b0b38b1ba06ddc74f8c77138a0473eaa9396540`:

- job 7277: repaired-head targeted SM103 subset **25 passed, 29 deselected** on B300;
- job 7281: repaired-head complete target file **35 passed, 19 skipped** on B300; the skips are the expected opt-in cuTile cases;
- all-files Ruff 0.14.11 check and format check passed (**373 files**), and `git diff --check` passed.

The repaired tests force the ordinary `torch.mm` plus Triton candidate only in the test process on any NVIDIA CUDA GPU, following the merged [Blackwell SwiGLU precedent #1271](https://github.com/linkedin/Liger-Kernel/pull/1271). The production source is unchanged from `3b4bb597878a5bdfd74c89dd157dec422ed01252`: dispatch still requires exact capability `(10, 3)`, a supported floating dtype, and `blackwell_ultra`. Upstream merge-queue H100 correctness has **not run yet**; the repaired suite makes the candidate path reachable when that H100 workflow runs.

Earlier exact-source B300 validation remains:

- job 5155 at `3b4bb597878a5bdfd74c89dd157dec422ed01252`: default target file **35 passed, 19 skipped**, including a forced BF16 `3+3+1` chunk/tail oracle that compares NLL, entropy, dX, and dW to independent FP32 PyTorch; `make checkstyle` passed; the tracked entropy-enabled CLI completed forward/backward/full speed and memory for both scaled providers;
- job 5136: opt-in cuTile target file **53 passed**; affected Llama/Qwen2 monkey-patch tests **12 passed**; BF16 mini Llama3/Qwen2 and VL convergence **4 passed**;
- job 5139: exact-source timeline and NCU completed.

The oracle coverage includes FP32/BF16/FP16, temperatures 0.5/0.8/1.0/1.7, NLL-only/entropy-only/mixed signed gradients, ignore mixtures/all ignored/invalid targets, ragged and V=131072 shapes, multi-chunk dW accumulation with a ragged tail, partial gradients, repeated backward, `torch.compile`, non-contiguous inputs, and actual-device dispatch/context.

### Reproduction

```bash
# Headline entropy-enabled workload
cd benchmark/scripts
python benchmark_fused_scaled_cross_entropy_sm90.py \
  --tokens 1024 2048 4096 8192 16384 32768 65536 \
  --hidden 4096 --vocab 128256 \
  --providers scaled-fallback scaled-default \
  --return-entropy

# NLL-only remains the default when --return-entropy is omitted.

# Focused correctness
python -m pytest test/transformers/test_fused_linear_scaled_cross_entropy.py -q

# Static checks
make checkstyle
```

Raw Slurm outputs and exact commands for the original engineering runs are retained under `.cache/b300-scaled-ce-c16-archived/`: jobs 5117, 5119, 5121, 5123, 5129, 5136, 5139, 5149, and 5155. Jobs 5115 (isolated optional-dependency setup), 5122 (temporary harness target generation), and 5124 (temporary test-module import) are retained as transparent pre-evidence failures; they do not affect the final exact-head results.

## Limitations

- Performance was measured on one B300 system; the dispatch deliberately excludes all other architectures.
- The bounded workspace trades recomputation for eliminating full-vocabulary FP32 intermediates. It is fixed globally at 512 MiB rather than shape-tuned.
- Open upstream PR #1391 changes FP32 gradient accumulation in the same surface. It remains open and semantically distinct; this branch does not copy or stack on it.
