### PR TITLE
ci: run NVIDIA GPU tests on manual dispatch and daily cron only

### DIFF
--- a/.github/workflows/nvi-ci.yml
+++ b/.github/workflows/nvi-ci.yml
@@ -1,25 +1,16 @@
 name: NVIDIA GPU
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-  merge_group:
-    types: [checks_requested]
-    branches:
-      - main
   workflow_dispatch:  # Enables manual trigger
+  schedule:
+    - cron: '0 0 * * *'  # Daily at 00:00 UTC
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   nvi-correctness-tests:
-    if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     env:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
@@ -44,7 +35,6 @@ jobs:
         modal run -m dev.modal.tests::liger_correctness_tests
 
   nvi-convergence-tests:
-    if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     env:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
@@ -69,7 +59,6 @@ jobs:
         modal run -m dev.modal.tests::liger_convergence_tests
 
   nvi-correctness-tests-with-transformers-4-52-0:
-    if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     env:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
@@ -95,7 +84,6 @@ jobs:
 
 
   nvi-convergence-tests-with-transformers-4-52-0:
-    if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     env:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->

Remove push, pull_request, and merge_group triggers from the NVIDIA GPU workflow so it no longer runs on every PR/merge. It now runs only via workflow_dispatch (manual) and a daily schedule (00:00 UTC). Also drop the now-dead merge_group if-guards on all jobs and simplify the concurrency key.

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->
CI test to be done

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
