### PR TITLE
fix(fused_moe): correct input-gradient (dx) on Blackwell/B300

### DIFF
--- a/src/liger_kernel/ops/fused_moe_kernels.py
+++ b/src/liger_kernel/ops/fused_moe_kernels.py
@@ -826,7 +826,16 @@ def _moe_bwd_dX_expanded_kernel(
 ):
     """Grid: (num_m_tiles, ceil(H/BLOCK_N)).
     dx_expanded[sorted_pos] = d_gate @ W1_gate^T + d_up @ W1_up^T.
-    No atomics — rows are unique per CTA in sorted space."""
+    No atomics — rows are unique per CTA in sorted space.
+
+    NOTE: the gate and up contributions accumulate into SEPARATE fp32 tiles
+    (acc_gate, acc_up), mirroring the forward _fused_up_proj_swiglu_kernel.
+    Folding both dots into one shared accumulator (two tl.dot(..., acc=acc) per
+    loop iteration) miscompiles on some backends (observed on B300/sm_103): one
+    of the two contributions is dropped or corrupted, making dx ~50-64% wrong
+    while leaving the forward, dW1, and dW2 paths correct. Keeping the two
+    accumulators simultaneously live prevents the compiler from reassociating
+    them back into the hazardous single-accumulator recurrence."""
     pid_m = tl.program_id(0)
     pid_n = tl.program_id(1)
 
@@ -846,7 +855,8 @@ def _moe_bwd_dX_expanded_kernel(
     h_idx = n_start + n_offs
     h_mask = h_idx < H_dim
 
-    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    acc_gate = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    acc_up = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
 
     for k in tl.range(0, I_dim, BLOCK_K):
         k_idx = k + k_offs
@@ -859,7 +869,7 @@ def _moe_bwd_dX_expanded_kernel(
             gate_up_proj_ptr + expert_idx * stride_w_E + k_idx[:, None] * stride_w_N + h_idx[None, :] * stride_w_K
         )
         w_gate = tl.load(w_gate_ptrs, mask=k_mask[:, None] & h_mask[None, :], other=0.0)
-        acc = tl.dot(d_gate, w_gate, acc=acc)
+        acc_gate = tl.dot(d_gate, w_gate, acc=acc_gate)
 
         d_up_ptrs = d_pre_act_ptr + row_offs[:, None] * stride_d_pre_TK + (I_dim + k_idx)[None, :] * stride_d_pre_N
         d_up = tl.load(d_up_ptrs, mask=row_mask[:, None] & k_mask[None, :], other=0.0)
@@ -871,8 +881,9 @@ def _moe_bwd_dX_expanded_kernel(
             + h_idx[None, :] * stride_w_K
         )
         w_up = tl.load(w_up_ptrs, mask=k_mask[:, None] & h_mask[None, :], other=0.0)
+        acc_up = tl.dot(d_up, w_up, acc=acc_up)
 
-        acc = tl.dot(d_up, w_up, acc=acc)
+    acc = acc_gate + acc_up
 
     dxe_ptrs = dx_expanded_ptr + row_offs[:, None] * stride_dxe_TK + h_idx[None, :] * stride_dxe_H
     tl.store(dxe_ptrs, acc.to(dx_expanded_ptr.dtype.element_ty), mask=row_mask[:, None] & h_mask[None, :])


### PR DESCRIPTION
# PR: Fix fused-MoE input gradient (dx) on Blackwell/B300

**Head:** `arde171:arde/optos-liger-moe-dx-fix`  →  **Base:** `linkedin/Liger-Kernel:main` (`4310065`)

---

## Summary

`LigerFusedMoEFunction` returns an **incorrect gradient with respect to its input** (`x.grad`) on **B300 / sm_103 (Blackwell)**. The error is ~50–64% relative-mean and **silently corrupts MoE training** (no NaN, no error) — the input gradient feeds every layer below the MoE block. Forward output, `gate_up_proj.grad` (dW1), and `down_proj.grad` (dW2) are all correct; only `dx` is affected.

The bug is **Blackwell-specific**: the identical code is correct on H200 / sm_90, which is why it isn't caught by upstream CI running on Hopper/Ampere.

## Root cause

`_moe_bwd_dX_expanded_kernel` computes `dx_expanded = d_gate @ W1_gateᵀ + d_up @ W1_upᵀ` by folding **both** matmuls into **one shared accumulator**, with two `tl.dot(..., acc=acc)` calls per loop iteration:

```python
acc = tl.zeros(...)
for k in range(0, I, BLOCK_K):
    acc = tl.dot(d_gate, w_gate, acc=acc)   # gate half
    acc = tl.dot(d_up,   w_up,   acc=acc)   # up half  → same acc, same iteration
```

On B300/sm_103 (Triton in torch 2.13/cu130) this pattern miscompiles and drops/corrupts one of the two contributions. Because SwiGLU's gate and up terms are comparable in magnitude, losing one produces the observed ~50–64% error. The error is:
- **top-k independent** (the router weight is already folded into `d_pre_act` upstream — even K=1 is wrong),
- **only visible with ≥2 experts** (with a single expert the failure cancels in the single contiguous tile),
- **config-dependent** (magnitude shifts with `BLOCK_N`/`BLOCK_K`), which is the fingerprint of a tiling/accumulation miscompile rather than numerical tolerance.

The forward counterpart `_fused_up_proj_swiglu_kernel` already computes the gate/up split with **two independent accumulators** (`acc_gate`, `acc_up`) and is correct.

## Fix

Accumulate the gate and up contributions into **separate fp32 tiles** and sum once after the loop — mirroring the forward kernel. Mathematically identical; the two independent recurrences stay simultaneously live, so the backend cannot reassociate them back into the hazardous single-accumulator form.

```python
acc_gate = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
acc_up   = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
for k in range(0, I, BLOCK_K):
    ...
    acc_gate = tl.dot(d_gate, w_gate, acc=acc_gate)
    ...
    acc_up   = tl.dot(d_up,   w_up,   acc=acc_up)
acc = acc_gate + acc_up
```

One file, `+15 / −4`.

## Validation

Measured on **B300 SXM6 (sm_103)** and **H200 (sm_90)**, torch 2.13.0+cu130.

**dx microbench** (trusted-autograd + `transformers` MixtralExperts references, fp32, K=1/2/4 × 3 seeds):

| | before | after |
|---|---|---|
| `dx` rel-mean (worst) | 52–64% | **0.22%** (tf32 level, matches fwd/dW1/dW2) |

**Test suite (B300), before → after:**

| test | before | after |
|---|---|---|
| `test/transformers/test_fused_moe.py` (fp32+bf16) | 5+ fp32 fail | **19 passed** |
| `test/transformers/test_swiglu.py::test_correctness_mixtralexperts` | 3 fail on `[x.grad]` (`max_abs≈1.5e4`) | **4 passed** |
| H200 (both suites) | already passed | passes (Blackwell-specific) |

Pre-existing, unrelated: `mini_qwen3_moe`/`qwen3_5_moe` bf16 convergence fails identically with and without this change — a known machine-dependent flaky test documented in the test file (`# TODO(tcc): ... diverges on ci test (A10G) ... diverges on h100`).

## Notes

- A single contiguous-`2I` GEMM (one dot per iteration) is an equivalent alternative and a good **follow-up performance** change; it should be validated separately with B300 perf + correctness. This PR intentionally makes the minimal correctness fix that mirrors the proven forward pattern.
- Upstream CI cannot reproduce this without Blackwell runners; the fix is validated on B300 hardware and is correct by construction (identical to the forward accumulator structure).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
