### PR TITLE
perf(flce): widen the transient-logits chunk-memory budget constant to C=16

### DIFF
--- a/src/liger_kernel/ops/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_cross_entropy.py
@@ -14,6 +14,22 @@ from liger_kernel.utils import infer_device
 # However, setting limit as 65536 as in LayerNorm tutorial is faster because of less register spilling
 # The optimal maximum block size depends on your hardware, your kernel, and your dtype
 MAX_FUSED_SIZE = 2048 if infer_device() == "npu" else 65536 // 2
+
+# Memory-budget constant for the token-chunk geometry below. The historical
+# formula (inc_factor = cdiv(V, H), i.e. budget C=1) sizes chunks to a memory
+# FLOOR of ~BT x H transient logits, which at LLM vocab shapes forces many tiny
+# chunks and a launch-bound wall. At llama_3 shapes (V=128256, H=4096) C=1 gives
+# inc_factor=32 -> chunk_size=BT/32 (256 rows @ BT=8192) = 32 loop iterations.
+# Widening the transient budget to C x BT x H collapses the loop. Measured
+# Blackwell B200 (full fwd+bwd, bf16): V=128256/H=4096 BT=8192 123.4ms (C=1) ->
+# 24.7ms (C=16) = 5.0x; BT=4096 119.3 -> 15.1 = 7.9x; BT=1024 116.9 -> 9.07 =
+# 12.9x; small V=32000 BT=8192 11.0 -> 5.4 = 2.0x (flat for C>=8). C=16 is the
+# knee (gains flatten beyond it at BT>=4096). Numerics are partition-invariant
+# per row: loss is bit-identical across C; input-grad differs only at the ~1e-5
+# GEMM reduction-order level; weight-grad differs only in addmm chunk-accumulation
+# order (same class as the fused_linear_jsd chunk-memory idiom). Same constant on
+# all devices.
+_CHUNK_MEM_CONST = 16
 _TORCH_VERSION = Version(torch.__version__.split("+")[0])
 _ADDMM_SUPPORTS_OUT_DTYPE = _TORCH_VERSION >= Version("2.8.0")
 
@@ -65,8 +81,10 @@ def fused_linear_cross_entropy_forward(
     V = weight.shape[0]
     BLOCK_SIZE = min(MAX_FUSED_SIZE, triton.next_power_of_2(V))
 
-    inc_factor = triton.cdiv(V, H)  # (V + H - 1) // H
+    # widen the transient logits budget to C x BT x H (C=1 is a memory floor, not a perf target)
+    inc_factor = triton.cdiv(V, _CHUNK_MEM_CONST * H)
     chunk_size = triton.next_power_of_2(triton.cdiv(BT, inc_factor))  # (BT + inc_factor - 1) // inc_factor
+    chunk_size = min(chunk_size, BT)  # a single chunk covers BT when the budget allows; never exceed BT
     num_chunks = triton.cdiv(BT, chunk_size)  # (BT + chunk_size - 1) // chunk_size
 
     grad_input = torch.zeros_like(_input, device=device)


### PR DESCRIPTION
# perf(flce): widen the transient-logits chunk-memory budget constant to C=16

**Head:** `arde171:arde/optos-liger-flce-chunk` → **Base:** `linkedin/Liger-Kernel:main` (`4310065`)
One file, `+18 / -1`: `src/liger_kernel/ops/fused_linear_cross_entropy.py`.

## Summary

The chunked `fused_linear_cross_entropy` sizes its token chunk from a memory budget constant. The historical formula `inc_factor = cdiv(V, H)` corresponds to a budget of **C=1** — the tightest possible transient-logits footprint (~`BT x H`). At real LLM vocab shapes this fractures the batch into many tiny chunks and makes the op **launch-bound**. Widening the budget to **C=16 x BT x H** collapses the chunk loop with a still-bounded, modest memory increase.

```diff
+_CHUNK_MEM_CONST = 16
...
-    inc_factor = triton.cdiv(V, H)                       # C=1: a memory floor, not a perf target
+    inc_factor = triton.cdiv(V, _CHUNK_MEM_CONST * H)    # widen transient-logits budget to C x BT x H
     chunk_size = triton.next_power_of_2(triton.cdiv(BT, inc_factor))
+    chunk_size = min(chunk_size, BT)                     # a single chunk covers BT when the budget allows
```

At llama-3 shapes (`V=128256, H=4096`), C=1 gives `inc_factor=32` -> `chunk_size=BT/32` -> 32 loop iterations; C=16 collapses that.

## Performance (B200, full fwd+bwd, bf16)

| shape | C=1 | C=16 | speedup |
|---|---|---|---|
| V=128256 H=4096 BT=8192 | 123.4 ms | 24.7 ms | **5.0x** |
| V=128256 H=4096 BT=4096 | 119.3 ms | 15.1 ms | **7.9x** |
| V=128256 H=4096 BT=1024 | 116.9 ms | 9.07 ms | **12.9x** |
| V=32000 H=4096 BT=8192 | 11.0 ms | 5.4 ms | 2.0x (flat for C>=8) |

C=16 is the knee -- gains flatten beyond it at BT>=4096. Memory stays bounded at `O(C x BT x H)`.

## Correctness

Numerics are **partition-invariant per row**: the loss is **bit-identical** across chunk count C; the input-gradient differs only at the ~1e-5 GEMM reduction-order level, and the weight-grad only in `addmm` chunk-accumulation order (the same class as the existing `fused_linear_jsd` chunk-memory idiom). Same constant on all devices.

**Tests** -- `test/transformers/test_fused_linear_cross_entropy.py`:
- **B300 (sm_103): 141 passed**
- **H200 (sm_90): 141 passed**

## Scope

One constant + a `min(chunk_size, BT)` clamp in the Triton composition. No kernel or API change; no new backend. Purely a chunk-geometry perf tuning.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
