### PR TITLE
ci: schedule NVIDIA tests by cadence/GPU with a hard 3-job concurrency cap

### DIFF
--- a/.github/workflows/nvi-ci.yml
+++ b/.github/workflows/nvi-ci.yml
@@ -2,18 +2,53 @@ name: NVIDIA GPU
 
 on:
   workflow_dispatch:  # Enables manual trigger
+    inputs:
+      suite:
+        description: "Which test set to run on manual dispatch"
+        type: choice
+        default: daily
+        options:
+          - daily
+          - weekly
   schedule:
-    # Randomized off-peak time (09:24 UTC) rather than a round hour like 00:00.
-    # GitHub throttles/delays scheduled workflows that pile up at the top of the
-    # hour (especially midnight), so an odd minute avoids that contention.
+    # Daily: correctness + cuTile + cuTeDSL (SM90) on H100, cuTeDSL (SM100) on B200.
+    # Randomized off-peak minute; round hours (esp. 00:00) get throttled/queued by GitHub.
     - cron: '24 9 * * *'
+    # Weekly (Sundays): convergence (latest tf) + oldest-tf correctness & convergence.
+    # Staggered a few hours after the daily run as an extra guard against overlap.
+    - cron: '24 13 * * 0'
 
+# Serialize whole runs so the daily and weekly runs never execute at the same time.
+# Together with `max-parallel: 3` on each job this caps concurrent Modal GPU calls at 3
+# (a 4th concurrent GPU call is rejected by the runner/Modal limit).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
-  nvi-correctness-tests:
+  # ---------------------------------------------------------------------------
+  # Daily: general correctness + cuTile + cuTeDSL, split across H100 and B200.
+  # cuTeDSL runs on BOTH archs on purpose: SM90 tests only run on H100 and SM100
+  # tests only run on B200 (each arch self-skips the other half).
+  # ---------------------------------------------------------------------------
+  daily:
+    name: daily / ${{ matrix.name }}
+    if: >-
+      github.event.schedule == '24 9 * * *'
+      || (github.event_name == 'workflow_dispatch' && github.event.inputs.suite == 'daily')
+    strategy:
+      max-parallel: 3      # never run more than 3 GPU jobs at once
+      fail-fast: false
+      matrix:
+        include:
+          - name: correctness (H100)
+            modal_fn: liger_correctness_tests
+          - name: cuTile (H100)
+            modal_fn: liger_cutile_tests
+          - name: cuTeDSL SM90 (H100)
+            modal_fn: liger_cutedsl_tests_h100
+          - name: cuTeDSL SM100 (B200)
+            modal_fn: liger_cutedsl_tests_b200
     runs-on: ubuntu-latest
     env:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
@@ -33,11 +68,30 @@ jobs:
         python -m pip install --upgrade pip
         pip install modal
 
-    - name: Run tests
+    - name: Run ${{ matrix.name }}
       run: |
-        modal run -m dev.modal.tests::liger_correctness_tests
+        modal run -m dev.modal.tests::${{ matrix.modal_fn }}
 
-  nvi-convergence-tests:
+  # ---------------------------------------------------------------------------
+  # Weekly (Sundays): convergence (latest tf) + oldest-supported-tf correctness
+  # and convergence. All on H100.
+  # ---------------------------------------------------------------------------
+  weekly:
+    name: weekly / ${{ matrix.name }}
+    if: >-
+      github.event.schedule == '24 13 * * 0'
+      || (github.event_name == 'workflow_dispatch' && github.event.inputs.suite == 'weekly')
+    strategy:
+      max-parallel: 3      # never run more than 3 GPU jobs at once
+      fail-fast: false
+      matrix:
+        include:
+          - name: convergence (H100)
+            modal_fn: liger_convergence_tests
+          - name: oldest-tf correctness (H100)
+            modal_fn: liger_oldest_v4_correctness_tests
+          - name: oldest-tf convergence (H100)
+            modal_fn: liger_oldest_v4_convergence_tests
     runs-on: ubuntu-latest
     env:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
@@ -57,55 +111,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install modal
 
-    - name: Run tests
+    - name: Run ${{ matrix.name }}
       run: |
-        modal run -m dev.modal.tests::liger_convergence_tests
-
-  nvi-correctness-tests-with-transformers-4-52-0:
-    runs-on: ubuntu-latest
-    env:
-      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.10'
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install modal
-
-    - name: Run tests
-      run: |
-        modal run -m dev.modal.tests::liger_oldest_v4_correctness_tests
-
-
-  nvi-convergence-tests-with-transformers-4-52-0:
-    runs-on: ubuntu-latest
-    env:
-      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.10'
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install modal
-
-    - name: Run tests
-      run: |
-        modal run -m dev.modal.tests::liger_oldest_v4_convergence_tests
+        modal run -m dev.modal.tests::${{ matrix.modal_fn }}

--- a/dev/modal/tests.py
+++ b/dev/modal/tests.py
@@ -42,6 +42,52 @@ def liger_convergence_tests():
     subprocess.run(["make test-convergence"], check=True, shell=True, cwd=REMOTE_ROOT_PATH)
 
 
+@app.function(gpu="H100!", image=repo, timeout=90 * 60)
+def liger_cutile_tests():
+    import subprocess
+
+    # cutile-tileiras pulls in the tileiras compiler so `import cuda.tile` resolves;
+    # without it the cuTile tests importorskip (skip) rather than run.
+    subprocess.run(
+        ["uv pip install -e '.[dev,cutile-tileiras]' --system"],
+        check=True,
+        shell=True,
+        cwd=REMOTE_ROOT_PATH,
+    )
+    # make test-cutile sets LIGER_KERNEL_IMPL=cutile internally.
+    subprocess.run(["make test-cutile"], check=True, shell=True, cwd=REMOTE_ROOT_PATH)
+
+
+@app.function(gpu="H100!", image=repo, timeout=90 * 60)
+def liger_cutedsl_tests_h100():
+    import subprocess
+
+    # On H100 (SM90) this runs the cutedsl SM90 + generic tests; the SM100 tests self-skip.
+    subprocess.run(
+        ["uv pip install -e '.[dev,cutedsl]' --system"],
+        check=True,
+        shell=True,
+        cwd=REMOTE_ROOT_PATH,
+    )
+    # make test-cutedsl sets LIGER_KERNEL_IMPL=cutedsl internally.
+    subprocess.run(["make test-cutedsl"], check=True, shell=True, cwd=REMOTE_ROOT_PATH)
+
+
+@app.function(gpu="B200", image=repo, timeout=90 * 60)
+def liger_cutedsl_tests_b200():
+    import subprocess
+
+    # On B200 (SM100) this runs the cutedsl SM100 + generic tests; the SM90 tests self-skip.
+    subprocess.run(
+        ["uv pip install -e '.[dev,cutedsl]' --system"],
+        check=True,
+        shell=True,
+        cwd=REMOTE_ROOT_PATH,
+    )
+    # make test-cutedsl sets LIGER_KERNEL_IMPL=cutedsl internally.
+    subprocess.run(["make test-cutedsl"], check=True, shell=True, cwd=REMOTE_ROOT_PATH)
+
+
 oldest_v4_app = modal.App("liger_oldest_v4_tests", image=image)  # 4.52.0
 
 


### PR DESCRIPTION
## Summary

Reorganizes the **NVIDIA GPU** workflow into a cadence- and GPU-aware schedule, and adds the Modal functions to back it. Follows up #1410 (which added the per-DSL test folders and `make test-cutile` / `test-cutedsl` / `test-cute` targets).

### Schedule

**Daily** (cron `24 9 * * *`):
| Suite | GPU | Modal fn |
|---|---|---|
| general correctness | H100 | `liger_correctness_tests` |
| cuTile | H100 | `liger_cutile_tests` (new) |
| cuTeDSL — SM90 half | H100 | `liger_cutedsl_tests_h100` (new) |
| cuTeDSL — SM100 half | B200 | `liger_cutedsl_tests_b200` (new) |

cuTeDSL runs on **both** archs on purpose: its SM90 tests only run on H100 and its SM100 tests only run on B200 — each arch self-skips the other half, so both are needed for full coverage.

**Weekly** (cron `24 13 * * 0`, Sundays, H100): `convergence` (latest tf) + oldest-supported-tf **correctness** and **convergence**.

**Not scheduled:** `cute` (fused-MoE) tests, for now.

### The ≤3-concurrent fix

A 4th simultaneous Modal GPU call was being rejected (one job died instantly at ~0.7 min). This is now capped two ways:
- **`strategy.max-parallel: 3`** on each matrix job (daily's 4 entries run 3-then-1; weekly's 3 run together).
- **Workflow-level `concurrency: { group: <workflow>, cancel-in-progress: false }`** serializes whole runs, so the daily and weekly runs never overlap.

Only **one** cadence job activates per trigger (the job-level `if` selects daily vs weekly from `github.event.schedule` / the `workflow_dispatch` `suite` input), so at most **3** GPU jobs ever run together. The `if` deliberately uses only the `github` context — **not** the `matrix` context, which isn't available in a job-level `if`.

### Manual runs
`workflow_dispatch` gains a `suite` input (`daily` / `weekly`, default `daily`).


## Notes / caveats
- **Convergence is currently red** on `main`'s scheduled runs (pre-existing; correctness passes). Weekly scheduling is fine but expect failures until that's fixed separately.
- **DSL suites run in CI for the first time** — the cuTeDSL-B200 (SM100) path and the cuTile routing test may surface latent failures on first run.
- **B200 access**: uses `gpu="B200"` on Modal — confirm the token/plan has B200 capacity.
- `cuTile` installs the `cutile-tileiras` extra so `import cuda.tile` resolves (otherwise those tests importorskip).
- Validated locally with a YAML parser + a gating simulation (exactly one job per trigger) + modal-fn-name cross-check; `actionlint` wasn't installable in the dev sandbox, and GPU suites can't run there.
