### PR TITLE
feat(cutedsl): CuTeDSL backends for SwiGLU, GeGLU, Softmax, RoPE, KL-div, JSD

### DIFF
--- a/src/liger_kernel/functional.py
+++ b/src/liger_kernel/functional.py
@@ -52,17 +52,26 @@ declare_op_locations(
 # route through the dispatcher and pick up cuTile when the user opts in.
 declare_op_locations(
     "jsd",
-    ("liger_kernel.ops.backends._triton.jsd",),
+    (
+        "liger_kernel.ops.backends._triton.jsd",
+        "liger_kernel.ops.backends._cutedsl.jsd",
+    ),
 )
 declare_op_locations(
     "jsd_loss_and_grad",
-    ("liger_kernel.ops.backends._triton.jsd",),
+    (
+        "liger_kernel.ops.backends._triton.jsd",
+        "liger_kernel.ops.backends._cutedsl.jsd",
+    ),
 )
 
 # Softmax: Triton (universal) + cuTile (Blackwell) + CuTe DSL (Hopper+).
 declare_op_locations(
     "softmax",
-    ("liger_kernel.ops.backends._triton.softmax",),
+    (
+        "liger_kernel.ops.backends._triton.softmax",
+        "liger_kernel.ops.backends._cutedsl.softmax",
+    ),
 )
 
 # SwiGLU: Triton (universal) + CuTe DSL (Hopper+). SwiGLU is a purely
@@ -70,14 +79,20 @@ declare_op_locations(
 # overhead and uses native exp2 for the sigmoid.
 declare_op_locations(
     "swiglu",
-    ("liger_kernel.ops.backends._triton.swiglu",),
+    (
+        "liger_kernel.ops.backends._triton.swiglu",
+        "liger_kernel.ops.backends._cutedsl.swiglu",
+    ),
 )
 
 # RoPE: Triton (universal) + CuTe DSL (Hopper+). RoPE is an elementwise
 # rotation; the CuTe DSL kernel shares one rotate primitive for fwd+bwd.
 declare_op_locations(
     "rope",
-    ("liger_kernel.ops.backends._triton.rope",),
+    (
+        "liger_kernel.ops.backends._triton.rope",
+        "liger_kernel.ops.backends._cutedsl.rope",
+    ),
 )
 
 # CrossEntropy: Triton (universal) + CuTe DSL (Hopper+). The CuTe DSL kernel
@@ -110,14 +125,20 @@ declare_op_locations(
 # mirrors the SwiGLU CuTe DSL pattern.
 declare_op_locations(
     "geglu",
-    ("liger_kernel.ops.backends._triton.geglu",),
+    (
+        "liger_kernel.ops.backends._triton.geglu",
+        "liger_kernel.ops.backends._cutedsl.geglu",
+    ),
 )
 
 # KL Divergence: Triton (universal) + CuTe DSL (Hopper+). Forward uses a
 # row-reduction (ReductionBase); backward is elementwise.
 declare_op_locations(
     "kl_div",
-    ("liger_kernel.ops.backends._triton.kl_div",),
+    (
+        "liger_kernel.ops.backends._triton.kl_div",
+        "liger_kernel.ops.backends._cutedsl.kl_div",
+    ),
 )
 
 # fused_linear_jsd: Triton (universal) + cuTile (Blackwell). The CuTe DSL

--- a/src/liger_kernel/ops/backends/_cutedsl/geglu.py
+++ b/src/liger_kernel/ops/backends/_cutedsl/geglu.py
@@ -1,0 +1,542 @@
+"""CuTe DSL (CUTLASS python) backend for ``geglu``.
+
+Strategy
+--------
+GeGLU is a purely elementwise op (no reductions), structurally identical to
+SwiGLU but with a GELU (tanh approximation) activation instead of SiLU.  The
+math (matching :mod:`liger_kernel.ops.geglu`)::
+
+    gelu(x) = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+    c       = gelu(a) * b
+
+The CuTe DSL kernel mirrors the SwiGLU sibling (:mod:`._cutedsl.swiglu`)
+exactly — same TiledCopy + ``cp.async`` load/store pattern — with only the
+activation math swapped.  The tanh is computed via the identity
+``tanh(x) = 2 * sigmoid(2x) - 1`` using the native ``exp2`` HW instruction
+(same ``rcp_approx`` path as the SwiGLU sigmoid), avoiding any external tanh
+intrinsic.
+
+Capability
+----------
+- Compute capability >= sm_90 (Hopper or newer), matching the swiglu sibling.
+- Requires only the ``cutlass`` Python package.
+
+Shapes and limits
+-----------------
+- ``a`` and ``b`` are flattened to 2D ``(M, N)``; arbitrary leading dims OK.
+- dtypes: fp16, bf16, fp32.
+
+References
+----------
+- Triton reference: :mod:`liger_kernel.ops.geglu` — fixes the exact numerics
+  (fp32 tanh, GELU tanh approximation constants).
+- CuTe DSL structure: :mod:`._cutedsl.swiglu` — the TiledCopy + autovec_copy
+  load/store pattern.
+"""
+
+import math
+
+from functools import partial
+from typing import Optional
+from typing import Tuple
+from typing import Type
+
+# ---------------------------------------------------------------------------
+# Top-level CuTe DSL imports. Identical pattern to the swiglu sibling.
+# ---------------------------------------------------------------------------
+import cuda.bindings.driver as cuda  # noqa: F401  (referenced by cute.compile)
+import cutlass
+import cutlass.cute as cute
+import torch
+
+from cutlass import const_expr
+from torch import Tensor
+
+# Inlined CuTe DSL utilities (adapted from Quack, Apache-2.0).
+import liger_kernel.ops.backends._cutedsl._cute_lib.copy_utils as copy_utils
+
+from liger_kernel.backends import Capability
+from liger_kernel.backends import register_op
+from liger_kernel.ops._nvidia_shared import to_local_if_dtensor as _to_local_if_dtensor
+from liger_kernel.ops.backends._cutedsl._cute_lib.compile_utils import make_fake_tensor as fake_tensor
+from liger_kernel.ops.backends._cutedsl._cute_lib.dtype_map import torch2cute_dtype_map
+
+# sqrt(2 / pi) — the GELU tanh approximation constant.
+_SQRT_2_OVER_PI = 0.7978845608028654
+# 0.044715 — the GELU tanh approximation cubic coefficient.
+_GELU_CUBIC_COEFF = 0.044715
+
+
+def _cutedsl_tanh(x):
+    """Compute tanh through the vector-aware fast-math MUFU path."""
+    return cute.math.tanh(x, fastmath=True)
+
+
+def _cutedsl_gelu(x):
+    """GELU tanh approximation: ``0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))``."""
+    x_cubed = x * x * x
+    tanh_arg = _SQRT_2_OVER_PI * (x + _GELU_CUBIC_COEFF * x_cubed)
+    tanh_result = _cutedsl_tanh(tanh_arg)
+    return 0.5 * x * (1.0 + tanh_result)
+
+
+def _cutedsl_gelu_grad(x):
+    """Gradient of the GELU tanh approximation w.r.t. x.
+
+    ``gelu'(x) = 0.5 * (1 + tanh(z)) + 0.5 * x * (1 - tanh(z)^2) * (sqrt(2/pi) * (1 + 3 * 0.044715 * x^2))``
+    where ``z = sqrt(2/pi) * (x + 0.044715 * x^3)``.
+    """
+    x_sq = x * x
+    x_cubed = x_sq * x
+    tanh_arg = _SQRT_2_OVER_PI * (x + _GELU_CUBIC_COEFF * x_cubed)
+    tanh_result = _cutedsl_tanh(tanh_arg)
+    tanh_sq = tanh_result * tanh_result
+    term1 = 0.5 * (1.0 + tanh_result)
+    term2 = 0.5 * x * (1.0 - tanh_sq) * (_SQRT_2_OVER_PI * (1.0 + 3.0 * _GELU_CUBIC_COEFF * x_sq))
+    return term1 + term2
+
+
+# ===========================================================================
+# Forward kernel — elementwise: c = gelu(a) * b
+# ===========================================================================
+class _LigerGeGLUCuTeDSLForward:
+    """CuTe DSL GeGLU forward.
+
+    Pure elementwise: load a tile of ``a`` and ``b`` into registers, compute
+    ``gelu(a) * b`` in fp32, store the result.  Identical structure to the
+    SwiGLU forward kernel.
+    """
+
+    def __init__(self, dtype: Type[cutlass.Numeric], N: int):
+        self.dtype = dtype
+        self.N = N
+        self.cluster_n = 1
+
+    def _threads_per_row(self):
+        N = self.N
+        for limit, threads in [(64, 8), (128, 16), (3072, 32), (6144, 64), (16384, 128)]:
+            if N <= limit:
+                return threads
+        # 128 threads/row for ALL N > 16384 (merging with the mid-N rung):
+        # paired with num_threads == 128 (1 row per block) and the 2-chunk
+        # grid-y cap, mirrored verbatim from the committed swiglu retune
+        # (2a956b1), where a B200 tile sweep beat BOTH the 1024-thread cap-2
+        # rung and Triton's lean Blackwell tiled path at every N >= 8192
+        # (swiglu kernel med ms @32768: 0.2454 at 128thr vs 0.3127 prior /
+        # 0.2554 Triton). All-elementwise math => the retile is bit-identical
+        # (see _get_tiled_copy; an A/B retime measurement showed the
+        # same whole-row-spill bwd win as swiglu @14336/16384).
+        return 128
+
+    def _num_threads(self):
+        # 1 row per block on every mid/wide rung (N>6144): threads_per_row
+        # is already 128 for 6144<N<=16384, and the N>16384 rung now uses
+        # 128 threads/row as well. Small-N rungs keep their tpr<128 fanout.
+        return 128
+
+    def _get_tiled_copy(self, vecsize: int = 1):
+        threads_per_row = self._threads_per_row()
+        num_threads = self._num_threads()
+        assert num_threads % cute.arch.WARP_SIZE == 0
+        if self.N >= 8192:
+            # Cap the N-chunks each block loops over at 2 and move the rest
+            # onto grid-y (see __call__ and kernel). Now applies to the whole
+            # N>=8192 rung (8192 itself included after the B200 gate-boundary
+            # A/B mirroring swiglu 4cc3075: the uncapped 8-chunk whole-row
+            # loop = 64 live fp32 elems/thread measured ~11% (bf16,
+            # 1.11-1.12x full fwd+bwd @M=8192 and 16384) / ~12% (fp16, 1.13x
+            # @M=4096) slower than cap-2 at N=8192; fp32's vecsize-4
+            # 32-elem/thread path re-routes neutral at 1.004x), not just
+            # N>16384: the uncapped whole-row loop spilled registers at
+            # mid-N, exactly as in the swiglu retune (2a956b1). All math is
+            # elementwise per element -- no cross-N reduction -- so
+            # N-blocking is bit-identical (16 elems/thread live at cap=2 x
+            # vecsize=8 for bf16). N < 8192 keeps the small-rung fanout tile.
+            num_blocks_N = min(cute.ceil_div(self.N // vecsize, threads_per_row * self.cluster_n), 2)
+        else:
+            num_blocks_N = cute.ceil_div(self.N // vecsize, threads_per_row * self.cluster_n)
+        tiler_mn = (num_threads // threads_per_row, vecsize * num_blocks_N * threads_per_row)
+        tiled_copy = copy_utils.tiled_copy_2d(self.dtype, threads_per_row, num_threads, vecsize)
+        return tiled_copy, tiler_mn, threads_per_row
+
+    @cute.jit
+    def __call__(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mC: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        assert mA.element_type == self.dtype
+        largest_dtype_width = const_expr(max(t.element_type.width for t in [mA, mB, mC]))
+        vecsize = math.gcd(self.N, 128 // largest_dtype_width)
+        tiled_copy, tiler_mn, _ = self._get_tiled_copy(vecsize=vecsize)
+        num_threads = tiled_copy.size
+        self.kernel(mA, mB, mC, tiler_mn, tiled_copy).launch(
+            grid=[cute.ceil_div(mA.shape[0], tiler_mn[0]), cute.ceil_div(self.N, tiler_mn[1]), 1],
+            block=[num_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mC: cute.Tensor,
+        tiler_mn: cute.Shape,
+        tiled_copy: cute.TiledCopy,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bnidx, _ = cute.arch.block_idx()
+
+        shape = mA.shape
+        idX = cute.make_identity_tensor(shape)
+        gA, gB, gC, cX = [cute.local_tile(mT, tiler_mn, (bidx, bnidx)) for mT in (mA, mB, mC, idX)]
+
+        thr_copy = tiled_copy.get_slice(tidx)
+        tAgA = thr_copy.partition_S(gA)
+        tBgB = thr_copy.partition_S(gB)
+        tCgC = thr_copy.partition_D(gC)
+        tXcX = thr_copy.partition_S(cX)[(0, None), None, None]
+        tArA, tBrB, tCrC = [cute.make_rmem_tensor_like(thr) for thr in (tAgA, tBgB, tCgC)]
+
+        is_even_N = const_expr(shape[1] % tiler_mn[1] == 0)
+        tXpX = None if is_even_N else copy_utils.predicate_k(thr_copy.partition_S(cX), limit=shape[1])
+        copy = partial(copy_utils.copy, pred=tXpX)
+
+        if tXcX[0][0] < shape[0]:
+            copy(tAgA, tArA)
+            copy(tBgB, tBrB)
+        a = tArA.load().to(cute.Float32)
+        b = tBrB.load()
+        gelu_a = _cutedsl_gelu(a)
+        c = gelu_a.to(b.element_type) * b
+        tCrC.store(c)
+        if tXcX[0][0] < shape[0]:
+            copy(tCrC, tCgC)
+
+
+# ===========================================================================
+# Backward kernel — elementwise: da, db from dc, a, b
+# ===========================================================================
+class _LigerGeGLUCuTeDSLBackward:
+    """CuTe DSL GeGLU backward.
+
+    Given ``dc``, ``a``, ``b``, compute::
+
+        gelu_a  = gelu(a)
+        db      = dc * gelu_a
+        da      = dc * b * gelu'(a)
+    """
+
+    def __init__(self, dtype: Type[cutlass.Numeric], N: int):
+        self.dtype = dtype
+        self.N = N
+        self.cluster_n = 1
+
+    def _threads_per_row(self):
+        N = self.N
+        for limit, threads in [(64, 8), (128, 16), (3072, 32), (6144, 64), (16384, 128)]:
+            if N <= limit:
+                return threads
+        # 128 threads/row for ALL N > 16384 (merging with the mid-N rung):
+        # paired with num_threads == 128 (1 row per block) and the 2-chunk
+        # grid-y cap, mirrored verbatim from the committed swiglu retune
+        # (2a956b1), where a B200 tile sweep beat BOTH the 1024-thread cap-2
+        # rung and Triton's lean Blackwell tiled path at every N >= 8192
+        # (swiglu kernel med ms @32768: 0.2454 at 128thr vs 0.3127 prior /
+        # 0.2554 Triton). All-elementwise math => the retile is bit-identical
+        # (see _get_tiled_copy; an A/B retime measurement showed the
+        # same whole-row-spill bwd win as swiglu @14336/16384).
+        return 128
+
+    def _num_threads(self):
+        # 1 row per block on every mid/wide rung (N>6144): threads_per_row
+        # is already 128 for 6144<N<=16384, and the N>16384 rung now uses
+        # 128 threads/row as well. Small-N rungs keep their tpr<128 fanout.
+        return 128
+
+    def _get_tiled_copy(self, vecsize: int = 1):
+        threads_per_row = self._threads_per_row()
+        num_threads = self._num_threads()
+        assert num_threads % cute.arch.WARP_SIZE == 0
+        if self.N >= 8192:
+            # Cap the N-chunks each block loops over at 2 and move the rest
+            # onto grid-y (see __call__ and kernel). Now applies to the whole
+            # N>=8192 rung (8192 itself included after the B200 gate-boundary
+            # A/B mirroring swiglu 4cc3075: the uncapped 8-chunk whole-row
+            # loop = 64 live fp32 elems/thread measured ~11% (bf16,
+            # 1.11-1.12x full fwd+bwd @M=8192 and 16384) / ~12% (fp16, 1.13x
+            # @M=4096) slower than cap-2 at N=8192; fp32's vecsize-4
+            # 32-elem/thread path re-routes neutral at 1.004x), not just
+            # N>16384: the uncapped whole-row loop spilled registers at
+            # mid-N, exactly as in the swiglu retune (2a956b1). All math is
+            # elementwise per element -- no cross-N reduction -- so
+            # N-blocking is bit-identical (16 elems/thread live at cap=2 x
+            # vecsize=8 for bf16). N < 8192 keeps the small-rung fanout tile.
+            num_blocks_N = min(cute.ceil_div(self.N // vecsize, threads_per_row * self.cluster_n), 2)
+        else:
+            num_blocks_N = cute.ceil_div(self.N // vecsize, threads_per_row * self.cluster_n)
+        tiler_mn = (num_threads // threads_per_row, vecsize * num_blocks_N * threads_per_row)
+        tiled_copy = copy_utils.tiled_copy_2d(self.dtype, threads_per_row, num_threads, vecsize)
+        return tiled_copy, tiler_mn, threads_per_row
+
+    @cute.jit
+    def __call__(
+        self,
+        mDC: cute.Tensor,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mDA: cute.Tensor,
+        mDB: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        assert mDC.element_type == self.dtype
+        largest_dtype_width = const_expr(max(t.element_type.width for t in [mDC, mA, mB, mDA, mDB]))
+        vecsize = math.gcd(self.N, 128 // largest_dtype_width)
+        tiled_copy, tiler_mn, _ = self._get_tiled_copy(vecsize=vecsize)
+        num_threads = tiled_copy.size
+        self.kernel(mDC, mA, mB, mDA, mDB, tiler_mn, tiled_copy).launch(
+            grid=[cute.ceil_div(mDC.shape[0], tiler_mn[0]), cute.ceil_div(self.N, tiler_mn[1]), 1],
+            block=[num_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mDC: cute.Tensor,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mDA: cute.Tensor,
+        mDB: cute.Tensor,
+        tiler_mn: cute.Shape,
+        tiled_copy: cute.TiledCopy,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bnidx, _ = cute.arch.block_idx()
+
+        shape = mDC.shape
+        idX = cute.make_identity_tensor(shape)
+        gDC, gA, gB, gDA, gDB, cX = [
+            cute.local_tile(mT, tiler_mn, (bidx, bnidx)) for mT in (mDC, mA, mB, mDA, mDB, idX)
+        ]
+
+        thr_copy = tiled_copy.get_slice(tidx)
+        tDCgDC = thr_copy.partition_S(gDC)
+        tAgA = thr_copy.partition_S(gA)
+        tBgB = thr_copy.partition_S(gB)
+        tDAgDA = thr_copy.partition_D(gDA)
+        tDBgDB = thr_copy.partition_D(gDB)
+        tXcX = thr_copy.partition_S(cX)[(0, None), None, None]
+        tDCrDC, tArA, tBrB, tDArDA, tDBrDB = [
+            cute.make_rmem_tensor_like(thr) for thr in (tDCgDC, tAgA, tBgB, tDAgDA, tDBgDB)
+        ]
+
+        is_even_N = const_expr(shape[1] % tiler_mn[1] == 0)
+        tXpX = None if is_even_N else copy_utils.predicate_k(thr_copy.partition_S(cX), limit=shape[1])
+        copy = partial(copy_utils.copy, pred=tXpX)
+
+        if tXcX[0][0] < shape[0]:
+            copy(tDCgDC, tDCrDC)
+            copy(tAgA, tArA)
+            copy(tBgB, tBrB)
+        dc = tDCrDC.load().to(cute.Float32)
+        a = tArA.load().to(cute.Float32)
+        b = tBrB.load().to(cute.Float32)
+
+        gelu_a = _cutedsl_gelu(a)
+        db = dc * gelu_a
+        da = dc * b * _cutedsl_gelu_grad(a)
+
+        tDArDA.store(da.to(tDArDA.element_type))
+        tDBrDB.store(db.to(tDBrDB.element_type))
+        if tXcX[0][0] < shape[0]:
+            copy(tDArDA, tDAgDA)
+            copy(tDBrDB, tDBgDB)
+
+
+# ---------------------------------------------------------------------------
+# Compile caches. ``cute.compile()`` is multi-second; key on the minimal set
+# of attributes that change codegen.
+# ---------------------------------------------------------------------------
+_FWD_COMPILE_CACHE: dict = {}
+_BWD_COMPILE_CACHE: dict = {}
+
+
+def _get_fwd_kernel(a_dtype: torch.dtype, b_dtype: torch.dtype, c_dtype: torch.dtype, N: int):
+    """Return a compiled forward kernel, building it on first miss."""
+    key = (a_dtype, b_dtype, c_dtype, N)
+    if key in _FWD_COMPILE_CACHE:
+        return _FWD_COMPILE_CACHE[key]
+
+    dtype = torch2cute_dtype_map[a_dtype]
+    b_cute_dtype = torch2cute_dtype_map[b_dtype]
+    c_cute_dtype = torch2cute_dtype_map[c_dtype]
+    batch_sym = cute.sym_int()
+    div = math.gcd(128 // dtype.width, N)
+    a_cute = fake_tensor(dtype, (batch_sym, N), div)
+    b_cute = fake_tensor(b_cute_dtype, (batch_sym, N), div)
+    c_cute = fake_tensor(c_cute_dtype, (batch_sym, N), div)
+
+    compiled = cute.compile(
+        _LigerGeGLUCuTeDSLForward(dtype, N),
+        a_cute,
+        b_cute,
+        c_cute,
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        options="--enable-tvm-ffi",
+    )
+    _FWD_COMPILE_CACHE[key] = compiled
+    return compiled
+
+
+def _get_bwd_kernel(
+    dc_dtype: torch.dtype,
+    a_dtype: torch.dtype,
+    b_dtype: torch.dtype,
+    da_dtype: torch.dtype,
+    db_dtype: torch.dtype,
+    N: int,
+):
+    """Return a compiled backward kernel, building it on first miss."""
+    key = (dc_dtype, a_dtype, b_dtype, da_dtype, db_dtype, N)
+    if key in _BWD_COMPILE_CACHE:
+        return _BWD_COMPILE_CACHE[key]
+
+    dtype = torch2cute_dtype_map[dc_dtype]
+    a_cute_dtype = torch2cute_dtype_map[a_dtype]
+    b_cute_dtype = torch2cute_dtype_map[b_dtype]
+    da_cute_dtype = torch2cute_dtype_map[da_dtype]
+    db_cute_dtype = torch2cute_dtype_map[db_dtype]
+    batch_sym = cute.sym_int()
+    div = math.gcd(128 // dtype.width, N)
+    dc_cute = fake_tensor(dtype, (batch_sym, N), div)
+    a_cute = fake_tensor(a_cute_dtype, (batch_sym, N), div)
+    b_cute = fake_tensor(b_cute_dtype, (batch_sym, N), div)
+    da_cute = fake_tensor(da_cute_dtype, (batch_sym, N), div)
+    db_cute = fake_tensor(db_cute_dtype, (batch_sym, N), div)
+
+    compiled = cute.compile(
+        _LigerGeGLUCuTeDSLBackward(dtype, N),
+        dc_cute,
+        a_cute,
+        b_cute,
+        da_cute,
+        db_cute,
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        options="--enable-tvm-ffi",
+    )
+    _BWD_COMPILE_CACHE[key] = compiled
+    return compiled
+
+
+# ===========================================================================
+# Host-side launchers and autograd Function
+# ===========================================================================
+def _geglu_cutedsl_forward(a: Tensor, b: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
+    """Forward via the inline CuTe DSL kernel.
+
+    Returns ``(a, b, c)`` where ``a`` and ``b`` are the contiguous inputs saved
+    for the backward.
+    """
+    shape = a.shape
+    N = shape[-1]
+    a_flat = a.view(-1, N).contiguous()
+    b_flat = b.view(-1, N).contiguous()
+    c_flat = torch.empty_like(a_flat)
+
+    compiled = _get_fwd_kernel(a_flat.dtype, b_flat.dtype, c_flat.dtype, N)
+    compiled(a_flat, b_flat, c_flat)
+    c = c_flat.view(shape)
+    return a_flat, b_flat, c
+
+
+def _geglu_cutedsl_backward(dc: Tensor, a: Tensor, b: Tensor) -> Tuple[Tensor, Tensor]:
+    """Backward via the inline CuTe DSL kernel.
+
+    Returns ``(da, db)``.
+    """
+    shape = dc.shape
+    N = shape[-1]
+    dc_flat = dc.view(-1, N).contiguous()
+    a_flat = a.view(-1, N).contiguous()
+    b_flat = b.view(-1, N).contiguous()
+    da_flat = torch.empty_like(a_flat)
+    db_flat = torch.empty_like(b_flat)
+
+    compiled = _get_bwd_kernel(dc_flat.dtype, a_flat.dtype, b_flat.dtype, da_flat.dtype, db_flat.dtype, N)
+    compiled(dc_flat, a_flat, b_flat, da_flat, db_flat)
+
+    da = da_flat.view(shape)
+    db = db_flat.view(shape)
+    return da, db
+
+
+class _LigerGeGLUCuTeDSLFunction(torch.autograd.Function):
+    """Autograd wrapper. Saves ``a`` and ``b`` for the backward."""
+
+    @staticmethod
+    def forward(ctx, a, b):
+        a = _to_local_if_dtensor(a)
+        b = _to_local_if_dtensor(b)
+        a = a.contiguous()
+        b = b.contiguous()
+        a_saved, b_saved, c = _geglu_cutedsl_forward(a, b)
+        ctx.save_for_backward(a_saved, b_saved)
+        return c
+
+    @staticmethod
+    def backward(ctx, dc):
+        dc = _to_local_if_dtensor(dc).contiguous()
+        a, b = ctx.saved_tensors
+        da, db = _geglu_cutedsl_backward(dc, a, b)
+        return da, db
+
+
+# ===========================================================================
+# Public registration
+# ===========================================================================
+_CUTEDSL_GELU_TOLERANCES = {
+    torch.float16: {"atol_fwd": 5e-3, "atol_bwd": 5e-2, "rtol_fwd": 1e-3, "rtol_bwd": 1e-2},
+    torch.bfloat16: {"atol_fwd": 2e-2, "atol_bwd": 1e-1, "rtol_fwd": 1e-2, "rtol_bwd": 2e-2},
+    torch.float32: {
+        "atol_fwd": 1e-4,
+        "atol_bwd": 1e-4,
+        "rtol_fwd": 1e-4,
+        "rtol_bwd": 1e-4,
+    },  # B300: CuTeDSL fast sigmoid/tanh gives ~1.5e-5 fp32 fwd error (tf32-class); 1e-5 was too strict
+}
+
+
+@register_op(
+    "geglu",
+    impl_name="nvidia-cutedsl",
+    capability=Capability(
+        min_cc=(9, 0),
+        modules=["cutlass.cute", "torch"],
+    ),
+    modes=("default",),
+    default_mode="default",
+    # Auto-preferred when satisfied (lowest rank).  GeGLU is elementwise so the
+    # CuTe DSL kernel avoids the Triton launch overhead and uses native exp2
+    # for the tanh.
+    preference_rank=10,
+    tolerances=_CUTEDSL_GELU_TOLERANCES,
+    notes="CuTe DSL GeGLU for Hopper+ (sm_90+); self-contained inline fwd+bwd.",
+)
+def geglu_cutedsl(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    *,
+    mode: Optional[str] = None,
+) -> torch.Tensor:
+    """CuTe DSL GeGLU dispatch entry point.
+
+    ``mode`` is accepted only for API parity with the other backends; the only
+    valid value is ``"default"`` (or ``None``).
+    """
+    if mode not in (None, "default"):
+        raise ValueError(f"CuTe DSL geglu has only mode='default'; got mode={mode!r}.")
+    return _LigerGeGLUCuTeDSLFunction.apply(a, b)

--- a/src/liger_kernel/ops/backends/_cutedsl/jsd.py
+++ b/src/liger_kernel/ops/backends/_cutedsl/jsd.py
@@ -1,0 +1,649 @@
+"""CuTe DSL (CUTLASS python) backend for the ``jsd_loss_and_grad`` primitive.
+
+The ``jsd_loss_and_grad`` primitive is the non-autograd inner kernel used by
+:class:`liger_kernel.ops.fused_linear_jsd.LigerFusedLinearJSDFunction`.  It
+computes the per-element JSD loss and gradient for one chunk of logits,
+returning ``(loss, dx)`` where ``loss`` is a ``(BT, V)`` fp32 tile (summed
+elsewhere) and ``dx`` overwrites the student log-probabilities.
+
+Strategy
+--------
+The JSD computation is **element-wise** (no row reduction is needed inside
+this primitive — the caller sums the loss tile).  This makes the CuTe DSL
+kernel structurally identical to the SwiGLU / GeGLU elementwise kernels:
+load tiles of ``X`` (student log-prob) and ``Y`` (teacher log-prob) into
+registers, compute the loss + gradient in fp32, store both outputs.
+
+Math (matching :mod:`liger_kernel.ops.jsd._jsd_kernel`)::
+
+    Q = exp(X)                           # student probabilities
+    P = exp(Y)                           # teacher probabilities
+
+    # General JSD (0 < beta < 1):
+    M       = beta * P + (1 - beta) * Q
+    log_M   = log(M)
+    loss    = beta * P * Y + (1 - beta) * Q * X - M * log_M
+    dX      = (1 - beta) * Q * (X - log_M)
+
+    # Forward KL (beta == 0):
+    loss    = P * (Y - X)
+    dX      = -P
+
+    # Reverse KL (beta == 1):
+    loss    = Q * (X - Y)
+    dX      = loss + Q
+
+    loss *= (1 / n_non_ignore)
+    dX   *= (1 / n_non_ignore)
+
+The max-subtraction for numerical stability in the Triton kernel is omitted
+here — log-probabilities are typically in ``[-30, 0]`` so ``exp`` does not
+overflow.  For bf16/fp16 inputs ``exp``/``log`` are computed via native
+``exp2``/``log2`` (``exp(x) = exp2(x * log2(e))``); for fp32 inputs the kernel
+switches to libdevice-precise ``exp``/``log`` (no fastmath) to match
+``torch.exp`` fp32 within the strict public JSD contract (1e-7 atol).
+
+Rows where ``label == ignore_index`` are zeroed in-kernel: the label stream is
+threaded through the CuTe DSL kernel as a compile-keyed ``Optional`` operand,
+and ignored rows are ``fill(0.0)``-ed before the gmem store, so no host-side
+``nonzero()``/scatter and no device->host sync are needed. Kernels compiled for
+``shift_labels is None`` or packed batches (``n_non_ignore == BT``) pass
+``None`` for the label operand and dead-code-eliminate the zero-fill.
+
+Capability
+----------
+- Compute capability >= sm_90 (Hopper or newer).
+- Requires only the ``cutlass`` Python package.
+
+References
+----------
+- Triton reference: :mod:`liger_kernel.ops.jsd._jsd_kernel`
+- Triton primitive: :mod:`liger_kernel.ops.backends._triton.jsd.jsd_loss_and_grad_triton`
+- CuTe DSL elementwise: :mod:`._cutedsl.swiglu`
+"""
+
+import math
+
+from functools import partial
+from typing import Optional
+from typing import Tuple
+from typing import Type
+
+# ---------------------------------------------------------------------------
+# Top-level CuTe DSL imports. Identical pattern to the swiglu sibling.
+# ---------------------------------------------------------------------------
+import cuda.bindings.driver as cuda  # noqa: F401  (referenced by cute.compile)
+import cutlass
+import cutlass.cute as cute
+import torch
+
+from cutlass import Float32
+from cutlass import Int64
+from cutlass import const_expr
+from torch import Tensor
+
+# Inlined CuTe DSL utilities (adapted from Quack, Apache-2.0).
+import liger_kernel.ops.backends._cutedsl._cute_lib.copy_utils as copy_utils
+
+from liger_kernel.backends import Capability
+from liger_kernel.backends import register_op
+from liger_kernel.backends.dispatch import emit_fallback_warning
+from liger_kernel.ops._nvidia_shared import to_local_if_dtensor as _to_local_if_dtensor  # noqa: F401
+from liger_kernel.ops.backends._cutedsl._cute_lib.compile_utils import make_fake_tensor as fake_tensor
+from liger_kernel.ops.backends._cutedsl._cute_lib.dtype_map import torch2cute_dtype_map
+from liger_kernel.ops.backends._triton.jsd import jsd_loss_and_grad_triton
+from liger_kernel.ops.jsd import LigerJSDFunction
+
+
+def _max_capability() -> int:
+    # Runtime dispatch-plane key (e.g. 100 = sm_100/B200, 103 = sm_103/B300).
+    # Called per wrapper invocation (never memoized) so mock-cc suites key
+    # separately per call, same idiom as capability.is_satisfied.
+    if torch.cuda.is_available():
+        try:
+            maj, minor = torch.cuda.get_device_capability()
+        except (IndexError, RuntimeError, AssertionError):  # pragma: no cover
+            return 0
+        return 10 * maj + minor
+    return 0
+
+
+# Dispatch-plane preference ranks (auto-select picks the LOWEST rank among
+# available impls -- backends/dispatch.py resolution rule 5).
+#
+# On Hopper and B200 (sm_90/sm_100) this file's impls stay at rank 20, which is
+# what they have always been (cuTile is Blackwell-only: min_cc=(10,0), so on
+# B200 cuTile rank 5 has silently won auto ahead of this 20 since the cutile
+# backend landed; B200's cuTile-vs-cutedsl split was never mapped and stays
+# untouched by the plane doctrine).
+#
+# On sm_103/B300 the end-to-end pinned map (
+# full fwd+bwd through LigerJSDFunction.apply with jsd_impl pinned, ABAB x3,
+# per-iter-sync CUDA-event medians) measured this file's kernels FASTER than
+# the auto-winning cuTile at every mapped cell -- bf16 2.27-3.55x, fp16
+# 2.22-3.08x, fp32 1.25-1.33x (V 8192..128256) -- EXCEPT one isolated fp32
+# V==16384 cliff cell where cutedsl runs at 0.1997x of cuTile (also 3.3-5.3x
+# behind Triton; the in-kernel wide-tile re-route was REFUTED at ratio ~1.0,
+# so the fp32 band at exactly 16384 is off-roofline for the precise-libdevice
+# kernels on sm_103). Rank 2 (below cuTile's 5) fixes the routing; the single
+# losing cell is handed to Triton (== cuTile within 1.6% pinned at the band,
+# a pinned band probe) by the _B300_FP32_SIDESTEP_VOCAB guard in
+# jsd_loss_and_grad_cutedsl below.
+_RANK_HOPPER_B200 = 20
+_RANK_B300 = 2
+
+_B300_FP32_SIDESTEP_VOCAB = 16384
+
+
+# log2(e) and ln(2) for exp2/log2 conversions (native HW instructions).
+_LOG2_E = math.log2(math.e)
+_LN2 = math.log(2.0)
+
+
+def _cutedsl_exp_fast(x):
+    """exp via native exp2: ``exp(x) = exp2(x * log2(e))`` (``ex2.approx``)."""
+    return cute.math.exp2(x * _LOG2_E, fastmath=True)
+
+
+def _cutedsl_log_fast(x):
+    """log via native log2: ``log(x) = log2(x) * ln(2)`` (``lg2.approx``)."""
+    return cute.math.log2(x, fastmath=True) * _LN2
+
+
+def _cutedsl_exp_precise(x):
+    """exp via ``math.exp`` without fastmath: libdevice ``__nv_expf`` (~1 ulp).
+
+    This matches ``torch.exp`` fp32 (which calls ``expf``/``__nv_expf``), so
+    fp32 tensors land exactly on the strict public JSD contract that the
+    ``ex2.approx`` fastmath path (~2 ulp) misses (fwd scalar drifted ~4e-7
+    vs the 1e-7 atol of ``test/transformers/test_jsd.py``).
+    """
+    return cute.math.exp(x, fastmath=False)
+
+
+def _cutedsl_log_precise(x):
+    """log via ``math.log`` without fastmath: libdevice ``__nv_logf``."""
+    return cute.math.log(x, fastmath=False)
+
+
+# ===========================================================================
+# Kernel — elementwise: loss + dX from student (X) and teacher (Y) log-probs
+# ===========================================================================
+class _LigerJSDLossAndGradCuTeDSL:
+    """CuTe DSL JSD loss + gradient primitive.
+
+    Pure elementwise: load tiles of ``X`` (student log-prob) and ``Y``
+    (teacher log-prob), compute loss + dX in fp32, store both.  The ``beta``
+    value is a constructor parameter so separate kernels are compiled for
+    forward KL (beta=0), reverse KL (beta=1), and general JSD.
+    """
+
+    def __init__(self, dtype: Type[cutlass.Numeric], N: int, beta: float):
+        self.dtype = dtype
+        self.N = N
+        self.beta = beta
+        self.cluster_n = 1
+        # fp32 needs a precise exp/log to hit the strict 1e-7 public JSD
+        # contract (bf16/fp16 tolerate the native ex2.approx/lg2.approx path,
+        # rounding away its ~2-ulp error on store). The decision is made at
+        # trace time from the input dtype, so each compiled kernel bakes in a
+        # single math path.
+        if self.dtype.width == 32:
+            self._exp = _cutedsl_exp_precise
+            self._log = _cutedsl_log_precise
+        else:
+            self._exp = _cutedsl_exp_fast
+            self._log = _cutedsl_log_fast
+
+    def _threads_per_row(self):
+        N = self.N
+        for limit, threads in [(64, 8), (128, 16), (3072, 32), (6144, 64), (16384, 128)]:
+            if N <= limit:
+                return threads
+        # 1024 for N > 16384 (not 256): at 256 threads/row each thread carries
+        # >=125 fp32 (or 250 bf16) elements and spills registers. Measured on
+        # B200: bf16 @N=32768 goes 0.61ms -> 0.13ms (4.8x), fp32 0.18 -> 0.17ms.
+        return 1024
+
+    def _num_threads(self):
+        return 128 if self.N <= 16384 else 1024
+
+    def _get_tiled_copy(self, vecsize: int = 1):
+        threads_per_row = self._threads_per_row()
+        num_threads = self._num_threads()
+        assert num_threads % cute.arch.WARP_SIZE == 0
+        if self.N > 16384:
+            # Wide-vocab N-blocking: cap the chunks each block loops over at
+            # 2 and move the remaining N chunk-groups onto grid-y (see
+            # __call__ and kernel). All math is elementwise per element -- no
+            # cross-N reduction -- so N-blocking is bit-identical, but it
+            # keeps the per-thread live-register footprint bounded: the old
+            # whole-row-per-block config makes each thread carry
+            # ceil(N/vecsize/1024)*vecsize*~6 fp32 temporaries
+            # (VEC=4 bf16 -> 128 fp32 regs @V=128256), spilling to local
+            # memory. Cap sweep on B200 (caps 1/2/4/8 x bf16/fp32 @
+            # N=32768/65536/128256, every nonzero cap bit-identical): cap=2
+            # (8 elems/thread live) wins at ALL shapes/dtypes -- cap=4 (the
+            # previous value) is 1.09-1.14x slower, cap=8 worse, and cap=1
+            # is also slower (grid-y gets too deep; fp32 even miscompiles).
+            num_blocks_N = min(cute.ceil_div(self.N // vecsize, threads_per_row * self.cluster_n), 2)
+        else:
+            num_blocks_N = cute.ceil_div(self.N // vecsize, threads_per_row * self.cluster_n)
+        tiler_mn = (num_threads // threads_per_row, vecsize * num_blocks_N * threads_per_row)
+        tiled_copy = copy_utils.tiled_copy_2d(self.dtype, threads_per_row, num_threads, vecsize)
+        return tiled_copy, tiler_mn, threads_per_row
+
+    def _row_math(self, tXrX, tYrY, scale, tLossRLoss, tDXrDX):
+        # Plain (undecorated) helper executed at trace time and inlined into the
+        # kernel body -- same proven trace-time idiom as ``self._exp`` /
+        # ``self._log`` above. Shared by the packed and labeled kernel
+        # specializations so the beta-math chain lives in exactly one place.
+        x = tXrX.load().to(cute.Float32)  # X = log Q (student)
+        y = tYrY.load().to(cute.Float32)  # Y = log P (teacher)
+
+        beta = const_expr(self.beta)
+        if const_expr(beta == 0.0):
+            # Forward KL: loss = P * (Y - X), dX = -P
+            p = self._exp(y)
+            loss = p * (y - x)
+            dx = -p
+        elif const_expr(beta == 1.0):
+            # Reverse KL: loss = Q * (X - Y), dX = loss + Q
+            q = self._exp(x)
+            loss = q * (x - y)
+            dx = loss + q
+        else:
+            # General JSD
+            q = self._exp(x)
+            p = self._exp(y)
+            beta_p = beta * p
+            one_minus_beta_q = (1.0 - beta) * q
+            m = beta_p + one_minus_beta_q
+            log_m = self._log(m)
+            loss = beta_p * y + one_minus_beta_q * x - m * log_m
+            dx = one_minus_beta_q * (x - log_m)
+
+        loss = loss * scale
+        dx = dx * scale
+
+        tLossRLoss.store(loss)
+        tDXrDX.store(dx.to(tDXrDX.element_type))
+
+    @cute.jit
+    def __call__(
+        self,
+        mX: cute.Tensor,
+        mY: cute.Tensor,
+        mLoss: cute.Tensor,
+        mDX: cute.Tensor,
+        mLabel: Optional[cute.Tensor],  # ignore-row labels (BT,) int64, or None
+        scale: Float32,
+        ignore_index: Int64,
+        stream: cuda.CUstream,
+    ):
+        assert mX.element_type == self.dtype
+        largest_dtype_width = const_expr(max(t.element_type.width for t in [mX, mY, mLoss, mDX]))
+        vecsize = math.gcd(self.N, 128 // largest_dtype_width)
+        tiled_copy, tiler_mn, _ = self._get_tiled_copy(vecsize=vecsize)
+        num_threads = tiled_copy.size
+        self.kernel(mX, mY, mLoss, mDX, mLabel, scale, ignore_index, tiler_mn, tiled_copy).launch(
+            grid=[cute.ceil_div(mX.shape[0], tiler_mn[0]), cute.ceil_div(self.N, tiler_mn[1]), 1],
+            block=[num_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mX: cute.Tensor,
+        mY: cute.Tensor,
+        mLoss: cute.Tensor,
+        mDX: cute.Tensor,
+        mLabel: Optional[cute.Tensor],
+        scale: Float32,
+        ignore_index: Int64,
+        tiler_mn: cute.Shape,
+        tiled_copy: cute.TiledCopy,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bnidx, _ = cute.arch.block_idx()
+
+        shape = mX.shape
+        idX = cute.make_identity_tensor(shape)
+        gX, gY, gLoss, gDX, cX = [cute.local_tile(mT_, tiler_mn, (bidx, bnidx)) for mT_ in (mX, mY, mLoss, mDX, idX)]
+
+        thr_copy = tiled_copy.get_slice(tidx)
+        tXgX = thr_copy.partition_S(gX)
+        tYgY = thr_copy.partition_S(gY)
+        tLossGLoss = thr_copy.partition_D(gLoss)
+        tDXgDX = thr_copy.partition_D(gDX)
+        tXcX = thr_copy.partition_S(cX)[(0, None), None, None]
+        tXrX, tYrY, tLossRLoss, tDXrDX = [cute.make_rmem_tensor_like(thr) for thr in (tXgX, tYgY, tLossGLoss, tDXgDX)]
+
+        # Same as the old full-row check (shape[1] == tiler_n * cluster_n) on
+        # the small rung (tiler_n >= N there); on the wide rung each grid-y
+        # block is full iff N % tiler_n == 0, in which case no N predication is
+        # needed at all (predicate_k uses global col indices from idX).
+        is_even_N = const_expr(shape[1] % tiler_mn[1] == 0)
+        tXpX = None if is_even_N else copy_utils.predicate_k(thr_copy.partition_S(cX), limit=shape[1])
+        copy = partial(copy_utils.copy, pred=tXpX)
+
+        # One scalar label read per thread. tiled_copy_2d lays the thread layout
+        # out as (num_rows_per_block, threads_per_row), so each thread covers
+        # exactly one row: tXcX[0][0] (this thread's element-row coord, already
+        # used for the row guard below) is that row's index.
+        label_row = tXcX[0][0]
+
+        if const_expr(mLabel is None):
+            # Packed / no-label specialization: byte-identical trace to the
+            # c848ced body (the label path is never traced in this variant).
+            if tXcX[0][0] < shape[0]:
+                copy(tXgX, tXrX)
+                copy(tYgY, tYrY)
+            self._row_math(tXrX, tYrY, scale, tLossRLoss, tDXrDX)
+            if tXcX[0][0] < shape[0]:
+                copy(tLossRLoss, tLossGLoss)
+                copy(tDXrDX, tDXgDX)
+        elif const_expr(self.dtype.width == 32):
+            # Labeled fp32 kernels: Triton HAS_LABEL-class early exit -- an
+            # ignored row skips the X/Y gmem loads AND the precise-libdevice
+            # exp/log math (c848ced folded the +0.0 stores into the epilogue
+            # but still paid the full read and math on every ignored row
+            # before zeroing it). fp32-only by measurement on B300 (ABAB x2
+            # fresh-process, ALL_BITWISE both constructions): the skip wins
+            # +7.1-7.6% at 1/3-ignore V=32000 and +27% at 90%-ignore for fp32
+            # -- its precise-libdevice body is expensive enough that skipping
+            # it beats load-uniformity loss -- while the fast-exp bf16/fp16
+            # path loses 5-9% at 1/3-ignore (uniform loads win) and only +5%
+            # at 90% (still behind Triton there), so 2-byte labeled kernels
+            # keep the c848ced trace below. The stores/copies write the same
+            # +0.0 fragments at the same sites -- a pure control decision,
+            # never an arithmetic reorder -- so every fp32 cell is bitwise ==
+            # the c848ced body (probe enforces ALL_BITWISE).
+            if label_row < shape[0]:
+                if mLabel[label_row] == ignore_index:
+                    tLossRLoss.fill(0.0)
+                    tDXrDX.fill(tDXrDX.element_type.zero)
+                    copy(tLossRLoss, tLossGLoss)
+                    copy(tDXrDX, tDXgDX)
+                else:
+                    copy(tXgX, tXrX)
+                    copy(tYgY, tYrY)
+                    self._row_math(tXrX, tYrY, scale, tLossRLoss, tDXrDX)
+                    copy(tLossRLoss, tLossGLoss)
+                    copy(tDXrDX, tDXgDX)
+        else:
+            # Labeled 2-byte kernels: byte-identical trace to the c848ced body
+            # (math unconditional under the row guard, epilogue fill overwrite,
+            # guarded stores) -- the measured never-win regime for the skip.
+            if tXcX[0][0] < shape[0]:
+                copy(tXgX, tXrX)
+                copy(tYgY, tYrY)
+            self._row_math(tXrX, tYrY, scale, tLossRLoss, tDXrDX)
+            if label_row < shape[0]:
+                if mLabel[label_row] == ignore_index:
+                    tLossRLoss.fill(0.0)
+                    tDXrDX.fill(tDXrDX.element_type.zero)
+            if tXcX[0][0] < shape[0]:
+                copy(tLossRLoss, tLossGLoss)
+                copy(tDXrDX, tDXgDX)
+        # Rows >= shape[0] (partial last M-block, has_label or packed): no
+        # loads and no stores -- identical predication coverage to c848ced,
+        # whose single row guard gated every copy the same way.
+
+
+# ---------------------------------------------------------------------------
+# Compile cache.
+# ---------------------------------------------------------------------------
+_COMPILE_CACHE: dict = {}
+
+
+def _get_kernel(
+    x_dtype: torch.dtype,
+    y_dtype: torch.dtype,
+    loss_dtype: torch.dtype,
+    dx_dtype: torch.dtype,
+    N: int,
+    beta: float,
+    has_label: bool = False,
+):
+    """Return a compiled kernel, building it on first miss."""
+    key = (x_dtype, y_dtype, loss_dtype, dx_dtype, N, beta, has_label)
+    if key in _COMPILE_CACHE:
+        return _COMPILE_CACHE[key]
+
+    dtype = torch2cute_dtype_map[x_dtype]
+    y_cute_dtype = torch2cute_dtype_map[y_dtype]
+    loss_cute_dtype = torch2cute_dtype_map[loss_dtype]
+    dx_cute_dtype = torch2cute_dtype_map[dx_dtype]
+    batch_sym = cute.sym_int()
+    div = math.gcd(128 // dtype.width, N)
+    x_cute = fake_tensor(dtype, (batch_sym, N), div)
+    y_cute = fake_tensor(y_cute_dtype, (batch_sym, N), div)
+    loss_cute = fake_tensor(loss_cute_dtype, (batch_sym, N), div)
+    dx_cute = fake_tensor(dx_cute_dtype, (batch_sym, N), div)
+    label_cute = fake_tensor(torch2cute_dtype_map[torch.int64], (batch_sym,)) if has_label else None
+
+    compiled = cute.compile(
+        _LigerJSDLossAndGradCuTeDSL(dtype, N, beta),
+        x_cute,
+        y_cute,
+        loss_cute,
+        dx_cute,
+        label_cute,
+        Float32(0.0),
+        Int64(0),
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        options="--enable-tvm-ffi",
+    )
+    _COMPILE_CACHE[key] = compiled
+    return compiled
+
+
+# ===========================================================================
+# Host-side launcher
+# ===========================================================================
+def _jsd_loss_and_grad_cutedsl(
+    student_prob: Tensor,
+    teacher_prob: Tensor,
+    beta: float,
+    n_non_ignore: int,
+    shift_labels: Optional[Tensor] = None,
+    ignore_index: int = -100,
+) -> Tuple[Tensor, Tensor]:
+    """Compute per-element JSD loss + dx via the inline CuTe DSL kernel.
+
+    Returns ``(loss, dx)`` where ``loss`` is a fresh ``(BT, V)`` fp32 tensor
+    and ``dx`` overwrites ``student_prob`` in-place (matching the Triton
+    primitive's contract).
+
+    ``shift_labels`` (optional) is the ignore-row label stream: when given AND a
+    real ignored row exists (``n_non_ignore < BT``), it is threaded into the
+    compiled kernel which zeroes those rows in the epilogue. ``None`` labels or a
+    packed batch (``n_non_ignore == BT``) pass ``None`` -- the absent-arg
+    specialization dead-code-eliminates the zero-fill.
+    """
+    BT, V = student_prob.shape
+    x_flat = student_prob.contiguous()
+    y_flat = teacher_prob.contiguous()
+    # empty, not zeros: the elementwise kernel stores loss+dX for EVERY
+    # in-tensor element unconditionally (predication only masks columns >= V
+    # and rows >= BT, both outside the (BT, V) allocation), so the zeros
+    # memset is a redundant (BT, V) fp32 write the kernel fully overwrites.
+    loss = torch.empty((BT, V), dtype=torch.float32, device=student_prob.device)
+    dx = x_flat  # in-place overwrite (matches Triton contract)
+
+    label_arg = None
+    if shift_labels is not None:
+        labels_i64 = shift_labels.contiguous().to(torch.int64)
+        # Thread labels whenever THIS (chunk-local) label tensor actually
+        # contains an ignored row. The previous `n_non_ignore < BT` compared the
+        # GLOBAL non-ignore count with the per-chunk BT, so multi-chunk batches
+        # with a few ignores (global_n_non_ignore >= chunk_BT) silently dropped
+        # the label stream and let ignored rows contribute loss/gradient.
+        if bool((labels_i64 == ignore_index).any()):
+            label_arg = labels_i64
+
+    scale = Float32(1.0 / max(n_non_ignore, 1))
+    compiled = _get_kernel(
+        x_flat.dtype, y_flat.dtype, loss.dtype, dx.dtype, V, float(beta), has_label=label_arg is not None
+    )
+    compiled(x_flat, y_flat, loss, dx, label_arg, scale, int(ignore_index))
+
+    return loss, dx
+
+
+# ===========================================================================
+# Public registration
+# ===========================================================================
+@register_op(
+    "jsd_loss_and_grad",
+    impl_name="nvidia-cutedsl",
+    capability=Capability(
+        min_cc=(9, 0),
+        modules=["cutlass.cute", "torch"],
+    ),
+    modes=("default",),
+    default_mode="default",
+    preference_rank=_RANK_B300 if _max_capability() > 100 else _RANK_HOPPER_B200,
+    notes=(
+        "Per-chunk JSD primitive (returns per-row loss tile + per-element dx). "
+        "CuTe DSL elementwise kernel for Hopper+ (sm_90+). Used by fused_linear_jsd. Auto preference_rank 20 on sm_90/sm_100, 2 on sm_103+ (see rank constants)."
+    ),
+)
+def jsd_loss_and_grad_cutedsl(
+    student_prob: torch.Tensor,
+    teacher_prob: torch.Tensor,
+    shift_labels: Optional[torch.Tensor],
+    beta: float,
+    ignore_index: int,
+    n_non_ignore: float,
+    *,
+    mode: Optional[str] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Compute per-element loss + dx for one chunk via CuTe DSL.
+
+    Mirrors the Triton primitive's contract: writes dx **in-place into**
+    ``student_prob`` and returns ``(loss, dx)``.
+
+    Args:
+        student_prob: ``(BT, V)`` log Q (student). Will be overwritten with dx.
+        teacher_prob: ``(BT, V)`` log P (teacher).
+        shift_labels: optional ``(BT,)`` mask; rows where the label equals
+            ``ignore_index`` contribute zero loss and zero gradient.
+        beta: mixing coefficient in [0, 1].
+        ignore_index: label value to ignore.
+        n_non_ignore: pre-computed count of non-ignored rows (caller's job).
+
+    Returns:
+        ``(loss, dx)`` where ``loss.shape == (BT, V)`` (fp32) and
+        ``dx is student_prob`` (the in-place write).
+    """
+    if mode not in (None, "default"):
+        raise ValueError(f"jsd_loss_and_grad_cutedsl: only mode='default'; got {mode!r}")
+
+    # fp32 V==16384 side-step (sm_103+): the one cell where the auto-routing
+    # flip above would REGRESS. The CuTe DSL kernel runs ~0.20x vs both cuTile
+    # and pinned Triton here (measured 4.99ms vs 1.00/0.99ms at BT=8192;
+    # wide-tile re-route refuted at ratio ~1.0), while Triton == cuTile within
+    # 1.6% pinned at the band. Delegate to the Triton primitive (identical
+    # in-place dx / fp32 (BT, V) loss contract) and let the rest of the map
+    # keep the rank flip.
+    if (
+        _max_capability() > 100
+        and student_prob.element_size() == 4
+        and teacher_prob.element_size() == 4
+        and student_prob.shape[-1] == _B300_FP32_SIDESTEP_VOCAB
+    ):
+        emit_fallback_warning(
+            "jsd_loss_and_grad",
+            "nvidia-cutedsl",
+            "nvidia-triton",
+            "fp32 V==16384 on sm_103+: CuTe DSL kernel measured ~0.20x vs cuTile/Triton at this one cell",
+        )
+        return jsd_loss_and_grad_triton(
+            student_prob,
+            teacher_prob,
+            shift_labels,
+            float(beta),
+            int(ignore_index),
+            n_non_ignore,
+            mode=mode,
+        )
+
+    # Ignore-row zeroing is folded into the kernel epilogue (see
+    # _jsd_loss_and_grad_cutedsl): the compare + both (BT, V) boolean-mask
+    # scatters that the host used to run on labeled-with-ignores shapes are
+    # deleted. Packed batches (n_non_ignore == BT) still skip the label stream
+    # entirely; no-label calls are unaffected.
+    loss, dx = _jsd_loss_and_grad_cutedsl(
+        student_prob,
+        teacher_prob,
+        float(beta),
+        int(round(n_non_ignore)),
+        shift_labels,
+        int(ignore_index),
+    )
+
+    return loss, dx
+
+
+# ===========================================================================
+# Standalone JSD op — autograd-aware wrapper.
+#
+# The CuTe DSL acceleration happens inside ``LigerJSDFunction.forward``:
+# it calls ``dispatch("jsd_loss_and_grad", ...)`` for the inner JSD kernel,
+# which selects CuTe DSL on Hopper and cuTile on Blackwell when available.
+# ===========================================================================
+_CUTEDSL_JSD_TOLERANCES = {
+    torch.float16: {"atol_fwd": 5e-3, "atol_bwd": 5e-3, "rtol_fwd": 1e-3, "rtol_bwd": 1e-3},
+    torch.bfloat16: {"atol_fwd": 2e-2, "atol_bwd": 2e-2, "rtol_fwd": 1e-2, "rtol_bwd": 1e-2},
+    torch.float32: {"atol_fwd": 1e-5, "atol_bwd": 1e-5, "rtol_fwd": 1e-5, "rtol_bwd": 1e-5},
+}
+
+
+@register_op(
+    "jsd",
+    impl_name="nvidia-cutedsl",
+    capability=Capability(
+        min_cc=(9, 0),
+        modules=["cutlass.cute", "torch"],
+    ),
+    modes=("default",),
+    default_mode="default",
+    preference_rank=_RANK_B300 if _max_capability() > 100 else _RANK_HOPPER_B200,
+    tolerances=_CUTEDSL_JSD_TOLERANCES,
+    notes=(
+        "CuTe DSL JSD for Hopper+ (sm_90+); inner JSD via CuTe DSL elementwise kernel."
+        " Auto preference_rank 20 on sm_90/sm_100, 2 on sm_103+; the fp32 V==16384 band is handed to Triton by the primitive-level side-step guard."
+    ),
+)
+def jsd_cutedsl(
+    _input: torch.Tensor,
+    target: torch.Tensor,
+    shift_labels: Optional[torch.Tensor] = None,
+    beta: float = 0.5,
+    ignore_index: int = -100,
+    *,
+    mode: Optional[str] = None,
+) -> torch.Tensor:
+    """CuTe DSL JSD dispatch entry point.
+
+    Delegates to ``LigerJSDFunction``, which internally dispatches the
+    ``jsd_loss_and_grad`` primitive through the dispatcher — picking up the
+    CuTe DSL kernel on Hopper+.
+
+    ``mode`` is accepted only for API parity with the other backends; the only
+    valid value is ``"default"`` (or ``None``).
+    """
+    if mode not in (None, "default"):
+        raise ValueError(f"CuTe DSL jsd has only mode='default'; got mode={mode!r}.")
+    return LigerJSDFunction.apply(
+        _input,
+        target,
+        shift_labels,
+        beta,
+        ignore_index,
+        "nvidia-cutedsl",
+        mode,
+    )

--- a/src/liger_kernel/ops/backends/_cutedsl/kl_div.py
+++ b/src/liger_kernel/ops/backends/_cutedsl/kl_div.py
@@ -1,0 +1,617 @@
+"""CuTe DSL (CUTLASS python) backend for ``kl_div``.
+
+Strategy
+--------
+KL-divergence loss is a row-reduction followed by a cross-row reduction::
+
+    loss_row = sum_v( target * (log(max(target, eps)) - y_pred) )   # not log_target
+    loss_row = sum_v( exp(target) * (target - y_pred) )             # log_target
+    loss     = reduce(loss_row)                                      # sum / mean / batchmean
+
+The CuTe DSL forward kernel uses the ``ReductionBase`` infrastructure (same as
+the rms_norm / layer_norm forward kernels) to load tiles of ``y_pred`` and
+``target`` into shared memory, compute the per-element loss in fp32, and reduce
+per row via ``row_reduce``.
+
+The backward is purely elementwise::
+
+    grad = -target            # not log_target
+    grad = -exp(target)       # log_target
+
+with ``grad_output`` and the reduction factor folded into the kernel epilogue
+as one dynamic fp32 scalar.  The backward kernel follows the SwiGLU elementwise
+pattern (TiledCopy + ``cp.async``).
+
+Capability
+----------
+- Compute capability >= sm_90 (Hopper or newer).
+- Forward kernel is capped at ``V <= 32768`` (shared-memory tile limit; same
+  ceiling as the rms_norm backward). Larger V raises ``RuntimeError`` so the
+  dispatcher falls back to Triton.
+
+References
+----------
+- Triton reference: :mod:`liger_kernel.ops.kl_div`
+- CuTe DSL reduction: :mod:`._cute_lib.reduction_base.ReductionBase`
+- CuTe DSL elementwise: :mod:`._cutedsl.swiglu`
+"""
+
+import math
+
+from functools import partial
+from typing import Optional
+from typing import Type
+
+# ---------------------------------------------------------------------------
+# Top-level CuTe DSL imports. Identical pattern to the rms_norm sibling.
+# ---------------------------------------------------------------------------
+import cuda.bindings.driver as cuda  # noqa: F401  (referenced by cute.compile)
+import cutlass
+import cutlass.cute as cute
+import torch
+
+from cutlass import Float32
+from cutlass import const_expr
+from torch import Tensor
+
+# Inlined CuTe DSL utilities (adapted from Quack, Apache-2.0).
+import liger_kernel.ops.backends._cutedsl._cute_lib.copy_utils as copy_utils
+
+from liger_kernel.backends import Capability
+from liger_kernel.backends import register_op
+from liger_kernel.backends.dispatch import emit_fallback_warning
+from liger_kernel.ops._nvidia_shared import to_local_if_dtensor as _to_local_if_dtensor
+from liger_kernel.ops.backends._cutedsl._cute_lib.compile_utils import make_fake_tensor as fake_tensor
+from liger_kernel.ops.backends._cutedsl._cute_lib.dtype_map import torch2cute_dtype_map
+from liger_kernel.ops.backends._cutedsl._cute_lib.reduce import row_reduce
+from liger_kernel.ops.backends._cutedsl._cute_lib.reduction_base import ReductionBase
+
+# log2(e) for the exp2-based exp (native HW instruction).
+_LOG2_E = math.log2(math.e)
+
+# Same ceiling as the rms_norm backward — beyond this the tile doesn't fit
+# in shared memory without the cluster-reduce path.
+_FWD_MAX_TILE_CUTEDSL = 32768
+
+# The FORWARD stages a full row of EACH input (y_pred + target) in dynamic
+# shared memory, i.e. ~ V * (es_y + es_t) bytes plus the reduction buffer.
+# That fits the 232448-byte sm_100 per-CTA cap across the 28672..32768 band
+# for 2-byte dtypes (128KB @32768) and for mixed-dtype calls (bf16+fp32 =
+# 192KB @32768), but overflows when BOTH inputs are 4-byte (vecsize 4):
+# fp32 fwd kernels at V=32000 / V=32768 COMPILE then fault at launch with
+# cudaErrorInvalidValue ("launch shared memory exceeds current GPU arch
+# sm_100a allowed. Allocated: 262176 bytes. Max: 232448" — measured on B200
+# by the wide-N fwd sweep; sY+sT alone = 2*4*32768 = 262144). Guard on the
+# measured power-of-two ceiling below: an all-4-byte call in the
+# (28672, 32768] band takes the Triton fallback in the public wrapper
+# instead of faulting; every other dtype mix keeps the CuTe DSL kernel over
+# the full band, byte-unchanged from before.
+_FWD_MAX_TILE_CUTEDSL_FP32 = 28672
+
+
+def _max_capability() -> int:
+    # Runtime dispatch-plane key (e.g. 100 = sm_100/B200, 103 = sm_103/B300).
+    # Called per wrapper invocation (never memoized) so mock-cc suites key
+    # separately per call, same idiom as capability.is_satisfied and the
+    # fused_add_rms_norm 305238c plane-guard.
+    if torch.cuda.is_available():
+        try:
+            maj, minor = torch.cuda.get_device_capability()
+        except (IndexError, RuntimeError, AssertionError):  # pragma: no cover
+            return 0
+        return 10 * maj + minor
+    return 0
+
+
+# B300 sm_103 no-grad fwd-only fp32-pair Triton-preference band. The full
+# fwd+bwd decision map has CuTe DSL winning
+# every fp32 rung 1.29-1.47x, and 2-byte dtypes keep their 1.20-1.91x wins
+# in the no-grad regime too (pinned backends,
+# M=8192, ABAB x3, per-iter-sync CUDA-event medians) -- but fp32-pair
+# no-grad fwd-only shows a rope-class regime inversion on sm_103:
+# ratio(T/C) = 0.9306x @16384, 0.9740x @24576, 0.7624x @28672 (reps tight
+# <2%), ~0.93-1.31x absolute ms deficit. The bwd never runs in this regime,
+# so the wrapper routes these calls to Triton. B200 sm_100 keeps the CuTe
+# route (never B300-class measured there; same sm_103-only scoping as
+# fused_add_rms_norm 305238c / jsd e8e4ed5 / fused_linear_jsd b977b0e).
+_B300_FP32_NO_GRAD_TRITON_LO = 16384
+_B300_FP32_NO_GRAD_TRITON_HI = 28672
+
+
+# ===========================================================================
+# Forward kernel — row reduction: loss_row = sum(loss_element)
+# ===========================================================================
+class _LigerKLDivCuTeDSLForward(ReductionBase):
+    """CuTe DSL KL-divergence forward.
+
+    One CTA per row.  Loads tiles of ``y_pred`` (log-space) and ``target``
+    into shared memory, computes the per-element loss in fp32, and reduces
+    per row via ``row_reduce``.
+    """
+
+    def __init__(self, dtype: Type[cutlass.Numeric], N: int, log_target: bool):
+        super().__init__(dtype, N, stage=1)
+        self.log_target = log_target
+
+    def _threads_per_row(self):
+        N = self.N
+        for limit, threads in [(64, 8), (128, 16), (3072, 32), (6144, 64), (16384, 128)]:
+            if N <= limit:
+                return threads
+        return 256
+
+    def _set_cluster_n(self):
+        self.cluster_n = 1
+
+    @cute.jit
+    def __call__(
+        self,
+        mY: cute.Tensor,  # y_pred (BT, V) in log-space
+        mT: cute.Tensor,  # target (BT, V)
+        mLoss: cute.Tensor,  # output (BT,) per-row loss
+        eps: Float32,
+        stream: cuda.CUstream,
+    ):
+        assert mY.element_type == self.dtype
+        self._set_cluster_n()
+        largest_dtype_width = const_expr(max(t.element_type.width for t in [mY, mT, mLoss]))
+        vecsize = math.gcd(self.N, 128 // largest_dtype_width)
+        tiled_copy, tiler_mn, threads_per_row = self._get_tiled_copy(vecsize=vecsize)
+        num_threads = tiled_copy.size
+        self.kernel(mY, mT, mLoss, eps, tiler_mn, tiled_copy, threads_per_row).launch(
+            grid=[cute.ceil_div(mY.shape[0], tiler_mn[0]), 1, 1],
+            block=[num_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mY: cute.Tensor,
+        mT: cute.Tensor,
+        mLoss: cute.Tensor,
+        eps: Float32,
+        tiler_mn: cute.Shape,
+        tiled_copy: cute.TiledCopy,
+        threads_per_row: cutlass.Constexpr[int],
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+
+        shape = mY.shape
+        idX = cute.make_identity_tensor(shape)
+        gY, gT, cX = [cute.local_tile(mT_, tiler_mn, (bidx, 0)) for mT_ in (mY, mT, idX)]
+
+        smem = cutlass.utils.SmemAllocator()
+        sY = smem.allocate_tensor(mY.element_type, cute.make_ordered_layout(tiler_mn, order=(1, 0)), byte_alignment=16)
+        sT = smem.allocate_tensor(mT.element_type, cute.make_ordered_layout(tiler_mn, order=(1, 0)), byte_alignment=16)
+        tv_layout = tiled_copy.layout_tv_tiled
+        reduction_buffer, mbar_ptr = self._allocate_reduction_buffer_and_mbar(smem, tv_layout)
+
+        thr_copy = tiled_copy.get_slice(tidx)
+        tYgY = thr_copy.partition_S(gY)
+        tYsY = thr_copy.partition_D(sY)
+        tTgT = thr_copy.partition_S(gT)
+        tTsT = thr_copy.partition_D(sT)
+        tXcX = thr_copy.partition_S(cX)[(0, None), None, None]
+
+        tYrY, tTrT = [cute.make_rmem_tensor_like(thr) for thr in (tYgY, tTgT)]
+
+        is_even_N = const_expr(shape[1] == tiler_mn[1] * self.cluster_n)
+        tXpX = None if is_even_N else copy_utils.predicate_k(thr_copy.partition_S(cX), limit=shape[1])
+        copy = partial(copy_utils.copy, pred=tXpX)
+
+        row = tXcX[0][0]
+        if row < shape[0]:
+            copy(tYgY, tYsY, is_async=True)
+            copy(tTgT, tTsT, is_async=True)
+        cute.arch.cp_async_commit_group()
+        cute.arch.cp_async_wait_group(0)
+
+        cute.autovec_copy(tYsY, tYrY)
+        cute.autovec_copy(tTsT, tTrT)
+        y = tYrY.load().to(cute.Float32)
+        t = tTrT.load().to(cute.Float32)
+
+        # KL(target || y_pred):
+        #   not log_target: target * (log(max(target, eps)) - y_pred)
+        #   log_target:     exp(target) * (target - y_pred)
+        if const_expr(not self.log_target):
+            t_safe = cute.where(t > eps, t, eps)
+            loss_elem = t * (cute.math.log2(t_safe, fastmath=True) * Float32(1.0 / _LOG2_E) - y)
+        else:
+            t_exp = cute.math.exp2(t * _LOG2_E, fastmath=True)
+            loss_elem = t_exp * (t - y)
+
+        loss_sum = row_reduce(
+            loss_elem,
+            cute.ReductionOp.ADD,
+            threads_per_row,
+            reduction_buffer[None, None, 0],
+            mbar_ptr,
+            init_val=0.0,
+        )
+
+        # Write per-row loss. Only the thread at column 0 writes.
+        if tXcX[0][1] == 0 and row < shape[0]:
+            mLoss[row] = loss_sum
+
+
+# ===========================================================================
+# Backward kernel — elementwise: grad = -target or -exp(target)
+# ===========================================================================
+class _LigerKLDivCuTeDSLBackward:
+    """CuTe DSL KL-divergence backward.
+
+    Pure elementwise: load a tile of ``target``, compute ``-target`` (or
+    ``-exp(target)`` if ``log_target``), store the result.
+    """
+
+    def __init__(self, dtype: Type[cutlass.Numeric], N: int, log_target: bool):
+        self.dtype = dtype
+        self.N = N
+        self.log_target = log_target
+        self.cluster_n = 1
+
+    def _threads_per_row(self):
+        N = self.N
+        for limit, threads in [(64, 8), (128, 16), (3072, 32), (6144, 64), (16384, 128)]:
+            if N <= limit:
+                return threads
+        return 256
+
+    def _num_threads(self):
+        return 128 if self.N <= 16384 else 256
+
+    def _get_tiled_copy(self, vecsize: int = 1):
+        threads_per_row = self._threads_per_row()
+        num_threads = self._num_threads()
+        assert num_threads % cute.arch.WARP_SIZE == 0
+        num_blocks_N = cute.ceil_div(self.N // vecsize, threads_per_row * self.cluster_n)
+        tiler_mn = (num_threads // threads_per_row, vecsize * num_blocks_N * threads_per_row)
+        tiled_copy = copy_utils.tiled_copy_2d(self.dtype, threads_per_row, num_threads, vecsize)
+        return tiled_copy, tiler_mn, threads_per_row
+
+    @cute.jit
+    def __call__(
+        self,
+        mT: cute.Tensor,
+        mGrad: cute.Tensor,
+        scale: Float32,
+        stream: cuda.CUstream,
+    ):
+        assert mT.element_type == self.dtype
+        largest_dtype_width = const_expr(max(t.element_type.width for t in [mT, mGrad]))
+        vecsize = math.gcd(self.N, 128 // largest_dtype_width)
+        tiled_copy, tiler_mn, _ = self._get_tiled_copy(vecsize=vecsize)
+        num_threads = tiled_copy.size
+        self.kernel(mT, mGrad, scale, tiler_mn, tiled_copy).launch(
+            grid=[cute.ceil_div(mT.shape[0], tiler_mn[0]), 1, 1],
+            block=[num_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mT: cute.Tensor,
+        mGrad: cute.Tensor,
+        scale: Float32,
+        tiler_mn: cute.Shape,
+        tiled_copy: cute.TiledCopy,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+
+        shape = mT.shape
+        idX = cute.make_identity_tensor(shape)
+        gT, gGrad, cX = [cute.local_tile(mT_, tiler_mn, (bidx, 0)) for mT_ in (mT, mGrad, idX)]
+
+        thr_copy = tiled_copy.get_slice(tidx)
+        tTgT = thr_copy.partition_S(gT)
+        tGradGGrad = thr_copy.partition_D(gGrad)
+        tXcX = thr_copy.partition_S(cX)[(0, None), None, None]
+        tTrT, tGradRGrad = [cute.make_rmem_tensor_like(thr) for thr in (tTgT, tGradGGrad)]
+
+        is_even_N = const_expr(shape[1] == tiler_mn[1] * self.cluster_n)
+        tXpX = None if is_even_N else copy_utils.predicate_k(thr_copy.partition_S(cX), limit=shape[1])
+        copy = partial(copy_utils.copy, pred=tXpX)
+
+        if tXcX[0][0] < shape[0]:
+            copy(tTgT, tTrT)
+        t = tTrT.load().to(cute.Float32)
+
+        if const_expr(not self.log_target):
+            grad = -t
+        else:
+            grad = -cute.math.exp2(t * _LOG2_E, fastmath=True)
+
+        # ``scale`` = grad_output / reduction_divisor, one host-supplied dynamic scalar: the
+        # upstream-grad multiply AND the batchmean (/BT) / mean (/(BT*V)) division are folded in
+        # here, in fp32, with a single store rounding. This removes the two full (BT,V)
+        # post-kernel elementwise passes (``* grad_output`` and ``/ BT``) plus the ``torch.equal``
+        # host sync and device ``torch.tensor(1.0)`` allocation the old wrapper paid every call.
+        grad = grad * scale
+
+        tGradRGrad.store(grad.to(tGradRGrad.element_type))
+        if tXcX[0][0] < shape[0]:
+            copy(tGradRGrad, tGradGGrad)
+
+
+# ---------------------------------------------------------------------------
+# Compile caches.
+# ---------------------------------------------------------------------------
+_FWD_COMPILE_CACHE: dict = {}
+_BWD_COMPILE_CACHE: dict = {}
+
+
+def _get_fwd_kernel(y_dtype: torch.dtype, t_dtype: torch.dtype, N: int, log_target: bool, eps: float):
+    """Return a compiled forward kernel, building it on first miss."""
+    key = (y_dtype, t_dtype, N, log_target, float(eps))
+    if key in _FWD_COMPILE_CACHE:
+        return _FWD_COMPILE_CACHE[key]
+
+    dtype = torch2cute_dtype_map[y_dtype]
+    t_cute_dtype = torch2cute_dtype_map[t_dtype]
+    batch_sym = cute.sym_int()
+    div = math.gcd(128 // dtype.width, N)
+    y_cute = fake_tensor(dtype, (batch_sym, N), div)
+    t_cute = fake_tensor(t_cute_dtype, (batch_sym, N), div)
+    loss_cute = fake_tensor(Float32, (batch_sym,))
+
+    compiled = cute.compile(
+        _LigerKLDivCuTeDSLForward(dtype, N, log_target),
+        y_cute,
+        t_cute,
+        loss_cute,
+        Float32(float(eps)),
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        options="--enable-tvm-ffi",
+    )
+    _FWD_COMPILE_CACHE[key] = compiled
+    return compiled
+
+
+def _get_bwd_kernel(t_dtype: torch.dtype, grad_dtype: torch.dtype, N: int, log_target: bool):
+    """Return a compiled backward kernel, building it on first miss."""
+    key = (t_dtype, grad_dtype, N, log_target)
+    if key in _BWD_COMPILE_CACHE:
+        return _BWD_COMPILE_CACHE[key]
+
+    dtype = torch2cute_dtype_map[t_dtype]
+    grad_cute_dtype = torch2cute_dtype_map[grad_dtype]
+    batch_sym = cute.sym_int()
+    div = math.gcd(128 // dtype.width, N)
+    t_cute = fake_tensor(dtype, (batch_sym, N), div)
+    grad_cute = fake_tensor(grad_cute_dtype, (batch_sym, N), div)
+
+    compiled = cute.compile(
+        _LigerKLDivCuTeDSLBackward(dtype, N, log_target),
+        t_cute,
+        grad_cute,
+        Float32(1.0),
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        options="--enable-tvm-ffi",
+    )
+    _BWD_COMPILE_CACHE[key] = compiled
+    return compiled
+
+
+# ===========================================================================
+# Host-side launchers and autograd Function
+# ===========================================================================
+def _kl_div_cutedsl_forward(
+    y_pred: Tensor,
+    y_true: Tensor,
+    log_target: bool,
+    reduction: str,
+    eps: float,
+) -> Tensor:
+    """Forward via the inline CuTe DSL reduction kernel.
+
+    Computes per-row loss sums, then applies the cross-row reduction
+    (sum / mean / batchmean) host-side — matching the Triton kernel's
+    post-kernel reduction logic.
+    """
+    BT, V = y_pred.shape
+    both_fp32 = y_pred.element_size() > 2 and y_true.element_size() > 2
+    fwd_limit = _FWD_MAX_TILE_CUTEDSL_FP32 if both_fp32 else _FWD_MAX_TILE_CUTEDSL
+    if V > fwd_limit:
+        raise RuntimeError(
+            f"cuTeDSL kl_div forward only supports V <= {fwd_limit} for "
+            f"4-byte-pair inputs; got {V}. Use impl='nvidia-triton' for wider rows."
+        )
+
+    y_flat = y_pred.contiguous()
+    t_flat = y_true.contiguous()
+    loss_per_row = torch.empty(BT, dtype=torch.float32, device=y_pred.device)
+
+    compiled = _get_fwd_kernel(y_flat.dtype, t_flat.dtype, V, log_target, eps)
+    compiled(y_flat, t_flat, loss_per_row, Float32(float(eps)))
+
+    # Cross-row reduction (matches Triton's host-side logic).
+    if reduction == "batchmean":
+        return loss_per_row.sum() / BT
+    elif reduction == "sum":
+        return loss_per_row.sum(dim=0)
+    elif reduction == "mean":
+        return loss_per_row.sum() / (BT * V)
+    else:  # "none"
+        return loss_per_row
+
+
+def _kl_div_cutedsl_backward(
+    y_true: Tensor,
+    grad_output: Tensor,
+    log_target: bool,
+    reduction: str,
+) -> Tensor:
+    """Backward via the inline CuTe DSL elementwise kernel.
+
+    Computes ``(-target) * scale`` (``-exp(target) * scale`` when ``log_target``) with the
+    scalar ``scale = grad_output / reduction_divisor`` folded INTO the kernel epilogue in fp32 —
+    one rounding at the store. The old wrapper ran the unscaled kernel and then paid a
+    ``torch.equal`` host sync + device ``torch.tensor(1.0)`` allocation every backward, plus up
+    to TWO extra full (BT,V) elementwise passes (``* grad_output`` and ``/ BT``) for the default
+    batchmean / mean reductions. Folding removes both passes and the allocation, and is strictly
+    MORE accurate (old: bf16 store -> bf16 mul -> bf16 div; new: one fp32 multiply -> one store).
+    """
+    BT, V = y_true.shape
+    t_flat = y_true.contiguous()
+    new_grads = torch.empty_like(t_flat)
+
+    # Reduction divisor (matches torch/Triton semantics): batchmean -> /BT, mean -> /(BT*V),
+    # sum -> 1 ("none" never reaches here — the public wrapper delegates it to Triton).
+    if reduction == "batchmean":
+        red_div = float(BT)
+    elif reduction == "mean":
+        red_div = float(BT * V)
+    else:
+        red_div = 1.0
+
+    compiled = _get_bwd_kernel(t_flat.dtype, new_grads.dtype, V, log_target)
+    if grad_output.numel() != 1:
+        # Rare elementwise upstream grad: keep the old broadcast path exactly (per-element go).
+        compiled(t_flat, new_grads, Float32(1.0))
+        derivative = new_grads * grad_output
+        if red_div != 1.0:
+            derivative = derivative / red_div
+        return derivative
+
+    # Scalar upstream grad (every scalar-loss autograd backward): a single host read of the
+    # value (the old torch.equal path synced as well) and one fused fp32 multiply in-kernel.
+    scale = float(grad_output) / red_div
+    compiled(t_flat, new_grads, Float32(scale))
+    return new_grads
+
+
+class _LigerKLDivCuTeDSLFunction(torch.autograd.Function):
+    """Autograd wrapper for KL-divergence loss via CuTe DSL."""
+
+    @staticmethod
+    def forward(ctx, y_pred, y_true, reduction="batchmean", log_target=False, eps=1e-10):
+        y_pred = _to_local_if_dtensor(y_pred).contiguous()
+        y_true = _to_local_if_dtensor(y_true).contiguous()
+        ctx.save_for_backward(y_true)
+        ctx.reduction = reduction
+        ctx.log_target = log_target
+        return _kl_div_cutedsl_forward(y_pred, y_true, log_target, reduction, eps)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (y_true,) = ctx.saved_tensors
+        derivative = _kl_div_cutedsl_backward(y_true, grad_output, ctx.log_target, ctx.reduction)
+        return derivative, None, None, None, None
+
+
+# ===========================================================================
+# Public registration
+# ===========================================================================
+_CUTEDSL_KLDIV_TOLERANCES = {
+    torch.float16: {"atol_fwd": 5e-3, "atol_bwd": 5e-2, "rtol_fwd": 1e-3, "rtol_bwd": 1e-2},
+    torch.bfloat16: {"atol_fwd": 2e-2, "atol_bwd": 1e-1, "rtol_fwd": 1e-2, "rtol_bwd": 2e-2},
+    torch.float32: {"atol_fwd": 1e-5, "atol_bwd": 1e-4, "rtol_fwd": 1e-5, "rtol_bwd": 1e-4},
+}
+
+
+@register_op(
+    "kl_div",
+    impl_name="nvidia-cutedsl",
+    capability=Capability(
+        min_cc=(9, 0),
+        modules=["cutlass.cute", "torch"],
+    ),
+    modes=("default",),
+    default_mode="default",
+    preference_rank=10,
+    tolerances=_CUTEDSL_KLDIV_TOLERANCES,
+    notes=(
+        "CuTe DSL KL-divergence for Hopper+ (sm_90+); row-reduction fwd + "
+        "elementwise bwd. On B300 sm_103, no-grad 4-byte-pair calls with V in "
+        "[16384, 28672] route to Triton (fwd-only regime inversion measured "
+        "0.76-0.97x there; 2-byte and grad-carrying calls keep CuTe)."
+    ),
+)
+def kl_div_cutedsl(
+    y_pred: torch.Tensor,
+    y_true: torch.Tensor,
+    reduction: str = "batchmean",
+    log_target: bool = False,
+    eps: float = 1e-10,
+    *,
+    mode: Optional[str] = None,
+) -> torch.Tensor:
+    """CuTe DSL KL-divergence dispatch entry point.
+
+    ``mode`` is accepted only for API parity with the other backends; the only
+    valid value is ``"default"`` (or ``None``).
+    """
+    if mode not in (None, "default"):
+        raise ValueError(f"CuTe DSL kl_div has only mode='default'; got mode={mode!r}.")
+    if reduction not in ("none", "sum", "mean", "batchmean"):
+        # Match the canonical Triton path, which rejects unknown reductions via
+        # `_str_to_reduction_mode[reduction]`. Without this the CuTe DSL forward
+        # would silently fall through to a row-sum and compute a different loss.
+        raise ValueError(f"reduction must be one of 'none', 'sum', 'mean', 'batchmean'; got {reduction!r}.")
+    if reduction == "none":
+        from liger_kernel.ops.backends._triton.kl_div import kl_div_triton
+
+        emit_fallback_warning(
+            "kl_div",
+            "nvidia-cutedsl",
+            "nvidia-triton",
+            "reduction='none' requires per-element output",
+        )
+        return kl_div_triton(
+            y_pred,
+            y_true,
+            reduction,
+            log_target,
+            eps,
+            mode=mode,
+        )
+    both_fp32 = y_pred.element_size() > 2 and y_true.element_size() > 2
+    fwd_limit = _FWD_MAX_TILE_CUTEDSL_FP32 if both_fp32 else _FWD_MAX_TILE_CUTEDSL
+    if y_pred.shape[-1] > fwd_limit:
+        from liger_kernel.ops.backends._triton.kl_div import kl_div_triton
+
+        emit_fallback_warning(
+            "kl_div",
+            "nvidia-cutedsl",
+            "nvidia-triton",
+            f"vocab size {y_pred.shape[-1]} exceeds CuTe DSL fwd limit {fwd_limit} for 4-byte-pair inputs",
+        )
+        return kl_div_triton(
+            y_pred,
+            y_true,
+            reduction,
+            log_target,
+            eps,
+            mode=mode,
+        )
+    if (
+        both_fp32
+        and _B300_FP32_NO_GRAD_TRITON_LO <= y_pred.shape[-1] <= _B300_FP32_NO_GRAD_TRITON_HI
+        and not (y_pred.requires_grad or y_true.requires_grad)
+        and _max_capability() > 100
+    ):
+        from liger_kernel.ops.backends._triton.kl_div import kl_div_triton
+
+        emit_fallback_warning(
+            "kl_div",
+            "nvidia-cutedsl",
+            "nvidia-triton",
+            f"no-grad 4-byte-pair input in the B300 sm_103 Triton-preference band "
+            f"[{_B300_FP32_NO_GRAD_TRITON_LO}, {_B300_FP32_NO_GRAD_TRITON_HI}] "
+            f"(V={y_pred.shape[-1]}); forward-only CuTe DSL measured 0.76-0.97x "
+            f"vs Triton there",
+        )
+        return kl_div_triton(
+            y_pred,
+            y_true,
+            reduction,
+            log_target,
+            eps,
+            mode=mode,
+        )
+    return _LigerKLDivCuTeDSLFunction.apply(y_pred, y_true, reduction, log_target, eps)

--- a/src/liger_kernel/ops/backends/_cutedsl/rope.py
+++ b/src/liger_kernel/ops/backends/_cutedsl/rope.py
@@ -1,0 +1,187 @@
+"""CuTe DSL (CUTLASS python) backend for ``rope``.
+
+Strategy
+--------
+The dispatcher registration delegates directly to the fused ops-layer kernels
+(:func:`liger_kernel.ops.cutedsl.ops.rope.rope_forward` and
+:func:`rope_backward`) — the same token-per-CTA / TMA path that powers the
+wholesale ``LIGER_KERNEL_IMPL=cutedsl`` backend. Those kernels fuse the whole
+rotation (q + k in one launch, cos/sin read per token, no host-side
+split/expand/concatenate), so the dispatcher inherits the wholesale layer's
+performance profile instead of paying for host-side tensor transforms.
+
+This replaces the original dispatcher-local implementation, which transposed
+and flattened q/k, split head halves with four ``.contiguous()`` copies,
+expanded ``cos``/``sin`` to a per-head ``(M, hd//2)`` layout (hundreds of MB
+for Llama-sized batches), ran two launches, and concatenated the halves back
+— ~12 device copies per call and ~3.8x slower than the Triton reference on
+H200. The ops-layer path measures within noise of Triton on the same shapes.
+
+Routing
+-------
+Promotion to this backend is shape- and regime-gated (preference rank 40,
+ahead of Triton's 50); everything outside the gate falls back to the Triton
+kernel via the in-wrapper fallback below (same pattern as layer_norm).
+
+Gate = 2-byte dtype AND ``q.requires_grad`` AND ``E >= 131072`` AND
+``head_dim >= 128``, where ``E = bsz * n_heads_q * seq_len`` is the total q
+head-row count (the routing key). Only the grad-carrying full fwd+bwd pair in
+this large-shape zone is routed here; the no-grad fwd-only path and smaller
+shapes keep Triton.
+
+Numerics: the ops-layer kernels compute the rotation in fp32 internally and
+store back at the input dtype, matching the Triton reference; parity is pinned
+by ``test/transformers/test_cutedsl_rope.py``.
+
+In-place convention: identical to the Triton ``LigerRopeFunction`` — for the
+standard projection-transpose layout the forward views native storage, so the
+caller's q/k storage may be rotated in place.
+
+Capability
+----------
+- Compute capability >= sm_90 (Hopper or newer), matching the rms_norm / softmax
+  CuTe DSL siblings; the TMA tile path activates on sm_100 (Blackwell) and falls
+  back to the token kernel otherwise.
+- Requires only the ``cutlass`` Python package.
+
+Shapes and limits
+-----------------
+- ``q`` shape ``(bsz, n_q_head, seq_len, head_dim)``; ``k`` shape
+  ``(bsz, n_kv_head, seq_len, head_dim)``; ``head_dim`` must be even.
+- ``cos`` / ``sin`` shape ``(1, seq_len, head_dim)`` or ``(bsz, seq_len, head_dim)``
+  (2-D vision tables are handled by the ops layer).
+- dtypes: fp16, bf16, fp32.
+
+Notes
+-----
+We deliberately do **not** put ``from __future__ import annotations`` here
+(same reasoning as the RMSNorm / softmax siblings).
+"""
+
+from typing import Optional
+
+import torch
+
+from liger_kernel.backends import Capability
+from liger_kernel.backends import register_op
+from liger_kernel.ops._nvidia_shared import to_local_if_dtensor as _to_local_if_dtensor
+from liger_kernel.ops.cutedsl.ops.rope import rope_backward as _ops_rope_backward
+from liger_kernel.ops.cutedsl.ops.rope import rope_forward as _ops_rope_forward
+
+
+# ===========================================================================
+# Autograd Function
+# ===========================================================================
+class _LigerRopeCuTeDSLFunction(torch.autograd.Function):
+    """Autograd wrapper delegating to the fused ops-layer kernels.
+
+    Mirrors the Triton ``LigerRopeFunction`` contract exactly: forward applies
+    ``rope_forward`` and saves the returned ``cos``/``sin``; backward applies
+    ``rope_backward`` (handles both contiguous fast-path and SDPA-style
+    transpose-view grads).
+    """
+
+    @staticmethod
+    def forward(ctx, q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+        del position_ids, unsqueeze_dim  # accepted for API parity with Triton
+        q = _to_local_if_dtensor(q)
+        k = _to_local_if_dtensor(k)
+        cos = _to_local_if_dtensor(cos)
+        sin = _to_local_if_dtensor(sin)
+        q, k, cos, sin = _ops_rope_forward(q, k, cos, sin)
+        ctx.save_for_backward(cos, sin)
+        return q, k
+
+    @staticmethod
+    def backward(ctx, dq, dk):
+        dq = _to_local_if_dtensor(dq)
+        dk = _to_local_if_dtensor(dk)
+        cos, sin = ctx.saved_tensors
+        dq_out, dk_out = _ops_rope_backward(dq, dk, cos, sin)
+        return dq_out, dk_out, None, None, None, None
+
+
+# ===========================================================================
+# Public registration
+# ===========================================================================
+_CUTEDSL_ROPE_TOLERANCES = {
+    torch.float16: {"atol_fwd": 5e-3, "atol_bwd": 5e-2, "rtol_fwd": 1e-3, "rtol_bwd": 1e-2},
+    torch.bfloat16: {"atol_fwd": 2e-2, "atol_bwd": 1e-1, "rtol_fwd": 1e-2, "rtol_bwd": 2e-2},
+    torch.float32: {"atol_fwd": 1e-5, "atol_bwd": 1e-4, "rtol_fwd": 1e-5, "rtol_bwd": 1e-4},
+}
+
+# Auto-select gate (B200 map in module docstring).  "_Q_ROWS" is the total
+# q head-row count E = bsz*n_heads_q*seq_len (== q.numel()/head_dim), NOT the
+# plain token count: E-keying is measured ((1,8192)~(4,2048)~(2,4096) win;
+# (1,2048) at E=65536 loses 0.88; wash rung E=98304 at 0.968; threshold cell
+# E=131072 wins 1.054-1.115 in three probes).  Strict head_dim >= 128 (the
+# hd=64 arm has a losing rung adjacent to a single win -- fragile).
+_ROPE_AUTO_MIN_Q_ROWS = 131072
+_ROPE_AUTO_MIN_HEAD_DIM = 128
+
+
+def _rope_auto_select_ok(q: torch.Tensor) -> bool:
+    if q.element_size() != 2 or q.shape[-1] < _ROPE_AUTO_MIN_HEAD_DIM or not q.requires_grad:
+        return False
+    q_rows = 1
+    for d in q.shape[:-1]:
+        q_rows *= d
+    return q_rows >= _ROPE_AUTO_MIN_Q_ROWS
+
+
+@register_op(
+    "rope",
+    impl_name="nvidia-cutedsl",
+    capability=Capability(
+        min_cc=(9, 0),
+        modules=["cutlass.cute", "torch"],
+    ),
+    modes=("default",),
+    default_mode="default",
+    # Delegates to the fused ops-layer token/TMA kernels — the earlier
+    # dispatcher-local expand/concatenate path was ~3.8x slower than Triton on
+    # H200; the fused path measures at parity, and is 2.2-6.2x faster than the
+    # deleted inline expand-cos/sin multi-launch path on B200 in the measured
+    # win zone.  Rank 40 (auto-select ahead of Triton at rank 50) but only for
+    # that zone: grad-carrying full fwd+bwd, 2-byte dtypes, q head-rows
+    # >= 131072, head_dim >= 128 (B200 2026-08-09 map in the module docstring);
+    # the wrapper silently Triton-falls-back outside it.
+    preference_rank=40,
+    tolerances=_CUTEDSL_ROPE_TOLERANCES,
+    notes=(
+        "CuTe DSL RoPE for Hopper+ (sm_90+) via the fused ops-layer token/TMA "
+        "kernels.  Rank 40 ahead of Triton in the measured zone (2-byte, grad "
+        "on, q head-rows>=131072, head_dim>=128); wrapper Triton-falls-back "
+        "outside it.  Even head_dim required; odd dims raise ValueError."
+    ),
+)
+def rope_cutedsl(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: Optional[torch.Tensor] = None,
+    unsqueeze_dim: int = 1,
+    *,
+    mode: Optional[str] = None,
+):
+    """CuTe DSL RoPE dispatch entry point.
+
+    ``mode`` is accepted only for API parity with the other backends; the only
+    valid value is ``"default"`` (or ``None``).  ``position_ids`` /
+    ``unsqueeze_dim`` are accepted for signature parity with
+    ``LigerRopeFunction`` and are unused (the cos/sin broadcast is implicit —
+    identical to the Triton kernel).
+    """
+    if mode not in (None, "default"):
+        raise ValueError(f"CuTe DSL rope has only mode='default'; got mode={mode!r}.")
+    if q.shape[-1] % 2 != 0 or k.shape[-1] % 2 != 0:
+        raise ValueError(f"CuTe DSL RoPE requires even q/k head dimensions; got q={q.shape[-1]}, k={k.shape[-1]}")
+    if not _rope_auto_select_ok(q):
+        # Outside the measured win zone (small shapes / no-grad fwd-only /
+        # fp32): the Triton kernel is faster on B200 -- keep it, silently
+        # (neither backend was ever selected here, so this is plain routing).
+        from liger_kernel.ops.backends._triton.rope import rope_triton
+
+        return rope_triton(q, k, cos, sin, position_ids, unsqueeze_dim, mode=mode)
+    return _LigerRopeCuTeDSLFunction.apply(q, k, cos, sin, position_ids, unsqueeze_dim)

--- a/src/liger_kernel/ops/backends/_cutedsl/softmax.py
+++ b/src/liger_kernel/ops/backends/_cutedsl/softmax.py
@@ -1,0 +1,562 @@
+"""CuTe DSL (CUTLASS python) backend for ``softmax``.
+
+Strategy
+--------
+Mirrors the sibling :mod:`liger_kernel.ops.backends._cutedsl.rms_norm`:
+
+- **Forward** is an inline CuTe DSL kernel (``_LigerSoftmaxCuTeDSLForward``)
+  adapted from Quack's ``Softmax`` (Apache-2.0; see ``_cute_lib/NOTICE.md``).
+  It uses the **two-pass** reduction (max, then sum-of-exp) built on the
+  in-repo ``_cute_lib.ReductionBase`` + ``row_reduce`` — we deliberately do
+  **not** depend on Quack's ``online_softmax_reduce`` because that helper was
+  intentionally excluded from the trimmed ``_cute_lib/reduce.py`` (it pulls in
+  the ``Int64``-packed online-reduction machinery). Two-pass is numerically
+  identical to the single-block Triton path:
+  ``y = exp(x - max(x)) / sum(exp(x - max(x)))``.
+
+- **Backward** is an inline CuTe DSL kernel (``_LigerSoftmaxCuTeDSLBackward``)
+  adapted from Quack's ``SoftmaxBackward``: a single fp32 dot-product
+  reduction ``dot = sum(dy * y)`` per row, then ``dx = y * (dy - dot)`` —
+  byte-for-byte the formula in :mod:`liger_kernel.ops.softmax`.
+
+Both kernels carry a per-process ``cute.compile`` cache keyed on the dtype mix
+and ``N`` (``cute.compile`` is multi-second).
+
+Capability
+----------
+- Compute capability >= sm_90 (Hopper or newer).
+- Requires only the ``cutlass`` Python package — the CuTe DSL utilities are
+  inlined under ``_cute_lib/``; no runtime dependency on Quack.
+
+Shapes and limits
+-----------------
+- ``x`` is flattened to 2D (``view(-1, N)``); arbitrary leading dims OK.
+- The cluster-reduce path (``cluster_n > 1``, triggered for very wide ``N``)
+  uses ``mbarrier`` plumbing identical to the RMSNorm-bwd sibling. We cap at
+  ``N <= _MAX_TILE_CUTEDSL`` and raise a ``RuntimeError`` above it so the test
+  harness auto-skips for wider rows (the same contract the RMSNorm sibling
+  documents for the cuda13.2 cutlass-cute wheels we ship on B200 today).
+- dtypes: fp16, bf16, fp32.
+
+Notes
+-----
+We deliberately do **not** put ``from __future__ import annotations`` here
+(same reasoning as the RMSNorm / LayerNorm siblings: keep annotations live for
+DSL introspection).
+
+References
+----------
+- Quack (adapted under Apache-2.0):
+  https://github.com/Dao-AILab/quack/blob/main/quack/softmax.py — source of the ``Softmax`` and
+  ``SoftmaxBackward`` ``ReductionBase`` subclasses, the ``_threads_per_row`` /
+  ``_set_cluster_n`` heuristics, and the ``cute.compile`` cache pattern. See
+  :mod:`._cute_lib` for the inlined reduction infrastructure.
+- Triton reference: :mod:`liger_kernel.ops.softmax` — fixes the exact numerics
+  (single/multi-block fwd, ``dx = y * (dy - sum(dy * y))`` bwd).
+"""
+
+import math
+
+from functools import partial
+from typing import Optional
+from typing import Tuple
+from typing import Type
+
+# ---------------------------------------------------------------------------
+# Top-level CuTe DSL imports. Identical pattern to the RMSNorm sibling (see its
+# header for the rationale: importing this module on a host without cutlass
+# raises ImportError, which the dispatcher's discovery layer catches, and the
+# Capability gate keeps it out of auto-select).
+# ---------------------------------------------------------------------------
+import cuda.bindings.driver as cuda  # noqa: F401  (referenced by cute.compile)
+import cutlass
+import cutlass.cute as cute
+import torch
+
+from cutlass import Float32
+from cutlass import const_expr
+from torch import Tensor
+
+# Inlined CuTe DSL utilities (adapted from Quack, Apache-2.0). Importing
+# ``_cute_lib`` does **not** require the upstream ``quack`` package.
+import liger_kernel.ops.backends._cutedsl._cute_lib.copy_utils as copy_utils
+import liger_kernel.ops.backends._cutedsl._cute_lib.utils as utils
+
+from liger_kernel.backends import Capability
+from liger_kernel.backends import register_op
+from liger_kernel.backends.dispatch import emit_fallback_warning
+from liger_kernel.ops._nvidia_shared import to_local_if_dtensor as _to_local_if_dtensor
+from liger_kernel.ops.backends._cutedsl._cute_lib.compile_utils import make_fake_tensor as fake_tensor
+from liger_kernel.ops.backends._cutedsl._cute_lib.dtype_map import torch2cute_dtype_map
+from liger_kernel.ops.backends._cutedsl._cute_lib.reduce import row_reduce
+from liger_kernel.ops.backends._cutedsl._cute_lib.reduction_base import ReductionBase
+
+# Same ceiling reasoning as the RMSNorm-bwd sibling: beyond this width the
+# kernel relies on the cluster-reduce path. Surface a RuntimeError so the test
+# harness auto-skips for wider rows rather than failing inside a launch.
+_MAX_TILE_CUTEDSL = 32768
+
+
+# ===========================================================================
+# Forward kernel — inline CuTe DSL (two-pass: max, then sum-of-exp)
+# ===========================================================================
+class _LigerSoftmaxCuTeDSLForward(ReductionBase):
+    """CuTe DSL softmax forward.
+
+    Two reduction stages: stage 0 for the row max, stage 1 for the denominator
+    (sum of exponentials). Adapted from Quack's ``Softmax`` with
+    ``online_softmax=False`` so it uses the in-repo ``row_reduce`` rather than
+    the excluded ``online_softmax_reduce``.
+    """
+
+    def __init__(self, dtype: Type[cutlass.Numeric], N: int):
+        # 2 stages: 1 for max, 1 for sum.
+        super().__init__(dtype, N, stage=2, reduction_dtype=Float32)
+
+    def _threads_per_row(self):
+        N = self.N
+        for limit, threads in [(64, 8), (128, 16), (3072, 32), (6144, 64), (16384, 128)]:
+            if N <= limit:
+                return threads
+        return 256
+
+    def _set_cluster_n(self):
+        N = self.N
+        for limit, cluster in [(16 * 1024, 1), (32 * 1024, 2), (64 * 1024, 4), (128 * 1024, 8)]:
+            if N <= limit:
+                self.cluster_n = cluster
+                return
+        self.cluster_n = 16
+
+    @cute.jit
+    def __call__(
+        self,
+        mX: cute.Tensor,
+        mO: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        assert mX.element_type == self.dtype
+        self._set_cluster_n()
+        largest_dtype_width = const_expr(max(t.element_type.width for t in [mX, mO]))
+        tiled_copy, tiler_mn, threads_per_row = self._get_tiled_copy(vecsize=128 // largest_dtype_width)
+        num_threads = tiled_copy.size
+        self.kernel(mX, mO, tiler_mn, tiled_copy, threads_per_row).launch(
+            grid=[cute.ceil_div(mX.shape[0], tiler_mn[0]), self.cluster_n, 1],
+            block=[num_threads, 1, 1],
+            cluster=[1, self.cluster_n, 1] if const_expr(self.cluster_n > 1) else None,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mX: cute.Tensor,
+        mO: cute.Tensor,
+        tiler_mn: cute.Shape,
+        tiled_copy: cute.TiledCopy,
+        threads_per_row: cutlass.Constexpr[int],
+    ):
+        tv_layout = tiled_copy.layout_tv_tiled
+
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        cluster_y = const_expr(0) if const_expr(self.cluster_n == 1) else cute.arch.block_idx()[1]
+
+        shape = mX.shape
+        idX = cute.make_identity_tensor(shape)
+        gX, gO, cX = [cute.local_tile(mT, tiler_mn, (bidx, cluster_y)) for mT in (mX, mO, idX)]
+
+        smem = cutlass.utils.SmemAllocator()
+        sX = smem.allocate_tensor(mX.element_type, cute.make_ordered_layout(tiler_mn, order=(1, 0)), byte_alignment=16)
+        reduction_buffer, mbar_ptr = self._allocate_reduction_buffer_and_mbar(smem, tv_layout)
+
+        thr_copy_X = tiled_copy.get_slice(tidx)
+
+        tXgX = thr_copy_X.partition_S(gX)
+        tXsX = thr_copy_X.partition_D(sX)
+        tXgO = thr_copy_X.partition_D(gO)
+        tXcX = thr_copy_X.partition_S(cX)[(0, None), None, None]
+        tXrX, tXrO = [cute.make_rmem_tensor_like(thr) for thr in (tXgX, tXgO)]
+
+        is_even_N = const_expr(shape[1] == tiler_mn[1] * self.cluster_n)
+        tXpX = None if is_even_N else copy_utils.predicate_k(thr_copy_X.partition_S(cX), limit=shape[1])
+        copy = partial(copy_utils.copy, pred=tXpX)
+
+        num_warps = cute.size(tiled_copy) // cute.arch.WARP_SIZE
+        self._initialize_cluster(tidx, mbar_ptr, num_warps)
+
+        if tXcX[0][0] < shape[0]:
+            copy(tXgX, tXsX, is_async=True)
+        cute.arch.cp_async_commit_group()
+        cute.arch.cp_async_wait_group(0)
+        # Fill OOB lanes with -inf so the max ignores them and exp(-inf)==0
+        # contributes nothing to the denominator.
+        if const_expr(not is_even_N):
+            utils.fill_oob(tXsX, tXpX, -tXsX.element_type.inf)
+
+        cute.autovec_copy(tXsX, tXrX)
+        x = tXrX.load().to(cute.Float32)
+
+        # Stage 0: row max.
+        max_x = row_reduce(
+            x,
+            cute.ReductionOp.MAX,
+            threads_per_row,
+            reduction_buffer[None, None, 0],
+            mbar_ptr + 0 if const_expr(self.cluster_n > 1) else None,
+            init_val=-Float32.inf,
+            hook_fn=cute.arch.cluster_wait if const_expr(self.cluster_n > 1) else None,
+        )
+
+        # exp(x - max). Use exp2 with the log2(e) factor (matches Quack's
+        # fastmath path; exp2 is the native HW instruction).
+        # Subtract BEFORE scaling: (x - max) * log2_e is shift-invariant in fp32.
+        # x * log2_e - max_x * log2_e cancels two large scaled values and loses
+        # the shift-invariance guarantee at large common offsets (fp32 stability).
+        log2_e = math.log2(math.e)
+        exp_x = cute.math.exp2((x - max_x) * log2_e, fastmath=True)
+
+        # Stage 1: denominator.
+        denom = row_reduce(
+            exp_x,
+            cute.ReductionOp.ADD,
+            threads_per_row,
+            reduction_buffer[None, None, 1],
+            mbar_ptr + 1 if const_expr(self.cluster_n > 1) else None,
+            init_val=0.0,
+        )
+
+        y = exp_x * cute.arch.rcp_approx(denom)
+        tXrO.store(y.to(tXrO.element_type))
+        if tXcX[0][0] < shape[0]:
+            copy(tXrO, tXgO)
+
+
+# ===========================================================================
+# Backward kernel — inline CuTe DSL (single dot-product reduction)
+# ===========================================================================
+class _LigerSoftmaxCuTeDSLBackward(ReductionBase):
+    """CuTe DSL softmax backward.
+
+    One reduction stage: the dot product ``dot = sum(dy * y)`` (fp32). The
+    gradient is then ``dx = y * (dy - dot)``. Adapted from Quack's
+    ``SoftmaxBackward``.
+    """
+
+    def __init__(self, dtype: Type[cutlass.Numeric], N: int):
+        super().__init__(dtype, N, stage=1, reduction_dtype=Float32)
+
+    def _threads_per_row(self):
+        N = self.N
+        # 2-byte dtypes (bf16/fp16): flat 128 threads/row for N > 6144,
+        # matching the fwd ladder. The smem-staged bwd keeps only a few fp32
+        # temporaries per vec-chunk live across the dot-reduce, so these rows
+        # were never in the spill regime of KL-bwd lore; 256 threads only hurt
+        # at predication-free full-tile boundaries (N % 16384 == 0), where
+        # 256->128 wins 1.28-1.43x on B200 and is noise-neutral elsewhere.
+        # fp32 stages 4 elems per 128b vec-copy (vs 8 for 2-byte) and keeps the
+        # old 256-thr rule - the gate probe measured c128 ~7% SLOWER there
+        # (a gate probe measured this; dtype is trace-time, compile-keyed,
+        # so each dtype bakes its own rule - the CE V-gate recipe applied to
+        # the softmax bwd thread rung; from a bwd thread sweep).
+        if self.dtype.width == 32:
+            for limit, threads in [(64, 8), (128, 16), (3072, 32), (6144, 64), (8192, 128)]:
+                if N <= limit:
+                    return threads
+            return 256
+        for limit, threads in [(64, 8), (128, 16), (3072, 32), (6144, 64), (16384, 128)]:
+            if N <= limit:
+                return threads
+        return 128
+
+    def _num_threads(self):
+        if self.dtype.width == 32:
+            return 128 if self.N <= 8192 else 256
+        return 128
+
+    def _set_cluster_n(self):
+        N = self.N
+        for limit, cluster in [(16 * 1024, 1), (32 * 1024, 2), (64 * 1024, 4), (128 * 1024, 8)]:
+            if N <= limit:
+                self.cluster_n = cluster
+                return
+        self.cluster_n = 16
+
+    @cute.jit
+    def __call__(
+        self,
+        mdY: cute.Tensor,
+        mY: cute.Tensor,
+        mdX: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        assert mdY.element_type == self.dtype
+        self._set_cluster_n()
+        largest_dtype_width = const_expr(max(t.element_type.width for t in [mdY, mY, mdX]))
+        tiled_copy, tiler_mn, threads_per_row = self._get_tiled_copy(vecsize=128 // largest_dtype_width)
+        num_threads = tiled_copy.size
+        self.kernel(mdY, mY, mdX, tiler_mn, tiled_copy, threads_per_row).launch(
+            grid=[cute.ceil_div(mdY.shape[0], tiler_mn[0]), self.cluster_n, 1],
+            block=[num_threads, 1, 1],
+            cluster=[1, self.cluster_n, 1] if const_expr(self.cluster_n > 1) else None,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mdY: cute.Tensor,
+        mY: cute.Tensor,
+        mdX: cute.Tensor,
+        tiler_mn: cute.Shape,
+        tiled_copy: cute.TiledCopy,
+        threads_per_row: cutlass.Constexpr[int],
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        cluster_y = const_expr(0) if const_expr(self.cluster_n == 1) else cute.arch.block_idx()[1]
+        tv_layout = tiled_copy.layout_tv_tiled
+
+        shape = mdY.shape
+        idX = cute.make_identity_tensor(shape)
+        gdY, gY, gdX, cX = [cute.local_tile(mT, tiler_mn, (bidx, cluster_y)) for mT in (mdY, mY, mdX, idX)]
+
+        smem = cutlass.utils.SmemAllocator()
+        sdY = smem.allocate_tensor(
+            mdY.element_type, cute.make_ordered_layout(tiler_mn, order=(1, 0)), byte_alignment=16
+        )
+        sY = smem.allocate_tensor(mY.element_type, cute.make_ordered_layout(tiler_mn, order=(1, 0)), byte_alignment=16)
+        reduction_buffer, mbar_ptr = self._allocate_reduction_buffer_and_mbar(smem, tv_layout)
+
+        thr_copy = tiled_copy.get_slice(tidx)
+
+        tdYgdY = thr_copy.partition_S(gdY)
+        tdYsdY = thr_copy.partition_D(sdY)
+        tYgY = thr_copy.partition_S(gY)
+        tYsY = thr_copy.partition_D(sY)
+        tdXgdX = thr_copy.partition_D(gdX)
+        tXcX = thr_copy.partition_S(cX)[(0, None), None, None]
+        tdYrdY, tYrY, tdXrdX = [cute.make_rmem_tensor_like(thr) for thr in (tdYgdY, tYgY, tdXgdX)]
+
+        is_even_N = const_expr(shape[1] == tiler_mn[1] * self.cluster_n)
+        tXpX = None if is_even_N else copy_utils.predicate_k(thr_copy.partition_S(cX), limit=shape[1])
+        copy = partial(copy_utils.copy, pred=tXpX)
+
+        num_warps = cute.size(tiled_copy) // cute.arch.WARP_SIZE
+        self._initialize_cluster(tidx, mbar_ptr, num_warps)
+
+        if tXcX[0][0] < shape[0]:
+            copy(tdYgdY, tdYsdY, is_async=True)
+            copy(tYgY, tYsY, is_async=True)
+        cute.arch.cp_async_commit_group()
+        cute.arch.cp_async_wait_group(0)
+        # cp.async automatically zero-fills OOB lanes; dy*y over a zeroed lane
+        # contributes 0 to the dot, so no explicit fill_oob is needed.
+
+        cute.autovec_copy(tdYsdY, tdYrdY)
+        cute.autovec_copy(tYsY, tYrY)
+        dy = tdYrdY.load().to(cute.Float32)
+        y = tYrY.load().to(cute.Float32)
+
+        # dot = sum_j dy_j * y_j
+        dot = row_reduce(
+            dy * y,
+            cute.ReductionOp.ADD,
+            threads_per_row,
+            reduction_buffer[None, None, 0],
+            mbar_ptr if const_expr(self.cluster_n > 1) else None,
+            init_val=0.0,
+            hook_fn=cute.arch.cluster_wait if const_expr(self.cluster_n > 1) else None,
+        )
+
+        # dx_i = y_i * (dy_i - dot)
+        dx = y * (dy - dot)
+        tdXrdX.store(dx.to(tdXrdX.element_type))
+        if tXcX[0][0] < shape[0]:
+            copy(tdXrdX, tdXgdX)
+
+
+# ---------------------------------------------------------------------------
+# Compile caches. ``cute.compile()`` is multi-second; key on the minimal set of
+# attributes that change codegen.
+# ---------------------------------------------------------------------------
+_FWD_COMPILE_CACHE: dict = {}
+_BWD_COMPILE_CACHE: dict = {}
+
+
+def _get_fwd_kernel(x_dtype: torch.dtype, out_dtype: torch.dtype, N: int):
+    """Return a compiled forward kernel, building it on first miss."""
+    key = (x_dtype, out_dtype, N)
+    if key in _FWD_COMPILE_CACHE:
+        return _FWD_COMPILE_CACHE[key]
+
+    dtype = torch2cute_dtype_map[x_dtype]
+    out_cute_dtype = torch2cute_dtype_map[out_dtype]
+    batch_sym = cute.sym_int()
+    div = math.gcd(128 // dtype.width, N)
+    x_cute = fake_tensor(dtype, (batch_sym, N), div)
+    out_cute = fake_tensor(out_cute_dtype, (batch_sym, N), div)
+
+    compiled = cute.compile(
+        _LigerSoftmaxCuTeDSLForward(dtype, N),
+        x_cute,
+        out_cute,
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        options="--enable-tvm-ffi",
+    )
+    _FWD_COMPILE_CACHE[key] = compiled
+    return compiled
+
+
+def _get_bwd_kernel(dy_dtype: torch.dtype, y_dtype: torch.dtype, dx_dtype: torch.dtype, N: int):
+    """Return a compiled backward kernel, building it on first miss."""
+    key = (dy_dtype, y_dtype, dx_dtype, N)
+    if key in _BWD_COMPILE_CACHE:
+        return _BWD_COMPILE_CACHE[key]
+
+    dtype = torch2cute_dtype_map[dy_dtype]
+    y_cute_dtype = torch2cute_dtype_map[y_dtype]
+    dx_cute_dtype = torch2cute_dtype_map[dx_dtype]
+    batch_sym = cute.sym_int()
+    div = math.gcd(128 // dtype.width, N)
+    dy_cute = fake_tensor(dtype, (batch_sym, N), div)
+    y_cute = fake_tensor(y_cute_dtype, (batch_sym, N), div)
+    dx_cute = fake_tensor(dx_cute_dtype, (batch_sym, N), div)
+
+    compiled = cute.compile(
+        _LigerSoftmaxCuTeDSLBackward(dtype, N),
+        dy_cute,
+        y_cute,
+        dx_cute,
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        options="--enable-tvm-ffi",
+    )
+    _BWD_COMPILE_CACHE[key] = compiled
+    return compiled
+
+
+# ===========================================================================
+# Host-side launchers and autograd Function
+# ===========================================================================
+def _softmax_cutedsl_forward(x: Tensor) -> Tuple[Tensor, Tensor]:
+    """Forward via the inline CuTe DSL kernel.
+
+    Returns ``(Y, Y)`` (the second copy is what backward needs saved). ``x`` is
+    flattened to 2D; the output keeps the original shape.
+    """
+    shape = x.shape
+    N = shape[-1]
+    if N > _MAX_TILE_CUTEDSL:
+        raise RuntimeError(
+            f"cuTeDSL softmax only supports hidden dim <= {_MAX_TILE_CUTEDSL}; "
+            f"got {N}. Use backend='triton' for wider rows. (Cluster-reduce "
+            f"path requires a newer cutlass-cute.)"
+        )
+    x_flat = x.view(-1, N).contiguous()
+    out = torch.empty_like(x_flat)
+
+    compiled = _get_fwd_kernel(x_flat.dtype, out.dtype, N)
+    # CuTe DSL compiled kernels read torch.cuda.current_stream() at launch via
+    # the tvm-ffi env stream; the ABI does not take a positional stream.
+    compiled(x_flat, out)
+    return out.view(shape), out
+
+
+def _softmax_cutedsl_backward(dy: Tensor, y: Tensor) -> Tensor:
+    """Backward via the inline CuTe DSL kernel. Returns ``dX``."""
+    shape = dy.shape
+    N = shape[-1]
+    if N > _MAX_TILE_CUTEDSL:
+        raise RuntimeError(
+            f"cuTeDSL softmax backward only supports hidden dim <= {_MAX_TILE_CUTEDSL}; "
+            f"got {N}. Use backend='triton' for wider rows."
+        )
+    dy_flat = dy.view(-1, N).contiguous()
+    y_flat = y.view(-1, N).contiguous()
+
+    # The compiled kernel is keyed by dtype; Quack asserts dy.dtype == y.dtype.
+    # The autograd graph hands us dy in the same dtype as the forward output,
+    # so this holds for the common path. Bridge defensively if not.
+    if dy_flat.dtype != y_flat.dtype:
+        dy_flat = dy_flat.to(y_flat.dtype)
+    dx = torch.empty_like(dy_flat)
+
+    compiled = _get_bwd_kernel(dy_flat.dtype, y_flat.dtype, dx.dtype, N)
+    compiled(dy_flat, y_flat, dx)
+    return dx.view(shape)
+
+
+class _LigerSoftmaxCuTeDSLFunction(torch.autograd.Function):
+    """Autograd wrapper. Saves the softmax output ``y`` for the inline backward."""
+
+    @staticmethod
+    def forward(ctx, input_: torch.Tensor):
+        input_ = _to_local_if_dtensor(input_)
+        input_ = input_.contiguous()
+        Y, Y_flat = _softmax_cutedsl_forward(input_)
+        ctx.save_for_backward(Y_flat)
+        ctx.input_shape = input_.shape
+        return Y
+
+    @staticmethod
+    def backward(ctx, dY):
+        dY = _to_local_if_dtensor(dY).contiguous()
+        (Y_flat,) = ctx.saved_tensors
+        dX = _softmax_cutedsl_backward(dY, Y_flat)
+        return dX.view(ctx.input_shape)
+
+
+_CUTEDSL_SOFTMAX_TOLERANCES = {
+    torch.float16: {"atol_fwd": 5e-3, "atol_bwd": 5e-2, "rtol_fwd": 1e-3, "rtol_bwd": 1e-2},
+    torch.bfloat16: {"atol_fwd": 2e-2, "atol_bwd": 1e-1, "rtol_fwd": 1e-2, "rtol_bwd": 2e-2},
+    torch.float32: {"atol_fwd": 1e-5, "atol_bwd": 1e-4, "rtol_fwd": 1e-5, "rtol_bwd": 1e-4},
+}
+
+
+@register_op(
+    "softmax",
+    impl_name="nvidia-cutedsl",
+    capability=Capability(
+        min_cc=(9, 0),
+        modules=["cutlass.cute", "torch"],
+    ),
+    modes=("default",),
+    default_mode="default",
+    # Auto-preferred when available. B200 re-measure (2026-08-07 cycle): fwd
+    # 1.05-1.73x vs Triton across N in [2048, 32768]; the 2-byte flat-128-thr
+    # bwd retune (fp32 keeps 256 - it measured slower at 128) closed the old
+    # 0.907-0.986x full fwd+bwd deficit at the full-tile boundaries
+    # N = 16384/32768 (bf16 now 1.11-1.17x faster there).
+    preference_rank=10,
+    tolerances=_CUTEDSL_SOFTMAX_TOLERANCES,
+    notes="CuTe DSL softmax for Hopper+ (sm_90+); self-contained inline fwd+bwd.",
+)
+def softmax_cutedsl(
+    x: torch.Tensor,
+    *,
+    mode: Optional[str] = None,
+) -> torch.Tensor:
+    """CuTe DSL softmax dispatch entry point.
+
+    ``mode`` is accepted only for API parity with the other backends; the only
+    valid value is ``"default"`` (or ``None``).
+    """
+    if mode not in (None, "default"):
+        raise ValueError(f"CuTe DSL softmax has only mode='default'; got mode={mode!r}.")
+    vector_width = 16 // x.element_size()
+    fallback_reason = None
+    if x.shape[-1] % vector_width:
+        fallback_reason = f"hidden size {x.shape[-1]} is not divisible by vector width {vector_width}"
+    elif x.shape[-1] > _MAX_TILE_CUTEDSL:
+        fallback_reason = f"hidden size {x.shape[-1]} exceeds CuTe DSL limit {_MAX_TILE_CUTEDSL}"
+    if fallback_reason is not None:
+        from liger_kernel.ops.backends._triton.softmax import softmax_triton
+
+        emit_fallback_warning(
+            "softmax",
+            "nvidia-cutedsl",
+            "nvidia-triton",
+            fallback_reason,
+        )
+        return softmax_triton(x, mode=mode)
+    return _LigerSoftmaxCuTeDSLFunction.apply(x)

--- a/src/liger_kernel/ops/backends/_cutedsl/swiglu.py
+++ b/src/liger_kernel/ops/backends/_cutedsl/swiglu.py
@@ -1,0 +1,564 @@
+"""CuTe DSL (CUTLASS python) backend for ``swiglu``.
+
+Strategy
+--------
+SwiGLU is a purely elementwise op (no reductions), which makes it the simplest
+CuTe DSL kernel in the suite.  The math (matching
+:mod:`liger_kernel.ops.swiglu`)::
+
+    silu(x) = x * sigmoid(x)
+    c       = silu(a) * b
+
+The ``gate_multiplier`` / ``down_multiplier`` scalars (used by Falcon-H1) are
+folded host-side — exactly as the Triton ``LigerSiLUMulFunction`` folds
+``down_multiplier`` outside the kernel.  Pre-scaling ``a`` by ``gate_mult``
+before the kernel and post-scaling ``da`` by ``gate_mult`` after the backward
+kernel reproduces the chain rule without baking scalars into the compiled
+artifact::
+
+    forward :  a' = a * gate_mult;  c = silu(a') * b;  c *= down_mult
+    backward:  dc' = dc * down_mult;  da', db = bwd(dc', a', b);  da = da' * gate_mult
+
+So the CuTe DSL kernel itself only ever sees the pure ``silu(a) * b`` form.
+
+Capability
+----------
+- Compute capability >= sm_90 (Hopper or newer), matching the rms_norm / softmax
+  CuTe DSL siblings.
+- Requires only the ``cutlass`` Python package — the CuTe DSL utilities are
+  inlined under ``_cute_lib/``; no runtime dependency on Quack.
+
+Shapes and limits
+-----------------
+- ``a`` and ``b`` are flattened to 2D ``(M, N)``; arbitrary leading dims OK.
+- dtypes: fp16, bf16, fp32.
+
+Notes
+-----
+We deliberately do **not** put ``from __future__ import annotations`` here
+(same reasoning as the RMSNorm / softmax siblings: keeps annotations live for
+DSL introspection).
+
+References
+----------
+- Triton reference: :mod:`liger_kernel.ops.swiglu` — fixes the exact numerics
+  (fp32 sigmoid, gate/down multiplier chain rule).
+- CuTe DSL structure: :mod:`liger_kernel.ops.backends._cutedsl.softmax` — the
+  TiledCopy + ``cute.autovec_copy`` load/store pattern (minus the reduction
+  stages that SwiGLU does not need).
+"""
+
+import math
+
+from functools import partial
+from typing import Optional
+from typing import Tuple
+from typing import Type
+
+# ---------------------------------------------------------------------------
+# Top-level CuTe DSL imports. Identical pattern to the softmax sibling.
+# ---------------------------------------------------------------------------
+import cuda.bindings.driver as cuda  # noqa: F401  (referenced by cute.compile)
+import cutlass
+import cutlass.cute as cute
+import torch
+
+from cutlass import const_expr
+from torch import Tensor
+
+# Inlined CuTe DSL utilities (adapted from Quack, Apache-2.0).
+import liger_kernel.ops.backends._cutedsl._cute_lib.copy_utils as copy_utils
+
+from liger_kernel.backends import Capability
+from liger_kernel.backends import register_op
+from liger_kernel.ops._nvidia_shared import is_dtensor as _is_dtensor
+from liger_kernel.ops._nvidia_shared import to_local_if_dtensor as _to_local_if_dtensor
+from liger_kernel.ops.backends._cutedsl._cute_lib.compile_utils import make_fake_tensor as fake_tensor
+from liger_kernel.ops.backends._cutedsl._cute_lib.dtype_map import torch2cute_dtype_map
+
+
+# ===========================================================================
+# Forward kernel — elementwise: c = silu(a) * b
+# ===========================================================================
+class _LigerSwiGLUCuTeDSLForward:
+    """CuTe DSL SwiGLU forward.
+
+    Pure elementwise: load a tile of ``a`` and ``b`` into registers, compute
+    ``silu(a) * b`` in fp32, store the result.  No shared-memory reduction is
+    needed (unlike softmax / rms_norm), but we still stage through shared
+    memory via ``cp.async`` so the global load is pipelined.
+    """
+
+    def __init__(self, dtype: Type[cutlass.Numeric], N: int):
+        self.dtype = dtype
+        self.N = N
+        self.cluster_n = 1
+
+    def _threads_per_row(self):
+        N = self.N
+        for limit, threads in [(64, 8), (128, 16), (3072, 32), (6144, 64), (16384, 128)]:
+            if N <= limit:
+                return threads
+        # 128 threads/row for ALL N > 16384 (merging with the mid-N rung):
+        # paired with num_threads == 128 (1 row per block) and the 2-chunk
+        # grid-y cap, a B200 fwd tile sweep (M=8192 bf16) beat BOTH the
+        # committed 1024-thread cap-2 rung and Triton's lean Blackwell tiled
+        # path at every N >= 8192 (kernel med ms @32768: 0.2454 at 128thr vs
+        # 0.3127 committed / 0.2554 Triton). All-elementwise math => the
+        # retile is bit-identical (see _get_tiled_copy and the sw_fwd_sweep
+        # sweep of (num_threads, threads_per_row, num_blocks_N)).
+        return 128
+
+    def _num_threads(self):
+        # 1 row per block on every mid/wide rung (N>6144): threads_per_row
+        # is already 128 for 6144<N<=16384, and the N>16384 rung now uses
+        # 128 threads/row as well. Small-N rungs keep their tpr<128 fanout.
+        return 128
+
+    def _get_tiled_copy(self, vecsize: int = 1):
+        threads_per_row = self._threads_per_row()
+        num_threads = self._num_threads()
+        assert num_threads % cute.arch.WARP_SIZE == 0
+        if self.N >= 8192:
+            # Cap the N-chunks each block loops over at 2 and move the rest
+            # onto grid-y (see __call__ and kernel). Now applies to the whole
+            # N>=8192 rung (8192 itself included after the B200 gate-boundary
+            # A/B: uncapped 8 chunks = 64 live fp32 elems/thread measured
+            # ~4.6% (bf16) / ~7.8% (fp16) slower than cap-2 in full fwd+bwd
+            # @M=8192,N=8192; fp32's vecsize-4 32-elem/thread path neutral),
+            # not just N>16384: the uncapped whole-row loop
+            # spilled registers at mid-N (14 vec-chunks @N=14336 gave 0.1583ms
+            # fwd kernel vs Triton 0.1243; 0.7543ms full fwd+bwd vs 0.4383).
+            # All math is elementwise per element -- no cross-N reduction --
+            # so N-blocking is bit-identical (16 elems/thread live at
+            # cap=2 x vecsize=8 for bf16). N <= 8192 stays whole-row.
+            num_blocks_N = min(cute.ceil_div(self.N // vecsize, threads_per_row * self.cluster_n), 2)
+        else:
+            num_blocks_N = cute.ceil_div(self.N // vecsize, threads_per_row * self.cluster_n)
+        tiler_mn = (num_threads // threads_per_row, vecsize * num_blocks_N * threads_per_row)
+        tiled_copy = copy_utils.tiled_copy_2d(self.dtype, threads_per_row, num_threads, vecsize)
+        return tiled_copy, tiler_mn, threads_per_row
+
+    @cute.jit
+    def __call__(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mC: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        assert mA.element_type == self.dtype
+        largest_dtype_width = const_expr(max(t.element_type.width for t in [mA, mB, mC]))
+        vecsize = math.gcd(self.N, 128 // largest_dtype_width)
+        tiled_copy, tiler_mn, _ = self._get_tiled_copy(vecsize=vecsize)
+        num_threads = tiled_copy.size
+        self.kernel(mA, mB, mC, tiler_mn, tiled_copy).launch(
+            grid=[cute.ceil_div(mA.shape[0], tiler_mn[0]), cute.ceil_div(self.N, tiler_mn[1]), 1],
+            block=[num_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mC: cute.Tensor,
+        tiler_mn: cute.Shape,
+        tiled_copy: cute.TiledCopy,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bnidx, _ = cute.arch.block_idx()
+
+        shape = mA.shape
+        idX = cute.make_identity_tensor(shape)
+        gA, gB, gC, cX = [cute.local_tile(mT, tiler_mn, (bidx, bnidx)) for mT in (mA, mB, mC, idX)]
+
+        thr_copy = tiled_copy.get_slice(tidx)
+        tAgA = thr_copy.partition_S(gA)
+        tBgB = thr_copy.partition_S(gB)
+        tCgC = thr_copy.partition_D(gC)
+        tXcX = thr_copy.partition_S(cX)[(0, None), None, None]
+        tArA, tBrB, tCrC = [cute.make_rmem_tensor_like(thr) for thr in (tAgA, tBgB, tCgC)]
+
+        is_even_N = const_expr(shape[1] % tiler_mn[1] == 0)
+        tXpX = None if is_even_N else copy_utils.predicate_k(thr_copy.partition_S(cX), limit=shape[1])
+        copy = partial(copy_utils.copy, pred=tXpX)
+
+        if tXcX[0][0] < shape[0]:
+            copy(tAgA, tArA)
+            copy(tBgB, tBrB)
+        a = tArA.load().to(cute.Float32)
+        b = tBrB.load()
+
+        # tanh.approx maps directly to the GPU MUFU path and accepts vector
+        # TensorSSA values, unlike the scalar-only rcp_approx wrapper.
+        sig = 0.5 + 0.5 * cute.math.tanh(0.5 * a, fastmath=True)
+        silu_a = a * sig
+        c = silu_a.to(b.element_type) * b
+        tCrC.store(c)
+        if tXcX[0][0] < shape[0]:
+            copy(tCrC, tCgC)
+
+
+# ===========================================================================
+# Backward kernel — elementwise: da, db from dc, a, b
+# ===========================================================================
+class _LigerSwiGLUCuTeDSLBackward:
+    """CuTe DSL SwiGLU backward.
+
+    Given ``dc``, ``a``, ``b`` (where ``a`` is the *effective* ``a * gate_mult``
+    saved by the forward), compute::
+
+        sig     = sigmoid(a)
+        silu_a  = a * sig
+        db      = dc * silu_a
+        da      = dc * (silu_a * (1 - sig) + sig) * b
+
+    The host launcher post-multiplies ``da`` by ``gate_mult`` to complete the
+    chain rule.
+    """
+
+    def __init__(self, dtype: Type[cutlass.Numeric], N: int):
+        self.dtype = dtype
+        self.N = N
+        self.cluster_n = 1
+
+    def _threads_per_row(self):
+        N = self.N
+        for limit, threads in [(64, 8), (128, 16), (3072, 32), (6144, 64), (16384, 128)]:
+            if N <= limit:
+                return threads
+        # 128 threads/row for ALL N > 16384 (merging with the mid-N rung):
+        # paired with num_threads == 128 (1 row per block) and the 2-chunk
+        # grid-y cap, a B200 fwd tile sweep (M=8192 bf16) beat BOTH the
+        # committed 1024-thread cap-2 rung and Triton's lean Blackwell tiled
+        # path at every N >= 8192 (kernel med ms @32768: 0.2454 at 128thr vs
+        # 0.3127 committed / 0.2554 Triton). All-elementwise math => the
+        # retile is bit-identical (see _get_tiled_copy and the sw_fwd_sweep
+        # sweep of (num_threads, threads_per_row, num_blocks_N)).
+        return 128
+
+    def _num_threads(self):
+        # 1 row per block on every mid/wide rung (N>6144): threads_per_row
+        # is already 128 for 6144<N<=16384, and the N>16384 rung now uses
+        # 128 threads/row as well. Small-N rungs keep their tpr<128 fanout.
+        return 128
+
+    def _get_tiled_copy(self, vecsize: int = 1):
+        threads_per_row = self._threads_per_row()
+        num_threads = self._num_threads()
+        assert num_threads % cute.arch.WARP_SIZE == 0
+        if self.N >= 8192:
+            # Cap the N-chunks each block loops over at 2 and move the rest
+            # onto grid-y (see __call__ and kernel). Now applies to the whole
+            # N>=8192 rung (8192 itself included after the B200 gate-boundary
+            # A/B: uncapped 8 chunks = 64 live fp32 elems/thread measured
+            # ~4.6% (bf16) / ~7.8% (fp16) slower than cap-2 in full fwd+bwd
+            # @M=8192,N=8192; fp32's vecsize-4 32-elem/thread path neutral),
+            # not just N>16384: the uncapped whole-row loop
+            # spilled registers at mid-N (14 vec-chunks @N=14336 gave 0.1583ms
+            # fwd kernel vs Triton 0.1243; 0.7543ms full fwd+bwd vs 0.4383).
+            # All math is elementwise per element -- no cross-N reduction --
+            # so N-blocking is bit-identical (16 elems/thread live at
+            # cap=2 x vecsize=8 for bf16). N <= 8192 stays whole-row.
+            num_blocks_N = min(cute.ceil_div(self.N // vecsize, threads_per_row * self.cluster_n), 2)
+        else:
+            num_blocks_N = cute.ceil_div(self.N // vecsize, threads_per_row * self.cluster_n)
+        tiler_mn = (num_threads // threads_per_row, vecsize * num_blocks_N * threads_per_row)
+        tiled_copy = copy_utils.tiled_copy_2d(self.dtype, threads_per_row, num_threads, vecsize)
+        return tiled_copy, tiler_mn, threads_per_row
+
+    @cute.jit
+    def __call__(
+        self,
+        mDC: cute.Tensor,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mDA: cute.Tensor,
+        mDB: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
+        assert mDC.element_type == self.dtype
+        largest_dtype_width = const_expr(max(t.element_type.width for t in [mDC, mA, mB, mDA, mDB]))
+        vecsize = math.gcd(self.N, 128 // largest_dtype_width)
+        tiled_copy, tiler_mn, _ = self._get_tiled_copy(vecsize=vecsize)
+        num_threads = tiled_copy.size
+        self.kernel(mDC, mA, mB, mDA, mDB, tiler_mn, tiled_copy).launch(
+            grid=[cute.ceil_div(mDC.shape[0], tiler_mn[0]), cute.ceil_div(self.N, tiler_mn[1]), 1],
+            block=[num_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mDC: cute.Tensor,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mDA: cute.Tensor,
+        mDB: cute.Tensor,
+        tiler_mn: cute.Shape,
+        tiled_copy: cute.TiledCopy,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bnidx, _ = cute.arch.block_idx()
+
+        shape = mDC.shape
+        idX = cute.make_identity_tensor(shape)
+        gDC, gA, gB, gDA, gDB, cX = [
+            cute.local_tile(mT, tiler_mn, (bidx, bnidx)) for mT in (mDC, mA, mB, mDA, mDB, idX)
+        ]
+
+        thr_copy = tiled_copy.get_slice(tidx)
+        tDCgDC = thr_copy.partition_S(gDC)
+        tAgA = thr_copy.partition_S(gA)
+        tBgB = thr_copy.partition_S(gB)
+        tDAgDA = thr_copy.partition_D(gDA)
+        tDBgDB = thr_copy.partition_D(gDB)
+        tXcX = thr_copy.partition_S(cX)[(0, None), None, None]
+        tDCrDC, tArA, tBrB, tDArDA, tDBrDB = [
+            cute.make_rmem_tensor_like(thr) for thr in (tDCgDC, tAgA, tBgB, tDAgDA, tDBgDB)
+        ]
+
+        is_even_N = const_expr(shape[1] % tiler_mn[1] == 0)
+        tXpX = None if is_even_N else copy_utils.predicate_k(thr_copy.partition_S(cX), limit=shape[1])
+        copy = partial(copy_utils.copy, pred=tXpX)
+
+        if tXcX[0][0] < shape[0]:
+            copy(tDCgDC, tDCrDC)
+            copy(tAgA, tArA)
+            copy(tBgB, tBrB)
+        dc = tDCrDC.load().to(cute.Float32)
+        a = tArA.load().to(cute.Float32)
+        b = tBrB.load().to(cute.Float32)
+
+        sig = 0.5 + 0.5 * cute.math.tanh(0.5 * a, fastmath=True)
+        silu_a = a * sig
+        db = dc * silu_a
+        # silu'(a) = silu(a) * (1 - sig) + sig
+        da = dc * (silu_a * (1.0 - sig) + sig) * b
+
+        tDArDA.store(da.to(tDArDA.element_type))
+        tDBrDB.store(db.to(tDBrDB.element_type))
+        if tXcX[0][0] < shape[0]:
+            copy(tDArDA, tDAgDA)
+            copy(tDBrDB, tDBgDB)
+
+
+# ---------------------------------------------------------------------------
+# Compile caches. ``cute.compile()`` is multi-second; key on the minimal set
+# of attributes that change codegen.
+# ---------------------------------------------------------------------------
+_FWD_COMPILE_CACHE: dict = {}
+_BWD_COMPILE_CACHE: dict = {}
+
+
+def _get_fwd_kernel(a_dtype: torch.dtype, b_dtype: torch.dtype, c_dtype: torch.dtype, N: int):
+    """Return a compiled forward kernel, building it on first miss."""
+    key = (a_dtype, b_dtype, c_dtype, N)
+    if key in _FWD_COMPILE_CACHE:
+        return _FWD_COMPILE_CACHE[key]
+
+    dtype = torch2cute_dtype_map[a_dtype]
+    b_cute_dtype = torch2cute_dtype_map[b_dtype]
+    c_cute_dtype = torch2cute_dtype_map[c_dtype]
+    batch_sym = cute.sym_int()
+    div = math.gcd(128 // dtype.width, N)
+    a_cute = fake_tensor(dtype, (batch_sym, N), div)
+    b_cute = fake_tensor(b_cute_dtype, (batch_sym, N), div)
+    c_cute = fake_tensor(c_cute_dtype, (batch_sym, N), div)
+
+    compiled = cute.compile(
+        _LigerSwiGLUCuTeDSLForward(dtype, N),
+        a_cute,
+        b_cute,
+        c_cute,
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        options="--enable-tvm-ffi",
+    )
+    _FWD_COMPILE_CACHE[key] = compiled
+    return compiled
+
+
+def _get_bwd_kernel(
+    dc_dtype: torch.dtype,
+    a_dtype: torch.dtype,
+    b_dtype: torch.dtype,
+    da_dtype: torch.dtype,
+    db_dtype: torch.dtype,
+    N: int,
+):
+    """Return a compiled backward kernel, building it on first miss."""
+    key = (dc_dtype, a_dtype, b_dtype, da_dtype, db_dtype, N)
+    if key in _BWD_COMPILE_CACHE:
+        return _BWD_COMPILE_CACHE[key]
+
+    dtype = torch2cute_dtype_map[dc_dtype]
+    a_cute_dtype = torch2cute_dtype_map[a_dtype]
+    b_cute_dtype = torch2cute_dtype_map[b_dtype]
+    da_cute_dtype = torch2cute_dtype_map[da_dtype]
+    db_cute_dtype = torch2cute_dtype_map[db_dtype]
+    batch_sym = cute.sym_int()
+    div = math.gcd(128 // dtype.width, N)
+    dc_cute = fake_tensor(dtype, (batch_sym, N), div)
+    a_cute = fake_tensor(a_cute_dtype, (batch_sym, N), div)
+    b_cute = fake_tensor(b_cute_dtype, (batch_sym, N), div)
+    da_cute = fake_tensor(da_cute_dtype, (batch_sym, N), div)
+    db_cute = fake_tensor(db_cute_dtype, (batch_sym, N), div)
+
+    compiled = cute.compile(
+        _LigerSwiGLUCuTeDSLBackward(dtype, N),
+        dc_cute,
+        a_cute,
+        b_cute,
+        da_cute,
+        db_cute,
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        options="--enable-tvm-ffi",
+    )
+    _BWD_COMPILE_CACHE[key] = compiled
+    return compiled
+
+
+# ===========================================================================
+# Host-side launchers and autograd Function
+# ===========================================================================
+def _swiglu_cutedsl_forward(
+    a: Tensor, b: Tensor, gate_multiplier: float, down_multiplier: float
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Forward via the inline CuTe DSL kernel.
+
+    Returns ``(a_eff, b, c)`` where ``a_eff`` is the gate-multiplied ``a``
+    saved for the backward.  ``c`` keeps the original shape.
+    """
+    shape = a.shape
+    N = shape[-1]
+    # Pre-scale a by gate_multiplier so the kernel only sees silu(a') * b.
+    if gate_multiplier != 1.0:
+        a_eff = a * gate_multiplier
+    else:
+        a_eff = a
+    a_flat = a_eff.view(-1, N).contiguous()
+    b_flat = b.view(-1, N).contiguous()
+    c_flat = torch.empty_like(a_flat)
+
+    compiled = _get_fwd_kernel(a_flat.dtype, b_flat.dtype, c_flat.dtype, N)
+    compiled(a_flat, b_flat, c_flat)
+    c = c_flat.view(shape)
+    if down_multiplier != 1.0:
+        c = c * down_multiplier
+    return a_eff, b, c
+
+
+def _swiglu_cutedsl_backward(
+    dc: Tensor, a_eff: Tensor, b: Tensor, gate_multiplier: float, down_multiplier: float
+) -> Tuple[Tensor, Tensor]:
+    """Backward via the inline CuTe DSL kernel.
+
+    Returns ``(da, db)``.  ``dc`` is pre-scaled by ``down_multiplier``;
+    ``da`` is post-scaled by ``gate_multiplier`` to complete the chain rule.
+    """
+    shape = dc.shape
+    N = shape[-1]
+    if down_multiplier != 1.0:
+        dc = dc * down_multiplier
+    dc_flat = dc.view(-1, N).contiguous()
+    a_flat = a_eff.view(-1, N).contiguous()
+    b_flat = b.view(-1, N).contiguous()
+    da_flat = torch.empty_like(a_flat)
+    db_flat = torch.empty_like(b_flat)
+
+    compiled = _get_bwd_kernel(dc_flat.dtype, a_flat.dtype, b_flat.dtype, da_flat.dtype, db_flat.dtype, N)
+    compiled(dc_flat, a_flat, b_flat, da_flat, db_flat)
+
+    da = da_flat.view(shape)
+    db = db_flat.view(shape)
+    if gate_multiplier != 1.0:
+        da = da * gate_multiplier
+    return da, db
+
+
+class _LigerSwiGLUCuTeDSLFunction(torch.autograd.Function):
+    """Autograd wrapper. Saves the effective ``a`` (gate-scaled) and ``b``."""
+
+    @staticmethod
+    def forward(ctx, a, b, gate_multiplier: float = 1.0, down_multiplier: float = 1.0):
+        a = _to_local_if_dtensor(a)
+        b = _to_local_if_dtensor(b)
+        a = a.contiguous()
+        b = b.contiguous()
+        gate_multiplier = float(gate_multiplier)
+        down_multiplier = float(down_multiplier)
+        ctx.gate_multiplier = gate_multiplier
+        ctx.down_multiplier = down_multiplier
+        a_eff, b_saved, c = _swiglu_cutedsl_forward(a, b, gate_multiplier, down_multiplier)
+        ctx.save_for_backward(a_eff, b_saved)
+        return c
+
+    @staticmethod
+    def backward(ctx, dc):
+        dc = _to_local_if_dtensor(dc).contiguous()
+        a_eff, b = ctx.saved_tensors
+        da, db = _swiglu_cutedsl_backward(dc, a_eff, b, ctx.gate_multiplier, ctx.down_multiplier)
+        return da, db, None, None
+
+
+# ===========================================================================
+# Public registration
+# ===========================================================================
+_CUTEDSL_SWIGLU_TOLERANCES = {
+    torch.float16: {"atol_fwd": 5e-3, "atol_bwd": 5e-2, "rtol_fwd": 1e-3, "rtol_bwd": 1e-2},
+    torch.bfloat16: {"atol_fwd": 2e-2, "atol_bwd": 1e-1, "rtol_fwd": 1e-2, "rtol_bwd": 2e-2},
+    torch.float32: {
+        "atol_fwd": 1e-4,
+        "atol_bwd": 1e-4,
+        "rtol_fwd": 1e-4,
+        "rtol_bwd": 1e-4,
+    },  # B300: CuTeDSL fast sigmoid/tanh gives ~1.5e-5 fp32 fwd error (tf32-class); 1e-5 was too strict
+}
+
+
+@register_op(
+    "swiglu",
+    impl_name="nvidia-cutedsl",
+    capability=Capability(
+        min_cc=(9, 0),
+        modules=["cutlass.cute", "torch"],
+    ),
+    modes=("default",),
+    default_mode="default",
+    # Auto-preferred when satisfied (lowest rank).  SwiGLU is elementwise so the
+    # CuTe DSL kernel avoids the Triton launch overhead and uses native exp2
+    # for the sigmoid.
+    preference_rank=10,
+    tolerances=_CUTEDSL_SWIGLU_TOLERANCES,
+    notes="CuTe DSL SwiGLU for Hopper+ (sm_90+); self-contained inline fwd+bwd.",
+)
+def swiglu_cutedsl(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    gate_multiplier: float = 1.0,
+    down_multiplier: float = 1.0,
+    *,
+    mode: Optional[str] = None,
+) -> torch.Tensor:
+    """CuTe DSL SwiGLU dispatch entry point.
+
+    ``mode`` is accepted only for API parity with the other backends; the only
+    valid value is ``"default"`` (or ``None``).
+    """
+    if mode not in (None, "default"):
+        raise ValueError(f"CuTe DSL swiglu has only mode='default'; got mode={mode!r}.")
+    # DTensor (tensor-parallel) inputs are excluded from the CuTe DSL fast path.
+    # The inline kernel operates on plain local tensors: materializing a DTensor
+    # via full_tensor() would trigger an all-gather and silently return a plain
+    # tensor, breaking TP distribution semantics for the output and gradients.
+    # Delegate such inputs to the Triton LigerSiLUMulFunction, which captures
+    # (device_mesh, placements) and re-wraps the output/grads with
+    # DTensor.from_local. The dense (non-DTensor) fast path below is untouched.
+    if _is_dtensor(a) or _is_dtensor(b):
+        from liger_kernel.ops.swiglu import LigerSiLUMulFunction
+
+        return LigerSiLUMulFunction.apply(a, b, float(gate_multiplier), float(down_multiplier))
+    return _LigerSwiGLUCuTeDSLFunction.apply(a, b, float(gate_multiplier), float(down_multiplier))

--- a/src/liger_kernel/ops/cutedsl/ops/rope.py
+++ b/src/liger_kernel/ops/cutedsl/ops/rope.py
@@ -282,6 +282,11 @@ def _tma_supported(dtype: torch.dtype, head_dim: int, device: torch.device = Non
     # innermost TMA box must be 16-byte aligned
     if (head_dim * bits) % 128 != 0:
         return False
+    # The TMA launch uses block = 16 * (hd_half / vec) threads; a CUDA block is
+    # capped at 1024 threads. Oversized heads (e.g. bf16 head_dim=2048 -> 2048
+    # threads) would fail to launch, so fall back to the portable token kernel.
+    if 16 * (hd_half // vec) > 1024:
+        return False
     return True
 
 


### PR DESCRIPTION
# feat(cutedsl): CuTeDSL backends for SwiGLU, GeGLU, Softmax, RoPE, KL-div, JSD

**Head:** `arde171:arde/liger-C-cutedsl-elementwise` → **Base:** `main` — stacks on PR 2. PR **3/5**.

## Summary

Adds the **CuTeDSL elementwise/reduction** op backends, registered via `declare_op_locations` (Blackwell auto-select, Triton fallback). Includes several **correctness fixes** surfaced by an independent GPT-5.6 review of these kernels.

## What's added

- `ops/backends/_cutedsl/{swiglu,geglu,softmax,rope,kl_div,jsd}.py` + `ops/cutedsl/ops/rope.py`.
- `functional.py` — appends the `_cutedsl` paths for these six ops.
- `test/cutedsl/test_rope.py`, `test/ops/test_jsd_chunk_ignore_regression.py`.

## Correctness fixes included

- **SwiGLU / DTensor:** the CuTeDSL SwiGLU now **preserves DTensor (tensor-parallel) semantics** by delegating DTensor inputs to Triton (the previous path materialized the full tensor and returned plain tensors). Dense fast path unchanged. fp32 fwd tolerance calibrated for the fast sigmoid.
- **Softmax fp32 stability:** compute `exp2((x - max) * log2e)` instead of `exp2(x*log2e - max*log2e)` — shift-invariant, avoids fp32 cancellation at large offsets.
- **JSD chunked ignore-labels (P0):** decide the label-stream per chunk (was comparing a global non-ignore count with the per-chunk size), which had let ignored rows leak loss/gradient. Regression test added (asserts ignored rows get exactly zero input-grad across chunked shapes).
- **RoPE TMA guard:** `_tma_supported` rejects shapes whose launch block would exceed 1024 threads (e.g. bf16 head_dim=2048) → falls back to the portable token kernel.
- **GeGLU:** fp32 tolerance calibrated for the fast tanh-gelu.

## Correctness & testing (B300 sm_103 + H200 sm_90)

- Registration: `swiglu:[triton,cutedsl]`, `jsd:[triton,cutedsl]`, `jsd_loss_and_grad:[triton,cutedsl]` (inner op declared here, co-located with its `_cutedsl/jsd.py` impl).
- Full backend suite `test/backends` + `test/ops`, deterministic (`-p no:randomly`): **B300 609 passed / 0 failed**, **H200 609 passed / 0 failed** (39 skipped). The chunked-FLJSD ignore-label regression test exercises the CuTeDSL JSD path on both archs.
- ruff clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
---
**Multi-backend series — review/merge in order:** #1416 (A · dispatcher foundation) → #1417 (B · CuTeDSL norms) → #1418 (C · CuTeDSL elementwise) → #1419 (D · CuTeDSL CE) → #1420 (E · cuTile). Each PR is stacked on the previous; the diff auto-narrows as earlier PRs land. GPU tests are cron-only (per #1409) so per-PR CI = checkstyle + CPU tests; multi-backend suites verified out-of-band on **B300 (sm_103)** + **H200 (sm_90)**.