### PR TITLE
feat(cutedsl): CuTeDSL backends for CrossEntropy, FusedLinearCE, FusedLinearJSD

### DIFF
--- a/src/liger_kernel/functional.py
+++ b/src/liger_kernel/functional.py
@@ -99,7 +99,10 @@ declare_op_locations(
 # uses an online-softmax reduction adapted from Quack.
 declare_op_locations(
     "cross_entropy",
-    ("liger_kernel.ops.backends._triton.cross_entropy",),
+    (
+        "liger_kernel.ops.backends._triton.cross_entropy",
+        "liger_kernel.ops.backends._cutedsl.cross_entropy",
+    ),
 )
 
 # cross_entropy_loss_and_grad: per-chunk CE primitive used by
@@ -107,7 +110,10 @@ declare_op_locations(
 # and picks up CuTe DSL on Hopper+.
 declare_op_locations(
     "cross_entropy_loss_and_grad",
-    ("liger_kernel.ops.backends._triton.cross_entropy",),
+    (
+        "liger_kernel.ops.backends._triton.cross_entropy",
+        "liger_kernel.ops.backends._cutedsl.cross_entropy",
+    ),
 )
 
 # fused_add_rms_norm: Triton (universal) + opt-in CuTe DSL (Hopper+). The
@@ -146,7 +152,10 @@ declare_op_locations(
 # JSD inputs to fp32, which safely falls back to Triton.
 declare_op_locations(
     "fused_linear_jsd",
-    ("liger_kernel.ops.backends._triton.fused_linear_jsd",),
+    (
+        "liger_kernel.ops.backends._triton.fused_linear_jsd",
+        "liger_kernel.ops.backends._cutedsl.fused_linear_jsd",
+    ),
 )
 
 # fused_linear_cross_entropy: Triton (universal) + CuTe DSL (Hopper+). The
@@ -155,7 +164,10 @@ declare_op_locations(
 # the CuTe DSL kernel on Hopper+).
 declare_op_locations(
     "fused_linear_cross_entropy",
-    ("liger_kernel.ops.backends._triton.fused_linear_cross_entropy",),
+    (
+        "liger_kernel.ops.backends._triton.fused_linear_cross_entropy",
+        "liger_kernel.ops.backends._cutedsl.fused_linear_cross_entropy",
+    ),
 )
 
 

--- a/src/liger_kernel/ops/backends/_cutedsl/cross_entropy.py
+++ b/src/liger_kernel/ops/backends/_cutedsl/cross_entropy.py
@@ -1,0 +1,254 @@
+"""CuTe DSL backend registration for ``cross_entropy``.
+
+Thin adapter: the kernel and ``LigerCrossEntropyFunction`` live in
+:mod:`liger_kernel.ops.cutedsl.ops.cross_entropy` (the CuTe DSL operator
+package).  This file only wraps it in a :func:`register_op`-decorated callable
+that the multi-DSL dispatcher can find — mirroring the
+:mod:`liger_kernel.ops.backends._triton.cross_entropy` sibling.
+
+Capability: requires the ``cutlass.cute`` package and compute capability >=
+sm_90 (Hopper or newer), matching the rms_norm / softmax CuTe DSL siblings.
+
+The underlying CuTe DSL cross-entropy kernel uses an online-softmax reduction
+adapted from Quack (Apache-2.0) and is numerically identical to the Triton
+kernel (:mod:`liger_kernel.ops.cross_entropy`).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+from typing import Tuple
+
+import torch
+
+from liger_kernel.backends import Capability
+from liger_kernel.backends import register_op
+from liger_kernel.backends.dispatch import emit_fallback_warning
+from liger_kernel.ops.cutedsl.ops.cross_entropy import LigerCrossEntropyFunction
+
+_CUTEDSL_CE_TOLERANCES = {
+    torch.float16: {"atol_fwd": 5e-3, "atol_bwd": 5e-2, "rtol_fwd": 1e-3, "rtol_bwd": 1e-2},
+    torch.bfloat16: {"atol_fwd": 2e-2, "atol_bwd": 1e-1, "rtol_fwd": 1e-2, "rtol_bwd": 2e-2},
+    torch.float32: {"atol_fwd": 1e-5, "atol_bwd": 1e-4, "rtol_fwd": 1e-5, "rtol_bwd": 1e-4},
+}
+
+
+@register_op(
+    "cross_entropy",
+    impl_name="nvidia-cutedsl",
+    capability=Capability(
+        min_cc=(9, 0),
+        modules=["cutlass.cute", "torch"],
+    ),
+    modes=("default",),
+    default_mode="default",
+    # Ranked BELOW Triton (50) for the standalone cross_entropy op: large-vocab CE is
+    # HBM-bandwidth-bound, and on Blackwell (B200/B300) the CuTe DSL kernel measured
+    # tied-to-slower than Triton (bf16 ~=, fp32 ~-5% @ T8192/V128256). Triton therefore
+    # stays the auto-default here; the CuTe DSL path remains available via explicit
+    # impl="nvidia-cutedsl". (The rank-10 cross_entropy_loss_and_grad primitive below is
+    # unchanged — it is the inner kernel the fused-linear CE path composes.)
+    preference_rank=60,
+    tolerances=_CUTEDSL_CE_TOLERANCES,
+    notes="CuTe DSL cross-entropy for Hopper+ (sm_90+); online-softmax reduction. Opt-in on Blackwell.",
+)
+def cross_entropy_cutedsl(
+    input: torch.Tensor,
+    target: torch.Tensor,
+    weight: Optional[torch.Tensor] = None,
+    ignore_index: int = -100,
+    lse_square_scale: float = 0.0,
+    label_smoothing: float = 0.0,
+    reduction: str = "mean",
+    softcap: Optional[float] = None,
+    return_z_loss: bool = False,
+    return_token_accuracy: bool = False,
+    return_predicted_tokens: bool = False,
+    *,
+    mode: Optional[str] = None,
+):
+    """CuTe DSL cross-entropy dispatch entry point.
+
+    ``mode`` is accepted only for API parity with the other backends; the only
+    valid value is ``"default"`` (or ``None``).
+    """
+    if mode not in (None, "default"):
+        raise ValueError(f"CuTe DSL cross_entropy has only mode='default'; got mode={mode!r}.")
+    vector_width = 16 // input.element_size()
+    if input.shape[-1] % vector_width:
+        from liger_kernel.ops.backends._triton.cross_entropy import cross_entropy_triton
+
+        emit_fallback_warning(
+            "cross_entropy",
+            "nvidia-cutedsl",
+            "nvidia-triton",
+            f"vocab size {input.shape[-1]} is not divisible by vector width {vector_width}",
+        )
+        return cross_entropy_triton(
+            input,
+            target,
+            weight,
+            ignore_index,
+            lse_square_scale,
+            label_smoothing,
+            reduction,
+            softcap,
+            return_z_loss,
+            return_token_accuracy,
+            return_predicted_tokens,
+        )
+    # The CuTe DSL forward's 128-bit vectorized loader requires every row to
+    # start on a 16-byte boundary (asserted in `_launch_ce_fwd`). A row-padded
+    # view (e.g. `base[:, :V]` where `base` has V+1 columns) is contiguous in
+    # the inner dim but not row-aligned, so materialize a contiguous copy that
+    # the kernel can consume. The Triton path accepts such views via its
+    # explicit row stride, so this keeps behavioral parity.
+    if input.stride(0) * input.element_size() % 16 != 0:
+        input = input.contiguous()
+    return LigerCrossEntropyFunction.apply(
+        input,
+        target,
+        weight,
+        ignore_index,
+        lse_square_scale,
+        label_smoothing,
+        reduction,
+        softcap,
+        return_z_loss,
+        return_token_accuracy,
+        return_predicted_tokens,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-chunk CE primitive — used by fused_linear_cross_entropy so the composed
+# op routes through the dispatcher and picks up CuTe DSL on Hopper+.
+# Mirrors the ``jsd_loss_and_grad`` primitive pattern.
+# ---------------------------------------------------------------------------
+@register_op(
+    "cross_entropy_loss_and_grad",
+    impl_name="nvidia-cutedsl",
+    capability=Capability(
+        min_cc=(9, 0),
+        modules=["cutlass.cute", "torch"],
+    ),
+    modes=("default",),
+    default_mode="default",
+    preference_rank=10,
+    notes=(
+        "Per-chunk CE primitive (returns per-row loss + in-place grad logits). "
+        "CuTe DSL online-softmax kernel for Hopper+ (sm_90+). Used by fused_linear_cross_entropy."
+    ),
+)
+def cross_entropy_loss_and_grad_cutedsl(
+    logits_chunk: torch.Tensor,
+    target_chunk: torch.Tensor,
+    ce_weight: Optional[torch.Tensor],
+    ignore_index: int,
+    lse_square_scale: float,
+    label_smoothing: float,
+    reduction: str,
+    softcap: Optional[float],
+    n_non_ignore: int,
+    sum_non_ignore_weight: float,
+    weight_sum: float,
+    return_z_loss: bool,
+    return_token_accuracy: bool,
+    return_predicted_tokens: bool,
+    has_gradients: bool,
+    *,
+    mode: Optional[str] = None,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor], torch.Tensor]:
+    """Compute per-row loss + in-place grad for one chunk of logits via CuTe DSL.
+
+    Delegates to the CuTe DSL CE kernel (``_launch_ce_fwd``) which uses an
+    online-softmax reduction with native HW exp2. Writes the gradient
+    **in-place into** ``logits_chunk`` (matching the Triton primitive's contract).
+
+    Returns:
+        ``(loss_1d, z_loss_1d, token_accuracy_1d, predicted_tokens_1d, grad_logits)``
+        where ``grad_logits is logits_chunk`` (the in-place write).
+    """
+    if mode not in (None, "default"):
+        raise ValueError(f"cross_entropy_loss_and_grad_cutedsl: only mode='default'; got {mode!r}")
+    vector_width = 16 // logits_chunk.element_size()
+    if logits_chunk.shape[-1] % vector_width:
+        from liger_kernel.ops.backends._triton.cross_entropy import cross_entropy_loss_and_grad_triton
+
+        emit_fallback_warning(
+            "cross_entropy_loss_and_grad",
+            "nvidia-cutedsl",
+            "nvidia-triton",
+            f"vocab size {logits_chunk.shape[-1]} is not divisible by vector width {vector_width}",
+        )
+        return cross_entropy_loss_and_grad_triton(
+            logits_chunk,
+            target_chunk,
+            ce_weight,
+            ignore_index,
+            lse_square_scale,
+            label_smoothing,
+            reduction,
+            softcap,
+            n_non_ignore,
+            sum_non_ignore_weight,
+            weight_sum,
+            return_z_loss,
+            return_token_accuracy,
+            return_predicted_tokens,
+            has_gradients,
+        )
+
+    from liger_kernel.ops.cutedsl.ops.cross_entropy import _launch_ce_fwd
+
+    n_rows, V = logits_chunk.shape
+
+    loss_1d = torch.zeros(n_rows, dtype=torch.float32, device=logits_chunk.device)
+    z_loss_1d = torch.zeros(n_rows, dtype=logits_chunk.dtype, device=logits_chunk.device) if return_z_loss else None
+    token_accuracy_1d = (
+        torch.zeros(n_rows, dtype=torch.float32, device=logits_chunk.device) if return_token_accuracy else None
+    )
+    predicted_tokens_1d = (
+        torch.full((n_rows,), -1, dtype=torch.int64, device=logits_chunk.device) if return_predicted_tokens else None
+    )
+
+    # Normalizers (matching cross_entropy_forward in cutedsl ops).
+    if reduction == "mean" and n_non_ignore > 0:
+        if ce_weight is not None and sum_non_ignore_weight > 0:
+            inv_n_loss = 1.0 / sum_non_ignore_weight
+        else:
+            inv_n_loss = 1.0 / n_non_ignore
+        inv_n_z = 1.0 / n_non_ignore
+    else:
+        inv_n_loss = 1.0
+        inv_n_z = 1.0
+
+    # The CuTe DSL kernel reads weight as fp32; upcast here (exact parity).
+    weight_fp32 = None
+    if ce_weight is not None:
+        weight_fp32 = ce_weight.to(torch.float32)
+        if weight_fp32.stride(-1) != 1:
+            weight_fp32 = weight_fp32.contiguous()
+
+    _launch_ce_fwd(
+        logits_chunk,
+        target_chunk,
+        loss_1d,
+        inv_n_loss,
+        ignore_index,
+        has_gradients,
+        lse_square_scale,
+        z_loss_1d,
+        return_z_loss,
+        softcap,
+        label_smoothing=label_smoothing,
+        weight=weight_fp32,
+        weight_sum=weight_sum,
+        return_token_accuracy=return_token_accuracy,
+        return_predicted_tokens=return_predicted_tokens,
+        token_acc_out=token_accuracy_1d,
+        pred_tok_out=predicted_tokens_1d,
+        inv_n_z=inv_n_z,
+    )
+
+    return loss_1d, z_loss_1d, token_accuracy_1d, predicted_tokens_1d, logits_chunk

--- a/src/liger_kernel/ops/backends/_cutedsl/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/ops/backends/_cutedsl/fused_linear_cross_entropy.py
@@ -1,0 +1,103 @@
+"""CuTe DSL backend registration for ``fused_linear_cross_entropy``.
+
+Thin adapter: the composed-op logic and ``LigerFusedLinearCrossEntropyFunction``
+live in :mod:`liger_kernel.ops.fused_linear_cross_entropy`. This file only wraps
+them in a :func:`register_op`-decorated callable that the multi-DSL dispatcher
+can find.
+
+The CuTe DSL acceleration happens **inside** the composed op: the
+``LigerFusedLinearCrossEntropyFunction.forward`` method calls
+``dispatch("cross_entropy_loss_and_grad", ...)`` for the inner CE computation,
+which auto-selects the CuTe DSL :mod:`._cutedsl.cross_entropy` primitive on
+Hopper+ (preference_rank=10 < Triton's 50). The matmul and accumulation
+portions use cuBLAS / PyTorch primitives, so no additional CuTe DSL kernel is
+needed here.
+
+Capability: requires the ``cutlass.cute`` package and compute capability >=
+sm_90 (Hopper or newer), matching the ``cross_entropy_loss_and_grad`` CuTeDSL
+primitive.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+from typing import Tuple
+
+import torch
+
+from liger_kernel.backends import Capability
+from liger_kernel.backends import register_op
+from liger_kernel.ops.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyFunction
+
+_CUTEDSL_FLCE_TOLERANCES = {
+    torch.float16: {"atol_fwd": 5e-3, "atol_bwd": 5e-2, "rtol_fwd": 1e-3, "rtol_bwd": 1e-2},
+    torch.bfloat16: {"atol_fwd": 2e-2, "atol_bwd": 1e-1, "rtol_fwd": 1e-2, "rtol_bwd": 2e-2},
+    torch.float32: {"atol_fwd": 1e-5, "atol_bwd": 1e-4, "rtol_fwd": 1e-5, "rtol_bwd": 1e-4},
+}
+
+
+@register_op(
+    "fused_linear_cross_entropy",
+    impl_name="nvidia-cutedsl",
+    capability=Capability(
+        min_cc=(9, 0),
+        modules=["cutlass.cute", "torch"],
+    ),
+    modes=("default",),
+    default_mode="default",
+    # Auto-preferred when satisfied (lowest rank). The inner
+    # cross_entropy_loss_and_grad primitive uses the CuTe DSL online-softmax
+    # kernel; matmuls use cuBLAS.
+    preference_rank=10,
+    tolerances=_CUTEDSL_FLCE_TOLERANCES,
+    notes="CuTe DSL fused_linear_cross_entropy for Hopper+ (sm_90+); inner CE via CuTe DSL online-softmax kernel.",
+)
+def fused_linear_cross_entropy_cutedsl(
+    _input: torch.Tensor,
+    weight: torch.Tensor,
+    target: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    ce_weight: Optional[torch.Tensor] = None,
+    ignore_index: int = -100,
+    lse_square_scale: float = 0.0,
+    label_smoothing: float = 0.0,
+    reduction: str = "mean",
+    softcap: Optional[float] = None,
+    return_z_loss: bool = False,
+    accum_dtype: Optional[torch.dtype] = None,
+    use_token_scaling: bool = False,
+    return_token_accuracy: bool = False,
+    return_predicted_tokens: bool = False,
+    *,
+    mode: Optional[str] = None,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
+    """CuTe DSL fused_linear_cross_entropy dispatch entry point.
+
+    Delegates to ``LigerFusedLinearCrossEntropyFunction``, which internally
+    dispatches the ``cross_entropy_loss_and_grad`` primitive through the
+    dispatcher — picking up the CuTe DSL kernel on Hopper+.
+
+    ``mode`` is accepted only for API parity with the other backends; the only
+    valid value is ``"default"`` (or ``None``).
+    """
+    if mode not in (None, "default"):
+        raise ValueError(f"CuTe DSL fused_linear_cross_entropy has only mode='default'; got mode={mode!r}.")
+    return LigerFusedLinearCrossEntropyFunction.apply(
+        _input,
+        weight,
+        target,
+        bias,
+        ce_weight,
+        ignore_index,
+        lse_square_scale,
+        label_smoothing,
+        reduction,
+        softcap,
+        return_z_loss,
+        accum_dtype,
+        use_token_scaling,
+        return_token_accuracy,
+        return_predicted_tokens,
+        "nvidia-cutedsl",
+        mode,
+    )

--- a/src/liger_kernel/ops/backends/_cutedsl/fused_linear_jsd.py
+++ b/src/liger_kernel/ops/backends/_cutedsl/fused_linear_jsd.py
@@ -1,0 +1,85 @@
+"""CuTe DSL backend registration for ``fused_linear_jsd``.
+
+Thin adapter: the composed-op logic and ``LigerFusedLinearJSDFunction`` live
+in :mod:`liger_kernel.ops.fused_linear_jsd`.  This file only wraps them in a
+:func:`register_op`-decorated callable that the multi-DSL dispatcher can find.
+
+The composed op computes logits and log-softmax in fp32; the CuTe DSL JSD
+primitive (b02ab91) handles fp32 natively via trace-time precise exp/log, so
+the whole composed op now runs on the CuTe DSL inner primitive.
+
+Capability: requires the ``cutlass.cute`` package and compute capability >=
+sm_90 (Hopper or newer), matching the ``jsd_loss_and_grad`` CuTeDSL primitive.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from liger_kernel.backends import Capability
+from liger_kernel.backends import register_op
+from liger_kernel.ops.fused_linear_jsd import LigerFusedLinearJSDFunction
+
+_CUTEDSL_FLJSD_TOLERANCES = {
+    torch.float16: {"atol_fwd": 5e-3, "atol_bwd": 5e-2, "rtol_fwd": 1e-3, "rtol_bwd": 1e-2},
+    torch.bfloat16: {"atol_fwd": 2e-2, "atol_bwd": 1e-1, "rtol_fwd": 1e-2, "rtol_bwd": 2e-2},
+    torch.float32: {"atol_fwd": 1e-5, "atol_bwd": 1e-4, "rtol_fwd": 1e-5, "rtol_bwd": 1e-4},
+}
+
+
+@register_op(
+    "fused_linear_jsd",
+    impl_name="nvidia-cutedsl",
+    capability=Capability(
+        min_cc=(9, 0),
+        modules=["cutlass.cute", "torch"],
+    ),
+    modes=("default",),
+    default_mode="default",
+    # Auto-select: fp32 inner JSD runs CuTe DSL natively (b02ab91), so the
+    # composed op beats cuTile (rank 5) by ~2-8% at V>=65536 and ties it at
+    # V=32000 on B200 (A/B flake-level at 32000, 1.02-1.08x at wide vocab);
+    # it also never loses to Triton (rank 50). Rank 4 sits below both so the
+    # dispatcher picks CuTe DSL on sm_90+; pre-Hopper falls to Triton via the
+    # min_cc gate.
+    preference_rank=4,
+    tolerances=_CUTEDSL_FLJSD_TOLERANCES,
+    notes="CuTe DSL FLJSD (fp32 inner JSD via precise exp/log); auto-selected on sm_90+, beats cuTile/Triton at wide vocab.",
+)
+def fused_linear_jsd_cutedsl(
+    student_input: torch.Tensor,
+    student_weight: torch.Tensor,
+    teacher_input: torch.Tensor,
+    teacher_weight: torch.Tensor,
+    shift_labels: Optional[torch.Tensor] = None,
+    jsd_beta: float = 0.5,
+    ignore_index: int = -100,
+    temperature: float = 1.0,
+    *,
+    mode: Optional[str] = None,
+) -> torch.Tensor:
+    """CuTe DSL fused_linear_jsd dispatch entry point.
+
+    Delegates to ``LigerFusedLinearJSDFunction`` with the inner
+    ``jsd_loss_and_grad`` primitive pinned to the CuTe DSL impl.
+
+    ``mode`` is accepted only for API parity with the other backends; the only
+    valid value is ``"default"`` (or ``None``).
+    """
+    if mode not in (None, "default"):
+        raise ValueError(f"CuTe DSL fused_linear_jsd has only mode='default'; got mode={mode!r}.")
+    return LigerFusedLinearJSDFunction.apply(
+        student_input,
+        student_weight,
+        teacher_input,
+        teacher_weight,
+        shift_labels,
+        jsd_beta,
+        ignore_index,
+        temperature,
+        None,
+        "nvidia-cutedsl",
+        mode,
+    )

--- a/src/liger_kernel/ops/cutedsl/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cutedsl/ops/cross_entropy.py
@@ -582,17 +582,40 @@ def _ce_fwd_kernel(
             w_vidx = w_vidx + THREADS
         cute.arch.cp_async_wait_group(0)  # drain remaining prefetches
         cute.arch.barrier()  # all grad writes visible before the target correction
-        # -(1 - ls) * weight_y / N_loss correction at the (non-ignored) target index, one thread.
+        # True-class gradient correction at the (non-ignored) target index, one thread.
+        # dx_y = softmax(x_y) - (1 - ls) cancels catastrophically once the model is confident
+        # (softmax(x_y) -> 1), so the -(1 - ls) term must be folded in *before* the result is
+        # rounded to X's low-precision dtype. The pass-2 loop already stored the per-element
+        # part softmax(x_y)*coef (+smoothing) at gX[y], but reading that low-precision value back
+        # and adding -(1 - ls)/N would lose most of the significant bits in bf16/fp16. Instead we
+        # recompute the *entire* dx_y once, fully in fp32, and OVERWRITE gX[y] with a single
+        # store. ori_xy is the (softcapped) fp32 logit at y, so softmax_y matches the loop exactly.
         do_correction = y != ignore_index
         if tid == 0:
             if do_correction:
-                dxy = (Float32(0.0) - (Float32(1.0) - label_smoothing)) * w_eff * inv_n_loss
+                softmax_y = cute.math.exp2(ori_xy * LOG2_E + neg_m2_p2, fastmath=True) / d
+                # dloss_ori (+ z_loss) coefficient, identical to the loop's `coef`.
+                if const_expr(HAS_WEIGHT):
+                    coef_y = (Float32(1.0) - label_smoothing) * w_eff * inv_n_loss
+                else:
+                    coef_y = inv_n_loss
+                if const_expr(HAS_ZLOSS):
+                    coef_y = coef_y + (Float32(2.0) * lse_sq_scale * lse) * inv_n_z
+                dxy = softmax_y * coef_y
+                # additive label-smoothing term (matches the loop's NEED_WBLOCK/else split).
+                if const_expr(HAS_SMOOTHING):
+                    eps_g = eps * inv_n_loss
+                    if const_expr(HAS_WEIGHT):
+                        dxy = dxy + (softmax_y * weight_sum - w_eff) * eps_g
+                    else:
+                        dxy = dxy + (Float32(0.0) - eps_g)
+                # true-class term: dx_y picks up -(1 - ls) * weight_y / N_loss.
+                dxy = dxy + (Float32(0.0) - (Float32(1.0) - label_smoothing)) * w_eff * inv_n_loss
                 if const_expr(HAS_SOFTCAP):
                     # same chain factor at y: t_y = tanh(x_y/softcap) = ori_xy_capped/softcap.
                     t_y = ori_xy / softcap
-                    dxy = dxy * (1.0 - t_y * t_y)
-                corr = gX[y].to(Float32) + dxy
-                gX[y] = corr.to(gX.element_type)
+                    dxy = dxy * (Float32(1.0) - t_y * t_y)
+                gX[y] = dxy.to(gX.element_type)
 
 
 # =============================================================================

--- a/test/cutedsl/test_cross_entropy.py
+++ b/test/cutedsl/test_cross_entropy.py
@@ -689,3 +689,49 @@ def test_ce_functional_structured_output_matches_triton(
             assert torch.equal(c, t), "predicted_tokens mismatch vs Triton"
         else:
             _assert_close(c.detach().float(), t.detach().float(), 1e-4, 1e-3, field)
+
+
+# =============================================================================
+# E. Confident-prediction true-class gradient precision (CuTe DSL analogue of Triton #1329)
+# =============================================================================
+@cuda_required
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
+@pytest.mark.parametrize("reduction", ["mean", "sum"])
+@pytest.mark.parametrize("label_smoothing", [0.0, 0.1])
+def test_ce_true_class_grad_confident_predictions(dtype, reduction, label_smoothing):
+    """``dx_y = softmax(x_y) - (1 - ls)`` cancels catastrophically once the model is confident
+    (``softmax(x_y) -> 1``), so the CuTe DSL backward must fold the ``-(1 - ls)`` term in fp32
+    *before* rounding to the low-precision gradient buffer (mirrors the Triton fix in #1329).
+    Drive ``softmax(x_y) -> 1`` and require the true-class gradient to be no less accurate than
+    torch's own low-precision backward on the same logits."""
+    torch.manual_seed(0)
+    device = "cuda"
+    B, T, V = 2, 64, 4096
+    logits = torch.randn(B * T, V, device=device, dtype=torch.float32)
+    target = torch.randint(0, V, (B * T,), device=device)
+    # Push the true-class logit far above the rest so softmax(x_y) is ~1 and the true-class
+    # gradient is a tiny difference of comparatively large terms.
+    logits[torch.arange(B * T, device=device), target] = logits.max(dim=-1).values + 10.0
+    base = logits.to(dtype)
+
+    xi = base.clone().detach().requires_grad_(True)  # cutedsl
+    xr = base.clone().detach().float().requires_grad_(True)  # fp32 reference
+    xt = base.clone().detach().requires_grad_(True)  # torch low-precision
+
+    loss = _run_or_skip(lambda: _apply(_cutedsl_ce(), xi, target, reduction=reduction, label_smoothing=label_smoothing))
+    if isinstance(loss, tuple):
+        loss = loss[0]
+    loss.backward()
+    F.cross_entropy(xr, target, reduction=reduction, label_smoothing=label_smoothing).backward()
+    F.cross_entropy(xt, target, reduction=reduction, label_smoothing=label_smoothing).backward()
+
+    rows = torch.arange(B * T, device=device)
+    ref = xr.grad[rows, target].double()
+    torch_err = (xt.grad[rows, target].double() - ref).abs().max().item()
+    cutedsl_err = (xi.grad[rows, target].double() - ref).abs().max().item()
+    # Rounding the softmax term before the subtraction inflates the error by ~1/(1 - softmax(x_y)),
+    # so a small constant factor over torch is a wide margin.
+    assert cutedsl_err <= max(4 * torch_err, torch.finfo(dtype).tiny), (
+        f"cutedsl true-class grad error {cutedsl_err:.3e} exceeds torch's {torch_err:.3e} "
+        f"(reduction={reduction}, label_smoothing={label_smoothing}, dtype={dtype})"
+    )


### PR DESCRIPTION
# feat(cutedsl): register CuTeDSL CrossEntropy / FusedLinearCE / FusedLinearJSD backends

**Head:** `arde171:arde/liger-D-cutedsl-ce` → **Base:** `main`. Stacks on #1418. PR **4/5**.

## What this PR is (and is not)

This is a **dispatcher-wiring + one correctness fix** PR. The CuTeDSL cross-entropy-family **kernels already exist on `main`** (added by #1334/#1355/#1370/#1380 etc.). This PR only **registers** them with the multi-backend dispatcher from #1416 and adds the composed-op adapters. **It does not modify any existing kernel implementation** — `fused_scaled_cross_entropy_sm90.py` (fragment forward, #1370), `_sm100_gemm.py` (selector, #1380), and `cross_entropy.py` `num_warps` are all **byte-identical to `upstream/main`**.

Diff: **532 insertions / 9 deletions**, 6 files.

## What's added
- `ops/backends/_cutedsl/{cross_entropy,fused_linear_cross_entropy,fused_linear_jsd}.py` — `register_op` adapters, plus the shared inner primitives `cross_entropy_loss_and_grad` / `jsd_loss_and_grad`.
- `functional.py` — `declare_op_locations` for the above.
- `ops/cutedsl/ops/cross_entropy.py` — **+33/-9**, the fp32 correctness fix only (see below).
- `test/cutedsl/test_cross_entropy.py` — **+46**, a focused confident-prediction precision test.

## Default-selection safety (addresses the perf review)
Large-vocab CE is **HBM-bandwidth-bound**. Measured on B200 (T=8192, V=128256, fwd+bwd): standalone cutedsl CE is **tied** in bf16 (1.185 vs Triton 1.179 ms) and **~5% slower** in fp32 (1.894 vs 1.803). So:
- **standalone `cross_entropy` cutedsl → `preference_rank=60`** (below Triton's 50): **Triton stays the auto-default**; cutedsl is opt-in via `impl="nvidia-cutedsl"`.
- **`cross_entropy_loss_and_grad` inner primitive stays `preference_rank=10`** — it's the kernel the fused-linear CE path composes.

## Correctness fix (CuTeDSL analogue of Triton #1329)
The cutedsl CE backward now **recomputes the true-class gradient `dx_y` fully in fp32 and overwrites the target slot with a single store** (was a read-modify-write of the already-low-precision value). `dx_y = softmax(x_y) − (1−ls)` cancels catastrophically as `softmax(x_y) → 1`, so the `−(1−ls)` term must be folded in fp32 before the round. Covers weighted / label-smoothing / z-loss / softcap / ignore-index; new `test_ce_true_class_grad_confident_predictions` locks it.

## Testing (Blackwell sm_100 ×2 + Hopper sm_90), deterministic `-p no:randomly`
| suite | B200 sm_100 | H200 sm_90 |
|---|---|---|
| `test/cutedsl/test_cross_entropy.py` (incl. new precision test) | **166 / 0** | ✓ |
| `test/transformers/test_cross_entropy.py` | **185 / 0** | 185 / 0 |
| `test/backends` + `test/ops` (D-only) | **634 / 0** | ✓ |

ruff check + format clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
---
**Multi-backend series — review/merge in order:** #1416 (A) → #1417 (B) → #1418 (C) → **#1419 (D)** → #1420 (E · cuTile). Stacked; diffs auto-narrow as earlier PRs land.
