### PR TITLE
fix(peft): patch the LayerNorm copies, not the ModulesToSaveWrapper itself

### DIFF
--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -104,13 +104,10 @@ def _patch_layer_norm_module(module, eps=1e-6):
     # Check if the module is a PEFT ModulesToSaveWrapper
     # If it is, we need to patch the modules_to_save.default and original_modules
     if PEFT_AVAILABLE and isinstance(module, peft.utils.other.ModulesToSaveWrapper):
-        module.hidden_size = module.normalized_shape
-        _bind_method_to_module(module, "forward", LigerLayerNorm.forward)
-        _bind_method_to_module(module, "extra_repr", LigerLayerNorm.extra_repr)
         module.modules_to_save.default.variance_epsilon = (
             getattr(module, "variance_epsilon", None) or getattr(module, "eps", None) or eps
         )
-        module.original_module.hidden_size = getattr(module, "hidden_size", None) or getattr(
+        module.modules_to_save.default.hidden_size = getattr(module, "hidden_size", None) or getattr(
             module, "normalized_shape", None
         )
         module.original_module.variance_epsilon = (

--- a/test/transformers/test_monkey_patch.py
+++ b/test/transformers/test_monkey_patch.py
@@ -282,6 +282,15 @@ def is_nemotron_available():
         return False
 
 
+def is_peft_available():
+    try:
+        import peft  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 def test_import_from_root():
     try:
         from liger_kernel.transformers import AutoLigerKernelForCausalLM  # noqa: F401
@@ -3719,3 +3728,28 @@ def test_apply_liger_kernel_to_instance_for_nemotron():
             print(dummy_model_instance)
         except Exception as e:
             pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+
+
+@pytest.mark.skipif(not is_peft_available(), reason="peft module not available")
+def test_patch_layer_norm_module_with_peft_modules_to_save():
+    from peft.utils.other import ModulesToSaveWrapper
+
+    layer_norm = torch.nn.LayerNorm(8, eps=1e-5)
+    wrapper = ModulesToSaveWrapper(layer_norm, "default")
+
+    monkey_patch._patch_layer_norm_module(wrapper)
+
+    for patched_module in (wrapper.modules_to_save.default, wrapper.original_module):
+        assert patched_module.variance_epsilon == layer_norm.eps
+        assert patched_module.hidden_size == layer_norm.normalized_shape
+        assert patched_module.forward.__func__ is LigerLayerNorm.forward
+        assert patched_module._get_name() == LigerLayerNorm.__name__
+
+    # The wrapper itself must keep PEFT's forward so adapter dispatch stays intact
+    assert "forward" not in wrapper.__dict__
+
+    # extra_repr is bound to the patched copies; printing the module must not raise
+    try:
+        print(wrapper)
+    except Exception as e:
+        pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")


### PR DESCRIPTION
## Root cause

The PEFT branch of `_patch_layer_norm_module` (src/liger_kernel/transformers/monkey_patch.py:103) diverges from its `_patch_rms_norm_module` sibling in three ways, all defects:

1. It binds `LigerLayerNorm.forward`/`extra_repr` onto the `ModulesToSaveWrapper` itself. The instance-level `forward` shadows PEFT's `_forward_wrapped` dispatch (which routes to the trainable `modules_to_save.default` copy when adapters are enabled, and to `original_module` under `disable_adapters`), silently breaking PEFT semantics. The RMSNorm branch from the same PR correctly leaves the wrapper untouched.
2. `hidden_size` is set on the wrapper and (twice) on `original_module`, but never on `modules_to_save.default` — yet `extra_repr` (which reads `self.hidden_size`) is bound to it, so `repr()`/`print()` of a patched model raises `AttributeError: 'LayerNorm' object has no attribute 'hidden_size'`.
3. The duplicated `original_module.hidden_size` assignment is dead weight.

The branch is reached whenever `apply_liger_kernel_to_*(model=...)` patches a LayerNorm wrapped by a PEFT config's `modules_to_save` (e.g. vision-tower layernorms in mllama/InternVL/SmolVLM-style setups). It was introduced by #632 (which fixed #631 for the RMSNorm path) and has zero test coverage — `grep -c peft test/transformers/test_monkey_patch.py` on main is 0.

## Fix

Mirror `_patch_rms_norm_module`: patch only `modules_to_save.default` and `original_module`, set `hidden_size` on both, and leave the wrapper's `forward` alone so PEFT's adapter dispatch stays intact. Net −3 lines in src. Adds a regression test covering the PEFT wrapper path, including the invariant that `"forward" not in wrapper.__dict__`.

## Verification

Executed on CPU (WSL, torch 2.13, transformers 4.56.2, peft 0.20.0):

- Red: on main, the new test fails with `AttributeError: 'LayerNorm' object has no attribute 'hidden_size'` on `print(wrapper)`, and the wrapper's `__dict__` carries the shadowing `forward`.
- Green: with the fix, full `test/transformers/test_monkey_patch.py` passes — 44 passed, 19 skipped, 0 failed. `ruff check` and `ruff format` clean.

Disclosure: the GPU kernel suite (`make test`) and convergence tests were not run — no GPU on this box. The change touches only patch-time attribute/binding structure, no kernel code.