### PR TITLE
[NPU] Optimize Ascend CE/FLCE, RMSNorm, and RoPE kernels

### DIFF
--- a/src/liger_kernel/functional.py
+++ b/src/liger_kernel/functional.py
@@ -36,6 +36,7 @@ declare_op_locations(
     (
         "liger_kernel.ops.backends._triton.rms_norm",
         "liger_kernel.ops.backends._cutedsl.rms_norm",
+        "liger_kernel.ops.backends._ascend.rms_norm",
     ),
 )
 
@@ -74,34 +75,33 @@ declare_op_locations(
     ),
 )
 
-# SwiGLU: Triton (universal) + CuTe DSL (Hopper+). SwiGLU is a purely
-# elementwise op (silu(a) * b) so the CuTe DSL kernel avoids Triton launch
-# overhead and uses native exp2 for the sigmoid.
+# SwiGLU: Triton (universal) + CuTe DSL (Hopper+) + Ascend Triton on NPU.
 declare_op_locations(
     "swiglu",
     (
         "liger_kernel.ops.backends._triton.swiglu",
         "liger_kernel.ops.backends._cutedsl.swiglu",
+        "liger_kernel.ops.backends._ascend.swiglu",
     ),
 )
 
-# RoPE: Triton (universal) + CuTe DSL (Hopper+). RoPE is an elementwise
-# rotation; the CuTe DSL kernel shares one rotate primitive for fwd+bwd.
+# RoPE: Triton (universal) + CuTe DSL (Hopper+) + Ascend Triton on NPU.
 declare_op_locations(
     "rope",
     (
         "liger_kernel.ops.backends._triton.rope",
         "liger_kernel.ops.backends._cutedsl.rope",
+        "liger_kernel.ops.backends._ascend.rope",
     ),
 )
 
-# CrossEntropy: Triton (universal) + CuTe DSL (Hopper+). The CuTe DSL kernel
-# uses an online-softmax reduction adapted from Quack.
+# CrossEntropy: NVIDIA Triton fallback + Ascend Triton on NPU.
 declare_op_locations(
     "cross_entropy",
     (
         "liger_kernel.ops.backends._triton.cross_entropy",
         "liger_kernel.ops.backends._cutedsl.cross_entropy",
+        "liger_kernel.ops.backends._ascend.cross_entropy",
     ),
 )
 
@@ -158,15 +158,16 @@ declare_op_locations(
     ),
 )
 
-# fused_linear_cross_entropy: Triton (universal) + CuTe DSL (Hopper+). The
-# CuTe DSL variant delegates to LigerFusedLinearCrossEntropyFunction which
-# internally dispatches the cross_entropy_loss_and_grad primitive (picking up
-# the CuTe DSL kernel on Hopper+).
+# fused_linear_cross_entropy: Triton (universal) + Ascend Triton on NPU.
+# On NVIDIA, the CuTe DSL acceleration is inside the composed op via
+# ``cross_entropy_loss_and_grad``. On Ascend the dedicated FLCE Function
+# is selected by preference_rank.
 declare_op_locations(
     "fused_linear_cross_entropy",
     (
         "liger_kernel.ops.backends._triton.fused_linear_cross_entropy",
         "liger_kernel.ops.backends._cutedsl.fused_linear_cross_entropy",
+        "liger_kernel.ops.backends._ascend.fused_linear_cross_entropy",
     ),
 )
 

--- a/src/liger_kernel/ops/backends/_ascend/cross_entropy.py
+++ b/src/liger_kernel/ops/backends/_ascend/cross_entropy.py
@@ -1,0 +1,61 @@
+"""Ascend Triton backend registration for ``cross_entropy``.
+
+``LigerCrossEntropyLoss`` and ``functional.cross_entropy`` dispatch through
+:func:`liger_kernel.backends.dispatch`. Without this adapter, auto-select only
+sees ``nvidia-triton`` (gradient-in-forward, ``BLOCK_SIZE=2048``) which is
+~3–4× slower than CANN ``npu_cross_entropy_loss`` on 910B.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from liger_kernel.backends import register_op
+from liger_kernel.ops.backends._ascend.dispatch_common import ASCEND_TRITON_CAPABILITY
+from liger_kernel.ops.backends._ascend.dispatch_common import ASCEND_TRITON_RANK
+from liger_kernel.ops.backends._ascend.dispatch_common import DEFAULT_TOLERANCES
+from liger_kernel.ops.backends._ascend.ops.cross_entropy import LigerCrossEntropyFunction
+
+
+@register_op(
+    "cross_entropy",
+    impl_name="ascend-triton",
+    capability=ASCEND_TRITON_CAPABILITY,
+    modes=("default",),
+    default_mode="default",
+    preference_rank=ASCEND_TRITON_RANK,
+    tolerances=DEFAULT_TOLERANCES,
+    notes="NPU-tuned CE (48-core persistent tiles, split fwd/bwd). Preferred on Ascend.",
+)
+def cross_entropy_ascend(
+    input: torch.Tensor,
+    target: torch.Tensor,
+    weight: Optional[torch.Tensor] = None,
+    ignore_index: int = -100,
+    lse_square_scale: float = 0.0,
+    label_smoothing: float = 0.0,
+    reduction: str = "mean",
+    softcap: Optional[float] = None,
+    return_z_loss: bool = False,
+    return_token_accuracy: bool = False,
+    return_predicted_tokens: bool = False,
+    *,
+    mode: Optional[str] = None,
+):
+    if mode not in (None, "default"):
+        raise ValueError(f"Ascend cross_entropy has only mode='default'; got mode={mode!r}.")
+    return LigerCrossEntropyFunction.apply(
+        input,
+        target,
+        weight,
+        ignore_index,
+        lse_square_scale,
+        label_smoothing,
+        reduction,
+        softcap,
+        return_z_loss,
+        return_token_accuracy,
+        return_predicted_tokens,
+    )

--- a/src/liger_kernel/ops/backends/_ascend/dispatch_common.py
+++ b/src/liger_kernel/ops/backends/_ascend/dispatch_common.py
@@ -1,0 +1,17 @@
+"""Shared capability / rank for Ascend Triton dispatcher adapters."""
+
+from __future__ import annotations
+
+import torch
+
+from liger_kernel.backends import Capability
+from liger_kernel.utils import is_npu_available
+
+ASCEND_TRITON_CAPABILITY = Capability(modules=["triton"], predicate=is_npu_available)
+ASCEND_TRITON_RANK = 10
+
+DEFAULT_TOLERANCES = {
+    torch.float16: {"atol_fwd": 5e-3, "atol_bwd": 5e-2, "rtol_fwd": 1e-3, "rtol_bwd": 1e-2},
+    torch.bfloat16: {"atol_fwd": 2e-2, "atol_bwd": 1e-1, "rtol_fwd": 1e-2, "rtol_bwd": 2e-2},
+    torch.float32: {"atol_fwd": 1e-5, "atol_bwd": 1e-4, "rtol_fwd": 1e-5, "rtol_bwd": 1e-4},
+}

--- a/src/liger_kernel/ops/backends/_ascend/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/ops/backends/_ascend/fused_linear_cross_entropy.py
@@ -1,0 +1,64 @@
+"""Ascend Triton backend registration for ``fused_linear_cross_entropy``."""
+
+from __future__ import annotations
+
+from typing import Optional
+from typing import Tuple
+
+import torch
+
+from liger_kernel.backends import register_op
+from liger_kernel.ops.backends._ascend.dispatch_common import ASCEND_TRITON_CAPABILITY
+from liger_kernel.ops.backends._ascend.dispatch_common import ASCEND_TRITON_RANK
+from liger_kernel.ops.backends._ascend.dispatch_common import DEFAULT_TOLERANCES
+from liger_kernel.ops.backends._ascend.ops.fused_linear_cross_entropy import LigerFusedLinearCrossEntropyFunction
+
+
+@register_op(
+    "fused_linear_cross_entropy",
+    impl_name="ascend-triton",
+    capability=ASCEND_TRITON_CAPABILITY,
+    modes=("default",),
+    default_mode="default",
+    preference_rank=ASCEND_TRITON_RANK,
+    tolerances=DEFAULT_TOLERANCES,
+    notes="NPU-tuned fused linear + CE. Preferred over nvidia-triton on Ascend.",
+)
+def fused_linear_cross_entropy_ascend(
+    _input: torch.Tensor,
+    weight: torch.Tensor,
+    target: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    ce_weight: Optional[torch.Tensor] = None,
+    ignore_index: int = -100,
+    lse_square_scale: float = 0.0,
+    label_smoothing: float = 0.0,
+    reduction: str = "mean",
+    softcap: Optional[float] = None,
+    return_z_loss: bool = False,
+    accum_dtype: Optional[torch.dtype] = None,
+    use_token_scaling: bool = False,
+    return_token_accuracy: bool = False,
+    return_predicted_tokens: bool = False,
+    *,
+    mode: Optional[str] = None,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
+    if mode not in (None, "default"):
+        raise ValueError(f"Ascend fused_linear_cross_entropy has only mode='default'; got mode={mode!r}.")
+    return LigerFusedLinearCrossEntropyFunction.apply(
+        _input,
+        weight,
+        target,
+        bias,
+        ce_weight,
+        ignore_index,
+        lse_square_scale,
+        label_smoothing,
+        reduction,
+        softcap,
+        return_z_loss,
+        accum_dtype,
+        use_token_scaling,
+        return_token_accuracy,
+        return_predicted_tokens,
+    )

--- a/src/liger_kernel/ops/backends/_ascend/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/cross_entropy.py
@@ -96,7 +96,8 @@ def liger_cross_entropy_forward_kernel(
     target_row_ptr = Y_ptr + row_start_int64
     logits_row_ptr = X_ptr + row_start_int64 * X_stride
     loss_row_ptr = loss_ptr + row_start_int64
-    lse_row_ptr = lse_ptr + row_start_int64
+    if RETURN_LSE:
+        lse_row_ptr = lse_ptr + row_start_int64
     if RETURN_Z_LOSS:
         z_loss_row_ptr = z_loss_ptr + row_start_int64
     if RETURN_TOKEN_ACCURACY:
@@ -208,55 +209,68 @@ def liger_cross_entropy_forward_kernel_plain(
     X_stride,
     Y_ptr,
     loss_ptr,
+    lse_ptr,
     n_cols,
     n_rows,
     ce_stats_ptr,
     ignore_index,
     reduction: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
+    HAS_TAIL: tl.constexpr,
+    RETURN_LSE: tl.constexpr,
 ):
     """
-    Plain CE forward fast path (no weight/softcap/smoothing/z-loss/metrics).
-    1 program processes 1 row to maximize parallelism (unlike the generic kernel
-    which chunks rows per program for flexibility).
-    Writes per-row loss to ``loss_ptr`` (float32 recommended).
+    Plain CE fast path (no weight/softcap/smoothing/z-loss/metrics).
+
+    Contiguous row chunks per vector core keep MTE2 sequential. Full tiles are
+    unmasked; ``HAS_TAIL`` is constexpr so the masked remainder is DCE'd when
+    ``n_cols`` divides ``BLOCK_SIZE``. ``tl.range`` pipelines MTE2/VEC/MTE3.
     """
-    row = tl.program_id(0)
-    if row >= n_rows:
-        return
-
-    row_i64 = row.to(tl.int64)
-    y = tl.load(Y_ptr + row_i64)
-
-    # Pre-load mean scaling. For sum/none we treat scale as 1.0.
+    pid = tl.program_id(0)
+    nprog = tl.num_programs(0)
     inv_n = tl.load(ce_stats_ptr + 0).cast(tl.float32)
+    cols = tl.arange(0, BLOCK_SIZE)
+    n_full = (n_cols // BLOCK_SIZE) * BLOCK_SIZE
+    row_chunk = (n_rows + nprog - 1) // nprog
+    row_start = pid * row_chunk
+    row_end = tl.minimum(row_start + row_chunk, n_rows)
 
-    if y == ignore_index:
-        tl.store(loss_ptr + row_i64, 0.0)
-        return
-    logits_row_ptr = X_ptr + row_i64 * X_stride
-    m = float("-inf")
-    d = 0.0
-    # Keep x[y] as a direct load outside the scan. Folding it into the block
-    # loop adds extra selection state and tends to increase UB/register pressure
-    # on Ascend.
-    x_y = tl.load(logits_row_ptr + y).cast(tl.float32)
-    for i in range(0, n_cols, BLOCK_SIZE):
-        offs = i + tl.arange(0, BLOCK_SIZE)
-        x = tl.load(
-            logits_row_ptr + offs,
-            mask=offs < n_cols,
-            other=float("-inf"),
-        ).cast(tl.float32)
-        block_max = tl.max(x)
-        m_new = tl.maximum(m, block_max)
-        d = d * tl.exp(m - m_new) + tl.sum(tl.exp(x - m_new))
-        m = m_new
-    lse = m + tl.log(d)
-    loss = lse - x_y
-    if reduction == "mean":
-        loss = loss * inv_n
-    tl.store(loss_ptr + row_i64, loss)
+    for row in tl.range(row_start, row_end):
+        row_i64 = tl.cast(row, tl.int64)
+        y = tl.load(Y_ptr + row_i64)
+        logits_row_ptr = X_ptr + row_i64 * X_stride
+
+        if y == ignore_index:
+            tl.store(loss_ptr + row_i64, 0.0)
+            if RETURN_LSE:
+                tl.store(lse_ptr + row_i64, 0.0)
+        else:
+            # Clamp so an out-of-range target cannot DMA-fault before the host
+            # OOB assert (queued after this kernel) raises AssertionError.
+            y_idx = tl.minimum(tl.maximum(y, 0), n_cols - 1)
+            x_y = tl.load(logits_row_ptr + y_idx).cast(tl.float32)
+            m = float("-inf")
+            d = 0.0
+            for i in tl.range(0, n_full, BLOCK_SIZE):
+                x = tl.load(logits_row_ptr + i + cols).cast(tl.float32)
+                block_max = tl.max(x)
+                m_new = tl.maximum(m, block_max)
+                d = d * tl.exp(m - m_new) + tl.sum(tl.exp(x - m_new))
+                m = m_new
+            if HAS_TAIL:
+                offs = n_full + cols
+                x = tl.load(logits_row_ptr + offs, mask=offs < n_cols, other=float("-inf")).cast(tl.float32)
+                block_max = tl.max(x)
+                m_new = tl.maximum(m, block_max)
+                d = d * tl.exp(m - m_new) + tl.sum(tl.exp(x - m_new))
+                m = m_new
+            lse = m + tl.log(d)
+            if RETURN_LSE:
+                tl.store(lse_ptr + row_i64, lse)
+            loss = lse - x_y
+            if reduction == "mean":
+                loss = loss * inv_n
+            tl.store(loss_ptr + row_i64, loss)
 
 
 @triton.jit
@@ -276,6 +290,7 @@ def liger_cross_entropy_backward_kernel_no_weight(
     reduction: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     HAS_LSE: tl.constexpr,
+    HAS_TAIL: tl.constexpr,
 ):
     """
     Specialized backward kernel for the common path without class weights, softcap, z-loss, or label smoothing.
@@ -286,7 +301,7 @@ def liger_cross_entropy_backward_kernel_no_weight(
         X_stride (int64): Stride between consecutive logits rows.
         Y_ptr: Target class index per row; ignored rows receive zero ``dX``.
         lse_ptr: Per-row LSE (fp32) when ``HAS_LSE``; otherwise aliases per-row loss buffer for LSE reconstruction.
-        grad_output_ptr: Scalar loss gradient or per-row vector (see ``HAS_GRAD_OUTPUT_VECTOR``).
+        grad_output_ptr: Scalar loss gradient, or per-row vector when ``reduction == "none"``.
         grad_output_stride (int64): Stride for vector ``grad_output`` (``0`` when scalar).
         dX_ptr: Output logits gradient; same logical layout as ``X_ptr`` with stride ``dX_stride``.
         dX_stride (int64): Stride between ``dX`` rows.
@@ -309,62 +324,54 @@ def liger_cross_entropy_backward_kernel_no_weight(
 
     pid = tl.program_id(0)
     num_progs = tl.num_programs(0)
-
+    scale_factor = tl.load(ce_stats_ptr + 0).cast(tl.float32)
+    cols = tl.arange(0, BLOCK_SIZE)
+    n_full = (n_cols // BLOCK_SIZE) * BLOCK_SIZE
     row_chunk = (n_rows + num_progs - 1) // num_progs
     row_start = pid * row_chunk
     row_end = tl.minimum(row_start + row_chunk, n_rows)
+    if reduction != "none":
+        grad_scale_scalar = tl.load(grad_output_ptr).cast(tl.float32)
+        final_scale_scalar = grad_scale_scalar * scale_factor
 
-    scale_factor = tl.load(ce_stats_ptr + 0)
+    for row_idx in tl.range(row_start, row_end):
+        row_i64 = tl.cast(row_idx, tl.int64)
+        y = tl.load(Y_ptr + row_i64)
+        logits_row_ptr = X_ptr + row_i64 * X_stride
+        dX_row_ptr = dX_ptr + row_i64 * dX_stride
 
-    for row_idx in range(row_start, row_end):
-        program_id = row_idx.to(tl.int64)
-        y = tl.load(Y_ptr + program_id)
-        X_ptr_offset = program_id * X_stride
-        dX_ptr_offset = program_id * dX_stride
-
-        # grad_output is a vector if reduction == "none"; otherwise, it is a scalar.
-        grad_scale = (
-            tl.load(grad_output_ptr + program_id * grad_output_stride)
-            if reduction == "none"
-            else tl.load(grad_output_ptr)
-        ).cast(tl.float32)
-
-        final_scale = grad_scale * scale_factor
+        if reduction == "none":
+            final_scale = tl.load(grad_output_ptr + row_i64 * grad_output_stride).cast(tl.float32) * scale_factor
+        else:
+            final_scale = final_scale_scalar
 
         if y == ignore_index:
-            for i in range(0, n_cols, BLOCK_SIZE):
-                X_offsets = i + tl.arange(0, BLOCK_SIZE)
-                tl.store(dX_ptr + dX_ptr_offset + X_offsets, 0.0, mask=X_offsets < n_cols)
+            for i in tl.range(0, n_full, BLOCK_SIZE):
+                tl.store(dX_row_ptr + i + cols, 0.0)
+            if HAS_TAIL:
+                offs = n_full + cols
+                tl.store(dX_row_ptr + offs, 0.0, mask=offs < n_cols)
         else:
+            y_idx = tl.minimum(tl.maximum(y, 0), n_cols - 1)
+            x_y = tl.load(logits_row_ptr + y_idx).cast(tl.float32)
             if HAS_LSE:
-                lse = tl.load(lse_ptr + program_id).cast(tl.float32)
+                lse = tl.load(lse_ptr + row_i64).cast(tl.float32)
             else:
-                loss_row = tl.load(lse_ptr + program_id).cast(tl.float32)
-                x_y = tl.load(X_ptr + X_ptr_offset + y).cast(tl.float32)
+                loss_row = tl.load(lse_ptr + row_i64).cast(tl.float32)
                 if reduction == "mean":
-                    inv_n = tl.load(ce_stats_ptr + 0).cast(tl.float32)
-                    lse = loss_row / inv_n + x_y
+                    lse = loss_row / scale_factor + x_y
                 else:
-                    # Per-row loss was stored without mean scaling (``reduction`` ``sum`` or ``none``).
                     lse = loss_row + x_y
 
-            ori_X_y = tl.load(X_ptr + X_ptr_offset + y).cast(tl.float32)
-            for i in range(0, n_cols, BLOCK_SIZE):
-                X_offsets = i + tl.arange(0, BLOCK_SIZE)
-                X_block = tl.load(
-                    X_ptr + X_ptr_offset + X_offsets,
-                    mask=X_offsets < n_cols,
-                    other=float("-inf"),
-                ).cast(tl.float32)
-                grad = tl.exp(X_block - lse) * final_scale
-                tl.store(dX_ptr + dX_ptr_offset + X_offsets, grad, mask=X_offsets < n_cols)
-
-            # Recompute dx_y in fp32 and overwrite dX[y]. A read-modify-write of the
-            # low-precision value stored in the loop loses bits when softmax(x_y) -> 1.
-            tl.debug_barrier()
-            softmax_X_y = tl.exp(ori_X_y - lse)
-            dx_y = (softmax_X_y - 1.0) * final_scale
-            tl.store(dX_ptr + dX_ptr_offset + y, dx_y)
+            for i in tl.range(0, n_full, BLOCK_SIZE):
+                x = tl.load(logits_row_ptr + i + cols).cast(tl.float32)
+                tl.store(dX_row_ptr + i + cols, tl.exp(x - lse) * final_scale)
+            if HAS_TAIL:
+                offs = n_full + cols
+                x = tl.load(logits_row_ptr + offs, mask=offs < n_cols, other=float("-inf")).cast(tl.float32)
+                tl.store(dX_row_ptr + offs, tl.exp(x - lse) * final_scale, mask=offs < n_cols)
+            dx_y = (tl.exp(x_y - lse) - 1.0) * final_scale
+            tl.store(dX_row_ptr + y_idx, dx_y)
 
 
 @triton.jit
@@ -431,15 +438,13 @@ def liger_cross_entropy_backward_kernel(
     weight_sum = tl.load(ce_stats_ptr + 2)
 
     for row_idx in range(row_start, row_end):
-        program_id = row_idx.to(tl.int64)
-        y = tl.load(Y_ptr + program_id)
-        X_ptr_offset = program_id * X_stride
-        dX_ptr_offset = program_id * dX_stride
+        row_i64 = row_idx.to(tl.int64)
+        y = tl.load(Y_ptr + row_i64)
+        X_ptr_offset = row_i64 * X_stride
+        dX_ptr_offset = row_i64 * dX_stride
         # grad_output is a vector if reduction == "none"; otherwise, it is a scalar.
         grad_scale = (
-            tl.load(grad_output_ptr + program_id * grad_output_stride)
-            if reduction == "none"
-            else tl.load(grad_output_ptr)
+            tl.load(grad_output_ptr + row_i64 * grad_output_stride) if reduction == "none" else tl.load(grad_output_ptr)
         ).cast(tl.float32)
 
         if y == ignore_index:
@@ -449,7 +454,7 @@ def liger_cross_entropy_backward_kernel(
         else:
             if HAS_WEIGHT:
                 weight_y = tl.load(weight_ptr + y).cast(tl.float32)
-            lse = tl.load(lse_ptr + program_id).cast(tl.float32)
+            lse = tl.load(lse_ptr + row_i64).cast(tl.float32)
             eps = label_smoothing / n_cols
             eps_weight_sum = eps * weight_sum
             z_scale = 1.0 + 2.0 * lse_square_scale * lse
@@ -499,51 +504,55 @@ def liger_cross_entropy_backward_kernel(
 
 def get_optimal_block_size(n_cols, has_gradients=True):
     """
-    Pick Triton block size along the vocabulary dimension for Ascend.
+    Pick Triton block size along the vocabulary dimension for the generic CE kernels.
 
-    Uses fixed thresholds when ``has_gradients`` is True; otherwise falls back to
-    ``compute_default_tiling_strategy`` with an NPU-oriented memory multiplier.
-
-    Args:
-        n_cols (int): Vocabulary size (number of columns).
-        has_gradients (bool): If True, use the fast heuristic table for backward-style kernels;
-            if False, query tiling strategy for forward-only sizing.
-
-    Returns:
-        int: Block size (positive). Defaults to 4096 when tiling yields nothing.
+    The generic kernel keeps extra live tiles (smoothing / softcap / weights /
+    argmax), so the multiplier is more conservative than the plain path.
     """
-    if has_gradients:
-        if n_cols <= 32768:
-            return 1024
-        if n_cols <= 131072:
-            return 2048
-        return 4096
-
-    multiplier = 12.0 if has_gradients else 8.0
-
+    multiplier = 8.0 if has_gradients else 6.0
     tile_shapes = compute_default_tiling_strategy(
-        safety_margin=0.9, dtype_size=4, memory_multiplier=multiplier, shapes=((n_cols,),), tiling_dims=(0,)
+        safety_margin=0.85, dtype_size=4, memory_multiplier=multiplier, shapes=((n_cols,),), tiling_dims=(0,)
     )
-    if tile_shapes and len(tile_shapes) > 0:
-        block_size = tile_shapes[0][0]
-        return block_size
-    else:
-        return 4096
+    if tile_shapes:
+        return max(256, tile_shapes[0][0])
+    return 4096
 
 
-def get_no_weight_fast_path_block_size(n_cols):
-    """
-    Block size for the no-weight backward fast path kernel.
+def get_plain_ce_block_size(n_cols, has_gradients=False):
+    """Block size for the plain / no-weight kernels (smaller live set)."""
+    multiplier = 4.0 if has_gradients else 2.5
+    tile_shapes = compute_default_tiling_strategy(
+        safety_margin=0.85, dtype_size=4, memory_multiplier=multiplier, shapes=((n_cols,),), tiling_dims=(0,)
+    )
+    if tile_shapes:
+        return max(256, tile_shapes[0][0])
+    return 4096
 
-    Args:
-        n_cols (int): Vocabulary size.
 
-    Returns:
-        int: ``2048`` when ``n_cols <= 4096``, otherwise ``get_optimal_block_size(n_cols, True)``.
-    """
-    if n_cols <= 4096:
-        return 2048
-    return get_optimal_block_size(n_cols, has_gradients=True)
+def _plain_ce_need_mask(n_cols, block_size):
+    return (n_cols % block_size) != 0
+
+
+def _is_plain_ce(
+    weight,
+    label_smoothing,
+    softcap,
+    lse_square_scale,
+    return_z_loss=False,
+    return_lse=False,
+    return_token_accuracy=False,
+    return_predicted_tokens=False,
+):
+    return (
+        weight is None
+        and label_smoothing == 0.0
+        and softcap is None
+        and float(lse_square_scale) == 0.0
+        and not return_z_loss
+        and not return_lse
+        and not return_token_accuracy
+        and not return_predicted_tokens
+    )
 
 
 def _make_ce_stats_buffer(
@@ -650,13 +659,25 @@ def cross_entropy_forward(
         f"return_predicted_tokens must be True or False. Got: {return_predicted_tokens}"
     )
 
-    BT, V = _input.shape
-    n_rows = BT
+    n_rows, V = _input.shape
 
-    BLOCK_SIZE = get_optimal_block_size(V, has_gradients=False)
-
-    # unreduced loss
-    loss_1d = torch.zeros(n_rows, dtype=_input.dtype, device=_input.device)
+    # Plain fused kernel writes every row (including ignore → 0). The generic
+    # kernel skips the loss store on ignored rows, so those must start at 0.
+    plain_lm = _is_plain_ce(
+        weight,
+        label_smoothing,
+        softcap,
+        lse_square_scale,
+        return_z_loss,
+        return_lse,
+        return_token_accuracy,
+        return_predicted_tokens,
+    )
+    loss_1d = (
+        torch.empty(n_rows, dtype=_input.dtype, device=_input.device)
+        if plain_lm
+        else torch.zeros(n_rows, dtype=_input.dtype, device=_input.device)
+    )
     z_loss_1d = torch.zeros(n_rows, dtype=_input.dtype, device=_input.device) if return_z_loss else None
     # Triton requires a tensor pointer; when ``return_lse`` is False the kernel never reads/writes LSE
     # (``RETURN_LSE`` false), so we pass ``loss_1d`` as the unused binding (``None`` is not supported).
@@ -670,16 +691,11 @@ def cross_entropy_forward(
     )
 
     target_mask = target != ignore_index
-    invalid_target_mask = target_mask & ((target < 0) | (target >= V))
-    assert not torch.any(invalid_target_mask), (
-        f"Target tensor contains out of bounds values. Expected targets in [0, {V}) or ignore_index={ignore_index}"
-    )
+    invalid_any = (target_mask & ((target < 0) | (target >= V))).any()
 
     ce_stats = _make_ce_stats_buffer(target, ignore_index, weight, reduction, target_mask=target_mask)
-    if weight is not None:
-        # ensure weight is contiguous
-        if weight.stride(-1) != 1:
-            weight = weight.contiguous()
+    if weight is not None and weight.stride(-1) != 1:
+        weight = weight.contiguous()
 
     # ensure _input and target are contiguous in the last dimension
     if _input.stride(-1) != 1:
@@ -687,67 +703,59 @@ def cross_entropy_forward(
     if target.stride(-1) != 1:
         target = target.contiguous()
 
-    # NPU-optimized grid configuration
-    # grid_size = min(get_npu_core_count(), n_rows)
-
     cores = min(get_npu_core_count(), n_rows)
-    plain_lm = (
-        weight is None
-        and label_smoothing == 0.0
-        and softcap is None
-        and float(lse_square_scale) == 0.0
-        and not return_z_loss
-        and not return_lse
-        and not return_token_accuracy
-        and not return_predicted_tokens
-    )
     if plain_lm:
-        ts = compute_default_tiling_strategy(
-            safety_margin=0.9,
-            dtype_size=4,
-            memory_multiplier=2.5,
-            shapes=((V,),),
-            tiling_dims=(0,),
+        BLOCK_SIZE = get_plain_ce_block_size(V)
+        liger_cross_entropy_forward_kernel_plain[(cores,)](
+            X_ptr=_input,
+            X_stride=_input.stride(-2),
+            Y_ptr=target,
+            loss_ptr=loss_1d,
+            lse_ptr=lse_ptr_for_kernel,
+            n_cols=V,
+            n_rows=n_rows,
+            ce_stats_ptr=ce_stats,
+            ignore_index=ignore_index,
+            reduction=reduction,
+            BLOCK_SIZE=BLOCK_SIZE,
+            HAS_TAIL=_plain_ce_need_mask(V, BLOCK_SIZE),
+            RETURN_LSE=return_lse,
         )
-        BLOCK_SIZE = max(256, ts[0][0]) if ts else 8192
-        grid_size = n_rows if n_rows <= 1024 else cores
     else:
         BLOCK_SIZE = get_optimal_block_size(V, has_gradients=False)
-        grid_size = cores
+        ls_eps = float(label_smoothing) / float(V) if label_smoothing else 0.0
+        liger_cross_entropy_forward_kernel[(cores,)](
+            X_ptr=_input,
+            X_stride=_input.stride(-2),
+            Y_ptr=target,
+            weight_ptr=weight,
+            loss_ptr=loss_1d,
+            z_loss_ptr=z_loss_1d,
+            lse_ptr=lse_ptr_for_kernel,
+            token_accuracy_ptr=token_accuracy_1d,
+            token_accuracy_stride=token_accuracy_1d.stride(-1) if return_token_accuracy else 0,
+            predicted_tokens_ptr=predicted_tokens_1d,
+            predicted_tokens_stride=predicted_tokens_1d.stride(-1) if return_predicted_tokens else 0,
+            n_cols=V,
+            n_rows=n_rows,
+            ce_stats_ptr=ce_stats,
+            ignore_index=ignore_index,
+            ls_eps=ls_eps,
+            lse_square_scale=lse_square_scale,
+            label_smoothing=label_smoothing,
+            reduction=reduction,
+            softcap=softcap,
+            RETURN_Z_LOSS=return_z_loss,
+            RETURN_LSE=return_lse,
+            RETURN_TOKEN_ACCURACY=return_token_accuracy,
+            RETURN_PREDICTED_TOKENS=return_predicted_tokens,
+            BLOCK_SIZE=BLOCK_SIZE,
+            HAS_WEIGHT=weight is not None,
+            HAS_SOFTCAPPING=softcap is not None,
+        )
 
-    ls_eps = float(label_smoothing) / float(V) if label_smoothing else 0.0
-    liger_cross_entropy_forward_kernel[(grid_size,)](
-        X_ptr=_input,
-        X_stride=_input.stride(-2),
-        Y_ptr=target,
-        weight_ptr=weight,
-        loss_ptr=loss_1d,
-        z_loss_ptr=z_loss_1d,
-        lse_ptr=lse_ptr_for_kernel,
-        token_accuracy_ptr=token_accuracy_1d,
-        token_accuracy_stride=token_accuracy_1d.stride(-1)
-        if return_token_accuracy
-        else 0,  # always 1 if accuracy is enabled
-        predicted_tokens_ptr=predicted_tokens_1d,
-        predicted_tokens_stride=predicted_tokens_1d.stride(-1)
-        if return_predicted_tokens
-        else 0,  # always 1 if predicted tokens is enabled
-        n_cols=V,
-        n_rows=n_rows,
-        ce_stats_ptr=ce_stats,
-        ignore_index=ignore_index,
-        ls_eps=ls_eps,
-        lse_square_scale=lse_square_scale,
-        label_smoothing=label_smoothing,
-        reduction=reduction,
-        softcap=softcap,
-        RETURN_Z_LOSS=return_z_loss,
-        RETURN_LSE=return_lse,
-        RETURN_TOKEN_ACCURACY=return_token_accuracy,
-        RETURN_PREDICTED_TOKENS=return_predicted_tokens,
-        BLOCK_SIZE=BLOCK_SIZE,
-        HAS_WEIGHT=True if weight is not None else False,
-        HAS_SOFTCAPPING=True if softcap is not None else False,
+    assert not invalid_any.item(), (
+        f"Target tensor contains out of bounds values. Expected targets in [0, {V}) or ignore_index={ignore_index}"
     )
 
     if reduction == "none":
@@ -791,10 +799,9 @@ def cross_entropy_backward(
     softcap,
     ce_stats=None,
     derive_lse_from_loss: bool = False,
+    out=None,
 ):
-    BT, V = _input.shape
-    n_rows = BT
-    BLOCK_SIZE = get_optimal_block_size(V, has_gradients=True)
+    n_rows, V = _input.shape
     # If reduction == "none", then grad_output is a vector (corresponding to row-wise gradients); otherwise, it is a scalar.
     has_grad_output_vector = reduction == "none"
 
@@ -805,12 +812,17 @@ def cross_entropy_backward(
 
     if _input.stride(-1) != 1:
         _input = _input.contiguous()
+        if out is not None:
+            out = _input
     if target.stride(-1) != 1:
         target = target.contiguous()
     if has_grad_output_vector and grad_output.stride(-1) != 1:
         grad_output = grad_output.contiguous()
 
-    grad_input = torch.empty_like(_input)
+    # Last-layer (``grad_output == 1``): ``out`` is the logits buffer, so the
+    # kernel overwrites it in-place (one BT×V peak). Non-unit scale allocates
+    # a fresh tensor to avoid AccumulateGrad TensorMove on a leaf.
+    grad_input = out if out is not None else torch.empty_like(_input)
     grid_size = min(get_npu_core_count(), n_rows)
     grad_output_stride = grad_output.stride(-1) if has_grad_output_vector else 0
     use_no_weight_fast_path = weight is None and softcap is None and label_smoothing == 0.0 and lse_square_scale == 0.0
@@ -818,7 +830,7 @@ def cross_entropy_backward(
     # Only the no-weight kernel matches plain CE; mean/sum reductions with weights/smoothing/softcap/z-loss
     # must use the general backward kernel regardless of grad_output layout.
     if use_no_weight_fast_path:
-        fast_path_block_size = get_no_weight_fast_path_block_size(V)
+        fast_path_block_size = get_plain_ce_block_size(V, has_gradients=True)
         liger_cross_entropy_backward_kernel_no_weight[(grid_size,)](
             X_ptr=_input,
             X_stride=_input.stride(-2),
@@ -835,8 +847,10 @@ def cross_entropy_backward(
             reduction=reduction,
             BLOCK_SIZE=fast_path_block_size,
             HAS_LSE=not derive_lse_from_loss,
+            HAS_TAIL=_plain_ce_need_mask(V, fast_path_block_size),
         )
     else:
+        BLOCK_SIZE = get_optimal_block_size(V, has_gradients=True)
         liger_cross_entropy_backward_kernel[(grid_size,)](
             X_ptr=_input,
             X_stride=_input.stride(-2),
@@ -856,8 +870,8 @@ def cross_entropy_backward(
             reduction=reduction,
             softcap=softcap,
             BLOCK_SIZE=BLOCK_SIZE,
-            HAS_WEIGHT=True if weight is not None else False,
-            HAS_SOFTCAPPING=True if softcap is not None else False,
+            HAS_WEIGHT=weight is not None,
+            HAS_SOFTCAPPING=softcap is not None,
         )
 
     return grad_input
@@ -985,6 +999,10 @@ class LigerCrossEntropyFunction(torch.autograd.Function):
         else:
             _input, target, lse_or_loss = ctx.saved_tensors
             weight = None
+        go_ptr = grad_output.data_ptr() if grad_output is not None else None
+        if getattr(ctx, "_last_layer_ptr", None) != go_ptr:
+            ctx._last_layer_ptr = go_ptr
+            ctx._last_layer = ctx.reduction != "none" and grad_output.ndim == 0 and grad_output.item() == 1.0
         _input = cross_entropy_backward(
             _input,
             target,
@@ -998,6 +1016,7 @@ class LigerCrossEntropyFunction(torch.autograd.Function):
             ctx.softcap,
             ctx.ce_stats,
             derive_lse_from_loss=ctx.derive_lse_from_loss,
+            out=_input if ctx._last_layer else None,
         )
         return (
             _input,

--- a/src/liger_kernel/ops/backends/_ascend/ops/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/fused_linear_cross_entropy.py
@@ -1,31 +1,17 @@
-import warnings
-
 import torch
 import triton
 
 from liger_kernel.ops.backends._ascend.ops.cross_entropy import _make_ce_stats_buffer
+from liger_kernel.ops.backends._ascend.ops.cross_entropy import _plain_ce_need_mask
+from liger_kernel.ops.backends._ascend.ops.cross_entropy import get_optimal_block_size
+from liger_kernel.ops.backends._ascend.ops.cross_entropy import get_plain_ce_block_size
 from liger_kernel.ops.backends._ascend.ops.cross_entropy import liger_cross_entropy_backward_kernel
 from liger_kernel.ops.backends._ascend.ops.cross_entropy import liger_cross_entropy_backward_kernel_no_weight
 from liger_kernel.ops.backends._ascend.ops.cross_entropy import liger_cross_entropy_forward_kernel
 from liger_kernel.ops.backends._ascend.ops.cross_entropy import liger_cross_entropy_forward_kernel_plain
-from liger_kernel.ops.backends._ascend.ub_manager import compute_default_tiling_strategy
 from liger_kernel.ops.utils import amp_custom_bwd
 from liger_kernel.ops.utils import amp_custom_fwd
 from liger_kernel.ops.utils import get_npu_core_count
-
-
-def get_optimal_block_size(n_cols, has_gradients=True):
-    """
-    Calculate optimal Block Size using compute_default_tiling_strategy
-    """
-    multiplier = 12.0 if has_gradients else 8.0
-    tile_shapes = compute_default_tiling_strategy(
-        safety_margin=0.9, dtype_size=4, memory_multiplier=multiplier, shapes=((n_cols,),), tiling_dims=(0,)
-    )
-
-    if tile_shapes:
-        return tile_shapes[0][0]
-    return 2048
 
 
 def _get_logits_save_limit_bytes(device):
@@ -43,22 +29,111 @@ def _get_logits_save_limit_bytes(device):
     return max(gib, min(default_limit, total_memory // 8))
 
 
-_PLAIN_CE_FAST_PATH_WARN_EMITTED = False
-
-
-def _warn_once_plain_cross_entropy_preferred():
-    """Plain CE fast path materializes full logits; nudge users who only need vanilla CE."""
-    global _PLAIN_CE_FAST_PATH_WARN_EMITTED
-    if _PLAIN_CE_FAST_PATH_WARN_EMITTED:
-        return
-    _PLAIN_CE_FAST_PATH_WARN_EMITTED = True
-    warnings.warn(
-        "Ascend fused_linear_cross_entropy is using the plain cross-entropy path (full BT×V "
-        "logits are materialized). If you only need standard cross-entropy, consider "
-        "cross_entropy instead.",
-        UserWarning,
-        stacklevel=3,
+def _is_plain_flce(
+    ce_weight,
+    softcap,
+    label_smoothing,
+    lse_square_scale,
+    return_z_loss,
+    return_token_accuracy,
+    return_predicted_tokens,
+    use_token_scaling,
+):
+    return (
+        ce_weight is None
+        and softcap is None
+        and float(label_smoothing) == 0.0
+        and float(lse_square_scale) == 0.0
+        and (not return_z_loss)
+        and (not return_token_accuracy)
+        and (not return_predicted_tokens)
+        and (not use_token_scaling)
     )
+
+
+def _launch_ce_forward(
+    logits,
+    target,
+    loss_1d,
+    ce_stats,
+    ce_weight,
+    n_rows,
+    V,
+    ignore_index,
+    ls_eps,
+    lse_square_scale,
+    label_smoothing,
+    reduction,
+    softcap,
+    return_z_loss,
+    return_lse,
+    return_token_accuracy,
+    return_predicted_tokens,
+    z_loss_1d,
+    lse_ptr,
+    token_accuracy_1d,
+    predicted_tokens_1d,
+    plain_fast_path,
+    forward_block_size,
+    num_cores,
+):
+    cores = min(n_rows, num_cores)
+    if not logits.is_contiguous():
+        logits = logits.contiguous()
+    if target.stride(-1) != 1:
+        target = target.contiguous()
+
+    if plain_fast_path:
+        liger_cross_entropy_forward_kernel_plain[(cores,)](
+            X_ptr=logits,
+            X_stride=logits.stride(-2),
+            Y_ptr=target,
+            loss_ptr=loss_1d,
+            lse_ptr=lse_ptr,
+            n_cols=V,
+            n_rows=n_rows,
+            ce_stats_ptr=ce_stats,
+            ignore_index=ignore_index,
+            reduction=reduction,
+            BLOCK_SIZE=forward_block_size,
+            HAS_TAIL=_plain_ce_need_mask(V, forward_block_size),
+            RETURN_LSE=return_lse,
+        )
+        return logits
+
+    z_loss_ptr = z_loss_1d if z_loss_1d is not None else loss_1d
+    token_accuracy_ptr = token_accuracy_1d if token_accuracy_1d is not None else loss_1d
+    predicted_tokens_ptr = predicted_tokens_1d if predicted_tokens_1d is not None else target
+    liger_cross_entropy_forward_kernel[(cores,)](
+        X_ptr=logits,
+        X_stride=logits.stride(-2),
+        Y_ptr=target,
+        weight_ptr=ce_weight,
+        loss_ptr=loss_1d,
+        z_loss_ptr=z_loss_ptr,
+        lse_ptr=lse_ptr,
+        token_accuracy_ptr=token_accuracy_ptr,
+        token_accuracy_stride=token_accuracy_ptr.stride(-1) if return_token_accuracy else 0,
+        predicted_tokens_ptr=predicted_tokens_ptr,
+        predicted_tokens_stride=predicted_tokens_ptr.stride(-1) if return_predicted_tokens else 0,
+        n_cols=V,
+        n_rows=n_rows,
+        ce_stats_ptr=ce_stats,
+        ignore_index=ignore_index,
+        ls_eps=ls_eps,
+        lse_square_scale=lse_square_scale,
+        label_smoothing=label_smoothing,
+        reduction=reduction,
+        softcap=softcap,
+        RETURN_Z_LOSS=return_z_loss,
+        RETURN_LSE=return_lse,
+        RETURN_TOKEN_ACCURACY=return_token_accuracy,
+        RETURN_PREDICTED_TOKENS=return_predicted_tokens,
+        HAS_WEIGHT=ce_weight is not None,
+        HAS_SOFTCAPPING=softcap is not None,
+        BLOCK_SIZE=forward_block_size,
+    )
+    return logits
 
 
 def fused_linear_cross_entropy_forward(
@@ -73,7 +148,6 @@ def fused_linear_cross_entropy_forward(
     reduction="mean",
     softcap=None,
     return_z_loss=False,
-    accum_dtype=None,
     use_token_scaling=False,
     return_token_accuracy=False,
     return_predicted_tokens=False,
@@ -87,16 +161,26 @@ def fused_linear_cross_entropy_forward(
     )
     device = _input.device
     input_requires_grad = _input.requires_grad
-    BT, H = _input.shape
+    BT = _input.shape[0]
     V = weight.shape[0]
-    forward_block_size = get_optimal_block_size(V, has_gradients=False)
 
-    inc_factor = triton.cdiv(V, H)  # (V + H - 1) // H
-    chunk_size = triton.next_power_of_2(triton.cdiv(BT, inc_factor))  # (BT + inc_factor - 1) // inc_factor
-    num_chunks = triton.cdiv(BT, chunk_size)  # (BT + chunk_size - 1) // chunk_size
+    plain_fast_path = _is_plain_flce(
+        ce_weight,
+        softcap,
+        label_smoothing,
+        lse_square_scale,
+        return_z_loss,
+        return_token_accuracy,
+        return_predicted_tokens,
+        use_token_scaling,
+    )
+    if plain_fast_path:
+        forward_block_size = get_plain_ce_block_size(V, has_gradients=False)
+    else:
+        forward_block_size = get_optimal_block_size(V, has_gradients=False)
 
     loss_1d = torch.zeros(BT, dtype=torch.float32, device=device)
-    z_loss_1d = torch.zeros(BT, dtype=_input.dtype, device=_input.device) if return_z_loss else None
+    z_loss_1d = torch.zeros(BT, dtype=_input.dtype, device=device) if return_z_loss else None
     token_accuracy_1d = torch.zeros(BT, dtype=torch.float32, device=device) if return_token_accuracy else None
     predicted_tokens_1d = torch.full((BT,), -1, dtype=torch.int64, device=device) if return_predicted_tokens else None
 
@@ -112,186 +196,64 @@ def fused_linear_cross_entropy_forward(
 
     num_cores = get_npu_core_count()
     ls_eps = float(label_smoothing) / float(V) if label_smoothing else 0.0
-    # Keep a single large matmul for performance; avoid materializing/storing full grad_logits.
-    logits = _input @ weight.t()  # BT x V
 
-    plain_fast_path = (
-        ce_weight is None
-        and softcap is None
-        and float(label_smoothing) == 0.0
-        and float(lse_square_scale) == 0.0
-        and (not return_z_loss)
-        and (not return_token_accuracy)
-        and (not return_predicted_tokens)
-        and (not use_token_scaling)
+    # One Cube GEMM: NPU prefers a single large matmul over many token chunks.
+    logits = _input @ weight.t()
+    if bias is not None:
+        logits = logits + bias
+
+    return_lse = input_requires_grad and not plain_fast_path
+    lse_1d = torch.empty(BT, dtype=torch.float32, device=device) if return_lse else None
+    lse_ptr = lse_1d if return_lse else loss_1d
+
+    scaling_factors_full = None
+
+    if use_token_scaling:
+        logits_for_softmax = logits.detach()
+        if softcap is not None:
+            logits_for_softmax = softcap * torch.tanh(logits_for_softmax / softcap)
+        probs = torch.softmax(logits_for_softmax, dim=-1)
+        safe_targets = torch.where(target_mask, target, torch.zeros_like(target))
+        scaling_factors_full = torch.gather(probs, -1, safe_targets.unsqueeze(-1)).squeeze(-1)
+        scaling_factors_full = (scaling_factors_full * target_mask.to(scaling_factors_full.dtype)).detach()
+
+    logits = _launch_ce_forward(
+        logits=logits,
+        target=target,
+        loss_1d=loss_1d,
+        ce_stats=ce_stats,
+        ce_weight=ce_weight,
+        n_rows=BT,
+        V=V,
+        ignore_index=ignore_index,
+        ls_eps=ls_eps,
+        lse_square_scale=lse_square_scale,
+        label_smoothing=label_smoothing,
+        reduction=reduction,
+        softcap=softcap,
+        return_z_loss=return_z_loss,
+        return_lse=return_lse,
+        return_token_accuracy=return_token_accuracy,
+        return_predicted_tokens=return_predicted_tokens,
+        z_loss_1d=z_loss_1d,
+        lse_ptr=lse_ptr,
+        token_accuracy_1d=token_accuracy_1d,
+        predicted_tokens_1d=predicted_tokens_1d,
+        plain_fast_path=plain_fast_path,
+        forward_block_size=forward_block_size,
+        num_cores=num_cores,
     )
 
-    # For plain CE, prefer a larger BLOCK_SIZE (fewer loop iters) using the same
-    # NPU-oriented tuning as `cross_entropy_forward`'s plain_lm path.
-    if plain_fast_path:
-        tile_shapes = compute_default_tiling_strategy(
-            safety_margin=0.9,
-            dtype_size=4,
-            memory_multiplier=2.5,
-            shapes=((V,),),
-            tiling_dims=(0,),
-        )
-        forward_block_size = max(256, tile_shapes[0][0]) if tile_shapes else 8192
-
-    # If we're in the plain path and bias-free, launch forward once for all rows
-    # to reduce Python overhead and kernel launch count.
-    scaling_factors_full = None
     logits_for_backward = None
-    if input_requires_grad and plain_fast_path and bias is None:
-        # Save logits for backward when memory allows, avoiding an extra
-        # input @ weight.T in backward. This is especially important once BT is
-        # large enough that the GEMM dominates the plain CE backward path.
+    if input_requires_grad:
         bytes_per_elem = logits.element_size()
         if BT * V * bytes_per_elem <= _get_logits_save_limit_bytes(device):
             logits_for_backward = logits
 
-    if plain_fast_path and bias is None:
-        _warn_once_plain_cross_entropy_preferred()
-        if not logits.is_contiguous():
-            logits = logits.contiguous()
-        if target.stride(-1) != 1:
-            target = target.contiguous()
-        liger_cross_entropy_forward_kernel_plain[(BT,)](
-            X_ptr=logits,
-            X_stride=logits.stride(-2),
-            Y_ptr=target,
-            loss_ptr=loss_1d,
-            n_cols=V,
-            n_rows=BT,
-            ce_stats_ptr=ce_stats,
-            ignore_index=ignore_index,
-            reduction=reduction,
-            BLOCK_SIZE=forward_block_size,
-        )
-        loss = loss_1d if reduction == "none" else torch.sum(loss_1d)
-        return (
-            loss,
-            None,
-            None,
-            None,
-            loss_1d,
-            ce_stats,
-            None,
-            plain_fast_path,
-            logits_for_backward,
-        )
-
-    # Forward-only: compute per-row loss (and optional metrics). Gradients are computed in backward.
-    for chunk_id in range(num_chunks):
-        start_idx = chunk_id * chunk_size
-        end_idx = min((chunk_id + 1) * chunk_size, BT)
-        # # when doing matmul, use the original precision
-
-        logits_chunk = logits[start_idx:end_idx]  # chunk_size x V
-        if bias is not None:
-            logits_chunk = logits_chunk + bias
-
-        target_chunk = target[start_idx:end_idx]  # chunk_size,
-
-        n_rows = logits_chunk.shape[0]
-
-        # Compute predicted probabilities for token scaling if needed
-        if use_token_scaling:
-            # Compute softmax probabilities for scaling
-            # We compute token scaling from the forward logits before any gradient kernel runs.
-            logits_for_softmax = logits_chunk.detach().clone()  # Detach to avoid gradient flow
-            if softcap is not None:
-                logits_for_softmax = softcap * torch.tanh(logits_for_softmax / softcap)
-
-            # Compute softmax to get predicted probabilities
-            probs = torch.softmax(logits_for_softmax, dim=-1)
-
-            # Get predicted probabilities for token scaling, handling ignored targets
-            valid_target_mask = target_chunk != ignore_index
-            safe_targets = torch.where(valid_target_mask, target_chunk, torch.zeros_like(target_chunk))
-            pred_probs = torch.gather(probs, -1, safe_targets.unsqueeze(-1)).squeeze(-1)
-            pred_probs = pred_probs * valid_target_mask.to(pred_probs.dtype)
-
-            # Store the scaling factors
-            scaling_factors = pred_probs.detach()  # Detach to ensure no gradient flow
-            if scaling_factors_full is None:
-                scaling_factors_full = torch.empty(BT, dtype=scaling_factors.dtype, device=scaling_factors.device)
-            scaling_factors_full[start_idx:end_idx] = scaling_factors
-
-        # unreduced loss
-        loss_1d_slice = loss_1d[start_idx:end_idx]  # chunk_size,
-        z_loss_1d_slice = z_loss_1d[start_idx:end_idx] if return_z_loss else None
-        token_accuracy_1d_slice = token_accuracy_1d[start_idx:end_idx] if return_token_accuracy else None
-        predicted_tokens_1d_slice = predicted_tokens_1d[start_idx:end_idx] if return_predicted_tokens else None
-
-        # Avoid unconditional materialization: slices are typically contiguous already.
-        if not logits_chunk.is_contiguous():
-            logits_chunk = logits_chunk.contiguous()
-        if not target_chunk.is_contiguous():
-            target_chunk = target_chunk.contiguous()
-
-        if plain_fast_path:
-            liger_cross_entropy_forward_kernel_plain[(n_rows,)](
-                X_ptr=logits_chunk,
-                X_stride=logits_chunk.stride(-2),
-                Y_ptr=target_chunk,
-                loss_ptr=loss_1d_slice,
-                n_cols=V,
-                n_rows=n_rows,
-                ce_stats_ptr=ce_stats,
-                ignore_index=ignore_index,
-                reduction=reduction,
-                BLOCK_SIZE=forward_block_size,
-            )
-        else:
-            liger_cross_entropy_forward_kernel[(min(n_rows, num_cores),)](
-                X_ptr=logits_chunk,
-                X_stride=logits_chunk.stride(-2),
-                Y_ptr=target_chunk,
-                weight_ptr=ce_weight,
-                loss_ptr=loss_1d_slice,
-                z_loss_ptr=z_loss_1d_slice,
-                lse_ptr=loss_1d_slice,
-                token_accuracy_ptr=token_accuracy_1d_slice,
-                token_accuracy_stride=token_accuracy_1d_slice.stride(-1)
-                if return_token_accuracy
-                else 0,  # always 1 if accuracy is enabled
-                predicted_tokens_ptr=predicted_tokens_1d_slice,
-                predicted_tokens_stride=predicted_tokens_1d_slice.stride(-1)
-                if return_predicted_tokens
-                else 0,  # always 1 if predicted tokens is enabled
-                n_cols=V,
-                n_rows=n_rows,
-                ce_stats_ptr=ce_stats,
-                ignore_index=ignore_index,
-                ls_eps=ls_eps,
-                lse_square_scale=lse_square_scale,
-                label_smoothing=label_smoothing,
-                reduction=reduction,
-                softcap=softcap,
-                RETURN_Z_LOSS=return_z_loss,
-                RETURN_LSE=False,
-                RETURN_TOKEN_ACCURACY=return_token_accuracy,
-                RETURN_PREDICTED_TOKENS=return_predicted_tokens,
-                HAS_WEIGHT=True if ce_weight is not None else False,
-                HAS_SOFTCAPPING=True if softcap is not None else False,
-                BLOCK_SIZE=forward_block_size,
-            )
-
-        # Apply token scaling if requested
-        if use_token_scaling:
-            loss_1d_slice = loss_1d_slice * scaling_factors
-            if return_z_loss:
-                z_loss_1d_slice = z_loss_1d_slice * scaling_factors
-
-        loss_1d[start_idx:end_idx] = loss_1d_slice
+    if use_token_scaling:
+        loss_1d = loss_1d * scaling_factors_full
         if return_z_loss:
-            z_loss_1d[start_idx:end_idx] = z_loss_1d_slice
-        if return_token_accuracy:
-            token_accuracy_1d[start_idx:end_idx] = token_accuracy_1d_slice
-        if return_predicted_tokens:
-            predicted_tokens_1d[start_idx:end_idx] = predicted_tokens_1d_slice
-        # No gradient work in forward anymore.
+            z_loss_1d = z_loss_1d * scaling_factors_full
 
     if reduction == "none":
         loss = loss_1d
@@ -313,11 +275,79 @@ def fused_linear_cross_entropy_forward(
         z_loss,
         token_accuracy,
         predicted_tokens,
-        loss_1d,  # saved for backward (plain path) / metrics
+        loss_1d,
         ce_stats,
         scaling_factors_full,
         plain_fast_path,
         logits_for_backward,
+        lse_1d,
+    )
+
+
+def _launch_ce_backward(
+    logits,
+    target,
+    loss_1d,
+    lse,
+    ce_stats,
+    ce_weight,
+    grad_output,
+    grad_output_stride,
+    n_rows,
+    V,
+    ignore_index,
+    lse_square_scale,
+    label_smoothing,
+    reduction,
+    softcap,
+    plain_fast_path,
+    backward_block_size,
+    num_cores,
+):
+    """Write CE logits-grad in-place into ``logits`` (no extra BT×V buffer)."""
+    cores = min(n_rows, num_cores)
+    if plain_fast_path:
+        liger_cross_entropy_backward_kernel_no_weight[(cores,)](
+            X_ptr=logits,
+            X_stride=logits.stride(-2),
+            Y_ptr=target,
+            lse_ptr=loss_1d,
+            grad_output_ptr=grad_output,
+            grad_output_stride=grad_output_stride,
+            dX_ptr=logits,
+            dX_stride=logits.stride(-2),
+            n_cols=V,
+            n_rows=n_rows,
+            ce_stats_ptr=ce_stats,
+            ignore_index=ignore_index,
+            reduction=reduction,
+            BLOCK_SIZE=backward_block_size,
+            HAS_LSE=False,
+            HAS_TAIL=_plain_ce_need_mask(V, backward_block_size),
+        )
+        return
+
+    liger_cross_entropy_backward_kernel[(cores,)](
+        X_ptr=logits,
+        X_stride=logits.stride(-2),
+        Y_ptr=target,
+        weight_ptr=ce_weight,
+        lse_ptr=lse,
+        grad_output_ptr=grad_output,
+        grad_output_stride=grad_output_stride,
+        dX_ptr=logits,
+        dX_stride=logits.stride(-2),
+        n_cols=V,
+        n_rows=n_rows,
+        ce_stats_ptr=ce_stats,
+        ignore_index=ignore_index,
+        lse_square_scale=lse_square_scale,
+        label_smoothing=label_smoothing,
+        reduction=reduction,
+        softcap=softcap,
+        BLOCK_SIZE=backward_block_size,
+        HAS_WEIGHT=ce_weight is not None,
+        HAS_SOFTCAPPING=softcap is not None,
     )
 
 
@@ -326,37 +356,22 @@ def fused_linear_cross_entropy_backward(ctx, grad_output):
     bias = ctx.bias
     ce_weight = ctx.ce_weight
     scaling_factors_full = ctx.scaling_factors_full
+    lse = ctx.lse
 
     device = _input.device
     BT = _input.shape[0]
     V = weight.shape[0]
 
-    forward_block_size = get_optimal_block_size(V, has_gradients=False)
-    backward_block_size = get_optimal_block_size(V, has_gradients=True)
-    if ctx.plain_fast_path and 32768 < V <= 131072:
-        backward_block_size = 4096
+    if ctx.plain_fast_path:
+        backward_block_size = get_plain_ce_block_size(V, has_gradients=True)
+    else:
+        backward_block_size = get_optimal_block_size(V, has_gradients=True)
 
-    # Use larger row tiles for GEMM efficiency.
-    # If forward saved logits (small/medium BT), process everything in one chunk
-    # to minimize launch overhead and maximize GEMM utilization.
     has_saved_logits = saved_logits.numel() != 0
     chunk_size = BT if has_saved_logits else min(BT, 4096)
     num_chunks = triton.cdiv(BT, chunk_size)
-
     num_cores = get_npu_core_count()
-    use_no_weight_backward = (
-        V > 4096
-        and ctx.plain_fast_path
-        and ce_weight is None
-        and ctx.softcap is None
-        and ctx.label_smoothing == 0.0
-        and ctx.lse_square_scale == 0.0
-    )
-    ls_eps = float(ctx.label_smoothing) / float(V) if ctx.label_smoothing else 0.0
 
-    # Prepare output grads. fp32 accumulation only buys precision when we
-    # accumulate multiple chunk GEMMs; for a single chunk it just adds a
-    # large dtype-conversion buffer on the hot path.
     grad_accum_dtype = ctx.accum_dtype if num_chunks > 1 else None
     grad_input = torch.empty_like(_input)
     grad_weight = torch.empty_like(weight, dtype=grad_accum_dtype or weight.dtype, device=device)
@@ -364,7 +379,6 @@ def fused_linear_cross_entropy_backward(ctx, grad_output):
         torch.empty_like(bias, dtype=grad_accum_dtype or bias.dtype, device=device) if bias is not None else None
     )
 
-    # grad_output is scalar for mean/sum, vector for none
     has_grad_output_vector = ctx.reduction == "none"
     if has_grad_output_vector and grad_output.stride(-1) != 1:
         grad_output = grad_output.contiguous()
@@ -376,6 +390,9 @@ def fused_linear_cross_entropy_backward(ctx, grad_output):
         input_chunk = _input[start_idx:end_idx]
         target_chunk = target[start_idx:end_idx]
         n_rows = end_idx - start_idx
+        loss_1d_slice = loss_1d[start_idx:end_idx]
+        lse_chunk = lse[start_idx:end_idx] if lse is not None else loss_1d_slice
+        go_chunk = grad_output[start_idx:end_idx] if has_grad_output_vector else grad_output
 
         if has_saved_logits:
             logits_chunk = saved_logits[start_idx:end_idx]
@@ -389,126 +406,90 @@ def fused_linear_cross_entropy_backward(ctx, grad_output):
         if not target_chunk.is_contiguous():
             target_chunk = target_chunk.contiguous()
 
-        grad_logits_chunk = torch.empty_like(logits_chunk)
-
-        if use_no_weight_backward:
-            # Derive lse from per-row loss + x[y]
-            loss_1d_slice = loss_1d[start_idx:end_idx]
-            liger_cross_entropy_backward_kernel_no_weight[(min(n_rows, num_cores),)](
-                X_ptr=logits_chunk,
-                X_stride=logits_chunk.stride(-2),
-                Y_ptr=target_chunk,
-                lse_ptr=loss_1d_slice,
-                grad_output_ptr=grad_output,
-                grad_output_stride=grad_output_stride,
-                dX_ptr=grad_logits_chunk,
-                dX_stride=grad_logits_chunk.stride(-2),
-                n_cols=V,
-                n_rows=n_rows,
-                ce_stats_ptr=ce_stats,
-                ignore_index=ctx.ignore_index,
-                reduction=ctx.reduction,
-                BLOCK_SIZE=backward_block_size,
-                HAS_LSE=False,
-            )
-        else:
-            # General path needs LSE; recompute it for this chunk (forward kernel with RETURN_LSE).
-            lse_chunk = torch.empty(n_rows, dtype=torch.float32, device=device)
-            loss_tmp = torch.empty(n_rows, dtype=torch.float32, device=device)
-            liger_cross_entropy_forward_kernel[(min(n_rows, num_cores),)](
-                X_ptr=logits_chunk,
-                X_stride=logits_chunk.stride(-2),
-                Y_ptr=target_chunk,
-                weight_ptr=ce_weight,
-                loss_ptr=loss_tmp,
-                z_loss_ptr=loss_tmp,
-                lse_ptr=lse_chunk,
-                token_accuracy_ptr=loss_tmp,
-                token_accuracy_stride=0,
-                predicted_tokens_ptr=target_chunk,
-                predicted_tokens_stride=0,
-                n_cols=V,
-                n_rows=n_rows,
-                ce_stats_ptr=ce_stats,
-                ignore_index=ctx.ignore_index,
-                ls_eps=ls_eps,
-                lse_square_scale=ctx.lse_square_scale,
-                label_smoothing=ctx.label_smoothing,
-                reduction=ctx.reduction,
-                softcap=ctx.softcap,
-                RETURN_Z_LOSS=False,
-                RETURN_LSE=True,
-                RETURN_TOKEN_ACCURACY=False,
-                RETURN_PREDICTED_TOKENS=False,
-                HAS_WEIGHT=True if ce_weight is not None else False,
-                HAS_SOFTCAPPING=True if ctx.softcap is not None else False,
-                BLOCK_SIZE=forward_block_size,
-            )
-
-            liger_cross_entropy_backward_kernel[(min(n_rows, num_cores),)](
-                X_ptr=logits_chunk,
-                X_stride=logits_chunk.stride(-2),
-                Y_ptr=target_chunk,
-                weight_ptr=ce_weight,
-                lse_ptr=lse_chunk,
-                grad_output_ptr=grad_output,
-                grad_output_stride=grad_output_stride,
-                dX_ptr=grad_logits_chunk,
-                dX_stride=grad_logits_chunk.stride(-2),
-                n_cols=V,
-                n_rows=n_rows,
-                ce_stats_ptr=ce_stats,
-                ignore_index=ctx.ignore_index,
-                lse_square_scale=ctx.lse_square_scale,
-                label_smoothing=ctx.label_smoothing,
-                reduction=ctx.reduction,
-                softcap=ctx.softcap,
-                BLOCK_SIZE=backward_block_size,
-                HAS_WEIGHT=True if ce_weight is not None else False,
-                HAS_SOFTCAPPING=True if ctx.softcap is not None else False,
-            )
+        _launch_ce_backward(
+            logits=logits_chunk,
+            target=target_chunk,
+            loss_1d=loss_1d_slice,
+            lse=lse_chunk,
+            ce_stats=ce_stats,
+            ce_weight=ce_weight,
+            grad_output=go_chunk,
+            grad_output_stride=grad_output_stride,
+            n_rows=n_rows,
+            V=V,
+            ignore_index=ctx.ignore_index,
+            lse_square_scale=ctx.lse_square_scale,
+            label_smoothing=ctx.label_smoothing,
+            reduction=ctx.reduction,
+            softcap=ctx.softcap,
+            plain_fast_path=ctx.plain_fast_path,
+            backward_block_size=backward_block_size,
+            num_cores=num_cores,
+        )
 
         if ctx.use_token_scaling and scaling_factors_full is not None:
-            grad_logits_chunk = grad_logits_chunk * scaling_factors_full[start_idx:end_idx].unsqueeze(-1)
+            logits_chunk = logits_chunk * scaling_factors_full[start_idx:end_idx].unsqueeze(-1)
 
-        grad_input[start_idx:end_idx] = grad_logits_chunk @ weight
-        grad_weight_ = grad_logits_chunk.t() @ input_chunk
-        if chunk_id == 0:
-            grad_weight.copy_(grad_weight_)
+        # Project dlogits → dX / dW without an extra V×H workspace when dtypes match.
+        grad_input_chunk = grad_input[start_idx:end_idx]
+        if grad_input_chunk.is_contiguous() and logits_chunk.dtype == weight.dtype == grad_input_chunk.dtype:
+            torch.mm(logits_chunk, weight, out=grad_input_chunk)
         else:
-            grad_weight.add_(grad_weight_)
+            grad_input_chunk.copy_(logits_chunk @ weight)
+
+        dlogits_t = logits_chunk.t()
+        if dlogits_t.dtype == grad_weight.dtype and input_chunk.dtype == grad_weight.dtype:
+            if chunk_id == 0:
+                torch.mm(dlogits_t, input_chunk, out=grad_weight)
+            else:
+                grad_weight.addmm_(dlogits_t, input_chunk)
+        else:
+            grad_weight_ = torch.mm(dlogits_t, input_chunk)
+            if grad_weight_.dtype != grad_weight.dtype:
+                grad_weight_ = grad_weight_.to(grad_weight.dtype)
+            if chunk_id == 0:
+                grad_weight.copy_(grad_weight_)
+            else:
+                grad_weight.add_(grad_weight_)
         if grad_bias is not None:
-            grad_bias_ = grad_logits_chunk.sum(dim=0)
+            grad_bias_ = logits_chunk.sum(dim=0)
+            if grad_bias_.dtype != grad_bias.dtype:
+                grad_bias_ = grad_bias_.to(grad_bias.dtype)
             if chunk_id == 0:
                 grad_bias.copy_(grad_bias_)
             else:
                 grad_bias.add_(grad_bias_)
 
-    # Keep fp32 accumulation results in fp32 when requested and actually used.
     if grad_accum_dtype is None:
         grad_weight = grad_weight.to(weight.dtype)
         grad_bias = grad_bias.to(bias.dtype) if grad_bias is not None else None
 
-    return (
-        grad_input,
-        grad_weight,
-        None,
-        grad_bias,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,  # use_token_scaling
-        None,  # return_token_accuracy
-        None,  # return_predicted_tokens
-    )
+        return (
+            grad_input,
+            grad_weight,
+            None,
+            grad_bias,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,  # ce_impl (NVIDIA dispatcher slots; unused on Ascend)
+            None,  # ce_mode
+        )
 
 
 class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
+    # NVIDIA FLCE forwards inner CE through dispatch(ce_impl, ce_mode).
+    # The Ascend kernel is self-contained; extra slots are accepted and ignored.
+    supports_inner_impl_dispatch = False
+
     @staticmethod
     @amp_custom_fwd
     def forward(
@@ -528,15 +509,17 @@ class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
         use_token_scaling: bool = False,
         return_token_accuracy: bool = False,
         return_predicted_tokens: bool = False,
+        ce_impl=None,
+        ce_mode=None,
     ):
         """
         Fusing the last linear layer with cross-entropy loss
             Reference: https://github.com/mgmalek/efficient_cross_entropy
 
         Handle the forward and backward pass of the final linear layer via cross-entropy loss. On Ascend,
-        gradients are computed in backward so that the real autograd grad_output is honored. The optimized
-        plain CE path may materialize logits internally; if logits are already available to the caller, use
-        the cross entropy operator directly.
+        a single Cube GEMM materializes logits, the optimized CE kernels compute loss (and optional
+        metrics), and backward overwrites those logits in-place with ``dlogits`` before the two
+        projection GEMMs. If logits are already available to the caller, use the cross entropy operator.
 
         _input: (B*T, H) where B is batch size, T is sequence length, H is hidden dimension.
         target: (B*T) where each value is in [0, V-1]
@@ -553,7 +536,9 @@ class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
             Default: False.
         return_token_accuracy (bool): When `return_token_accuracy` is `True`, computes and returns per-token accuracy without materializing logits. Default: `False`
         return_predicted_tokens (bool): When `return_predicted_tokens` is `True`, returns per-token predicted class indices (argmax) without materializing logits. Default: `False`
+        ce_impl / ce_mode: accepted for NVIDIA FLCE signature parity; unused on Ascend.
         """
+        _ = (ce_impl, ce_mode)
         (
             loss,
             z_loss,
@@ -564,6 +549,7 @@ class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
             scaling_factors_full,
             plain_fast_path,
             logits_for_backward,
+            lse_1d,
         ) = fused_linear_cross_entropy_forward(
             _input=_input,
             weight=weight,
@@ -576,14 +562,11 @@ class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
             reduction=reduction,
             softcap=softcap,
             return_z_loss=return_z_loss,
-            accum_dtype=accum_dtype,
             use_token_scaling=use_token_scaling,
             return_token_accuracy=return_token_accuracy,
             return_predicted_tokens=return_predicted_tokens,
         )
 
-        # Save minimal tensors; optional tensors are stored on ctx attributes
-        # (save_for_backward only accepts Tensors).
         to_save = [_input.detach(), weight.detach(), target.detach(), loss_1d, ce_stats]
         if logits_for_backward is not None:
             to_save.append(logits_for_backward.detach())
@@ -592,7 +575,8 @@ class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
         ctx.save_for_backward(*to_save)
         ctx.bias = bias.detach() if bias is not None else None
         ctx.ce_weight = ce_weight.detach() if ce_weight is not None else None
-        ctx.scaling_factors_full = scaling_factors_full if scaling_factors_full is not None else None
+        ctx.scaling_factors_full = scaling_factors_full
+        ctx.lse = lse_1d
 
         ctx.ignore_index = ignore_index
         ctx.lse_square_scale = float(lse_square_scale)
@@ -611,9 +595,9 @@ class LigerFusedLinearCrossEntropyFunction(torch.autograd.Function):
     @amp_custom_bwd
     def backward(ctx, grad_output, grad_output2, grad_output3, grad_output4):
         if ctx.return_z_loss:
-            del grad_output2  # z_loss is only for logging
+            del grad_output2
         if ctx.return_token_accuracy:
-            del grad_output3  # token_accuracy is only for metrics
+            del grad_output3
         if ctx.return_predicted_tokens:
-            del grad_output4  # predicted_tokens is only for metrics
+            del grad_output4
         return fused_linear_cross_entropy_backward(ctx, grad_output)

--- a/src/liger_kernel/ops/backends/_ascend/ops/rms_norm.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/rms_norm.py
@@ -1,3 +1,15 @@
+"""Ascend RMSNorm: UB-aware fused row / 2D / column-tiled Triton kernels.
+
+Profiling on 910B (BT=8192, H=4096, bf16) showed the previous two-pass tiled
+forward spent 350us at aiv_mte2_ratio=0.69 because it reloaded X after the
+rstd reduction. torch_npu.npu_rms_norm finishes in 107us at vec_ratio=0.81.
+Full-width single-pass kernels (same pattern as Ascend LayerNorm) keep X in UB
+and cut that extra HBM round-trip. Column tiling remains only when a full row
+does not fit UB.
+"""
+
+import functools
+
 import torch
 import triton
 import triton.language as tl
@@ -13,133 +25,21 @@ _CASTING_MODE_NONE: tl.constexpr = tl.constexpr(-1)
 _CASTING_MODE_LLAMA: tl.constexpr = tl.constexpr(0)
 _CASTING_MODE_GEMMA: tl.constexpr = tl.constexpr(1)
 
-
-def torch_dtype_to_triton(dtype):
-    mapping = {
-        torch.float32: tl.float32,
-        torch.bfloat16: tl.bfloat16,
-    }
-    return mapping.get(dtype, tl.float32)
-
-
-# -----------------------------------------------------------------------------
-# Forward Kernel - No Tiling (for n_cols <= 2048)
-# -----------------------------------------------------------------------------
-
-
-@triton.jit
-def _rms_norm_forward_kernel_no_tiling(
-    Y_ptr,
-    Y_row_stride,
-    X_ptr,
-    X_row_stride,
-    W_ptr,
-    RSTD_ptr,
-    RSTD_row_stride,
-    n_rows: tl.constexpr,
-    n_cols: tl.constexpr,
-    eps,
-    offset,
-    casting_mode: tl.constexpr,
-    elementwise_affine: tl.constexpr,
-    X_DTYPE: tl.constexpr,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-):
-    """
-    NPU-optimized rms_norm forward kernel for small n_cols (< 2048).
-
-    Performance optimizations:
-    1. Use 2D vector loading to maximize UB utilization (e.g., (1,2048), (2,1024), (4,512))
-    2. Process multiple rows at once using 2D indexing
-    3. Keep data in registers, minimize conversions
-    4. Use optimal cache policies
-
-    Used when n_cols < 2048 to avoid the overhead of column blocking.
-    """
-    pid = tl.program_id(0)
-    num_progs = tl.num_programs(0)
-
-    if casting_mode == _CASTING_MODE_NONE:
-        eps = eps.to(X_DTYPE)
-        offset = offset.to(X_DTYPE)
-
-    # Grid-stride loop setup for 2D blocks
-    grid_stride = num_progs * BLOCK_SIZE_M
-    num_iterations = tl.cdiv(n_rows, grid_stride)
-
-    col_offsets = tl.arange(0, BLOCK_SIZE_N)
-    col_mask = col_offsets < n_cols
-    row_offsets = tl.arange(0, BLOCK_SIZE_M)
-
-    if elementwise_affine:
-        W_row = tl.load(W_ptr + col_offsets, mask=col_mask, other=0.0)
-
-    # Grid-stride loop over row blocks
-    for i in range(num_iterations):
-        row_idx = i * grid_stride + pid * BLOCK_SIZE_M + row_offsets
-        row_mask = row_idx < n_rows
-        block_mask = row_mask[:, None] & col_mask[None, :]
-
-        # Load multiple rows at once using 2D indexing
-        X_rows = tl.load(
-            X_ptr + row_idx[:, None] * X_row_stride + col_offsets[None, :],
-            mask=block_mask,
-            other=0.0,
-        )
-
-        # Compute sum_square for all rows
-        if casting_mode == _CASTING_MODE_LLAMA or casting_mode == _CASTING_MODE_GEMMA:
-            X_rows = X_rows.to(tl.float32)
-
-        sum_squares = tl.sum(tl.where(block_mask, X_rows * X_rows, 0.0), axis=1)
-
-        # Compute rstd for all rows
-        mean_squares = sum_squares / n_cols
-        rstd_rows = rsqrt(mean_squares + eps)
-
-        # Store rstd_rows
-        tl.store(RSTD_ptr + row_idx * RSTD_row_stride, rstd_rows, mask=row_mask)
-
-        # Apply casting based on mode
-        if casting_mode == _CASTING_MODE_GEMMA:
-            X_rows = X_rows.to(tl.float32)
-            if elementwise_affine:
-                W_row_fp32 = W_row.to(tl.float32)
-        elif casting_mode == _CASTING_MODE_LLAMA:
-            X_rows = X_rows.to(tl.float32)
-
-        # Normalize
-        X_rows = X_rows * rstd_rows[:, None]
-
-        # Cast back for Llama mode before weight multiplication
-        if casting_mode == _CASTING_MODE_LLAMA:
-            X_rows = X_rows.to(X_DTYPE)
-
-        # Apply weight
-        if elementwise_affine:
-            if casting_mode == _CASTING_MODE_GEMMA:
-                Y_rows = X_rows * (offset + W_row_fp32[None, :])
-            else:
-                Y_rows = X_rows * (offset + W_row[None, :])
-        else:
-            Y_rows = X_rows
-
-        # Cast back for Gemma mode
-        if casting_mode == _CASTING_MODE_GEMMA:
-            Y_rows = Y_rows.to(X_DTYPE)
-
-        # Store results
-        tl.store(Y_ptr + row_idx[:, None] * Y_row_stride + col_offsets[None, :], Y_rows, mask=block_mask)
+# Peak live fp32 tiles. Wide rows keep fewer copies so a full 4096/8192 vector fits.
+_FUSED_FWD_MEM_MULT = 5.0
+_FUSED_FWD_MEM_MULT_WIDE = 4.0
+_FUSED_BWD_MEM_MULT = 7.0
+_TILED_MEM_MULT = 8.0
+_UB_SAFETY_MARGIN = 0.85
 
 
 # -----------------------------------------------------------------------------
-# Forward Kernel - With Tiling (for n_cols > 2048)
+# Forward kernels
 # -----------------------------------------------------------------------------
 
 
 @triton.jit
-def _rms_norm_forward_kernel_tiled(
+def _rms_norm_forward_row(
     Y_ptr,
     Y_row_stride,
     X_ptr,
@@ -156,71 +56,192 @@ def _rms_norm_forward_kernel_tiled(
     X_DTYPE: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
-    """
-    NPU-optimized rms_norm forward kernel for large n_cols (>= 2048).
-
-    This kernel processes rows using a grid-stride loop pattern:
-    1. Each program handles multiple rows
-    2. For each row, we process it in column chunks of BLOCK_SIZE
-    3. Grid size is limited to NPU core count to avoid resource overflow
-
-    This solves two problems:
-    1. UB overflow when n_cols is too large (original kernel used n_cols as BLOCK_SIZE)
-    2. Efficient multi-row processing within a single kernel launch
-    """
+    """Grid-stride full-width row forward. One vector load of X per row."""
     pid = tl.program_id(0)
     num_progs = tl.num_programs(0)
-    num_col_blocks = tl.cdiv(n_cols, BLOCK_SIZE)
-
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    col_mask = col_offsets < n_cols
+    n_cols_inv = 1.0 / n_cols
+    # Python float scalars can specialize to fp64 (#1358). Pin so rsqrt / W+offset stay fp32.
     if casting_mode == _CASTING_MODE_NONE:
         eps = eps.to(X_DTYPE)
         offset = offset.to(X_DTYPE)
+    else:
+        eps = eps.to(tl.float32)
+        offset = offset.to(tl.float32)
 
+    if elementwise_affine:
+        W_row = tl.load(W_ptr + col_offsets, mask=col_mask, other=0.0)
+
+    row_chunk = (n_rows + num_progs - 1) // num_progs
+    row_start = pid * row_chunk
+    row_end = tl.minimum(row_start + row_chunk, n_rows)
+
+    for row_idx in tl.range(row_start, row_end):
+        row_X_ptr = X_ptr + row_idx * X_row_stride
+        row_Y_ptr = Y_ptr + row_idx * Y_row_stride
+
+        X_row = tl.load(row_X_ptr + col_offsets, mask=col_mask, other=0.0)
+        if casting_mode == _CASTING_MODE_LLAMA or casting_mode == _CASTING_MODE_GEMMA:
+            X_f32 = X_row.to(tl.float32)
+        else:
+            X_f32 = X_row
+
+        sum_sq = tl.sum(tl.where(col_mask, X_f32 * X_f32, 0.0), axis=0)
+        rstd = rsqrt(sum_sq * n_cols_inv + eps)
+        tl.store(RSTD_ptr + row_idx * RSTD_row_stride, rstd)
+
+        X_hat = X_f32 * rstd
+        if casting_mode == _CASTING_MODE_LLAMA:
+            X_hat = X_hat.to(X_DTYPE)
+        if elementwise_affine:
+            if casting_mode == _CASTING_MODE_GEMMA:
+                Y_row = X_hat * (offset + W_row.to(tl.float32))
+            else:
+                Y_row = X_hat * (offset + W_row)
+        else:
+            Y_row = X_hat
+        if casting_mode == _CASTING_MODE_GEMMA:
+            Y_row = Y_row.to(X_DTYPE)
+        tl.store(row_Y_ptr + col_offsets, Y_row, mask=col_mask)
+
+
+@triton.jit
+def _rms_norm_forward_fused_2d(
+    Y_ptr,
+    Y_row_stride,
+    X_ptr,
+    X_row_stride,
+    W_ptr,
+    RSTD_ptr,
+    RSTD_row_stride,
+    n_rows: tl.constexpr,
+    n_cols: tl.constexpr,
+    eps,
+    offset,
+    casting_mode: tl.constexpr,
+    elementwise_affine: tl.constexpr,
+    X_DTYPE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    ROWS_PER_BLOCK: tl.constexpr,
+):
+    """2D fused forward: ROWS_PER_BLOCK rows x full n_cols in one load."""
+    pid = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    row_offsets = tl.arange(0, ROWS_PER_BLOCK)
+    col_mask = col_offsets < n_cols
+    n_cols_inv = 1.0 / n_cols
+    if casting_mode == _CASTING_MODE_NONE:
+        eps = eps.to(X_DTYPE)
+        offset = offset.to(X_DTYPE)
+    else:
+        eps = eps.to(tl.float32)
+        offset = offset.to(tl.float32)
+
+    if elementwise_affine:
+        W_row = tl.load(W_ptr + col_offsets, mask=col_mask, other=0.0)
+
+    n_row_blocks = tl.cdiv(n_rows, ROWS_PER_BLOCK)
+    blocks_per_prog = (n_row_blocks + num_progs - 1) // num_progs
+    block_start = pid * blocks_per_prog
+    block_end = tl.minimum(block_start + blocks_per_prog, n_row_blocks)
+
+    for block_i in tl.range(block_start, block_end):
+        row_idx = block_i * ROWS_PER_BLOCK + row_offsets
+        row_mask = row_idx < n_rows
+        block_mask = row_mask[:, None] & col_mask[None, :]
+
+        X_rows = tl.load(
+            X_ptr + row_idx[:, None] * X_row_stride + col_offsets[None, :],
+            mask=block_mask,
+            other=0.0,
+        )
+        if casting_mode == _CASTING_MODE_LLAMA or casting_mode == _CASTING_MODE_GEMMA:
+            X_f32 = X_rows.to(tl.float32)
+        else:
+            X_f32 = X_rows
+
+        sum_sq = tl.sum(tl.where(block_mask, X_f32 * X_f32, 0.0), axis=1)
+        rstd = rsqrt(sum_sq * n_cols_inv + eps)
+        tl.store(RSTD_ptr + row_idx * RSTD_row_stride, rstd, mask=row_mask)
+
+        X_hat = X_f32 * rstd[:, None]
+        if casting_mode == _CASTING_MODE_LLAMA:
+            X_hat = X_hat.to(X_DTYPE)
+        if elementwise_affine:
+            if casting_mode == _CASTING_MODE_GEMMA:
+                Y_rows = X_hat * (offset + W_row.to(tl.float32))[None, :]
+            else:
+                Y_rows = X_hat * (offset + W_row)[None, :]
+        else:
+            Y_rows = X_hat
+        if casting_mode == _CASTING_MODE_GEMMA:
+            Y_rows = Y_rows.to(X_DTYPE)
+        tl.store(
+            Y_ptr + row_idx[:, None] * Y_row_stride + col_offsets[None, :],
+            Y_rows,
+            mask=block_mask,
+        )
+
+
+@triton.jit
+def _rms_norm_forward_tiled(
+    Y_ptr,
+    Y_row_stride,
+    X_ptr,
+    X_row_stride,
+    W_ptr,
+    RSTD_ptr,
+    RSTD_row_stride,
+    n_rows: tl.constexpr,
+    n_cols: tl.constexpr,
+    eps,
+    offset,
+    casting_mode: tl.constexpr,
+    elementwise_affine: tl.constexpr,
+    X_DTYPE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Two-pass column-tiled forward when a full row does not fit UB."""
+    pid = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+    num_col_blocks = tl.cdiv(n_cols, BLOCK_SIZE)
     offsets = tl.arange(0, BLOCK_SIZE)
-    # Grid-stride loop over rows
-    for row_idx in tl.range(pid, n_rows, num_progs):
+    n_cols_inv = 1.0 / n_cols
+    if casting_mode == _CASTING_MODE_NONE:
+        eps = eps.to(X_DTYPE)
+        offset = offset.to(X_DTYPE)
+    else:
+        eps = eps.to(tl.float32)
+        offset = offset.to(tl.float32)
+
+    row_chunk = (n_rows + num_progs - 1) // num_progs
+    row_start = pid * row_chunk
+    row_end = tl.minimum(row_start + row_chunk, n_rows)
+
+    for row_idx in tl.range(row_start, row_end):
         Y_row_ptr = Y_ptr + row_idx * Y_row_stride
         X_row_ptr = X_ptr + row_idx * X_row_stride
-        RSTD_row_ptr = RSTD_ptr + row_idx * RSTD_row_stride
 
-        # Accumulator for mean_square computation across all column blocks
         sum_square = 0.0
-
-        # First pass: accumulate sum of squares
         for col_block_idx in range(num_col_blocks):
-            col_start = col_block_idx * BLOCK_SIZE
-            col_offsets = col_start + offsets
+            col_offsets = col_block_idx * BLOCK_SIZE + offsets
             mask = col_offsets < n_cols
-
             X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0)
-
             if casting_mode == _CASTING_MODE_LLAMA or casting_mode == _CASTING_MODE_GEMMA:
                 X_block = X_block.to(tl.float32)
+            sum_square += tl.sum(tl.where(mask, X_block * X_block, 0.0))
 
-            # Accumulate sum of squares (only for valid elements)
-            sum_square += tl.sum(X_block * X_block)
+        rstd = rsqrt(sum_square * n_cols_inv + eps)
+        tl.store(RSTD_ptr + row_idx * RSTD_row_stride, rstd)
 
-        # Compute rstd for this row
-        mean_square = sum_square / n_cols
-
-        rstd = rsqrt(mean_square + eps)
-
-        # Store rstd
-        tl.store(RSTD_row_ptr, rstd)
-
-        # Second pass: normalize and multiply by weight
         for col_block_idx in range(num_col_blocks):
-            col_start = col_block_idx * BLOCK_SIZE
-            col_offsets = col_start + offsets
+            col_offsets = col_block_idx * BLOCK_SIZE + offsets
             mask = col_offsets < n_cols
-
-            # Load X_block
             X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0)
-
             if elementwise_affine:
                 W_block = tl.load(W_ptr + col_offsets, mask=mask, other=0.0)
-
-            # Apply casting based on mode
             if casting_mode == _CASTING_MODE_GEMMA:
                 X_block = X_block.to(tl.float32)
                 if elementwise_affine:
@@ -228,34 +249,25 @@ def _rms_norm_forward_kernel_tiled(
             elif casting_mode == _CASTING_MODE_LLAMA:
                 X_block = X_block.to(tl.float32)
 
-            # Normalize
             X_block = X_block * rstd
-
-            # Cast back for Llama mode before weight multiplication
             if casting_mode == _CASTING_MODE_LLAMA:
                 X_block = X_block.to(X_DTYPE)
-
-            # Apply weight
             if elementwise_affine:
                 Y_block = X_block * (offset + W_block)
             else:
                 Y_block = X_block
-
-            # Cast back for Gemma mode
             if casting_mode == _CASTING_MODE_GEMMA:
                 Y_block = Y_block.to(X_DTYPE)
-
-            # Store result
             tl.store(Y_row_ptr + col_offsets, Y_block, mask=mask)
 
 
 # -----------------------------------------------------------------------------
-# Backward Kernel - No Tiling (for n_cols <= 2048)
+# Backward kernels
 # -----------------------------------------------------------------------------
 
 
 @triton.jit
-def _rms_norm_backward_kernel_no_tiling(
+def _rms_norm_backward_row(
     dY_ptr,
     dY_row_stride,
     dX_ptr,
@@ -273,38 +285,104 @@ def _rms_norm_backward_kernel_no_tiling(
     offset,
     casting_mode: tl.constexpr,
     elementwise_affine: tl.constexpr,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
 ):
-    """
-    NPU-optimized rms_norm backward kernel for small n_cols (< 2048).
-
-    Performance optimizations:
-    1. Keep all data in registers, minimize conversions
-    2. Reuse X_normalized (X * rstd) for both dX and dW
-    3. Optimize computation order to reduce register pressure
-    4. Combine operations where possible
-    5. Use 2D vector loading to maximize UB utilization (e.g., (1,2048), (2,1024), (4,512))
-    """
+    """Full-width row backward. Per-program dW is reduced on the host."""
     pid = tl.program_id(0)
     num_progs = tl.num_programs(0)
-
-    # Grid-stride loop setup for 2D blocks
-    grid_stride = num_progs * BLOCK_SIZE_M
-    num_iterations = tl.cdiv(n_rows, grid_stride)
-
-    col_offsets = tl.arange(0, BLOCK_SIZE_N)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
     col_mask = col_offsets < n_cols
-    row_offsets = tl.arange(0, BLOCK_SIZE_M)
+    n_cols_inv = 1.0 / n_cols
+    offset = offset.to(tl.float32)
 
-    # Load W once for all iterations
     if elementwise_affine:
         W_row = tl.load(W_ptr + col_offsets, mask=col_mask, other=0.0)
         W_offset = W_row + offset
+        dW_acc = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
 
-    # Grid-stride loop over row blocks
-    for i in range(num_iterations):
-        row_idx = i * grid_stride + pid * BLOCK_SIZE_M + row_offsets
+    row_chunk = (n_rows + num_progs - 1) // num_progs
+    row_start = pid * row_chunk
+    row_end = tl.minimum(row_start + row_chunk, n_rows)
+
+    for row_idx in tl.range(row_start, row_end):
+        dY_row = tl.load(dY_ptr + row_idx * dY_row_stride + col_offsets, mask=col_mask, other=0.0)
+        X_row = tl.load(X_ptr + row_idx * X_row_stride + col_offsets, mask=col_mask, other=0.0)
+        rstd = tl.load(RSTD_ptr + row_idx * RSTD_row_stride)
+        X_f32 = X_row.to(tl.float32)
+        X_hat = X_f32 * rstd
+
+        if elementwise_affine:
+            if casting_mode == _CASTING_MODE_LLAMA:
+                m = (dY_row * W_offset).to(tl.float32)
+                X_hat_dw = X_hat.to(X_dtype)
+            elif casting_mode == _CASTING_MODE_GEMMA:
+                m = dY_row.to(tl.float32) * W_offset
+                X_hat_dw = X_hat
+            else:
+                m = dY_row * W_offset
+                X_hat_dw = X_hat
+        else:
+            if casting_mode == _CASTING_MODE_LLAMA or casting_mode == _CASTING_MODE_GEMMA:
+                m = dY_row.to(tl.float32)
+            else:
+                m = dY_row
+            X_hat_dw = X_hat
+
+        sum_m_X = tl.sum(tl.where(col_mask, m * X_f32, 0.0), axis=0)
+        correction = -n_cols_inv * rstd * rstd * sum_m_X
+        dX = rstd * m + rstd * correction * X_f32
+        tl.store(dX_ptr + row_idx * dX_row_stride + col_offsets, dX.to(X_dtype), mask=col_mask)
+
+        if elementwise_affine:
+            dW_acc += tl.where(col_mask, (dY_row * X_hat_dw).to(tl.float32), 0.0)
+
+    if elementwise_affine:
+        tl.store(dW_ptr + pid * dW_row_stride + col_offsets, dW_acc, mask=col_mask)
+
+
+@triton.jit
+def _rms_norm_backward_fused_2d(
+    dY_ptr,
+    dY_row_stride,
+    dX_ptr,
+    dX_row_stride,
+    X_ptr,
+    X_row_stride,
+    X_dtype: tl.constexpr,
+    W_ptr,
+    RSTD_ptr,
+    RSTD_row_stride,
+    dW_ptr,
+    dW_row_stride,
+    n_rows: tl.constexpr,
+    n_cols: tl.constexpr,
+    offset,
+    casting_mode: tl.constexpr,
+    elementwise_affine: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    ROWS_PER_BLOCK: tl.constexpr,
+):
+    """2D fused backward: several rows x full n_cols."""
+    pid = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    row_offsets = tl.arange(0, ROWS_PER_BLOCK)
+    col_mask = col_offsets < n_cols
+    n_cols_inv = 1.0 / n_cols
+    offset = offset.to(tl.float32)
+
+    if elementwise_affine:
+        W_row = tl.load(W_ptr + col_offsets, mask=col_mask, other=0.0)
+        W_offset = W_row + offset
+        dW_acc = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+
+    n_row_blocks = tl.cdiv(n_rows, ROWS_PER_BLOCK)
+    blocks_per_prog = (n_row_blocks + num_progs - 1) // num_progs
+    block_start = pid * blocks_per_prog
+    block_end = tl.minimum(block_start + blocks_per_prog, n_row_blocks)
+
+    for block_i in tl.range(block_start, block_end):
+        row_idx = block_i * ROWS_PER_BLOCK + row_offsets
         row_mask = row_idx < n_rows
         block_mask = row_mask[:, None] & col_mask[None, :]
 
@@ -318,62 +396,44 @@ def _rms_norm_backward_kernel_no_tiling(
             mask=block_mask,
             other=0.0,
         )
+        rstd = tl.load(RSTD_ptr + row_idx * RSTD_row_stride, mask=row_mask, other=0.0)
+        X_f32 = X_rows.to(tl.float32)
+        X_hat = X_f32 * rstd[:, None]
 
-        # Load rstd for all rows in the block
-        rstd_rows = tl.load(RSTD_ptr + row_idx * RSTD_row_stride, mask=row_mask, other=0.0)
-
-        # Convert X to fp32 once
-        X_rows = X_rows.to(tl.float32)
-
-        # Compute X_normalized (reused in dX and dW)
-        X_normalized = X_rows * rstd_rows[:, None]
-
-        # Compute m based on casting mode and elementwise_affine
         if elementwise_affine:
             if casting_mode == _CASTING_MODE_LLAMA:
-                m_rows = (dY_rows * W_offset[None, :]).to(tl.float32)
-                # For dW in Llama mode, we need X_normalized in original dtype
-                X_normalized = X_normalized.to(X_dtype)
+                m = (dY_rows * W_offset[None, :]).to(tl.float32)
+                X_hat_dw = X_hat.to(X_dtype)
             elif casting_mode == _CASTING_MODE_GEMMA:
-                m_rows = dY_rows.to(tl.float32) * W_offset[None, :]
+                m = dY_rows.to(tl.float32) * W_offset[None, :]
+                X_hat_dw = X_hat
             else:
-                m_rows = dY_rows * W_offset[None, :]
+                m = dY_rows * W_offset[None, :]
+                X_hat_dw = X_hat
         else:
             if casting_mode == _CASTING_MODE_LLAMA or casting_mode == _CASTING_MODE_GEMMA:
-                m_rows = dY_rows.to(tl.float32)
+                m = dY_rows.to(tl.float32)
             else:
-                m_rows = dY_rows
+                m = dY_rows
+            X_hat_dw = X_hat
 
-        # Compute sum(m * X) for correction factor
-        sum_m_X = tl.sum(tl.where(block_mask, m_rows * X_rows, 0.0), axis=1)
-
-        # Compute correction factor
-        correction_factors = -(1.0 / n_cols) * rstd_rows * rstd_rows * sum_m_X
-
-        # Compute dX = rstd * m + rstd * correction_factor * X
-        dX_rows = rstd_rows[:, None] * m_rows + rstd_rows[:, None] * correction_factors[:, None] * X_rows
-
-        # Store dX
-        tl.store(dX_ptr + row_idx[:, None] * dX_row_stride + col_offsets[None, :], dX_rows.to(X_dtype), mask=block_mask)
-
+        sum_m_X = tl.sum(tl.where(block_mask, m * X_f32, 0.0), axis=1)
+        correction = -n_cols_inv * rstd * rstd * sum_m_X
+        dX = rstd[:, None] * m + rstd[:, None] * correction[:, None] * X_f32
+        tl.store(
+            dX_ptr + row_idx[:, None] * dX_row_stride + col_offsets[None, :],
+            dX.to(X_dtype),
+            mask=block_mask,
+        )
         if elementwise_affine:
-            # Compute dW contribution: dY * X_normalized
-            dW_rows = (dY_rows * X_normalized).to(tl.float32)
+            dW_acc += tl.sum(tl.where(block_mask, (dY_rows * X_hat_dw).to(tl.float32), 0.0), axis=0)
 
-            # Accumulate to per-program dW buffer
-            dW_row_ptr = dW_ptr + pid * dW_row_stride
-            existing_dW = tl.load(dW_row_ptr + col_offsets, mask=col_mask, other=0.0)
-            new_dW = existing_dW + tl.sum(tl.where(block_mask, dW_rows, 0.0), axis=0)
-            tl.store(dW_row_ptr + col_offsets, new_dW, mask=col_mask)
-
-
-# -----------------------------------------------------------------------------
-# Backward Kernel - With Tiling (for n_cols > 2048)
-# -----------------------------------------------------------------------------
+    if elementwise_affine:
+        tl.store(dW_ptr + pid * dW_row_stride + col_offsets, dW_acc, mask=col_mask)
 
 
 @triton.jit
-def _rms_norm_backward_kernel_tiled(
+def _rms_norm_backward_tiled(
     dY_ptr,
     dY_row_stride,
     dX_ptr,
@@ -393,174 +453,147 @@ def _rms_norm_backward_kernel_tiled(
     elementwise_affine: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
-    """
-    NPU-optimized rms_norm backward kernel for large n_cols (>= 2048).
-
-    Each program processes multiple rows using grid-stride loop.
-    For each row, we process columns in blocks to avoid UB overflow.
-    """
+    """Two-pass column-tiled backward when a full row does not fit UB."""
     pid = tl.program_id(0)
     num_progs = tl.num_programs(0)
-
-    # Initialize dW accumulator (per-program, will be reduced later)
     num_col_blocks = tl.cdiv(n_cols, BLOCK_SIZE)
     offsets = tl.arange(0, BLOCK_SIZE)
+    n_cols_inv = 1.0 / n_cols
+    offset = offset.to(tl.float32)
 
-    # Grid-stride loop over rows
-    for row_idx in tl.range(pid, n_rows, num_progs):
-        # Base pointers for this row
+    row_chunk = (n_rows + num_progs - 1) // num_progs
+    row_start = pid * row_chunk
+    row_end = tl.minimum(row_start + row_chunk, n_rows)
+
+    for row_idx in tl.range(row_start, row_end):
         dY_row_ptr = dY_ptr + row_idx * dY_row_stride
         dX_row_ptr = dX_ptr + row_idx * dX_row_stride
         X_row_ptr = X_ptr + row_idx * X_row_stride
-        RSTD_row_ptr = RSTD_ptr + row_idx * RSTD_row_stride
+        rstd = tl.load(RSTD_ptr + row_idx * RSTD_row_stride)
 
-        # Load rstd for this row
-        rstd = tl.load(RSTD_row_ptr)
-
-        # First pass: compute sum(m * X) for the correction term
         sum_m_X = 0.0
-
         for col_block_idx in range(num_col_blocks):
-            col_start = col_block_idx * BLOCK_SIZE
-            col_offsets = col_start + offsets
+            col_offsets = col_block_idx * BLOCK_SIZE + offsets
             mask = col_offsets < n_cols
-
             dY_block = tl.load(dY_row_ptr + col_offsets, mask=mask, other=0.0)
-            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0)
-
-            # Convert to fp32 for computation
-            X_block = X_block.to(tl.float32)
-
+            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
             if elementwise_affine:
                 W_block = tl.load(W_ptr + col_offsets, mask=mask, other=0.0)
                 W_offset = W_block + offset
-
-                # Compute m based on casting mode
                 if casting_mode == _CASTING_MODE_LLAMA:
                     m = (dY_block * W_offset).to(tl.float32)
                 elif casting_mode == _CASTING_MODE_GEMMA:
-                    dY_block = dY_block.to(tl.float32)
-                    m = dY_block * W_offset
+                    m = dY_block.to(tl.float32) * W_offset
                 else:
                     m = dY_block * W_offset
             else:
-                # Compute m based on casting mode
-                if casting_mode == _CASTING_MODE_LLAMA:
-                    m = dY_block.to(tl.float32)
-                elif casting_mode == _CASTING_MODE_GEMMA:
+                if casting_mode == _CASTING_MODE_LLAMA or casting_mode == _CASTING_MODE_GEMMA:
                     m = dY_block.to(tl.float32)
                 else:
                     m = dY_block
+            sum_m_X += tl.sum(tl.where(mask, m * X_block, 0.0))
 
-            # Accumulate sum(m * X)
-            sum_m_X += tl.sum(m * X_block)
+        correction = -n_cols_inv * rstd * rstd * sum_m_X
 
-        # Compute the correction factor
-        correction_factor = -(1.0 / n_cols) * rstd * rstd * sum_m_X
-
-        # Second pass: compute gradients
         for col_block_idx in range(num_col_blocks):
-            col_start = col_block_idx * BLOCK_SIZE
-            col_offsets = col_start + offsets
+            col_offsets = col_block_idx * BLOCK_SIZE + offsets
             mask = col_offsets < n_cols
-
             dY_block = tl.load(dY_row_ptr + col_offsets, mask=mask, other=0.0)
-            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0)
-
-            X_block = X_block.to(tl.float32)
-
+            X_block = tl.load(X_row_ptr + col_offsets, mask=mask, other=0.0).to(tl.float32)
             if elementwise_affine:
                 W_block = tl.load(W_ptr + col_offsets, mask=mask, other=0.0)
                 W_offset = W_block + offset
-
-                # Compute m based on casting mode
                 if casting_mode == _CASTING_MODE_LLAMA:
                     m = (dY_block * W_offset).to(tl.float32)
+                    dW_block = dY_block * (X_block * rstd).to(X_dtype)
                 elif casting_mode == _CASTING_MODE_GEMMA:
-                    dY_block = dY_block.to(tl.float32)
-                    m = dY_block * W_offset
+                    m = dY_block.to(tl.float32) * W_offset
+                    dW_block = dY_block * (X_block * rstd)
                 else:
                     m = dY_block * W_offset
+                    dW_block = dY_block * (X_block * rstd)
             else:
-                # Compute m based on casting mode
-                if casting_mode == _CASTING_MODE_LLAMA:
-                    m = dY_block.to(tl.float32)
-                elif casting_mode == _CASTING_MODE_GEMMA:
+                if casting_mode == _CASTING_MODE_LLAMA or casting_mode == _CASTING_MODE_GEMMA:
                     m = dY_block.to(tl.float32)
                 else:
                     m = dY_block
+                dW_block = None
 
-            # Compute dX
-            dX_block = rstd * m + rstd * correction_factor * X_block
-
-            # Store dX
+            dX_block = rstd * m + rstd * correction * X_block
             tl.store(dX_row_ptr + col_offsets, dX_block.to(X_dtype), mask=mask)
 
             if elementwise_affine:
-                # Compute dW contribution (accumulate per program)
-                if casting_mode == _CASTING_MODE_LLAMA:
-                    dW_block = dY_block * (X_block * rstd).to(X_dtype)
-                else:
-                    dW_block = dY_block * (X_block * rstd)
-
-                # Atomic add to dW_ptr (each program writes to its own row)
                 dW_row_ptr = dW_ptr + pid * dW_row_stride
-
-                # Load existing dW, add contribution, store back
-                existing_dW = tl.load(dW_row_ptr + col_offsets, mask=mask, other=0.0)
-                new_dW = existing_dW + dW_block.to(tl.float32)
-                tl.store(dW_row_ptr + col_offsets, new_dW, mask=mask)
+                existing = tl.load(dW_row_ptr + col_offsets, mask=mask, other=0.0)
+                tl.store(dW_row_ptr + col_offsets, existing + dW_block.to(tl.float32), mask=mask)
 
 
 # -----------------------------------------------------------------------------
-# Helper Functions
+# Tiling helpers
 # -----------------------------------------------------------------------------
 
 
-def get_optimal_block_size(n_cols, is_forward: bool):
-    """
-    Calculate optimal block size for forward pass using compute_default_tiling_strategy.
-
-    Memory analysis for forward pass (per row):
-    - Load: X_block, W_block (2 blocks)
-    - Compute: X_block (fp32), Y_block (1-2 blocks)
-    - Total: conservative estimate 6 blocks of memory
-
-    Memory analysis for backward pass (per row):
-    - Load: dY_block, X_block, W_block (3 blocks)
-    - Compute: m, dX_block, dW_block (3 blocks)
-    - Store: dX_block, accumulated dW (2 blocks)
-    - Total: conservative estimate 8 blocks of memory
-
-    Args:
-        n_cols: Number of columns in the tensor
-        is_forward: Whether this is for forward pass
-
-    Returns:
-        Optimal block size
-    """
-    if n_cols <= 2048:
-        return triton.next_power_of_2(n_cols)
-
-    memory_multiplier = 6.0 if is_forward else 8.0
-
+def _safe_column_block(n_cols: int, memory_multiplier: float) -> int:
     tile_shapes = compute_default_tiling_strategy(
-        safety_margin=0.9,
+        safety_margin=_UB_SAFETY_MARGIN,
         dtype_size=4,
         memory_multiplier=memory_multiplier,
         shapes=((n_cols,),),
         tiling_dims=(0,),
     )
+    if tile_shapes:
+        return max(128, tile_shapes[0][0])
+    return 1024
 
-    if tile_shapes and len(tile_shapes) > 0:
-        block_size = tile_shapes[0][0]
-        return max(2048, block_size)
-    else:
-        return 2048
+
+def _safe_fused_rows_per_block(n_cols: int, col_block: int, memory_multiplier: float) -> int:
+    desired_rows = 8
+    tile_shapes = compute_default_tiling_strategy(
+        safety_margin=_UB_SAFETY_MARGIN,
+        dtype_size=4,
+        memory_multiplier=memory_multiplier,
+        shapes=((desired_rows, col_block),),
+        tiling_dims=(0,),
+    )
+    if tile_shapes:
+        return max(1, tile_shapes[0][0])
+    return 1
+
+
+@functools.lru_cache(maxsize=64)
+def _fused_tile(n_cols: int, is_forward: bool) -> tuple[int, int, bool]:
+    """Return (col_block, rows_per_block, use_fused_full_width)."""
+    mem_mult = _FUSED_FWD_MEM_MULT if is_forward else _FUSED_BWD_MEM_MULT
+    if is_forward and n_cols >= 2048:
+        mem_mult = _FUSED_FWD_MEM_MULT_WIDE
+    safe_col = _safe_column_block(n_cols, mem_mult)
+    col_pow2 = triton.next_power_of_2(n_cols)
+    col_block = min(col_pow2, safe_col)
+    if col_block < n_cols:
+        return _safe_column_block(n_cols, _TILED_MEM_MULT), 1, False
+    wide_mult = _FUSED_FWD_MEM_MULT_WIDE if is_forward else _FUSED_BWD_MEM_MULT
+    rows_per_block = _safe_fused_rows_per_block(n_cols, col_block, wide_mult)
+    return col_block, rows_per_block, True
+
+
+def _forward_grid_size(n_rows: int, num_cores: int) -> int:
+    if n_rows <= 1024:
+        return min(num_cores * 2, n_rows)
+    if n_rows >= 8192:
+        return min(num_cores * 4, n_rows)
+    if n_rows >= 4096:
+        return min(num_cores * 2, n_rows)
+    return min(num_cores, n_rows)
+
+
+def _backward_grid_size(n_rows: int, num_cores: int) -> int:
+    if n_rows >= 8192:
+        return min(num_cores * 2, n_rows)
+    return min(num_cores, n_rows)
 
 
 # -----------------------------------------------------------------------------
-# Forward and Backward Functions
+# Launchers
 # -----------------------------------------------------------------------------
 
 
@@ -581,69 +614,52 @@ def rms_norm_forward(X, W, eps, offset, casting_mode):
     dim = shape[-1]
     X = X.view(-1, dim)
     n_rows, n_cols = X.shape
-    X_DTYPE = torch_dtype_to_triton(X.dtype)
-
-    # Get optimal block size for column processing
-    BLOCK_SIZE = get_optimal_block_size(n_cols, True)
-    BLOCK_SIZE_M = 2048 // BLOCK_SIZE
+    X_DTYPE = torch_to_triton_dtype[X.dtype]
 
     Y = torch.empty((n_rows, n_cols), dtype=X.dtype, device=X.device)
-
-    # RSTD is always fp32 for Llama/Gemma modes
     rstd_dtype = torch.float32 if casting_mode in (_CASTING_MODE_LLAMA.value, _CASTING_MODE_GEMMA.value) else X.dtype
     RSTD = torch.empty(n_rows, dtype=rstd_dtype, device=X.device)
 
     if W is not None:
-        # Check constraints
         assert X.shape[1] == W.shape[0], "Incompatible hidden size dimension"
         elementwise_affine = True
+        w_arg = W
     else:
         elementwise_affine = False
+        w_arg = X
 
-    # Grid size limited to NPU core count
     num_cores = get_npu_core_count()
-    grid_size = min(num_cores * 2, n_rows)
+    col_block, rows_per_block, use_fused = _fused_tile(n_cols, True)
 
-    # Choose kernel based on n_cols
-    if n_cols <= 2048:
-        # Use no-tiling kernel for small n_cols
-        _rms_norm_forward_kernel_no_tiling[(grid_size,)](
-            Y,
-            Y.stride(0),
-            X,
-            X.stride(0),
-            W,
-            RSTD,
-            RSTD.stride(0),
-            n_rows,
-            n_cols,
-            eps,
-            offset,
-            casting_mode,
-            elementwise_affine,
-            X_DTYPE,
-            BLOCK_SIZE_M=BLOCK_SIZE_M,
-            BLOCK_SIZE_N=BLOCK_SIZE,
-        )
+    common = dict(
+        Y_ptr=Y,
+        Y_row_stride=Y.stride(0),
+        X_ptr=X,
+        X_row_stride=X.stride(0),
+        W_ptr=w_arg,
+        RSTD_ptr=RSTD,
+        RSTD_row_stride=RSTD.stride(0),
+        n_rows=n_rows,
+        n_cols=n_cols,
+        eps=eps,
+        offset=offset,
+        casting_mode=casting_mode,
+        elementwise_affine=elementwise_affine,
+        X_DTYPE=X_DTYPE,
+        BLOCK_SIZE=col_block,
+    )
+
+    if use_fused:
+        if rows_per_block <= 1:
+            grid_size = _forward_grid_size(n_rows, num_cores)
+            _rms_norm_forward_row[(grid_size,)](**common)
+        else:
+            num_row_blocks = triton.cdiv(n_rows, rows_per_block)
+            grid_size = min(num_cores, num_row_blocks)
+            _rms_norm_forward_fused_2d[(grid_size,)](**common, ROWS_PER_BLOCK=rows_per_block)
     else:
-        # Use tiled kernel for large n_cols
-        _rms_norm_forward_kernel_tiled[(grid_size,)](
-            Y,
-            Y.stride(0),
-            X,
-            X.stride(0),
-            W,
-            RSTD,
-            RSTD.stride(0),
-            n_rows,
-            n_cols,
-            eps,
-            offset,
-            casting_mode,
-            elementwise_affine,
-            X_DTYPE,
-            BLOCK_SIZE=BLOCK_SIZE,
-        )
+        grid_size = min(num_cores * 2, n_rows)
+        _rms_norm_forward_tiled[(grid_size,)](**common)
 
     return Y.view(*shape), X, RSTD, casting_mode
 
@@ -654,81 +670,61 @@ def rms_norm_backward(dY, X, W, RSTD, offset, casting_mode, in_place):
     dY = dY.view(-1, dim)
     n_rows, n_cols = dY.shape
 
-    # Get NPU core count for grid size
     num_cores = get_npu_core_count()
-    grid_size = min(num_cores * 2, n_rows)
+    col_block, rows_per_block, use_fused = _fused_tile(n_cols, False)
 
-    # Get optimal block size for backward pass
-    BLOCK_SIZE = get_optimal_block_size(n_cols, False)
-    BLOCK_SIZE_M = 2048 // BLOCK_SIZE
+    if use_fused:
+        grid_size = _backward_grid_size(n_rows, num_cores)
+        if rows_per_block > 1:
+            num_row_blocks = triton.cdiv(n_rows, rows_per_block)
+            grid_size = min(num_cores, num_row_blocks)
+    else:
+        grid_size = min(num_cores * 2, n_rows)
 
     if W is not None:
-        # fp32 for numerical stability
         _dW = torch.zeros((grid_size, n_cols), dtype=torch.float32, device=W.device)
         elementwise_affine = True
+        w_arg = W
+        dw_stride = _dW.stride(0)
     else:
-        _dW = None
+        _dW = X
         elementwise_affine = False
+        w_arg = X
+        dw_stride = 0
 
-    if in_place:
-        dX = dY
-    else:
-        dX = torch.empty_like(dY)
+    dX = dY if in_place else torch.empty_like(dY)
 
-    # Choose kernel based on n_cols
-    if n_cols <= 2048:
-        # Use no-tiling kernel for small n_cols
-        _rms_norm_backward_kernel_no_tiling[(grid_size,)](
-            dY,
-            dY.stride(0),
-            dX,
-            dX.stride(0),
-            X,
-            X.stride(0),
-            torch_to_triton_dtype[X.dtype],
-            W,
-            RSTD,
-            RSTD.stride(0),
-            _dW,
-            _dW.stride(0) if elementwise_affine else 0,
-            n_rows,
-            n_cols,
-            offset,
-            casting_mode,
-            elementwise_affine,
-            BLOCK_SIZE_M=BLOCK_SIZE_M,
-            BLOCK_SIZE_N=BLOCK_SIZE,
-        )
+    common = dict(
+        dY_ptr=dY,
+        dY_row_stride=dY.stride(0),
+        dX_ptr=dX,
+        dX_row_stride=dX.stride(0),
+        X_ptr=X,
+        X_row_stride=X.stride(0),
+        X_dtype=torch_to_triton_dtype[X.dtype],
+        W_ptr=w_arg,
+        RSTD_ptr=RSTD,
+        RSTD_row_stride=RSTD.stride(0),
+        dW_ptr=_dW,
+        dW_row_stride=dw_stride,
+        n_rows=n_rows,
+        n_cols=n_cols,
+        offset=offset,
+        casting_mode=casting_mode,
+        elementwise_affine=elementwise_affine,
+        BLOCK_SIZE=col_block,
+    )
+
+    if use_fused:
+        if rows_per_block <= 1:
+            _rms_norm_backward_row[(grid_size,)](**common)
+        else:
+            _rms_norm_backward_fused_2d[(grid_size,)](**common, ROWS_PER_BLOCK=rows_per_block)
     else:
-        # Use tiled kernel for large n_cols
-        _rms_norm_backward_kernel_tiled[(grid_size,)](
-            dY,
-            dY.stride(0),
-            dX,
-            dX.stride(0),
-            X,
-            X.stride(0),
-            torch_to_triton_dtype[X.dtype],
-            W,
-            RSTD,
-            RSTD.stride(0),
-            _dW,
-            _dW.stride(0) if elementwise_affine else 0,
-            n_rows,
-            n_cols,
-            offset,
-            casting_mode,
-            elementwise_affine,
-            BLOCK_SIZE=BLOCK_SIZE,
-        )
+        _rms_norm_backward_tiled[(grid_size,)](**common)
 
     dX = dX.view(*shape)
-
-    if elementwise_affine:
-        dW = _dW.sum(dim=0).to(W.dtype)
-    else:
-        dW = None
-
+    dW = _dW.sum(dim=0).to(W.dtype) if elementwise_affine else None
     return dX, dW
 
 
@@ -741,10 +737,6 @@ class LigerRMSNormFunction(torch.autograd.Function):
         W: (H,)
         """
         if isinstance(X, torch.distributed.tensor.DTensor):
-            # Input tensor is output of a tensor parallel module and
-            # needs to be gathered to a local tensor to compute
-            # RMSE layer norm on each TP worker.
-            # TODO: support CP.
             X = X.full_tensor()
 
         Y, X, RSTD, casting_mode = rms_norm_forward(X, W, eps, offset, casting_mode)
@@ -770,9 +762,6 @@ class LigerRMSNormFunction(torch.autograd.Function):
             X, RSTD = ctx.saved_tensors
             W = None
         if isinstance(dY, torch.distributed.tensor.DTensor):
-            # Gradients are output of a tensor parallel module and
-            # needs to be gathered to a local tensor for computing RMSE layer.
-            # TODO: support CP.
             dY = dY.full_tensor()
 
         dX, dW = rms_norm_backward(dY, X, W, RSTD, ctx.offset, ctx.casting_mode, ctx.in_place)

--- a/src/liger_kernel/ops/backends/_ascend/ops/rope.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/rope.py
@@ -1,238 +1,984 @@
+"""Ascend RoPE with a layout-aware dispatch.
+
+HuggingFace Qwen/LLaMA build q/k as ``(B, S, H, D).transpose(1, 2)``: logical
+BNSD, storage BSHD. Transposing back to BSND is a view (no copy). That path
+loads cos/sin once per (batch, s_tile) and reuses them across heads, matching
+CANN RotaryPositionEmbeddingGrad.
+
+Already-contiguous BNSD stays on the native-BNSD kernels: forcing a BSND
+transpose there copies ~40% of Liger time.
+
+q and k stay sequential on the default stream. Dual-stream overlap fights over
+the same 48 AIV cores and corrupts k; a fused kernel with divergent q/k
+pointers is predicated into illegal GM access. Short aligned shapes (and the
+BSND path) use one two-phase launch (q then k) to hide the second launch.
+
+rotate_half splits each row into (D/2, D/2). Two half-width loads on a
+contiguous (S, D) plane are strided (skip the other half every row) and
+saturate MTE2. The BNSD fast path loads the full (BLOCK_S, D) row, splits in
+UB with extract_slice, and writes one contiguous store.
+
+Four launch kernels cover the old ten via constexpr flags (MASKED, USE_FULLROW,
+USE_FLAT). Binary specializations stay separate; Python dispatch never emits
+MASKED together with USE_FULLROW/USE_FLAT.
+"""
+
+import functools
+
 import torch
 import triton
 import triton.language as tl
+
+from triton.language.extra.cann.extension import extract_slice
+from triton.language.extra.cann.extension import insert_slice
 
 from liger_kernel.ops.backends._ascend.ub_manager import compute_default_tiling_strategy
 from liger_kernel.ops.utils import get_npu_core_count
 
 
 @triton.jit
-def _triton_rope_npu(
-    q_ptr,
-    q_row_stride,
-    k_ptr,
-    k_row_stride,
-    cos,
-    cos_row_stride,
-    sin,
-    sin_row_stride,
-    sl,
-    total_rows: tl.constexpr,
-    cos_bs: tl.constexpr,
-    n_qh: tl.constexpr,
-    n_kh: tl.constexpr,
-    hd: tl.constexpr,
-    BLOCK_Q: tl.constexpr,
-    BLOCK_K: tl.constexpr,
-    BACKWARD_PASS: tl.constexpr = False,
+def _rotate_half(left, right, cos_vals, sin_vals, BACKWARD_PASS: tl.constexpr):
+    """Shared rotate_half body. Specialized kernels only differ in load/store."""
+    if not BACKWARD_PASS:
+        new_left = left * cos_vals - right * sin_vals
+        new_right = right * cos_vals + left * sin_vals
+    else:
+        new_left = left * cos_vals + right * sin_vals
+        new_right = right * cos_vals - left * sin_vals
+    return new_left, new_right
+
+
+@triton.jit
+def _get_work_tile_coord(tile_id, n_s_tiles, n_heads):
+    seq_idx = tile_id % n_s_tiles
+    tmp = tile_id // n_s_tiles
+    head_idx = tmp % n_heads
+    batch_idx = tmp // n_heads
+    return batch_idx, head_idx, seq_idx
+
+
+@triton.jit
+def _load_cos_sin(
+    cos_ptr,
+    sin_ptr,
+    cos_base,
+    sin_base,
+    s_off,
+    d_off,
+    cos_stride_s,
+    sin_stride_s,
+    s0,
+    seq_len,
+    half_hd,
+    MASKED: tl.constexpr,
 ):
-    program_id = tl.program_id(0)
-    num_programs = tl.num_programs(0)
-
-    rows_per_program = (total_rows + num_programs - 1) // num_programs
-    start_row = program_id * rows_per_program
-    actual_rows = tl.minimum(rows_per_program, total_rows - start_row)
-
-    for row_offset in tl.range(0, actual_rows):
-        pid = start_row + row_offset
-
-        row_idx = pid % sl
-        cos_ptr = cos + tl.where(cos_bs == 1, row_idx * cos_row_stride, pid * cos_row_stride)
-        sin_ptr = sin + tl.where(cos_bs == 1, row_idx * sin_row_stride, pid * sin_row_stride)
-
-        # Pre-compute d_idx and cos/sin values outside loops (they don't depend on heads)
-        d_idx = tl.arange(0, hd // 2)
-        d_mask = d_idx < (hd // 2)  # Always True, but kept for clarity
-        cos_vals = tl.load(cos_ptr + d_idx, mask=d_mask, other=0)
-        sin_vals = tl.load(sin_ptr + d_idx, mask=d_mask, other=0)
-
-        # Process q heads in chunks to prevent UB overflow
-        for qh_block in range(0, n_qh, BLOCK_Q):
-            qh_idx = tl.arange(0, BLOCK_Q) + qh_block
-            qh_mask = qh_idx < n_qh
-
-            # block_mask: qh_mask broadcasted over d_idx dimension
-            block_mask = qh_mask[:, None]
-
-            offsets = qh_idx[:, None] * hd + d_idx[None, :]
-            q_base = q_ptr + pid * q_row_stride
-
-            q_left = tl.load(q_base + offsets, mask=block_mask, other=0)
-            q_right = tl.load(q_base + offsets + (hd // 2), mask=block_mask, other=0)
-
-            if not BACKWARD_PASS:
-                new_left = q_left * cos_vals - q_right * sin_vals
-                new_right = q_right * cos_vals + q_left * sin_vals
-            else:
-                new_left = q_left * cos_vals + q_right * sin_vals
-                new_right = q_right * cos_vals - q_left * sin_vals
-
-            tl.store(q_base + offsets, new_left, mask=block_mask)
-            tl.store(q_base + offsets + (hd // 2), new_right, mask=block_mask)
-
-        # Process k heads in chunks to prevent UB overflow
-        for kh_block in range(0, n_kh, BLOCK_K):
-            kh_idx = tl.arange(0, BLOCK_K) + kh_block
-            kh_mask = kh_idx < n_kh
-
-            # block_mask: kh_mask broadcasted over d_idx dimension
-            block_mask = kh_mask[:, None]
-
-            offsets = kh_idx[:, None] * hd + d_idx[None, :]
-            k_base = k_ptr + pid * k_row_stride
-
-            k_left = tl.load(k_base + offsets, mask=block_mask, other=0)
-            k_right = tl.load(k_base + offsets + (hd // 2), mask=block_mask, other=0)
-
-            if not BACKWARD_PASS:
-                new_left = k_left * cos_vals - k_right * sin_vals
-                new_right = k_right * cos_vals + k_left * sin_vals
-            else:
-                new_left = k_left * cos_vals + k_right * sin_vals
-                new_right = k_right * cos_vals - k_left * sin_vals
-
-            tl.store(k_base + offsets, new_left, mask=block_mask)
-            tl.store(k_base + offsets + (hd // 2), new_right, mask=block_mask)
+    if MASKED:
+        s_mask = (s0 + s_off) < seq_len
+        d_mask = d_off < half_hd
+        block_mask = s_mask[:, None] & d_mask[None, :]
+        cos_vals = tl.load(
+            cos_ptr + cos_base + s_off[:, None] * cos_stride_s + d_off[None, :],
+            mask=block_mask,
+            other=0,
+        )
+        sin_vals = tl.load(
+            sin_ptr + sin_base + s_off[:, None] * sin_stride_s + d_off[None, :],
+            mask=block_mask,
+            other=0,
+        )
+    else:
+        cos_vals = tl.load(cos_ptr + cos_base + s_off[:, None] * cos_stride_s + d_off[None, :])
+        sin_vals = tl.load(sin_ptr + sin_base + s_off[:, None] * sin_stride_s + d_off[None, :])
+    return cos_vals, sin_vals
 
 
-def get_optimal_block_size(pad_n_q_head, pad_n_kv_head, pad_hd, dtype_size):
-    # Compute tiling strategy based on UB capacity
-    # ROPE forward tiling strategy (based on optimized ROPE kernel):
-    # - cos_vals and sin_vals are loaded once outside loops (shared): pad_hd // 2 elements each
-    # - In q heads loop (peak memory):
-    #   * q_left: BLOCK_Q * (pad_hd // 2) elements
-    #   * q_right: BLOCK_Q * (pad_hd // 2) elements
-    #   * new_left: BLOCK_Q * (pad_hd // 2) elements (intermediate result)
-    #   * new_right: BLOCK_Q * (pad_hd // 2) elements (intermediate result)
-    #   * Total: 4 * BLOCK_Q * (pad_hd // 2) = 2 * BLOCK_Q * pad_hd elements
-    # - In k heads loop (peak memory):
-    #   * k_left: BLOCK_K * (pad_hd // 2) elements
-    #   * k_right: BLOCK_K * (pad_hd // 2) elements
-    #   * new_left: BLOCK_K * (pad_hd // 2) elements (intermediate result)
-    #   * new_right: BLOCK_K * (pad_hd // 2) elements (intermediate result)
-    #   * Total: 4 * BLOCK_K * (pad_hd // 2) = 2 * BLOCK_K * pad_hd elements
-    # - Since q and k are processed separately, peak memory is max(BLOCK_Q, BLOCK_K) case
-    # - Plus shared cos/sin: 2 * (pad_hd // 2) = pad_hd elements
-    # - Conservative estimate: (2 * BLOCK_SIZE * pad_hd + pad_hd) * dtype_size * 8 bits
-    # - Simplified: (2 * BLOCK_SIZE + 1) * pad_hd * dtype_size * 8 bits
-    # - For safety, use: memory_multiplier=3.0 * BLOCK_SIZE * pad_hd * dtype_size * 8 bits
-    # - shapes: ((pad_n_q_head, pad_hd), (pad_n_kv_head, pad_hd))
-    # - tiling_dims: (0, 0) means first dimension of each shape can be tiled
-    # - Returns: ((block_size_q, pad_hd), (block_size_kv, pad_hd))
-    shapes = ((pad_n_q_head, pad_hd), (pad_n_kv_head, pad_hd))
+@triton.jit
+def _apply_rope_halves(
+    x_ptr,
+    x_out_ptr,
+    x_base,
+    x_stride_s,
+    s_off,
+    d_off,
+    half_hd,
+    cos_vals,
+    sin_vals,
+    s0,
+    seq_len,
+    BACKWARD_PASS: tl.constexpr,
+    MASKED: tl.constexpr,
+):
+    if MASKED:
+        s_mask = (s0 + s_off) < seq_len
+        d_mask = d_off < half_hd
+        block_mask = s_mask[:, None] & d_mask[None, :]
+        x_left = tl.load(
+            x_ptr + x_base + s_off[:, None] * x_stride_s + d_off[None, :],
+            mask=block_mask,
+            other=0,
+        )
+        x_right = tl.load(
+            x_ptr + x_base + s_off[:, None] * x_stride_s + (d_off + half_hd)[None, :],
+            mask=block_mask,
+            other=0,
+        )
+        new_left, new_right = _rotate_half(x_left, x_right, cos_vals, sin_vals, BACKWARD_PASS)
+        tl.store(x_out_ptr + x_base + s_off[:, None] * x_stride_s + d_off[None, :], new_left, mask=block_mask)
+        tl.store(
+            x_out_ptr + x_base + s_off[:, None] * x_stride_s + (d_off + half_hd)[None, :], new_right, mask=block_mask
+        )
+    else:
+        x_left = tl.load(x_ptr + x_base + s_off[:, None] * x_stride_s + d_off[None, :])
+        x_right = tl.load(x_ptr + x_base + s_off[:, None] * x_stride_s + (d_off + half_hd)[None, :])
+        new_left, new_right = _rotate_half(x_left, x_right, cos_vals, sin_vals, BACKWARD_PASS)
+        tl.store(x_out_ptr + x_base + s_off[:, None] * x_stride_s + d_off[None, :], new_left)
+        tl.store(x_out_ptr + x_base + s_off[:, None] * x_stride_s + (d_off + half_hd)[None, :], new_right)
+
+
+@triton.jit
+def _apply_rope_fullrow(
+    x_ptr,
+    x_out_ptr,
+    x_base,
+    x_stride_s,
+    s_off,
+    cos_vals,
+    sin_vals,
+    hd: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BACKWARD_PASS: tl.constexpr,
+):
+    # arange(0, hd) lives here so parent kernels never see a non-pow2 hd.
+    d_full = tl.arange(0, hd)
+    x = tl.load(x_ptr + x_base + s_off[:, None] * x_stride_s + d_full[None, :])
+    left = extract_slice(x, (0, 0), (BLOCK_S, BLOCK_D), (1, 1))
+    right = extract_slice(x, (0, BLOCK_D), (BLOCK_S, BLOCK_D), (1, 1))
+    new_left, new_right = _rotate_half(left, right, cos_vals, sin_vals, BACKWARD_PASS)
+    y = insert_slice(x, new_left, (0, 0), (BLOCK_S, BLOCK_D), (1, 1))
+    y = insert_slice(y, new_right, (0, BLOCK_D), (BLOCK_S, BLOCK_D), (1, 1))
+    tl.store(x_out_ptr + x_base + s_off[:, None] * x_stride_s + d_full[None, :], y)
+
+
+@triton.jit
+def _apply_rope_flat(
+    x_ptr,
+    x_out_ptr,
+    x_base,
+    row,
+    d_off,
+    half_hd,
+    hd: tl.constexpr,
+    cos_vals,
+    sin_vals,
+    BACKWARD_PASS: tl.constexpr,
+):
+    x_left = tl.load(x_ptr + x_base + row[:, None] * hd + d_off[None, :])
+    x_right = tl.load(x_ptr + x_base + row[:, None] * hd + (d_off + half_hd)[None, :])
+    new_left, new_right = _rotate_half(x_left, x_right, cos_vals, sin_vals, BACKWARD_PASS)
+    tl.store(x_out_ptr + x_base + row[:, None] * hd + d_off[None, :], new_left)
+    tl.store(x_out_ptr + x_base + row[:, None] * hd + (d_off + half_hd)[None, :], new_right)
+
+
+@triton.jit
+def _rope_bnsd_tile(
+    x_ptr,
+    x_out_ptr,
+    cos_ptr,
+    sin_ptr,
+    x_base,
+    cos_base,
+    sin_base,
+    x_stride_s,
+    cos_stride_s,
+    sin_stride_s,
+    s_off,
+    d_off,
+    half_hd,
+    seq_len,
+    s0,
+    hd: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    MASKED: tl.constexpr,
+    USE_FULLROW: tl.constexpr,
+    BACKWARD_PASS: tl.constexpr,
+):
+    cos_vals, sin_vals = _load_cos_sin(
+        cos_ptr, sin_ptr, cos_base, sin_base, s_off, d_off, cos_stride_s, sin_stride_s, s0, seq_len, half_hd, MASKED
+    )
+    if USE_FULLROW:
+        _apply_rope_fullrow(
+            x_ptr, x_out_ptr, x_base, x_stride_s, s_off, cos_vals, sin_vals, hd, BLOCK_S, BLOCK_D, BACKWARD_PASS
+        )
+    else:
+        _apply_rope_halves(
+            x_ptr,
+            x_out_ptr,
+            x_base,
+            x_stride_s,
+            s_off,
+            d_off,
+            half_hd,
+            cos_vals,
+            sin_vals,
+            s0,
+            seq_len,
+            BACKWARD_PASS,
+            MASKED,
+        )
+
+
+@triton.jit
+def _triton_rope_bnsd(
+    x_ptr,
+    x_out_ptr,
+    cos_ptr,
+    sin_ptr,
+    x_stride_b,
+    x_stride_h,
+    x_stride_s,
+    cos_stride_b,
+    cos_stride_s,
+    sin_stride_b,
+    sin_stride_s,
+    seq_len,
+    n_heads,
+    n_s_tiles,
+    total_tiles,
+    hd: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BACKWARD_PASS: tl.constexpr,
+    MASKED: tl.constexpr,
+    USE_FULLROW: tl.constexpr,
+):
+    """BNSD single-tensor. Replaces aligned / fullrow / masked."""
+    pid = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+    s_off = tl.arange(0, BLOCK_S)
+    d_off = tl.arange(0, BLOCK_D)
+    half_hd = hd // 2
+    for tile_id in tl.range(pid, total_tiles, num_progs):
+        batch_idx, head_idx, seq_idx = _get_work_tile_coord(tile_id, n_s_tiles, n_heads)
+        s0 = seq_idx * BLOCK_S
+        cos_base = batch_idx * cos_stride_b + s0 * cos_stride_s
+        sin_base = batch_idx * sin_stride_b + s0 * sin_stride_s
+        x_base = batch_idx * x_stride_b + head_idx * x_stride_h + s0 * x_stride_s
+        _rope_bnsd_tile(
+            x_ptr,
+            x_out_ptr,
+            cos_ptr,
+            sin_ptr,
+            x_base,
+            cos_base,
+            sin_base,
+            x_stride_s,
+            cos_stride_s,
+            sin_stride_s,
+            s_off,
+            d_off,
+            half_hd,
+            seq_len,
+            s0,
+            hd,
+            BLOCK_S,
+            BLOCK_D,
+            MASKED,
+            USE_FULLROW,
+            BACKWARD_PASS,
+        )
+
+
+@triton.jit
+def _triton_rope_bnsd_qk(
+    q_ptr,
+    q_out_ptr,
+    k_ptr,
+    k_out_ptr,
+    cos_ptr,
+    sin_ptr,
+    q_stride_b,
+    q_stride_h,
+    q_stride_s,
+    k_stride_b,
+    k_stride_h,
+    k_stride_s,
+    cos_stride_b,
+    cos_stride_s,
+    sin_stride_b,
+    sin_stride_s,
+    n_q_heads,
+    n_k_heads,
+    n_s_tiles,
+    q_tiles,
+    k_tiles,
+    hd: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BACKWARD_PASS: tl.constexpr,
+    USE_FULLROW: tl.constexpr,
+):
+    """Sequential q-then-k phases in one launch. Replaces aligned_qk / fullrow_qk.
+
+    Pointers are never predicated against the other tensor, so addresses stay
+    in-bounds.
+    """
+    pid = tl.program_id(0).to(tl.int64)
+    num_progs = tl.num_programs(0).to(tl.int64)
+    s_off = tl.arange(0, BLOCK_S)
+    d_off = tl.arange(0, BLOCK_D)
+    half_hd = hd // 2
+    seq_len = 0
+    for tile_id in tl.range(pid, q_tiles, num_progs):
+        batch_idx, head_idx, seq_idx = _get_work_tile_coord(tile_id, n_s_tiles, n_q_heads)
+        s0 = seq_idx * BLOCK_S
+        cos_base = batch_idx * cos_stride_b + s0 * cos_stride_s
+        sin_base = batch_idx * sin_stride_b + s0 * sin_stride_s
+        x_base = batch_idx * q_stride_b + head_idx * q_stride_h + s0 * q_stride_s
+        _rope_bnsd_tile(
+            q_ptr,
+            q_out_ptr,
+            cos_ptr,
+            sin_ptr,
+            x_base,
+            cos_base,
+            sin_base,
+            q_stride_s,
+            cos_stride_s,
+            sin_stride_s,
+            s_off,
+            d_off,
+            half_hd,
+            seq_len,
+            s0,
+            hd,
+            BLOCK_S,
+            BLOCK_D,
+            False,
+            USE_FULLROW,
+            BACKWARD_PASS,
+        )
+    for tile_id in tl.range(pid, k_tiles, num_progs):
+        batch_idx, head_idx, seq_idx = _get_work_tile_coord(tile_id, n_s_tiles, n_k_heads)
+        s0 = seq_idx * BLOCK_S
+        cos_base = batch_idx * cos_stride_b + s0 * cos_stride_s
+        sin_base = batch_idx * sin_stride_b + s0 * sin_stride_s
+        x_base = batch_idx * k_stride_b + head_idx * k_stride_h + s0 * k_stride_s
+        _rope_bnsd_tile(
+            k_ptr,
+            k_out_ptr,
+            cos_ptr,
+            sin_ptr,
+            x_base,
+            cos_base,
+            sin_base,
+            k_stride_s,
+            cos_stride_s,
+            sin_stride_s,
+            s_off,
+            d_off,
+            half_hd,
+            seq_len,
+            s0,
+            hd,
+            BLOCK_S,
+            BLOCK_D,
+            False,
+            USE_FULLROW,
+            BACKWARD_PASS,
+        )
+
+
+@triton.jit
+def _triton_rope_bsnd(
+    x_ptr,
+    x_out_ptr,
+    cos_ptr,
+    sin_ptr,
+    x_stride_b,
+    x_stride_s,
+    x_stride_h,
+    cos_stride_b,
+    cos_stride_s,
+    sin_stride_b,
+    sin_stride_s,
+    n_heads,
+    seq_len,
+    n_s_tiles,
+    total_tiles,
+    hd: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BACKWARD_PASS: tl.constexpr,
+    MASKED: tl.constexpr,
+    USE_FLAT: tl.constexpr,
+):
+    """Contiguous BSND (B, S, H, D). Replaces bsnd / bsnd_flat / bsnd_masked.
+
+    Three mutually exclusive tile paths (Python sets MASKED and USE_FLAT):
+
+    * **MASKED** (``aligned=False``): ``seq_len % BLOCK_S != 0`` or
+      ``BLOCK_D != head_dim // 2``. Tail sequence positions get load/store
+      masks; cos/sin are loaded once per (batch, s_tile) and reused in a
+      per-head ``tl.range`` loop.
+
+    * **USE_FLAT** (``aligned and _can_flat_bsnd``): ``n_heads`` and
+      ``BLOCK_S * n_heads`` are both unpadded powers of two. The
+      ``(BLOCK_S, H, D)`` tile is flattened to ``(BLOCK_S * H, D)`` so each
+      head row is contiguous in GM — one unmasked vector load/store per tile,
+      no head loop, no tail masks. Typical training shapes (e.g. H=32/64).
+
+    * **Head-loop** (``aligned and not USE_FLAT``): full tiles, no tail masks,
+      but H is not a power of two (e.g. GQA H=8) so rows cannot be flattened;
+      cos/sin load once per (batch, s_tile), then ``tl.range(0, n_heads)``.
+    """
+    pid = tl.program_id(0).to(tl.int64)
+    num_progs = tl.num_programs(0).to(tl.int64)
+    d_off = tl.arange(0, BLOCK_D)
+    half_hd = hd // 2
+    if USE_FLAT:
+        BLOCK_ROWS: tl.constexpr = BLOCK_S * BLOCK_H
+        row = tl.arange(0, BLOCK_ROWS)
+        s_idx = row // BLOCK_H
+        for tile_id in tl.range(pid, total_tiles, num_progs):
+            s_tile = tile_id % n_s_tiles
+            batch_idx = tile_id // n_s_tiles
+            s0 = s_tile * BLOCK_S
+            x_base = batch_idx * x_stride_b + s0 * x_stride_s
+            cos_base = batch_idx * cos_stride_b + s0 * cos_stride_s
+            sin_base = batch_idx * sin_stride_b + s0 * sin_stride_s
+            cos_vals = tl.load(cos_ptr + cos_base + s_idx[:, None] * cos_stride_s + d_off[None, :])
+            sin_vals = tl.load(sin_ptr + sin_base + s_idx[:, None] * sin_stride_s + d_off[None, :])
+            _apply_rope_flat(x_ptr, x_out_ptr, x_base, row, d_off, half_hd, hd, cos_vals, sin_vals, BACKWARD_PASS)
+    else:
+        s_off = tl.arange(0, BLOCK_S)
+        for tile_id in tl.range(pid, total_tiles, num_progs):
+            s_tile = tile_id % n_s_tiles
+            batch_idx = tile_id // n_s_tiles
+            s0 = s_tile * BLOCK_S
+            cos_base = batch_idx * cos_stride_b + s0 * cos_stride_s
+            sin_base = batch_idx * sin_stride_b + s0 * sin_stride_s
+            x_base = batch_idx * x_stride_b + s0 * x_stride_s
+            cos_vals, sin_vals = _load_cos_sin(
+                cos_ptr,
+                sin_ptr,
+                cos_base,
+                sin_base,
+                s_off,
+                d_off,
+                cos_stride_s,
+                sin_stride_s,
+                s0,
+                seq_len,
+                half_hd,
+                MASKED,
+            )
+            for h in tl.range(0, n_heads):
+                x_row = x_base + h * x_stride_h
+                _apply_rope_halves(
+                    x_ptr,
+                    x_out_ptr,
+                    x_row,
+                    x_stride_s,
+                    s_off,
+                    d_off,
+                    half_hd,
+                    cos_vals,
+                    sin_vals,
+                    s0,
+                    seq_len,
+                    BACKWARD_PASS,
+                    MASKED,
+                )
+
+
+@triton.jit
+def _triton_rope_bsnd_qk(
+    q_ptr,
+    q_out_ptr,
+    k_ptr,
+    k_out_ptr,
+    cos_ptr,
+    sin_ptr,
+    q_stride_b,
+    q_stride_s,
+    q_stride_h,
+    k_stride_b,
+    k_stride_s,
+    k_stride_h,
+    cos_stride_b,
+    cos_stride_s,
+    sin_stride_b,
+    sin_stride_s,
+    n_q_heads,
+    n_k_heads,
+    n_s_tiles,
+    total_tiles,
+    hd: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+    BLOCK_HQ: tl.constexpr,
+    BLOCK_HK: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BACKWARD_PASS: tl.constexpr,
+    USE_FLAT: tl.constexpr,
+):
+    """Sequential q-then-k with one cos/sin load per (batch, s_tile). Replaces bsnd_qk / bsnd_qk_flat."""
+    pid = tl.program_id(0).to(tl.int64)
+    num_progs = tl.num_programs(0).to(tl.int64)
+    d_off = tl.arange(0, BLOCK_D)
+    half_hd = hd // 2
+    if USE_FLAT:
+        Q_ROWS: tl.constexpr = BLOCK_S * BLOCK_HQ
+        K_ROWS: tl.constexpr = BLOCK_S * BLOCK_HK
+        q_row = tl.arange(0, Q_ROWS)
+        k_row = tl.arange(0, K_ROWS)
+        q_s = q_row // BLOCK_HQ
+        k_s = k_row // BLOCK_HK
+        for tile_id in tl.range(pid, total_tiles, num_progs):
+            s_tile = tile_id % n_s_tiles
+            batch_idx = tile_id // n_s_tiles
+            s0 = s_tile * BLOCK_S
+            q_base = batch_idx * q_stride_b + s0 * q_stride_s
+            k_base = batch_idx * k_stride_b + s0 * k_stride_s
+            cos_base = batch_idx * cos_stride_b + s0 * cos_stride_s
+            sin_base = batch_idx * sin_stride_b + s0 * sin_stride_s
+            q_cos = tl.load(cos_ptr + cos_base + q_s[:, None] * cos_stride_s + d_off[None, :])
+            q_sin = tl.load(sin_ptr + sin_base + q_s[:, None] * sin_stride_s + d_off[None, :])
+            _apply_rope_flat(q_ptr, q_out_ptr, q_base, q_row, d_off, half_hd, hd, q_cos, q_sin, BACKWARD_PASS)
+            k_cos = tl.load(cos_ptr + cos_base + k_s[:, None] * cos_stride_s + d_off[None, :])
+            k_sin = tl.load(sin_ptr + sin_base + k_s[:, None] * sin_stride_s + d_off[None, :])
+            _apply_rope_flat(k_ptr, k_out_ptr, k_base, k_row, d_off, half_hd, hd, k_cos, k_sin, BACKWARD_PASS)
+    else:
+        s_off = tl.arange(0, BLOCK_S)
+        seq_len = 0
+        for tile_id in tl.range(pid, total_tiles, num_progs):
+            s_tile = tile_id % n_s_tiles
+            batch_idx = tile_id // n_s_tiles
+            s0 = s_tile * BLOCK_S
+            cos_base = batch_idx * cos_stride_b + s0 * cos_stride_s
+            sin_base = batch_idx * sin_stride_b + s0 * sin_stride_s
+            cos_vals, sin_vals = _load_cos_sin(
+                cos_ptr,
+                sin_ptr,
+                cos_base,
+                sin_base,
+                s_off,
+                d_off,
+                cos_stride_s,
+                sin_stride_s,
+                s0,
+                seq_len,
+                half_hd,
+                False,
+            )
+            q_base = batch_idx * q_stride_b + s0 * q_stride_s
+            for h in tl.range(0, n_q_heads):
+                x_row = q_base + h * q_stride_h
+                _apply_rope_halves(
+                    q_ptr,
+                    q_out_ptr,
+                    x_row,
+                    q_stride_s,
+                    s_off,
+                    d_off,
+                    half_hd,
+                    cos_vals,
+                    sin_vals,
+                    s0,
+                    seq_len,
+                    BACKWARD_PASS,
+                    False,
+                )
+            k_base = batch_idx * k_stride_b + s0 * k_stride_s
+            for h in tl.range(0, n_k_heads):
+                x_row = k_base + h * k_stride_h
+                _apply_rope_halves(
+                    k_ptr,
+                    k_out_ptr,
+                    x_row,
+                    k_stride_s,
+                    s_off,
+                    d_off,
+                    half_hd,
+                    cos_vals,
+                    sin_vals,
+                    s0,
+                    seq_len,
+                    BACKWARD_PASS,
+                    False,
+                )
+
+
+@functools.lru_cache(maxsize=64)
+def _rope_block_s(seq_len: int, head_dim: int) -> int:
+    half = max(1, triton.next_power_of_2(head_dim // 2))
     tile_shapes = compute_default_tiling_strategy(
-        safety_margin=0.90,
-        dtype_size=dtype_size,
-        memory_multiplier=3.0,
-        shapes=shapes,
-        tiling_dims=(0, 0),
+        safety_margin=0.70,
+        dtype_size=4,
+        memory_multiplier=8.0,
+        shapes=((seq_len, half),),
+        tiling_dims=(0,),
+    )
+    if tile_shapes:
+        block_s = max(8, tile_shapes[0][0])
+    else:
+        block_s = 32
+    return min(block_s, triton.next_power_of_2(seq_len), 64)
+
+
+def _as_bnsd_cos_sin(cos, sin):
+    """Accept (seq, dim) vision tables or (batch, seq, dim) tables."""
+    if cos.dim() == 2:
+        cos = cos.unsqueeze(0)
+        sin = sin.unsqueeze(0)
+    if cos.dim() != 3:
+        raise ValueError(f"Unsupported cos rank {cos.dim()}, expected 2 or 3")
+    return cos, sin
+
+
+def _cos_sin_strides(cos, sin):
+    cos_bs = cos.shape[0]
+    cos_stride_b = 0 if cos_bs == 1 else cos.stride(0)
+    sin_stride_b = 0 if cos_bs == 1 else sin.stride(0)
+    return cos_stride_b, cos.stride(1), sin_stride_b, sin.stride(1)
+
+
+def _ensure_innermost_contiguous(t):
+    return t if t.stride(-1) == 1 else t.contiguous()
+
+
+def _as_contiguous_bnsd(t):
+    """Force standard contiguous (B, H, S, D).
+
+    HuggingFace Qwen3 (and most LLaMA-style models) build q/k as
+    ``view(B, S, H, D).transpose(1, 2)`` so the logical layout is BNSD but
+    the storage is still BSHD (``stride(-1)==1`` yet ``not is_contiguous()``).
+    ``empty_like`` on NPU then allocates a *contiguous* buffer while the
+    kernel still indexes with the input's strided BSHD layout, so stores
+    land in the wrong places and FlashAttention sees garbage (loss ~ln(V)).
+    """
+    return t if t.is_contiguous() else t.contiguous()
+
+
+def _is_free_bsnd(t) -> bool:
+    """True when ``t.transpose(1, 2)`` is a contiguous BSND view (no copy)."""
+    return t is not None and t.dim() == 4 and t.stride(-1) == 1 and t.transpose(1, 2).is_contiguous()
+
+
+@functools.lru_cache(maxsize=128)
+def _bsnd_block_s(seq_len: int, n_heads: int, head_dim: int, dtype_size: int = 2) -> int:
+    """S-tile for the BSND kernel.
+
+    Flattened (BLOCK_S * H, D/2) tiles must fit UB; the head-loop fallback
+    is smaller, so this heuristic is sized for the flattened path.
+    """
+    half = max(1, triton.next_power_of_2(head_dim // 2))
+    n_heads = max(1, n_heads)
+    # 6 live (BLOCK_S, H, D/2) tiles at 4 bytes so fp32 cannot UB-overflow.
+    denom = 6 * n_heads * half * 4
+    max_s = max(1, (96 * 1024) // denom) if denom else 1
+    block_s = 1
+    cap = min(32, triton.next_power_of_2(max(1, seq_len)), max_s)
+    while block_s * 2 <= cap:
+        block_s *= 2
+    cores = get_npu_core_count()
+    while block_s > 1 and (seq_len // block_s) < cores:
+        block_s //= 2
+    return max(1, block_s)
+
+
+def _can_flat_bsnd(n_heads: int, block_s: int) -> bool:
+    """True when the BSND tile can be flattened to (BLOCK_S * H, D) rows.
+
+    Requires unpadded power-of-two ``n_heads`` and ``block_s * n_heads`` so
+    ``tl.arange(0, BLOCK_S * BLOCK_H)`` is legal and every head row in the
+    tile is contiguous in GM. When False but ``seq_len % block_s == 0``, the
+    head-loop path still runs without tail masks (see ``MASKED`` in
+    ``_triton_rope_bsnd``).
+    """
+    rows = block_s * n_heads
+    return n_heads == triton.next_power_of_2(n_heads) and rows == triton.next_power_of_2(rows)
+
+
+def _use_fullrow(head_dim: int, block_d: int, seq_len: int, block_s: int) -> bool:
+    """Full-row DMA needs a power-of-two hd so tl.arange(0, hd) is legal.
+
+    Tiny BLOCK_S (functional S=2) trips a vector-core exception in
+    extract_slice / insert_slice; keep those shapes on the half-load kernel.
+    """
+    return (
+        block_s >= 32
+        and head_dim >= 64
+        and seq_len % block_s == 0
+        and head_dim == block_d * 2
+        and head_dim == triton.next_power_of_2(head_dim)
     )
 
-    if tile_shapes is not None and len(tile_shapes) == len(shapes):
-        # Strategy returns ((block_size_q, pad_hd), (block_size_kv, pad_hd))
-        q_tile_shape, k_tile_shape = tile_shapes
-        BLOCK_Q, _ = q_tile_shape
-        BLOCK_K, _ = k_tile_shape
-    else:
-        # Fallback to conservative defaults
-        BLOCK_Q = 2048
-        BLOCK_K = 2048
 
-    return BLOCK_Q, BLOCK_K
+def _launch_one(x, x_out, cos, sin, backward: bool, block_s: int, block_d: int):
+    batch_size, n_heads, seq_len, head_dim = x.shape
+    n_s_tiles = triton.cdiv(seq_len, block_s)
+    total_tiles = batch_size * n_heads * n_s_tiles
+    aligned = seq_len % block_s == 0 and block_d == (head_dim // 2)
+    use_fullrow = _use_fullrow(head_dim, block_d, seq_len, block_s)
+    cos_stride_b, cos_stride_s, sin_stride_b, sin_stride_s = _cos_sin_strides(cos, sin)
+    # Oversubscribing (num_cores * 2) lengthens this kernel; 48 persistent
+    # programs with a grid-stride loop is the measured peak.
+    grid_size = max(1, min(get_npu_core_count(), total_tiles))
+    _triton_rope_bnsd[(grid_size,)](
+        x,
+        x_out,
+        cos,
+        sin,
+        x.stride(0),
+        x.stride(1),
+        x.stride(2),
+        cos_stride_b,
+        cos_stride_s,
+        sin_stride_b,
+        sin_stride_s,
+        seq_len,
+        n_heads,
+        n_s_tiles,
+        total_tiles,
+        head_dim,
+        BLOCK_S=block_s,
+        BLOCK_D=block_d,
+        BACKWARD_PASS=backward,
+        MASKED=not aligned,
+        USE_FULLROW=use_fullrow,
+    )
+
+
+def _launch_qk_aligned(q, q_out, k, k_out, cos, sin, backward: bool, block_s: int, block_d: int):
+    batch_size, n_q_heads, seq_len, head_dim = q.shape
+    n_k_heads = k.shape[1]
+    n_s_tiles = triton.cdiv(seq_len, block_s)
+    q_tiles = batch_size * n_q_heads * n_s_tiles
+    k_tiles = batch_size * n_k_heads * n_s_tiles
+    grid_size = max(1, min(get_npu_core_count(), q_tiles + k_tiles))
+    cos_stride_b, cos_stride_s, sin_stride_b, sin_stride_s = _cos_sin_strides(cos, sin)
+    _triton_rope_bnsd_qk[(grid_size,)](
+        q,
+        q_out,
+        k,
+        k_out,
+        cos,
+        sin,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        cos_stride_b,
+        cos_stride_s,
+        sin_stride_b,
+        sin_stride_s,
+        n_q_heads,
+        n_k_heads,
+        n_s_tiles,
+        q_tiles,
+        k_tiles,
+        head_dim,
+        BLOCK_S=block_s,
+        BLOCK_D=block_d,
+        BACKWARD_PASS=backward,
+        USE_FULLROW=_use_fullrow(head_dim, block_d, seq_len, block_s),
+    )
+
+
+def _launch_bsnd_one(x_bsnd, x_out_bsnd, cos, sin, backward: bool, block_s: int, block_d: int):
+    batch_size, seq_len, n_heads, head_dim = x_bsnd.shape
+    n_s_tiles = triton.cdiv(seq_len, block_s)
+    total_tiles = batch_size * n_s_tiles
+    aligned = seq_len % block_s == 0 and block_d == (head_dim // 2)
+    use_flat = aligned and _can_flat_bsnd(n_heads, block_s)
+    grid_size = max(1, min(get_npu_core_count(), total_tiles))
+    cos_stride_b, cos_stride_s, sin_stride_b, sin_stride_s = _cos_sin_strides(cos, sin)
+    _triton_rope_bsnd[(grid_size,)](
+        x_bsnd,
+        x_out_bsnd,
+        cos,
+        sin,
+        x_bsnd.stride(0),
+        x_bsnd.stride(1),
+        x_bsnd.stride(2),
+        cos_stride_b,
+        cos_stride_s,
+        sin_stride_b,
+        sin_stride_s,
+        n_heads,
+        seq_len,
+        n_s_tiles,
+        total_tiles,
+        head_dim,
+        BLOCK_S=block_s,
+        BLOCK_H=n_heads,
+        BLOCK_D=block_d,
+        BACKWARD_PASS=backward,
+        MASKED=not aligned,
+        USE_FLAT=use_flat,
+    )
+
+
+def _launch_bsnd_qk(q_bsnd, q_out, k_bsnd, k_out, cos, sin, backward: bool, block_s: int, block_d: int):
+    batch_size, seq_len, n_q_heads, head_dim = q_bsnd.shape
+    n_k_heads = k_bsnd.shape[2]
+    n_s_tiles = triton.cdiv(seq_len, block_s)
+    total_tiles = batch_size * n_s_tiles
+    grid_size = max(1, min(get_npu_core_count(), total_tiles))
+    use_flat = _can_flat_bsnd(n_q_heads, block_s) and _can_flat_bsnd(n_k_heads, block_s)
+    cos_stride_b, cos_stride_s, sin_stride_b, sin_stride_s = _cos_sin_strides(cos, sin)
+    _triton_rope_bsnd_qk[(grid_size,)](
+        q_bsnd,
+        q_out,
+        k_bsnd,
+        k_out,
+        cos,
+        sin,
+        q_bsnd.stride(0),
+        q_bsnd.stride(1),
+        q_bsnd.stride(2),
+        k_bsnd.stride(0),
+        k_bsnd.stride(1),
+        k_bsnd.stride(2),
+        cos_stride_b,
+        cos_stride_s,
+        sin_stride_b,
+        sin_stride_s,
+        n_q_heads,
+        n_k_heads,
+        n_s_tiles,
+        total_tiles,
+        head_dim,
+        BLOCK_S=block_s,
+        BLOCK_HQ=n_q_heads,
+        BLOCK_HK=n_k_heads,
+        BLOCK_D=block_d,
+        BACKWARD_PASS=backward,
+        USE_FLAT=use_flat,
+    )
+
+
+def _hf_like(t):
+    """Allocate BNSD output with HF BSHD storage (``transpose(1,2)`` is BSND).
+
+    ``torch.empty_like(t)`` would allocate standard contiguous ``(B, H, S, D)``
+    storage because ``t`` is already logically BNSD. The kernel indexes with
+    ``t``'s strided BSHD layout, so a contiguous ``(B, H, S, D)`` buffer would
+    store results at the wrong offsets.
+    """
+    b, h, s, d = t.shape
+    return torch.empty((b, s, h, d), device=t.device, dtype=t.dtype).transpose(1, 2)
+
+
+def _launch_bsnd(q, k, cos, sin, backward: bool, q_out=None, k_out=None):
+    """RoPE on the contiguous BSND view of HF-layout BNSD tensors.
+
+    Accepts optional ``q_out``/``k_out`` in BNSD layout (same as ``_launch_bnsd``).
+    Pass the input tensor for in-place store (backward); omit for a fresh buffer.
+    """
+    q_bsnd = q.transpose(1, 2) if q is not None else None
+    k_bsnd = k.transpose(1, 2) if k is not None else None
+    if q is not None:
+        if q_out is None:
+            q_out = _hf_like(q)
+        q_out_bsnd = q_out.transpose(1, 2)
+    else:
+        q_out = None
+        q_out_bsnd = None
+    if k is not None:
+        if k_out is None:
+            k_out = _hf_like(k)
+        k_out_bsnd = k_out.transpose(1, 2)
+    else:
+        k_out = None
+        k_out_bsnd = None
+    ref = q_bsnd if q_bsnd is not None else k_bsnd
+    head_dim = ref.shape[-1]
+    seq_len = ref.shape[1]
+    block_d = triton.next_power_of_2(max(1, head_dim // 2))
+    block_s = _bsnd_block_s(
+        seq_len,
+        max(q.shape[1] if q is not None else 1, k.shape[1] if k is not None else 1),
+        head_dim,
+        ref.element_size(),
+    )
+    aligned = seq_len % block_s == 0 and block_d == (head_dim // 2)
+    if q_bsnd is not None and k_bsnd is not None and aligned:
+        _launch_bsnd_qk(q_bsnd, q_out_bsnd, k_bsnd, k_out_bsnd, cos, sin, backward, block_s, block_d)
+    else:
+        if q_bsnd is not None:
+            _launch_bsnd_one(q_bsnd, q_out_bsnd, cos, sin, backward, block_s, block_d)
+        if k_bsnd is not None:
+            _launch_bsnd_one(k_bsnd, k_out_bsnd, cos, sin, backward, block_s, block_d)
+    if head_dim % 2:
+        mid = head_dim - 1
+        if q_out is not None:
+            q_out[..., mid] = q[..., mid]
+        if k_out is not None:
+            k_out[..., mid] = k[..., mid]
+    return q_out, k_out, cos, sin
+
+
+def _launch_bnsd(q, k, cos, sin, backward: bool, q_out=None, k_out=None):
+    q = _as_contiguous_bnsd(q) if q is not None else None
+    k = _as_contiguous_bnsd(k) if k is not None else None
+    ref = q if q is not None else k
+    head_dim = ref.shape[-1]
+    seq_len = ref.shape[2]
+    block_d = triton.next_power_of_2(max(1, head_dim // 2))
+    block_s = _rope_block_s(seq_len, head_dim)
+    aligned = seq_len % block_s == 0 and block_d == (head_dim // 2)
+    if q is not None and (q_out is None or not q_out.is_contiguous()):
+        q_out = torch.empty_like(q)
+    if k is not None and (k_out is None or not k_out.is_contiguous()):
+        k_out = torch.empty_like(k)
+    if q is not None and k is not None and aligned:
+        n_s_tiles = triton.cdiv(seq_len, block_s)
+        q_tiles = q.shape[0] * q.shape[1] * n_s_tiles
+        k_tiles = k.shape[0] * k.shape[1] * n_s_tiles
+        if q_tiles + k_tiles <= get_npu_core_count() * 4:
+            _launch_qk_aligned(q, q_out, k, k_out, cos, sin, backward, block_s, block_d)
+        else:
+            _launch_one(q, q_out, cos, sin, backward, block_s, block_d)
+            _launch_one(k, k_out, cos, sin, backward, block_s, block_d)
+    else:
+        if q is not None:
+            _launch_one(q, q_out, cos, sin, backward, block_s, block_d)
+        if k is not None:
+            _launch_one(k, k_out, cos, sin, backward, block_s, block_d)
+    if head_dim % 2:
+        mid = head_dim - 1
+        if q is not None:
+            q_out[..., mid] = q[..., mid]
+        if k is not None:
+            k_out[..., mid] = k[..., mid]
+    return q_out, k_out, cos, sin
+
+
+def _launch_rope(q, k, cos, sin, backward: bool, q_out=None, k_out=None):
+    if q is None and k is None:
+        return None, None, cos, sin
+    cos, sin = _as_bnsd_cos_sin(cos, sin)
+    cos = _ensure_innermost_contiguous(cos)
+    sin = _ensure_innermost_contiguous(sin)
+    use_bsnd = (q is None or _is_free_bsnd(q)) and (k is None or _is_free_bsnd(k))
+    if use_bsnd:
+        return _launch_bsnd(q, k, cos, sin, backward, q_out=q_out, k_out=k_out)
+    return _launch_bnsd(q, k, cos, sin, backward, q_out=q_out, k_out=k_out)
 
 
 def rope_forward(q, k, cos, sin):
-    # transpose it back to the physical shape because Triton looks at the physical storage
-    # note: q and k are incontiguous before the transformation and will become contiguous after transpose
-    q = q.transpose(1, 2)
-    k = k.transpose(1, 2)
-
-    batch_size, seq_len, n_q_head, head_dim = q.shape
-    n_kv_head = k.shape[2]
-    pad_hd = triton.next_power_of_2(head_dim)
-    pad_n_q_head = triton.next_power_of_2(n_q_head)
-    pad_n_kv_head = triton.next_power_of_2(n_kv_head)
-
-    n_row = batch_size * seq_len
-
-    # ensure tensors passed into the kernel are contiguous. It will be no-op if they are already contiguous
-    q = q.contiguous()
-    k = k.contiguous()
-    cos = cos.contiguous()
-    sin = sin.contiguous()
-    cos_batch_size = cos.shape[0]
-
-    dtype_size = q.element_size()
-    BLOCK_Q, BLOCK_K = get_optimal_block_size(pad_n_q_head, pad_n_kv_head, pad_hd, dtype_size)
-
-    num_cores = get_npu_core_count()
-    grid_size = min(num_cores, n_row)
-
-    _triton_rope_npu[(grid_size,)](
-        q,
-        q.stride(1),
-        k,
-        k.stride(1),
-        cos,
-        cos.stride(-2),
-        sin,
-        sin.stride(-2),
-        seq_len,
-        n_row,
-        cos_batch_size,
-        n_q_head,
-        n_kv_head,
-        head_dim,
-        BLOCK_Q,
-        BLOCK_K,
-        BACKWARD_PASS=False,
-    )
-    return q.transpose(1, 2), k.transpose(1, 2), cos, sin
+    return _launch_rope(q, k, cos, sin, backward=False)
 
 
 def rope_backward(dq, dk, cos, sin):
-    dq = dq.transpose(1, 2)
-    dk = dk.transpose(1, 2)
-
-    batch_size, seq_len, n_q_head, head_dim = dq.shape
-    cos_batch_size = cos.shape[0]
-    n_kv_head = dk.shape[2]
-    pad_hd = triton.next_power_of_2(head_dim)
-    pad_n_q_head = triton.next_power_of_2(n_q_head)
-    pad_n_kv_head = triton.next_power_of_2(n_kv_head)
-
-    n_row = batch_size * seq_len
-
-    # ensure dq and dk are contiguous
-    dq = dq.contiguous()
-    dk = dk.contiguous()
-
-    dtype_size = dq.element_size()
-    BLOCK_Q, BLOCK_K = get_optimal_block_size(pad_n_q_head, pad_n_kv_head, pad_hd, dtype_size)
-
-    num_cores = get_npu_core_count()
-    grid_size = min(num_cores, n_row)
-
-    _triton_rope_npu[(grid_size,)](
-        dq,
-        dq.stride(1),
-        dk,
-        dk.stride(1),
-        cos,
-        cos.stride(-2),
-        sin,
-        sin.stride(-2),
-        seq_len,
-        n_row,
-        cos_batch_size,
-        n_q_head,
-        n_kv_head,
-        head_dim,
-        BLOCK_Q,
-        BLOCK_K,
-        BACKWARD_PASS=True,
-    )
-    return dq.transpose(1, 2), dk.transpose(1, 2)
+    dq_out, dk_out, _, _ = _launch_rope(dq, dk, cos, sin, backward=True, q_out=dq, k_out=dk)
+    return dq_out, dk_out
 
 
 class LigerRopeFunction(torch.autograd.Function):
@@ -244,6 +990,7 @@ class LigerRopeFunction(torch.autograd.Function):
         cos size: (1, seq_len, head_dim) or (bsz, seq_len, head_dim)
         sin size: (1, seq_len, head_dim) or (bsz, seq_len, head_dim)
         """
+        ctx.set_materialize_grads(False)
         q, k, cos, sin = rope_forward(q, k, cos, sin)
         ctx.save_for_backward(cos, sin)
         return q, k
@@ -253,10 +1000,11 @@ class LigerRopeFunction(torch.autograd.Function):
         """
         dq size: (bsz, n_q_head, seq_len, head_dim)
         dk size: (bsz, n_kv_head, seq_len, head_dim)
-        cos size: (1, seq_len, head_dim) or (bsz, seq_len, head_dim)
-        sin size: (1, seq_len, head_dim) or (bsz, seq_len, head_dim)
         """
-
+        # set_materialize_grads(False) passes None for unused outputs. Both-None
+        # is the unused-outputs guard; a single None is handled by _launch_rope.
+        if dq is None and dk is None:
+            return None, None, None, None, None, None
         cos, sin = ctx.saved_tensors
         dq, dk = rope_backward(dq, dk, cos, sin)
         return dq, dk, None, None, None, None

--- a/src/liger_kernel/ops/backends/_ascend/rms_norm.py
+++ b/src/liger_kernel/ops/backends/_ascend/rms_norm.py
@@ -1,0 +1,39 @@
+"""Ascend Triton backend registration for ``rms_norm``."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from liger_kernel.backends import register_op
+from liger_kernel.ops.backends._ascend.dispatch_common import ASCEND_TRITON_CAPABILITY
+from liger_kernel.ops.backends._ascend.dispatch_common import ASCEND_TRITON_RANK
+from liger_kernel.ops.backends._ascend.dispatch_common import DEFAULT_TOLERANCES
+from liger_kernel.ops.backends._ascend.ops.rms_norm import LigerRMSNormFunction
+
+
+@register_op(
+    "rms_norm",
+    impl_name="ascend-triton",
+    capability=ASCEND_TRITON_CAPABILITY,
+    modes=("default",),
+    default_mode="default",
+    preference_rank=ASCEND_TRITON_RANK,
+    tolerances=DEFAULT_TOLERANCES,
+    notes="NPU-tuned RMSNorm. Preferred over nvidia-triton on Ascend.",
+)
+def rms_norm_ascend(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    offset: float = 0.0,
+    casting_mode: str = "llama",
+    in_place: bool = False,
+    row_mode: Optional[bool] = None,
+    *,
+    mode: Optional[str] = None,
+) -> torch.Tensor:
+    if mode not in (None, "default"):
+        raise ValueError(f"Ascend rms_norm has only mode='default'; got mode={mode!r}.")
+    return LigerRMSNormFunction.apply(x, weight, eps, offset, casting_mode, in_place, row_mode)

--- a/src/liger_kernel/ops/backends/_ascend/rope.py
+++ b/src/liger_kernel/ops/backends/_ascend/rope.py
@@ -1,0 +1,38 @@
+"""Ascend Triton backend registration for ``rope``."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from liger_kernel.backends import register_op
+from liger_kernel.ops.backends._ascend.dispatch_common import ASCEND_TRITON_CAPABILITY
+from liger_kernel.ops.backends._ascend.dispatch_common import ASCEND_TRITON_RANK
+from liger_kernel.ops.backends._ascend.dispatch_common import DEFAULT_TOLERANCES
+from liger_kernel.ops.backends._ascend.ops.rope import LigerRopeFunction
+
+
+@register_op(
+    "rope",
+    impl_name="ascend-triton",
+    capability=ASCEND_TRITON_CAPABILITY,
+    modes=("default",),
+    default_mode="default",
+    preference_rank=ASCEND_TRITON_RANK,
+    tolerances=DEFAULT_TOLERANCES,
+    notes="NPU-tuned RoPE. Preferred over nvidia-triton on Ascend.",
+)
+def rope_ascend(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: Optional[torch.Tensor] = None,
+    unsqueeze_dim: int = 1,
+    *,
+    mode: Optional[str] = None,
+):
+    if mode not in (None, "default"):
+        raise ValueError(f"Ascend rope has only mode='default'; got mode={mode!r}.")
+    return LigerRopeFunction.apply(q, k, cos, sin, position_ids, unsqueeze_dim)

--- a/src/liger_kernel/ops/backends/_ascend/swiglu.py
+++ b/src/liger_kernel/ops/backends/_ascend/swiglu.py
@@ -1,0 +1,36 @@
+"""Ascend Triton backend registration for ``swiglu``."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from liger_kernel.backends import register_op
+from liger_kernel.ops.backends._ascend.dispatch_common import ASCEND_TRITON_CAPABILITY
+from liger_kernel.ops.backends._ascend.dispatch_common import ASCEND_TRITON_RANK
+from liger_kernel.ops.backends._ascend.dispatch_common import DEFAULT_TOLERANCES
+from liger_kernel.ops.backends._ascend.ops.swiglu import LigerSiLUMulFunction
+
+
+@register_op(
+    "swiglu",
+    impl_name="ascend-triton",
+    capability=ASCEND_TRITON_CAPABILITY,
+    modes=("default",),
+    default_mode="default",
+    preference_rank=ASCEND_TRITON_RANK,
+    tolerances=DEFAULT_TOLERANCES,
+    notes="NPU-tuned SwiGLU. Preferred over nvidia-triton on Ascend.",
+)
+def swiglu_ascend(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    gate_multiplier: float = 1.0,
+    down_multiplier: float = 1.0,
+    *,
+    mode: Optional[str] = None,
+) -> torch.Tensor:
+    if mode not in (None, "default"):
+        raise ValueError(f"Ascend swiglu has only mode='default'; got mode={mode!r}.")
+    return LigerSiLUMulFunction.apply(a, b, float(gate_multiplier), float(down_multiplier))

--- a/src/liger_kernel/ops/utils.py
+++ b/src/liger_kernel/ops/utils.py
@@ -141,6 +141,7 @@ def element_mul_kernel(
         tl.store(X_ptr + X_offsets, X_block * grad_output, mask=X_offsets < n_cols)
 
 
+@functools.cache
 def get_npu_core_count(default: int = 20) -> int:
     """Return NPU vector core count.
     Fallback to `default` if Triton runtime or NPU device is unavailable.


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
The core idea of the fusion operator in torch_npu is to combine multiple scattered computation operations (operators) into one larger operation. This aims to reduce unnecessary overhead, make full use of the hardware features of Ascend NPU, and thus significantly improve the performance of model training and inference. Typically, we directly call the corresponding interfaces in torch_npu, for example: torch_npu.npu_cross_entropy_loss/torch_npu.npu_rms_norm/torch_npu.npu_rotary_mul/torch_npu.npu_swiglu.

Tune the Ascend Triton backends for CrossEntropy, FusedLinearCrossEntropy, RMSNorm, and RoPE. The common theme is fewer HBM round‑trips, constexpr‑DCE'd masks, software‑pipelined tl.range, and in‑place buffers so last‑layer training does not peak at two full BT×V tensors, so as to achieve performance on par with or even exceeding the fused operators in torch_npu. Refer to [torch_npu_baselines.py](https://github.com/user-attachments/files/31633905/torch_npu_baselines.py) for the complete implementation script


<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->
### CrossEntropy
- Plain forward processes contiguous row chunks per vector core (sequential MTE2) instead of one row per program.
- Full tiles are unmasked; `HAS_TAIL` is constexpr so the remainder mask is DCE'd when `V` divides `BLOCK_SIZE`.
- `tl.range` pipelines MTE2 / VEC / MTE3; OOB labels are clamped before DMA to avoid a fault ahead of the host assert.
- Dedicated `get_plain_ce_block_size` for the smaller live set on the no-weight path.
- Last-layer backward (`grad_output == 1`) overwrites the logits buffer in-place.
### FusedLinearCrossEntropy
- One Cube GEMM for the full `(BT, V)` logits instead of many token chunks.
- Reuses the optimized CE kernels; writes `dlogits` in-place into the logits buffer (no extra BT×V).
- Optionally retains forward logits (capped at `min(4 GiB, device_mem / 8)`) to skip the backward logits GEMM.
- `torch.mm(..., out=)` for `dX` / `dW` when dtypes match, avoiding an extra V×H workspace.
### RMSNorm
- Full-width single-pass fused kernels when a row fits UB (same pattern as Ascend LayerNorm), avoiding a second load of X after the rstd reduction.
- 2D fused path (`ROWS_PER_BLOCK × n_cols`) when UB allows; column tiling only when a full row does not fit.
- On 910B (`BT=8192, H=4096, bf16`) the previous two-pass tiled forward was ~350 µs (`aiv_mte2_ratio=0.69`) vs `npu_rms_norm` at ~107 µs.
### RoPE
- Native BNSD layout; the old BSND transpose round-trip was ~40% of Liger RoPE time.
- Work maps to `(batch, head, s_tile)` so 48 AIV cores stay occupied.
- Fast path: contiguous `(BLOCK_S, D)` DMA, `rotate_half` in UB via `extract_slice` / `insert_slice`.
- Sequential q-then-k launches (dual-stream fights over the same 48 AIV cores). Short aligned shapes use one two-phase launch to hide the second host launch.


## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->
pytest test/transformers/test_cross_entropy.py test/transformers/test_rms_norm.py test/transformers/test_rope.py test/transformers/test_fused_linear_cross_entropy.py 
<img width="1215" height="250" alt="image" src="https://github.com/user-attachments/assets/29f8e01a-a690-4d43-84df-00a80a38db11" />


- Hardware Type:  Atls 800T A3(X86)
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [x] run `make test-convergence` to ensure convergence

| Kernel name | Performance |
|---------------|----------------|
| rope forward    | <img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/e95a09cc-9ae4-41b7-a425-cf2b97967f22" />|
| rope backward | <img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/63dca63b-d2cd-4c3f-9ec2-3896cc15eeba" /> |
| rope full           | <img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/cfd901fb-ee2b-42b2-88dd-12a89d44eb0d" />|
| cross_entropy forward | <img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/9960806f-0da4-4215-b7ee-1820c5130187" />|
| cross_entropy backward | <img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/d631bb0e-6d13-40da-97fa-bffdd9c06ea6" />|
| cross_entropy full | <img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/fd90e4b7-506e-4229-b6d1-74ce435b52d5" /> |
| cross_entropy no grad forward | <img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/1eaa515b-adef-4570-9359-13108969dd1c" />|
| rms_norm forward | <img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/a677522c-4d42-4ea4-8a70-1a8970b2d097" /> |
| rms_norm backward | <img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/c9b3e04c-11cd-43c5-ad6d-49d376a41375" />|
| rms_norm full | <img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/101ccd94-0a6a-4012-90f9-b5828d28a6a2" />|
| fused_linear_cross_entropy forward |<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/cfdc390a-aff9-4397-95a3-b7a8862a55e8" />|
| fused_linear_cross_entropy backward | <img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/ddc65a5d-eb3f-4efb-8893-09330ff86076" />|
| fused_linear_cross_entropy full |<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/470090ed-db0d-4aa1-b8c7-861228fed38b" />|
| swiglu forward |<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/83474768-c545-4ee5-8d0d-b596e5eddd48" />|
| swiglu backward |<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/a198dbd3-7f6f-4886-8b46-75f374817fe7" />|
| swiglu full |<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/112527a4-7226-45ac-920e-43387b03d725" />|
