### PR TITLE
fix(cutile): pin cuda-tile>=1.5.0 so CI gets CompilerOptions.num_worker_warps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,15 @@ def get_default_dependencies():
 
 def get_optional_dependencies():
     """Get optional dependency groups."""
+    # cuTile kernels use CompilerOptions.num_worker_warps (replace_hints / @ct.kernel),
+    # which only exists in cuda-tile >= 1.4.0. Pin the floor to 1.5.0 (validated) so the
+    # resolver can't backtrack to an older cuda-tile whose CompilerOptions lacks that
+    # field (which raises "unexpected keyword argument 'num_worker_warps'" at import).
     cutile_deps = [
-        "cuda-tile",
+        "cuda-tile>=1.5.0",
     ]
     cutile_tileiras_deps = [
-        "cuda-tile[tileiras]",
+        "cuda-tile[tileiras]>=1.5.0",
     ]
     cutedsl_deps = [
         "nvidia-cutlass-dsl>=4.6.0",


### PR DESCRIPTION
## Summary

Fixes the scheduled **cuTile (H100)** job, which failed at import/collection with:

```
src/liger_kernel/ops/cutile/ops/dyt.py:144: in <module>
    _dyt_bwd_kernel_nww8 = _dyt_bwd_kernel.replace_hints(num_worker_warps=8)
...
E   TypeError: CompilerOptions.__init__() got an unexpected keyword argument 'num_worker_warps'
```

## Root cause

The cuTile ops use `num_worker_warps` both as a `@ct.kernel(...)` argument and via
`replace_hints(num_worker_warps=...)` (in `dyt.py`, `fused_add_rms_norm.py`,
`poly_norm.py`, `softmax.py`, `fused_linear_cross_entropy.py`, `swiglu.py`).

That `CompilerOptions` field was **only added in cuda-tile 1.4.0** — it's absent in
1.3.0 and 1.0.0 (verified by inspecting the wheels). Because the `cutile` /
`cutile-tileiras` extras pinned only `"cuda-tile"` (unpinned), dependency resolution
backtracked to an older cuda-tile whose `[tileiras]` extra constraints were
satisfiable, landing below 1.4.0. The field was then missing, so importing
`liger_kernel.ops.cutile.ops` (triggered under `LIGER_KERNEL_IMPL=cutile`) crashed and
took down the whole cuTile suite at collection.

Since this runs at import via the backend-replacement in `liger_kernel/ops/__init__.py`,
it is not recoverable at runtime — the version floor must guarantee the field exists.

## Fix

Pin the floor to `cuda-tile>=1.5.0` (the validated version) in both cuTile extras in
`setup.py`, so the resolver can no longer fall back to a version without
`num_worker_warps`.

## Notes

- cuTeDSL (SM90/SM100) jobs also failed in the same run, but that's a **separate**
  library (`nvidia-cutlass-dsl`) and will be addressed separately.
- Verified locally: `num_worker_warps` present in cuda-tile 1.4.0 & 1.5.0, absent in
  1.3.0 & 1.0.0; `setup.py` parses and is ruff-clean. The full cuTile suite needs an
  H100 to confirm end-to-end (no GPU in the dev sandbox).
