### PR TITLE
[CUDA] Add tensor-parallel fused scaled cross entropy frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,10 +264,9 @@ nll, entropy = LigerFusedLinearScaledCrossEntropyTPFunction.apply(
 The TP frontend derives `vocab_start` from the process-group rank. BF16 inputs on Hopper use the optional
 `liger_cute_kernels` (LCK) implementation when its native core is available; other configurations use Liger's chunked
 tensor-parallel fallback adapted from Verl's fused PPO formulas. Both paths return globally correct per-token outputs
-and sum the input gradient across the TP group. LCK borrows the caller-owned PyTorch NCCL communicator only when the
-PyTorch and LCK NCCL runtime versions match; the TVM-FFI core remains independent of the Torch C++ ABI and never owns or
-destroys that communicator. Calls remain collectives on `tp_group`, so they must have the same ordering on every member
-and must not be reordered around other collectives on that group.
+and sum the input gradient across the TP group. The LCK forward and backward paths communicate exclusively through
+NVSHMEM; no Torch communicator or Torch C++ ABI crosses the TVM-FFI boundary. Calls remain collectives on `tp_group`, so
+they must have the same ordering on every member.
 
 LCK shares the process-wide NVSHMEM bootstrap used by `LigerExpertParallelFusedMoe`, while TP and EP use separate cached
 teams and separately named workspaces. Application setup must initialize NVSHMEM from a common parent group (normally

--- a/README.md
+++ b/README.md
@@ -250,6 +250,25 @@ The implementations share this public contract but use different schedules:
 - **CuTe SM90** uses `LigerFusedScaledCrossEntropySM90Function` for BF16 inputs on Hopper. Its sole forward uses the fixed cluster-M2 N160 fragment kernel, with a measured split-N lookup for profiled long-sequence shapes, and never writes logits to HBM; `m_tiles_per_cluster` remains accepted for API compatibility but does not change that schedule. Backward runs `dZ`, `dX`, and `dW` in one persistent cluster kernel with a reusable 1024-token `dZ` workspace.
 - **Fallback** uses a 512-token chunked PyTorch implementation adapted from Verl's fused PPO formulas when the default frontend cannot use the SM90 kernel.
 
+For a classifier weight sharded into equally sized contiguous ranges across a tensor-parallel process group, use the
+TP frontend. Targets remain global vocabulary indices:
+
+```python
+from liger_kernel.ops import LigerFusedLinearScaledCrossEntropyTPFunction
+
+nll, entropy = LigerFusedLinearScaledCrossEntropyTPFunction.apply(
+    x, local_weight, target, tp_group, 1.0, -100, 1, True
+)
+```
+
+The TP frontend derives `vocab_start` from the process-group rank. BF16 inputs on Hopper use the optional
+`liger_cute_kernels` (LCK) implementation when its native core is available; other configurations call Verl's
+tensor-parallel linear cross entropy. Both paths return globally correct per-token outputs and sum the input gradient
+across the TP group. The first LCK call initializes its NVSHMEM/NCCL runtime and fixes workspace capacity, so warm it
+up with the largest expected token, hidden, local-vocabulary, and `tiles_per_reduce` settings before CUDA Graph capture.
+LCK shares the process-wide NVSHMEM bootstrap used by `LigerExpertParallelFusedMoe`; TP and EP use separate cached teams
+and separately named workspaces. Initialize NVSHMEM from a common parent group (normally `WORLD`) when both are used.
+
 H100 BF16 forward medians from 60 interleaved samples per provider at
 `H=4096`, `V=131072`. Effective TFLOPS count the common projection work,
 `2*M*H*V`:

--- a/README.md
+++ b/README.md
@@ -262,10 +262,11 @@ nll, entropy = LigerFusedLinearScaledCrossEntropyTPFunction.apply(
 ```
 
 The TP frontend derives `vocab_start` from the process-group rank. BF16 inputs on Hopper use the optional
-`liger_cute_kernels` (LCK) implementation when its native core is available; other configurations call Verl's
-tensor-parallel linear cross entropy. Both paths return globally correct per-token outputs and sum the input gradient
-across the TP group. The first LCK call initializes its NVSHMEM/NCCL runtime and fixes workspace capacity, so warm it
-up with the largest expected token, hidden, local-vocabulary, and `tiles_per_reduce` settings before CUDA Graph capture.
+`liger_cute_kernels` (LCK) implementation when its native core is available; other configurations use Liger's chunked
+tensor-parallel fallback adapted from Verl's fused PPO formulas. Both paths return globally correct per-token outputs
+and sum the input gradient across the TP group. The first LCK call initializes its NVSHMEM/NCCL runtime and fixes
+workspace capacity, so warm it up with the largest expected token, hidden, local-vocabulary, and `tiles_per_reduce`
+settings before CUDA Graph capture.
 LCK shares the process-wide NVSHMEM bootstrap used by `LigerExpertParallelFusedMoe`; TP and EP use separate cached teams
 and separately named workspaces. Initialize NVSHMEM from a common parent group (normally `WORLD`) when both are used.
 

--- a/README.md
+++ b/README.md
@@ -264,11 +264,16 @@ nll, entropy = LigerFusedLinearScaledCrossEntropyTPFunction.apply(
 The TP frontend derives `vocab_start` from the process-group rank. BF16 inputs on Hopper use the optional
 `liger_cute_kernels` (LCK) implementation when its native core is available; other configurations use Liger's chunked
 tensor-parallel fallback adapted from Verl's fused PPO formulas. Both paths return globally correct per-token outputs
-and sum the input gradient across the TP group. The first LCK call initializes its NVSHMEM/NCCL runtime and fixes
-workspace capacity, so warm it up with the largest expected token, hidden, local-vocabulary, and `tiles_per_reduce`
-settings before CUDA Graph capture.
-LCK shares the process-wide NVSHMEM bootstrap used by `LigerExpertParallelFusedMoe`; TP and EP use separate cached teams
-and separately named workspaces. Initialize NVSHMEM from a common parent group (normally `WORLD`) when both are used.
+and sum the input gradient across the TP group. LCK borrows the caller-owned PyTorch NCCL communicator only when the
+PyTorch and LCK NCCL runtime versions match; the TVM-FFI core remains independent of the Torch C++ ABI and never owns or
+destroys that communicator. Calls remain collectives on `tp_group`, so they must have the same ordering on every member
+and must not be reordered around other collectives on that group.
+
+LCK shares the process-wide NVSHMEM bootstrap used by `LigerExpertParallelFusedMoe`, while TP and EP use separate cached
+teams and separately named workspaces. Application setup must initialize NVSHMEM from a common parent group (normally
+`WORLD`) and resolve both process groups before invoking either kernel. The first FSLCE call fixes its workspace
+capacity, so warm it up with the largest expected token, hidden, local-vocabulary, and `tiles_per_reduce` settings
+before CUDA Graph capture.
 
 H100 BF16 forward medians from 60 interleaved samples per provider at
 `H=4096`, `V=131072`. Effective TFLOPS count the common projection work,

--- a/liger_cute_kernels/CMakeLists.txt
+++ b/liger_cute_kernels/CMakeLists.txt
@@ -50,21 +50,6 @@ option(LIGER_CUTE_TESTS_ONLY
 # ---------- Common CUDA / device dependencies (needed by core AND bindings) --
 find_package(CUDAToolkit REQUIRED)
 
-if(NOT LIGER_CUTE_TESTS_ONLY)
-    if(NOT DEFINED NCCL_HOME AND DEFINED ENV{NCCL_HOME})
-        set(NCCL_HOME "$ENV{NCCL_HOME}")
-    endif()
-    find_path(NCCL_INCLUDE_DIR NAMES nccl.h
-        HINTS "${NCCL_HOME}/include"
-        PATHS /usr/include /usr/local/cuda/include)
-    find_library(NCCL_LIBRARY NAMES nccl
-        HINTS "${NCCL_HOME}/lib" "${NCCL_HOME}/lib64"
-        PATHS /usr/lib /usr/lib64 /usr/lib/x86_64-linux-gnu)
-    if(NOT NCCL_INCLUDE_DIR OR NOT NCCL_LIBRARY)
-        message(FATAL_ERROR "NCCL not found (set NCCL_HOME=<prefix>)")
-    endif()
-endif()
-
 # The 'a' suffix enables architecture-accelerated features (WGMMA/TMA/multicast
 # on sm_90a; tcgen05/UMMA on sm_100a). Override with -DLIGER_CUTE_CUDA_ARCH=100a
 # for a Blackwell build. Strip any gencode flags a parent/toolchain may have

--- a/liger_cute_kernels/README.md
+++ b/liger_cute_kernels/README.md
@@ -59,29 +59,23 @@ uses split-K=1. Direct-peer and hierarchical two-host transports remain
 available when the single-host NVLS path is not selected.
 
 The `liger_cute_kernels.tvm_ffi` facade exposes configuration plus forward and
-backward entry points. Forward accepts the caller's tensor-parallel
-`ncclComm_t` as an integer handle; backward accepts the NVSHMEM team configured
-for the same tensor-parallel ranks. Both calls take inverse temperature.
+backward entry points. Both accept the NVSHMEM team configured for the same
+tensor-parallel ranks and take inverse temperature.
 Capacities for tokens, hidden size, local vocabulary, and reduction grouping
 must be configured before capture or execution.
-
-The facade owns NCCL communicator bootstrap helpers:
-`nccl_get_unique_id`, `nccl_comm_init_rank`, and `nccl_comm_destroy`. Broadcast
-the returned CPU `uint8` unique-ID tensor to the tensor-parallel ranks, create
-one communicator per rank, and pass its integer handle to forward.
 
 Hierarchical NVLS+remote backward currently requires the configured
 tensor-parallel team to cover the full NVSHMEM world. Single-host NVLS
 subgroups remain supported; a multi-host subgroup that is only part of a
 larger world fails explicitly rather than communicating with nonmembers.
 
-Tensor-parallel reduction transport is implemented in
-`liger_cute::detail`. Host setup selects either the NVLS or DirectPeer local
-backend and passes only that backend's compact device view to the kernel.
-Two-host execution is composed as local NVLS reduce-scatter, an explicit
-RDC-compiled remote reduction follow-up, and the same local all-gather/scatter
-used by single-host execution. Whether the remote follow-up is required is a
-launcher template parameter, not a runtime kernel argument.
+Tensor-parallel reduction transport is implemented in `liger_cute::detail`.
+Host setup selects either the NVLS or DirectPeer local backend and passes only
+that backend's compact device view to the kernel. Forward performs local MAX
+and corrected SUM reductions in its WGMMA epilogue; the RDC follow-up exchanges
+one unique token shard per local GPU over IBRC, gathers the merged shards with
+NVLS, and writes NLL/LSE/entropy. Backward retains its local reduce-scatter,
+remote reduction, and local all-gather/scatter pipeline.
 
 ## Package architecture
 

--- a/liger_cute_kernels/csrc/core/CMakeLists.txt
+++ b/liger_cute_kernels/csrc/core/CMakeLists.txt
@@ -55,12 +55,10 @@ target_compile_definitions(liger_cute_fslce_forward_sm90 PRIVATE
 target_include_directories(liger_cute_fslce_forward_sm90 PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/src/moe
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/fused_scaled_linear_cross_entropy
-    ${NCCL_INCLUDE_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/fused_scaled_linear_cross_entropy)
 target_link_libraries(liger_cute_fslce_forward_sm90 PRIVATE
     CUTLASS::CUTLASS
-    CUDA::cudart
-    ${NCCL_LIBRARY})
+    CUDA::cudart)
 
 add_library(liger_cute_fslce_forward_reduce OBJECT
     "${LIGER_CUTE_FSLCE_FORWARD_REDUCE_SOURCE}")
@@ -155,7 +153,6 @@ target_include_directories(liger_cute_kernels
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/moe
         ${CMAKE_CURRENT_SOURCE_DIR}/src/fused_scaled_linear_cross_entropy
-        ${NCCL_INCLUDE_DIR}
 )
 
 # Deliberately NO torch here — that is the entire point of the split.
@@ -168,7 +165,6 @@ target_link_libraries(liger_cute_kernels PUBLIC
     NVSHMEM::nvshmem_device
     CUDA::cudart
     CUDA::cuda_driver
-    ${NCCL_LIBRARY}
     ${TVM_FFI_LDFLAGS}
     tvm_ffi
 )

--- a/liger_cute_kernels/csrc/core/include/liger_cute/detail/local_reduce.cuh
+++ b/liger_cute_kernels/csrc/core/include/liger_cute/detail/local_reduce.cuh
@@ -14,11 +14,51 @@
 namespace liger_cute {
 namespace detail {
 
+__device__ __forceinline__ std::uint32_t ordered_float_bits(float value) {
+	std::uint32_t bits = __float_as_uint(value);
+	std::uint32_t mask =
+		static_cast<std::int32_t>(bits) < 0
+		? 0xffffffffu
+		: 0x80000000u;
+	return bits ^ mask;
+}
+
+__device__ __forceinline__ float ordered_bits_float(std::uint32_t ordered) {
+	std::uint32_t mask =
+		(ordered & 0x80000000u) != 0
+		? 0x80000000u
+		: 0xffffffffu;
+	return __uint_as_float(ordered ^ mask);
+}
+
+__device__ __forceinline__ void encode_ordered_float_warp(
+		float* values, std::size_t count) {
+	unsigned int lane = nvls_lane_id();
+	for (std::size_t index = lane; index < count; index += 32) {
+		reinterpret_cast<std::uint32_t*>(values)[index] =
+			ordered_float_bits(values[index]);
+	}
+	__syncwarp();
+}
+
+__device__ __forceinline__ void decode_ordered_float_warp(
+		float* values, std::size_t count) {
+	unsigned int lane = nvls_lane_id();
+	for (std::size_t index = lane; index < count; index += 32) {
+		std::uint32_t ordered =
+			reinterpret_cast<std::uint32_t*>(values)[index];
+		values[index] = ordered_bits_float(ordered);
+	}
+	__syncwarp();
+}
+
 template <LocalReduceBackend Backend, typename Element>
 struct LocalReduceContext;
 
 template <typename Element>
 struct LocalReduceContext<LocalReduceBackend::kNvls, Element> {
+	Element* local_source;
+	Element* local_destination;
 	std::uint64_t* local_ready;
 	std::uint64_t* multicast_ready;
 	std::uint64_t* local_complete;
@@ -70,7 +110,7 @@ __device__ __forceinline__ void direct_peer_barrier_warp(
 	__syncwarp();
 }
 
-template <LocalReduceBackend Backend, typename Element>
+template <LocalReduceBackend Backend, ReduceOp Op, typename Element>
 __device__ __forceinline__ void local_all_reduce(
 		const LocalReduceContext<Backend, Element>& context,
 		Element* destination,
@@ -80,29 +120,52 @@ __device__ __forceinline__ void local_all_reduce(
 	if constexpr (Backend == LocalReduceBackend::kNvls) {
 		static_assert(
 			std::is_same_v<Element, float>,
-			"NVLS two-shot currently supports FP32 SUM");
+			"NVLS two-shot currently supports FP32 reductions");
+		if constexpr (Op == ReduceOp::kMax) {
+			encode_ordered_float_warp(
+				context.local_source, count);
+			publish_local_reduce_source();
+		}
 		nvls_barrier_warp(
 			context.local_ready,
 			context.multicast_ready,
 			context.rank,
 			context.size,
 			epoch);
-		nvls_sum_reduce_warp_twoshot(
-			destination,
-			source,
-			count,
-			context.rank,
-			context.size);
+		if constexpr (Op == ReduceOp::kSum) {
+			nvls_sum_reduce_warp_twoshot(
+				destination,
+				source,
+				count,
+				context.rank,
+				context.size);
+		} else {
+			nvls_max_reduce_warp_twoshot(
+				destination,
+				source,
+				count,
+				context.rank,
+				context.size);
+		}
 		nvls_barrier_warp(
 			context.local_complete,
 			context.multicast_complete,
 			context.rank,
 			context.size,
 			epoch);
+		if constexpr (Op == ReduceOp::kMax) {
+			decode_ordered_float_warp(
+				context.local_destination, count);
+		}
 	} else {
 		static_assert(
 			std::is_same_v<Element, float>,
-			"direct-peer all-reduce currently supports FP32 SUM");
+			"direct-peer all-reduce currently supports FP32 reductions");
+		if constexpr (Op == ReduceOp::kMax) {
+			encode_ordered_float_warp(
+				const_cast<Element*>(source), count);
+			publish_local_reduce_source();
+		}
 		direct_peer_barrier_warp(
 			context.local_ready,
 			context.peer_sync,
@@ -114,29 +177,76 @@ __device__ __forceinline__ void local_all_reduce(
 		unsigned int lane = nvls_lane_id();
 		std::size_t vectors = count / 4;
 		for (std::size_t vector = lane; vector < vectors; vector += 32) {
-			float4 sum = {0.0f, 0.0f, 0.0f, 0.0f};
+			float4 reduced = {0.0f, 0.0f, 0.0f, 0.0f};
+			std::uint32_t reduced_bits[4] = {0, 0, 0, 0};
 			for (int peer = 0; peer < context.size; ++peer) {
-				const auto* peer_source =
-					reinterpret_cast<const float4*>(
-						context.peer_sources[peer] +
-						context.source_offset);
-				float4 value = peer_source[vector];
-				sum.x += value.x;
-				sum.y += value.y;
-				sum.z += value.z;
-				sum.w += value.w;
+				if constexpr (Op == ReduceOp::kSum) {
+					const auto* peer_source =
+						reinterpret_cast<const float4*>(
+							context.peer_sources[peer] +
+							context.source_offset);
+					float4 value = peer_source[vector];
+					reduced.x += value.x;
+					reduced.y += value.y;
+					reduced.z += value.z;
+					reduced.w += value.w;
+				} else {
+					const auto* peer_source =
+						reinterpret_cast<const uint4*>(
+							context.peer_sources[peer] +
+							context.source_offset);
+					uint4 value_bits = peer_source[vector];
+					reduced_bits[0] = reduced_bits[0] > value_bits.x
+						? reduced_bits[0]
+						: value_bits.x;
+					reduced_bits[1] = reduced_bits[1] > value_bits.y
+						? reduced_bits[1]
+						: value_bits.y;
+					reduced_bits[2] = reduced_bits[2] > value_bits.z
+						? reduced_bits[2]
+						: value_bits.z;
+					reduced_bits[3] = reduced_bits[3] > value_bits.w
+						? reduced_bits[3]
+						: value_bits.w;
+				}
 			}
-			reinterpret_cast<float4*>(destination)[vector] = sum;
+			if constexpr (Op == ReduceOp::kSum) {
+				reinterpret_cast<float4*>(destination)[vector] = reduced;
+			} else {
+				auto* destination_bits =
+					reinterpret_cast<std::uint32_t*>(destination) +
+					vector * 4;
+				destination_bits[0] = reduced_bits[0];
+				destination_bits[1] = reduced_bits[1];
+				destination_bits[2] = reduced_bits[2];
+				destination_bits[3] = reduced_bits[3];
+			}
 		}
 		for (std::size_t index = vectors * 4 + lane;
 				index < count;
 				index += 32) {
-			float sum = 0.0f;
-			for (int peer = 0; peer < context.size; ++peer) {
-				sum += context.peer_sources[peer][
-					context.source_offset + index];
+			if constexpr (Op == ReduceOp::kSum) {
+				float reduced = 0.0f;
+				for (int peer = 0; peer < context.size; ++peer) {
+					float value = context.peer_sources[peer][
+						context.source_offset + index];
+					reduced += value;
+				}
+				destination[index] = reduced;
+			} else {
+				std::uint32_t reduced = 0;
+				for (int peer = 0; peer < context.size; ++peer) {
+					const auto* peer_source =
+						reinterpret_cast<const std::uint32_t*>(
+							context.peer_sources[peer] +
+							context.source_offset);
+					reduced = reduced > peer_source[index]
+						? reduced
+						: peer_source[index];
+				}
+				reinterpret_cast<std::uint32_t*>(destination)[index] =
+					reduced;
 			}
-			destination[index] = sum;
 		}
 		__syncwarp();
 
@@ -147,6 +257,9 @@ __device__ __forceinline__ void local_all_reduce(
 			context.rank,
 			context.size,
 			epoch);
+		if constexpr (Op == ReduceOp::kMax) {
+			decode_ordered_float_warp(destination, count);
+		}
 	}
 }
 

--- a/liger_cute_kernels/csrc/core/include/liger_cute/detail/nvls.cuh
+++ b/liger_cute_kernels/csrc/core/include/liger_cute/detail/nvls.cuh
@@ -192,6 +192,53 @@ __device__ __forceinline__ void nvls_sum_reduce_warp_twoshot(
 #endif
 }
 
+__device__ __forceinline__ void nvls_max_reduce_warp_twoshot(
+    float* multicast_dest, const float* multicast_source, std::size_t count,
+    int team_rank, int team_size) {
+#if defined(__CUDA_ARCH__)
+  static_assert(__CUDA_ARCH__ >= 900,
+                "nvls_max_reduce_warp_twoshot requires SM90 or newer");
+
+  if (count == 0) return;
+
+  const unsigned int lane = nvls_lane_id();
+  const std::size_t elements_per_pe =
+      count / static_cast<std::size_t>(team_size);
+  const std::size_t rank_offset =
+      elements_per_pe * static_cast<std::size_t>(team_rank);
+  const std::size_t local_count =
+      elements_per_pe +
+      (team_rank == team_size - 1
+           ? count % static_cast<std::size_t>(team_size)
+           : 0);
+  const float* source = multicast_source + rank_offset;
+  float* dest = multicast_dest + rank_offset;
+
+  __syncwarp();
+  asm volatile("" ::: "memory");
+  for (std::size_t index = static_cast<std::size_t>(lane);
+       index < local_count; index += 32) {
+    std::uint32_t value;
+    asm volatile("multimem.ld_reduce.relaxed.sys.global.max.u32 %0, [%1];"
+                 : "=r"(value)
+                 : "l"(source + index)
+                 : "memory");
+    asm volatile("multimem.st.relaxed.sys.global.f32 [%0], %1;"
+                 :
+                 : "l"(dest + index), "r"(value)
+                 : "memory");
+  }
+  asm volatile("fence.acq_rel.sys;" ::: "memory");
+  __syncwarp();
+#else
+  (void)multicast_dest;
+  (void)multicast_source;
+  (void)count;
+  (void)team_rank;
+  (void)team_size;
+#endif
+}
+
 __device__ __forceinline__ std::size_t nvls_rank_count(
     std::size_t count, int rank, int size) {
   std::size_t per_rank = count / static_cast<std::size_t>(size);

--- a/liger_cute_kernels/csrc/core/include/liger_cute/detail/tp_reduce.cuh
+++ b/liger_cute_kernels/csrc/core/include/liger_cute/detail/tp_reduce.cuh
@@ -15,6 +15,11 @@ enum class LocalReduceBackend : std::uint8_t {
 	kDirectPeer,
 };
 
+enum class ReduceOp : std::uint8_t {
+	kSum,
+	kMax,
+};
+
 // Minimal device view for the local NVLS reduce-scatter/all-gather path.
 struct NvlsReduceView {
 	float* multicast_partial;

--- a/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/backward_reduce_sm90.cu
+++ b/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/backward_reduce_sm90.cu
@@ -147,7 +147,8 @@ __device__ void direct_peer_communicate(
 			mapping.rank,
 			mapping.size};
 		liger_cute::detail::local_all_reduce<
-			liger_cute::detail::LocalReduceBackend::kDirectPeer>(
+			liger_cute::detail::LocalReduceBackend::kDirectPeer,
+			liger_cute::detail::ReduceOp::kSum>(
 			context,
 			local_reduced,
 			comm.partial + base + segment_begin,

--- a/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/forward_gemm_mainloop_sm90.cuh
+++ b/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/forward_gemm_mainloop_sm90.cuh
@@ -14,8 +14,8 @@
 //   warp  0     : TMA producer, 24 registers. Loads the CTA's own M128xK64 X
 //                 tile and multicasts two N160xK64 W panels to the cluster
 //                 peer through one 3-stage mbarrier pipeline.
-//   warps 1..3  : idle in forward (they carry the dX comms in backward), but
-//                 they still take PRODUCER_REGISTERS so the warp group's
+//   warp  1     : last-arrival local MAX/SUM communication epilogue.
+//   warps 2..3  : idle; they still take PRODUCER_REGISTERS so the warp group's
 //                 setmaxnreg is uniform.
 //   warps 4..11 : two WGMMA consumer warp groups, 240 registers. Each owns 64
 //                 token rows and two FP32 N160 accumulators.
@@ -39,7 +39,9 @@
 // must be the first CUTLASS/CuTe include of any TU using this header.
 #include "gemm_sm90.cuh"
 
+#include "dx_reduce.cuh"
 #include "forward_gemm_sm90.cuh"
+#include "liger_cute/detail/local_reduce.cuh"
 #include "online_softmax.cuh"
 
 #include <cstdint>
@@ -163,6 +165,7 @@ struct ForwardGemmSmemSm90 {
 	alignas(16) float segment_sum[Traits::kTileM];
 	alignas(16) float segment_target[Traits::kTileM];
 	alignas(16) float segment_weighted[kWeightedElements];
+	int finalizer;
 
 	CUTE_DEVICE Element* x_data() { return &smem_x[0]; }
 	CUTE_DEVICE Element* w0_data() { return &smem_w0[0]; }
@@ -634,13 +637,13 @@ struct ForwardGemmConsumerSm90 {
 // ───────────────────────────────────────────────────────────────────────────
 
 template <bool ReturnEntropy, int Compute, class TmaLoadX, class TmaLoadW>
-__global__ __launch_bounds__(ForwardGemmTraitsSm90<Compute>::kNumThreads, 1)
-void forward_gemm_kernel_sm90(
-		__grid_constant__ const TmaLoadX tma_load_x,
-		__grid_constant__ const TmaLoadW tma_load_w,
-		__grid_constant__ const ForwardGemmParamsSm90<Compute> params,
-		__grid_constant__ const ForwardGemmPartialsSm90<Compute> partials,
-		__grid_constant__ const ForwardGemmSplitSm90<Compute> split) {
+__device__ __forceinline__ void forward_gemm_compute_sm90(
+		ForwardGemmSmemSm90<Compute, ReturnEntropy>& smem,
+		const TmaLoadX& tma_load_x,
+		const TmaLoadW& tma_load_w,
+		const ForwardGemmParamsSm90<Compute>& params,
+		const ForwardGemmPartialsSm90<Compute>& partials,
+		const ForwardGemmSplitSm90<Compute>& split) {
 	using Traits = ForwardGemmTraitsSm90<Compute>;
 	using Config = typename Traits::Config;
 	using Launch = ForwardGemmLaunchSm90<Compute>;
@@ -649,9 +652,6 @@ void forward_gemm_kernel_sm90(
 	using ClusterShape = typename Traits::ClusterShape;
 	using Registers = sm90::WarpSpecializedRegistersSm90<
 		Config::kProducerRegisters, Config::kMmaRegisters, Compute>;
-
-	extern __shared__ char raw_smem[];
-	Smem& smem = *reinterpret_cast<Smem*>(raw_smem);
 
 	int warp_group = cutlass::canonical_warp_group_idx();
 	int warp = cutlass::canonical_warp_idx_sync();
@@ -729,12 +729,394 @@ void forward_gemm_kernel_sm90(
 			num_k_tiles);
 	}
 
+}
+
+template <bool ReturnEntropy, int Compute, class TmaLoadX, class TmaLoadW>
+__global__ __launch_bounds__(ForwardGemmTraitsSm90<Compute>::kNumThreads, 1)
+void forward_gemm_kernel_sm90(
+		__grid_constant__ const TmaLoadX tma_load_x,
+		__grid_constant__ const TmaLoadW tma_load_w,
+		__grid_constant__ const ForwardGemmParamsSm90<Compute> params,
+		__grid_constant__ const ForwardGemmPartialsSm90<Compute> partials,
+		__grid_constant__ const ForwardGemmSplitSm90<Compute> split) {
+	using Smem = ForwardGemmSmemSm90<Compute, ReturnEntropy>;
+	extern __shared__ char raw_smem[];
+	Smem& smem = *reinterpret_cast<Smem*>(raw_smem);
+	forward_gemm_compute_sm90<ReturnEntropy, Compute>(
+		smem, tma_load_x, tma_load_w, params, partials, split);
+	sm90::cluster_exit_sm90<Compute>();
+}
+
+template <
+	liger_cute::detail::LocalReduceBackend Backend,
+	liger_cute::detail::ReduceOp Op,
+	class Mapping>
+__device__ __forceinline__ void forward_local_reduce_warp(
+		const DxReduceWorkspace<float>& comm,
+		const Mapping& mapping,
+		std::size_t data_offset,
+		std::size_t count,
+		int m_tile,
+		int phase) {
+	unsigned int lane = liger_cute::detail::nvls_lane_id();
+	if (mapping.size == 1) {
+		for (std::size_t index = lane; index < count; index += 32) {
+			comm.reduced[data_offset + index] =
+				comm.partial[data_offset + index];
+		}
+		__syncwarp();
+		return;
+	}
+
+	std::size_t ready_offset =
+		static_cast<std::size_t>(m_tile * 4 + phase * 2) *
+		static_cast<std::size_t>(mapping.size);
+	std::size_t complete_offset =
+		ready_offset + static_cast<std::size_t>(mapping.size);
+	std::uint64_t epoch =
+		dx_epoch_base(comm) | 0x10000000u |
+		(static_cast<std::uint64_t>(m_tile) << 4) |
+		static_cast<std::uint64_t>(phase + 1);
+
+	if constexpr (
+		Backend == liger_cute::detail::LocalReduceBackend::kNvls) {
+		liger_cute::detail::LocalReduceContext<Backend, float> context{
+			comm.partial + data_offset,
+			comm.reduced + data_offset,
+			comm.sync + ready_offset,
+			mapping.multicast_sync + ready_offset,
+			comm.sync + complete_offset,
+			mapping.multicast_sync + complete_offset,
+			mapping.rank,
+			mapping.size};
+		liger_cute::detail::local_all_reduce<Backend, Op>(
+			context,
+			mapping.multicast_reduced + data_offset,
+			mapping.multicast_partial + data_offset,
+			count,
+			epoch);
+	} else {
+		liger_cute::detail::LocalReduceContext<Backend, float> context{
+			mapping.peer_partial,
+			data_offset,
+			comm.sync + ready_offset,
+			mapping.peer_sync,
+			ready_offset,
+			comm.sync + complete_offset,
+			complete_offset,
+			mapping.rank,
+			mapping.size};
+		liger_cute::detail::local_all_reduce<Backend, Op>(
+			context,
+			comm.reduced + data_offset,
+			comm.partial + data_offset,
+			count,
+			epoch);
+	}
+}
+
+template <
+	bool ReturnEntropy,
+	int Compute,
+	bool RequiresRemote,
+	liger_cute::detail::LocalReduceBackend Backend,
+	class Mapping>
+__device__ __forceinline__ void forward_finalize_splits_and_reduce_sm90(
+		ForwardGemmSmemSm90<Compute, ReturnEntropy>& smem,
+		const ForwardGemmParamsSm90<Compute>& params,
+		const ForwardGemmPartialsSm90<Compute>& partials,
+		const ForwardGemmSplitSm90<Compute>& split,
+		const DxReduceWorkspace<float>& comm,
+		const Mapping& mapping,
+		int* split_ready,
+		float* global_max,
+		float* reduced,
+		float* remote_source) {
+	using Traits = ForwardGemmTraitsSm90<Compute>;
+	using Config = typename Traits::Config;
+	using Epilogue = ForwardGemmEpilogueSm90<Compute>;
+
+	ForwardGemmWorkSm90 work = forward_gemm_assign_work_sm90<Compute>(
+		split,
+		static_cast<int>(blockIdx.z),
+		static_cast<int>(blockIdx.x));
+	int warp_group = cutlass::canonical_warp_group_idx();
+	int consumer_thread =
+		static_cast<int>(threadIdx.x) - Traits::kWarpGroupSize;
+	bool wrote_partial =
+		warp_group != 0 &&
+		consumer_thread % Traits::kWarpGroupSize <
+			Traits::kRowsPerWarpGroup;
+	if (wrote_partial && work.store_enabled) {
+		__threadfence();
+	}
+	__syncthreads();
+
+	if (threadIdx.x == 0) {
+		smem.finalizer = 0;
+		if (work.store_enabled) {
+			int completed = atomicAdd(
+				split_ready + work.raw_pid_m, 1) + 1;
+			smem.finalizer =
+				completed == split.split_count_for_pair(
+					work.raw_pid_m / Config::kClusterM);
+		}
+	}
+	__syncthreads();
+
+	if (smem.finalizer != 0) {
+		int tid = static_cast<int>(threadIdx.x);
+		if (tid < Config::kTileM) {
+			int row = work.raw_pid_m * Config::kTileM + tid;
+			int split_count = split.split_count_for_pair(
+				work.raw_pid_m / Config::kClusterM);
+			float row_max = kForwardNegInf;
+			float row_target = 0.0f;
+			for (int split_id = 0; split_id < split_count; ++split_id) {
+				int index =
+					(work.raw_pid_m * split.split_n + split_id) *
+						Config::kTileM +
+					tid;
+				row_max = fmaxf(row_max, partials.partial_max[index]);
+				row_target += partials.partial_target[index];
+			}
+
+			float row_sum = 0.0f;
+			float row_weighted = 0.0f;
+			for (int split_id = 0; split_id < split_count; ++split_id) {
+				int index =
+					(work.raw_pid_m * split.split_n + split_id) *
+						Config::kTileM +
+					tid;
+				float split_scale = forward_exp2_sm90(
+					(partials.partial_max[index] - row_max) *
+						kForwardLog2E);
+				row_sum += partials.partial_sum[index] * split_scale;
+				if constexpr (ReturnEntropy) {
+					row_weighted +=
+						partials.partial_weighted[index] * split_scale;
+				}
+			}
+
+			OnlineSoftmaxState state;
+			state.max_value = row_max;
+			state.exp_sum = row_sum;
+			state.target_logit = row_target;
+			if constexpr (ReturnEntropy) {
+				state.exp_weighted_sum = row_weighted;
+			}
+			state.has_target = 0;
+			if (row < params.tokens) {
+				std::int64_t target_id = params.target[row];
+				std::int64_t local = target_id - params.vocab_start;
+				state.has_target =
+					target_id != params.ignore_index &&
+					local >= 0 &&
+					local < static_cast<std::int64_t>(
+						params.local_vocab);
+				Epilogue::template store_row<ReturnEntropy>(
+					state, params.output, row);
+			}
+		}
+		__syncthreads();
+
+		int warp = cutlass::canonical_warp_idx_sync();
+		int lane = static_cast<int>(threadIdx.x) % Traits::kWarpSize;
+		if (warp == 1) {
+			constexpr std::size_t kRows = Config::kTileM;
+			constexpr std::size_t kStride =
+				kForwardReducedFields * kRows;
+			std::size_t base =
+				static_cast<std::size_t>(work.raw_pid_m) * kStride;
+			for (int row_in_tile = lane;
+					row_in_tile < Config::kTileM;
+					row_in_tile += Traits::kWarpSize) {
+				int row =
+					work.raw_pid_m * Config::kTileM + row_in_tile;
+				comm.partial[base + row_in_tile] =
+					row < params.tokens
+					? params.output.local_max[row]
+					: kForwardNegInf;
+			}
+			__syncwarp();
+			forward_local_reduce_warp<
+				Backend,
+				liger_cute::detail::ReduceOp::kMax>(
+					comm,
+					mapping,
+					base,
+					kRows,
+					work.raw_pid_m,
+					0);
+
+			constexpr std::size_t kFields =
+				ReturnEntropy ? kForwardReducedFields : 2;
+			constexpr std::size_t kStateFields = 1 + kFields;
+			int padded_tokens = ceil_div(
+				params.tokens, mapping.size) * mapping.size;
+			int rows_per_rank = padded_tokens / mapping.size;
+			int owned_row_begin =
+				mapping.rank * rows_per_rank;
+			for (int row_in_tile = lane;
+					row_in_tile < Config::kTileM;
+					row_in_tile += Traits::kWarpSize) {
+				int row =
+					work.raw_pid_m * Config::kTileM + row_in_tile;
+				float local_sum = row < params.tokens
+					? params.output.local_sum[row]
+					: 0.0f;
+				float local_max = row < params.tokens
+					? params.output.local_max[row]
+					: kForwardNegInf;
+				float node_max = comm.reduced[base + row_in_tile];
+				if (row < params.tokens) {
+					params.output.local_max[row] = node_max;
+					global_max[row] = node_max;
+				}
+				float correction = local_sum == 0.0f
+					? 0.0f
+					: forward_exp2_sm90(
+						(local_max - node_max) * kForwardLog2E);
+				float local_target = row < params.tokens
+					? params.output.local_target[row]
+					: 0.0f;
+				float local_weighted = 0.0f;
+				if constexpr (ReturnEntropy) {
+					local_weighted = row < params.tokens
+						? params.output.local_weighted_sum[row]
+						: 0.0f;
+				}
+				comm.partial[
+					base +
+					kForwardReducedSumField * kRows +
+					row_in_tile] =
+					local_sum * correction;
+				comm.partial[
+					base +
+					kForwardReducedTargetField * kRows +
+					row_in_tile] =
+					local_target;
+				if constexpr (ReturnEntropy) {
+					comm.partial[
+						base +
+						kForwardReducedWeightedField * kRows +
+						row_in_tile] =
+						local_weighted * correction;
+				}
+				if constexpr (RequiresRemote) {
+					// Every local GPU has the complete node state. Pack only
+					// this rank's contiguous token shard for the IBRC pair.
+					if (row >= owned_row_begin &&
+						row < owned_row_begin + rows_per_rank) {
+						int local_row = row - owned_row_begin;
+						remote_source[
+							static_cast<std::size_t>(local_row) *
+								kStateFields] =
+							node_max;
+					}
+				}
+			}
+			__syncwarp();
+			liger_cute::detail::publish_local_reduce_source();
+			forward_local_reduce_warp<
+				Backend,
+				liger_cute::detail::ReduceOp::kSum>(
+					comm,
+					mapping,
+					base,
+					kFields * kRows,
+					work.raw_pid_m,
+					1);
+			for (int row_in_tile = lane;
+					row_in_tile < Config::kTileM;
+					row_in_tile += Traits::kWarpSize) {
+				int row =
+					work.raw_pid_m * Config::kTileM + row_in_tile;
+				if constexpr (RequiresRemote) {
+					if (row >= owned_row_begin &&
+						row < owned_row_begin + rows_per_rank) {
+						int local_row = row - owned_row_begin;
+						for (int field = 0;
+								field < static_cast<int>(kFields);
+								++field) {
+							remote_source[
+								static_cast<std::size_t>(local_row) *
+									kStateFields +
+								1 +
+								field] =
+								comm.reduced[
+									base +
+									static_cast<std::size_t>(field) *
+										kRows +
+									row_in_tile];
+						}
+					}
+				} else if (row < params.tokens) {
+					CUTE_UNROLL
+					for (int field = 0;
+							field < static_cast<int>(kFields);
+							++field) {
+							reduced[field * params.tokens + row] =
+								comm.reduced[
+									base +
+									static_cast<std::size_t>(field) *
+										kRows +
+										row_in_tile];
+					}
+				}
+			}
+		}
+		__syncthreads();
+	}
+}
+
+template <
+	bool ReturnEntropy,
+	int Compute,
+	bool RequiresRemote,
+	liger_cute::detail::LocalReduceBackend Backend,
+	class TmaLoadX,
+	class TmaLoadW,
+	class Mapping>
+__global__ __launch_bounds__(ForwardGemmTraitsSm90<Compute>::kNumThreads, 1)
+void forward_gemm_tp_kernel_sm90(
+		__grid_constant__ const TmaLoadX tma_load_x,
+		__grid_constant__ const TmaLoadW tma_load_w,
+		__grid_constant__ const ForwardGemmParamsSm90<Compute> params,
+		__grid_constant__ const ForwardGemmPartialsSm90<Compute> partials,
+		__grid_constant__ const ForwardGemmSplitSm90<Compute> split,
+		__grid_constant__ const DxReduceWorkspace<float> comm,
+		__grid_constant__ const Mapping mapping,
+		int* split_ready,
+		float* global_max,
+		float* reduced,
+		float* remote_source) {
+	using Smem = ForwardGemmSmemSm90<Compute, ReturnEntropy>;
+	extern __shared__ char raw_smem[];
+	Smem& smem = *reinterpret_cast<Smem*>(raw_smem);
+	forward_gemm_compute_sm90<ReturnEntropy, Compute>(
+		smem, tma_load_x, tma_load_w, params, partials, split);
+	forward_finalize_splits_and_reduce_sm90<
+		ReturnEntropy,
+		Compute,
+		RequiresRemote,
+		Backend>(
+			smem,
+			params,
+			partials,
+			split,
+			comm,
+			mapping,
+			split_ready,
+			global_max,
+			reduced,
+			remote_source);
 	sm90::cluster_exit_sm90<Compute>();
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// Split reducer — the reference finalizer, stopped at *local* statistics so
-// The host forward wrapper reduces across the tensor-parallel group.
+// Test-only split reducer for the GEMM-only self-test. Production performs this
+// merge through the last-arrival epilogue above.
 // ───────────────────────────────────────────────────────────────────────────
 
 template <bool ReturnEntropy, int Compute>

--- a/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/forward_gemm_sm90.cuh
+++ b/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/forward_gemm_sm90.cuh
@@ -57,6 +57,11 @@ struct ForwardLocalStatsBuffers {
 	float* local_weighted_sum;
 };
 
+inline constexpr int kForwardReducedSumField = 0;
+inline constexpr int kForwardReducedTargetField = 1;
+inline constexpr int kForwardReducedWeightedField = 2;
+inline constexpr int kForwardReducedFields = 3;
+
 // _fused_scaled_cross_entropy_utils_sm90.py constants.
 inline constexpr float kForwardLog2E = 1.4426950408889634f;
 inline constexpr float kForwardLn2 = 0.6931471805599453f;
@@ -482,10 +487,9 @@ struct ForwardGemmLaunchSm90 {
 		"SM90 forward shared-memory footprint exceeds the Hopper limit");
 };
 
-// End-to-end tensor-parallel forward: the exact CuTe-DSL local-statistic GEMM
-// followed by NCCL MAX, correction/packing, NCCL SUM, and finalization. This
-// is the sole production forward host launcher; it directly prepares and
-// launches forward_gemm_kernel_sm90.
+// End-to-end tensor-parallel forward: the exact CuTe-DSL local-statistic GEMM,
+// in-kernel local MAX and corrected SUM reductions, then the optional remote
+// reduction and finalization follow-up.
 //
 // `gemm` describes this rank's contiguous vocabulary shard. Its `output` and
 // `workspace` fields are launcher-owned and overwritten: both the local
@@ -503,8 +507,7 @@ struct ForwardTpParamsSm90 {
 	float* lse = nullptr;      // [tokens]
 	float* entropy = nullptr;  // [tokens], required when ReturnEntropy=true
 
-	// ncclComm_t for the tensor-parallel communicator, as an int64 handle.
-	std::int64_t nccl_comm_handle = 0;
+	std::int64_t team_handle = 0;
 };
 
 template <bool ReturnEntropy, int Compute = 90>

--- a/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/forward_reduce.cu
+++ b/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/forward_reduce.cu
@@ -1,9 +1,15 @@
 #include "forward_reduce.cuh"
 
 #include <cstddef>
+#include <cstdint>
+
+#include <nvshmem.h>
+#include <nvshmemx.h>
 
 #include "buffer_pool.cuh"
 #include "liger_cute/check.h"
+#include "liger_cute/detail/nvls.cuh"
+#include "online_softmax.cuh"
 
 namespace liger {
 namespace fused_scaled_linear_cross_entropy {
@@ -26,6 +32,11 @@ std::size_t split_partials_bytes_at(int tokens, int local_vocab) {
 		tokens, local_vocab, /*return_entropy=*/true);
 }
 
+std::size_t split_ready_bytes_at(int tokens) {
+	return static_cast<std::size_t>(
+		ForwardGemmLaunchSm90<90>::num_m_tiles(tokens)) * sizeof(int);
+}
+
 void ensure_capacity(int tokens) {
 	LIGER_CHECK(tokens > 0, "tokens must be positive");
 	LIGER_CHECK(
@@ -41,6 +52,208 @@ void ensure_capacity(int tokens) {
 		" tokens but ",
 		tokens,
 		" were requested");
+}
+
+template <bool ReturnEntropy>
+__device__ __forceinline__ void store_finalized_row(
+		const float* global_max,
+		const float* reduced,
+		const std::int64_t* target,
+		float* nll,
+		float* lse,
+		float* entropy,
+		int tokens,
+		std::int64_t ignore_index,
+		int row) {
+	float global_weighted = 0.0f;
+	if constexpr (ReturnEntropy) {
+		global_weighted =
+			reduced[kForwardReducedWeightedField * tokens + row];
+	}
+	FinalizedSoftmax result = finalize_softmax<ReturnEntropy>(
+		global_max[row],
+		reduced[kForwardReducedSumField * tokens + row],
+		reduced[kForwardReducedTargetField * tokens + row],
+		global_weighted,
+		target[row] == ignore_index);
+	nll[row] = result.nll;
+	lse[row] = result.lse;
+	if constexpr (ReturnEntropy) {
+		entropy[row] = result.entropy;
+	}
+}
+
+template <bool ReturnEntropy>
+__global__ void local_finalize_forward_kernel(
+		const float* global_max,
+		const float* reduced,
+		const std::int64_t* target,
+		float* nll,
+		float* lse,
+		float* entropy,
+		int tokens,
+		std::int64_t ignore_index) {
+	for (int row = static_cast<int>(
+				blockIdx.x * blockDim.x + threadIdx.x);
+			row < tokens;
+			row += static_cast<int>(blockDim.x * gridDim.x)) {
+		store_finalized_row<ReturnEntropy>(
+			global_max,
+			reduced,
+			target,
+			nll,
+			lse,
+			entropy,
+			tokens,
+			ignore_index,
+			row);
+	}
+}
+
+__device__ __forceinline__ void remote_handshake_block(
+		std::uint64_t* signal,
+		const std::uint64_t* launch_epoch,
+		std::uint64_t suffix,
+		int peer) {
+	__syncthreads();
+	if (threadIdx.x == 0) {
+		std::uint64_t epoch = *launch_epoch | suffix;
+		nvshmemx_signal_op(
+			signal, epoch, NVSHMEM_SIGNAL_SET, peer);
+		nvshmem_quiet();
+		nvshmem_signal_wait_until(
+			signal, NVSHMEM_CMP_EQ, epoch);
+	}
+	__syncthreads();
+}
+
+template <bool ReturnEntropy>
+__global__ void remote_finalize_forward_kernel(
+		__grid_constant__ const liger_cute::detail::RemoteReduceView remote,
+		__grid_constant__ const liger_cute::detail::NvlsReduceView local,
+		__grid_constant__ const DxReduceWorkspace<float> comm,
+		const std::uint64_t* launch_epoch,
+		float* remote_source,
+		float* global_max,
+		float* reduced,
+		const std::int64_t* target,
+		float* nll,
+		float* lse,
+		float* entropy,
+		int tokens,
+		std::int64_t ignore_index) {
+	constexpr int kFields =
+		ReturnEntropy ? kForwardReducedFields : 2;
+	constexpr int kStateFields = 1 + kFields;
+	int rows_per_rank =
+		(tokens + local.size - 1) / local.size;
+	int padded_tokens = rows_per_rank * local.size;
+	std::size_t rows_owned =
+		static_cast<std::size_t>(rows_per_rank);
+
+	// Corresponding local ranks exchange disjoint token shards. The merged
+	// shards are gathered once through the node-local NVLS mapping below.
+	nvshmemx_float_put_block(
+		remote.inbox,
+		remote_source,
+		rows_owned * static_cast<std::size_t>(kStateFields),
+		remote.peer_world);
+	remote_handshake_block(
+		remote.ready,
+		launch_epoch,
+		0x40000000u,
+		remote.peer_world);
+
+	for (std::size_t owned_row =
+				static_cast<std::size_t>(threadIdx.x);
+			owned_row < rows_owned;
+			owned_row += static_cast<std::size_t>(blockDim.x)) {
+		std::size_t state =
+			owned_row * static_cast<std::size_t>(kStateFields);
+		float node_max = remote_source[state];
+		float remote_max = remote.inbox[state];
+		float max_value = fmaxf(node_max, remote_max);
+		float node_sum =
+			remote_source[state + 1 + kForwardReducedSumField];
+		float remote_sum =
+			remote.inbox[state + 1 + kForwardReducedSumField];
+		float node_correction = node_sum == 0.0f
+			? 0.0f
+			: expf(node_max - max_value);
+		float remote_correction = remote_sum == 0.0f
+			? 0.0f
+			: expf(remote_max - max_value);
+		remote_source[state] = max_value;
+		remote_source[state + 1 + kForwardReducedSumField] =
+			node_sum * node_correction +
+			remote_sum * remote_correction;
+		remote_source[state + 1 + kForwardReducedTargetField] =
+			remote_source[state + 1 + kForwardReducedTargetField] +
+			remote.inbox[state + 1 + kForwardReducedTargetField];
+		if constexpr (ReturnEntropy) {
+			remote_source[state + 1 + kForwardReducedWeightedField] =
+				remote_source[
+					state + 1 + kForwardReducedWeightedField] *
+					node_correction +
+				remote.inbox[
+					state + 1 + kForwardReducedWeightedField] *
+					remote_correction;
+		}
+	}
+	remote_handshake_block(
+		remote.consumed,
+		launch_epoch,
+		0x40000000u,
+		remote.peer_world);
+
+	__syncthreads();
+	int warp = static_cast<int>(threadIdx.x) / 32;
+	if (warp == 0) {
+		std::uint64_t epoch = *launch_epoch | 0x60000000u;
+		liger_cute::detail::nvls_barrier_warp(
+			comm.sync,
+			local.multicast_sync,
+			local.rank,
+			local.size,
+			epoch);
+		liger_cute::detail::nvls_allgather_warp(
+			local.multicast_reduced,
+			remote_source,
+			static_cast<std::size_t>(padded_tokens) *
+				static_cast<std::size_t>(kStateFields),
+			local.rank,
+			local.size);
+		liger_cute::detail::nvls_barrier_warp(
+			comm.sync + local.size,
+			local.multicast_sync + local.size,
+			local.rank,
+			local.size,
+			epoch);
+	}
+	__syncthreads();
+
+	for (int row = static_cast<int>(threadIdx.x);
+			row < tokens;
+			row += static_cast<int>(blockDim.x)) {
+		std::size_t state =
+			static_cast<std::size_t>(row) *
+				static_cast<std::size_t>(kStateFields);
+		global_max[row] = comm.reduced[state];
+		for (int field = 0; field < kFields; ++field) {
+			reduced[field * tokens + row] =
+				comm.reduced[state + 1 + field];
+		}
+		store_finalized_row<ReturnEntropy>(
+			global_max,
+			reduced,
+			target,
+			nll,
+			lse,
+			entropy,
+			tokens,
+			ignore_index,
+			row);
+	}
 }
 
 }  // namespace
@@ -67,9 +280,9 @@ void configure_forward_tp_workspace(int max_tokens, int max_local_vocab) {
 
 	pool.get_device(Names::kLocalMax, token_bytes);
 	pool.get_device(Names::kGlobalMax, token_bytes);
-	pool.get_device(Names::kPacked, packed_bytes);
 	pool.get_device(Names::kReduced, packed_bytes);
 	pool.get_device(Names::kGemmSplitPartials, split_bytes);
+	pool.get_device(Names::kSplitReady, split_ready_bytes_at(max_tokens));
 	pool.get_device(Names::kLocalSum, token_bytes);
 	pool.get_device(Names::kLocalTarget, token_bytes);
 	pool.get_device(Names::kLocalWeighted, token_bytes);
@@ -83,8 +296,9 @@ std::size_t forward_tp_workspace_device_bytes(
 	LIGER_CHECK(max_tokens > 0, "max_tokens must be positive");
 	LIGER_CHECK(max_local_vocab > 0, "max_local_vocab must be positive");
 	return 5 * token_bytes_at(max_tokens) +
-		2 * packed_bytes_at(max_tokens) +
-		split_partials_bytes_at(max_tokens, max_local_vocab);
+		packed_bytes_at(max_tokens) +
+		split_partials_bytes_at(max_tokens, max_local_vocab) +
+		split_ready_bytes_at(max_tokens);
 }
 
 void reset_forward_tp_workspace_configuration() {
@@ -106,10 +320,10 @@ ForwardTpWorkspace reserve_forward_tp_workspace(int tokens) {
 		pool.get_device(Names::kLocalMax, token_bytes));
 	workspace.global_max = static_cast<float*>(
 		pool.get_device(Names::kGlobalMax, token_bytes));
-	workspace.packed = static_cast<float*>(
-		pool.get_device(Names::kPacked, packed_bytes));
 	workspace.reduced = static_cast<float*>(
 		pool.get_device(Names::kReduced, packed_bytes));
+	workspace.split_ready = static_cast<int*>(
+		pool.get_device(Names::kSplitReady, split_ready_bytes_at(g_capacity_tokens)));
 	workspace.gemm_split_partials = pool.get_device(
 		Names::kGemmSplitPartials, g_capacity_split_partials_bytes);
 	workspace.gemm_split_partials_bytes =
@@ -120,13 +334,109 @@ ForwardTpWorkspace reserve_forward_tp_workspace(int tokens) {
 		pool.get_device(Names::kLocalTarget, token_bytes));
 	workspace.local.local_weighted_sum = static_cast<float*>(
 		pool.get_device(Names::kLocalWeighted, token_bytes));
-	workspace.tokens = tokens;
 	workspace.fields = forward_reduced_fields(ReturnEntropy);
 	return workspace;
 }
 
 template ForwardTpWorkspace reserve_forward_tp_workspace<false>(int);
 template ForwardTpWorkspace reserve_forward_tp_workspace<true>(int);
+
+template <bool ReturnEntropy>
+void launch_forward_remote_finalize_typed(
+		const liger_cute::detail::RemoteReduceView& remote,
+		const liger_cute::detail::NvlsReduceView& local,
+		const DxReduceWorkspace<float>& comm,
+		const std::uint64_t* launch_epoch,
+		const ForwardTpWorkspace& workspace,
+		const std::int64_t* target,
+		float* nll,
+		float* lse,
+		float* entropy,
+		int tokens,
+		std::int64_t ignore_index,
+		cudaStream_t stream) {
+	if (!remote.enabled()) {
+		constexpr int kThreads = 256;
+		int blocks = (tokens + kThreads - 1) / kThreads;
+		local_finalize_forward_kernel<ReturnEntropy>
+			<<<blocks, kThreads, 0, stream>>>(
+			workspace.global_max,
+			workspace.reduced,
+			target,
+			nll,
+			lse,
+			entropy,
+			tokens,
+			ignore_index);
+	} else {
+		float* remote_source = remote.reduced_shard;
+		remote_finalize_forward_kernel<ReturnEntropy>
+			<<<1, 256, 0, stream>>>(
+			remote,
+			local,
+			comm,
+			launch_epoch,
+			remote_source,
+			workspace.global_max,
+			workspace.reduced,
+			target,
+			nll,
+			lse,
+			entropy,
+			tokens,
+			ignore_index);
+	}
+	cudaError_t error = cudaGetLastError();
+	LIGER_CHECK(
+		error == cudaSuccess,
+		"forward finalize launch failed: ",
+		cudaGetErrorString(error));
+}
+
+void launch_forward_remote_finalize(
+		bool return_entropy,
+		const liger_cute::detail::RemoteReduceView& remote,
+		const liger_cute::detail::NvlsReduceView& local,
+		const DxReduceWorkspace<float>& comm,
+		const std::uint64_t* launch_epoch,
+		const ForwardTpWorkspace& workspace,
+		const std::int64_t* target,
+		float* nll,
+		float* lse,
+		float* entropy,
+		int tokens,
+		std::int64_t ignore_index,
+		cudaStream_t stream) {
+	if (return_entropy) {
+		launch_forward_remote_finalize_typed<true>(
+			remote,
+			local,
+			comm,
+			launch_epoch,
+			workspace,
+			target,
+			nll,
+			lse,
+			entropy,
+			tokens,
+			ignore_index,
+			stream);
+	} else {
+		launch_forward_remote_finalize_typed<false>(
+			remote,
+			local,
+			comm,
+			launch_epoch,
+			workspace,
+			target,
+			nll,
+			lse,
+			entropy,
+			tokens,
+			ignore_index,
+			stream);
+	}
+}
 
 }  // namespace fused_scaled_linear_cross_entropy
 }  // namespace liger

--- a/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/forward_reduce.cuh
+++ b/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/forward_reduce.cuh
@@ -1,36 +1,32 @@
 #pragma once
 
-// Launcher-owned workspace for the tensor-parallel forward. The GEMM and
-// split reducer produce rank-local FP32 statistics here; the host launcher then
-// performs NCCL MAX/SUM all-reduces with small CUDA kernels between/after them.
-// No forward buffer is remotely addressed by device code, so every allocation
-// is ordinary device memory from the shared BufferPool.
+// Launcher-owned device workspace for forward split partials, local statistics,
+// split completion counters, and finalized global statistics. Cross-PE staging
+// reuses the symmetric TP reduction workspace configured for backward.
 
 #include <cuda_runtime.h>
 
 #include <cstddef>
+#include <cstdint>
 
+#include "dx_reduce.cuh"
 #include "forward_gemm_sm90.cuh"
+#include "liger_cute/detail/tp_reduce.cuh"
 
 namespace liger {
 namespace fused_scaled_linear_cross_entropy {
-
-inline constexpr int kForwardReducedSumField = 0;
-inline constexpr int kForwardReducedTargetField = 1;
-inline constexpr int kForwardReducedWeightedField = 2;
-inline constexpr int kForwardReducedFields = 3;
 
 struct ForwardBufferNames {
 	static constexpr const char* kLocalMax =
 		"fused_scaled_linear_cross_entropy_tp_forward_local_max";
 	static constexpr const char* kGlobalMax =
 		"fused_scaled_linear_cross_entropy_tp_forward_global_max";
-	static constexpr const char* kPacked =
-		"fused_scaled_linear_cross_entropy_tp_forward_packed";
 	static constexpr const char* kReduced =
 		"fused_scaled_linear_cross_entropy_tp_forward_reduced";
 	static constexpr const char* kGemmSplitPartials =
 		"fused_scaled_linear_cross_entropy_tp_forward_split_partials";
+	static constexpr const char* kSplitReady =
+		"fused_scaled_linear_cross_entropy_tp_forward_split_ready";
 	static constexpr const char* kLocalSum =
 		"fused_scaled_linear_cross_entropy_tp_forward_local_sum";
 	static constexpr const char* kLocalTarget =
@@ -49,11 +45,10 @@ __host__ __device__ constexpr int forward_reduced_fields(
 struct ForwardTpWorkspace {
 	ForwardLocalStatsBuffers local;
 	float* global_max;
-	float* packed;
 	float* reduced;
+	int* split_ready;
 	void* gemm_split_partials;
 	std::size_t gemm_split_partials_bytes;
-	int tokens;
 	int fields;
 };
 
@@ -75,6 +70,21 @@ extern template ForwardTpWorkspace
 	reserve_forward_tp_workspace<false>(int);
 extern template ForwardTpWorkspace
 	reserve_forward_tp_workspace<true>(int);
+
+void launch_forward_remote_finalize(
+	bool return_entropy,
+	const liger_cute::detail::RemoteReduceView& remote,
+	const liger_cute::detail::NvlsReduceView& local,
+	const DxReduceWorkspace<float>& comm,
+	const std::uint64_t* launch_epoch,
+	const ForwardTpWorkspace& workspace,
+	const std::int64_t* target,
+	float* nll,
+	float* lse,
+	float* entropy,
+	int tokens,
+	std::int64_t ignore_index,
+	cudaStream_t stream);
 
 }  // namespace fused_scaled_linear_cross_entropy
 }  // namespace liger

--- a/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/forward_tp_sm90_selftest.cu
+++ b/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/forward_tp_sm90_selftest.cu
@@ -27,12 +27,10 @@
 
 #include <nvshmem.h>
 #include <nvshmemx.h>
-#include <nccl.h>
 
 #include <cuda_runtime.h>
 
 #include <cmath>
-#include <cstring>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -42,6 +40,7 @@
 #include "buffer_pool.cuh"
 #include "forward_gemm_sm90.cuh"
 #include "forward_reduce.cuh"
+#include "workspace.cuh"
 
 namespace {
 
@@ -52,7 +51,6 @@ using Element = __nv_bfloat16;
 int g_pe = 0;
 int g_n_pes = 1;
 int g_failures = 0;
-ncclComm_t g_nccl_comm = nullptr;
 
 #define CUDA_OK(expr)                                                        \
 	do {                                                                     \
@@ -64,42 +62,6 @@ ncclComm_t g_nccl_comm = nullptr;
 			std::exit(1);                                                    \
 		}                                                                    \
 	} while (0)
-
-#define NCCL_OK(expr)                                                        \
-	do {                                                                     \
-		ncclResult_t status = (expr);                                         \
-		if (status != ncclSuccess) {                                         \
-			std::printf("[pe %d] NCCL error %s at %s:%d: %s\n",              \
-				g_pe, #expr, __FILE__, __LINE__, ncclGetErrorString(status)); \
-			std::exit(1);                                                    \
-		}                                                                    \
-	} while (0)
-
-ncclComm_t bootstrap_nccl() {
-	ncclUniqueId id;
-	std::memset(&id, 0, sizeof(id));
-	if (g_pe == 0) NCCL_OK(ncclGetUniqueId(&id));
-
-	void* source = nvshmem_malloc(sizeof(id));
-	void* destination = nvshmem_malloc(sizeof(id));
-	CUDA_OK(cudaMemcpy(source, &id, sizeof(id), cudaMemcpyHostToDevice));
-	nvshmem_barrier_all();
-	nvshmem_broadcastmem(
-		NVSHMEM_TEAM_WORLD,
-		destination,
-		source,
-		sizeof(id),
-		0);
-	nvshmem_barrier_all();
-	CUDA_OK(cudaMemcpy(
-		&id, destination, sizeof(id), cudaMemcpyDeviceToHost));
-	nvshmem_free(destination);
-	nvshmem_free(source);
-
-	ncclComm_t comm = nullptr;
-	NCCL_OK(ncclCommInitRank(&comm, g_n_pes, id, g_pe));
-	return comm;
-}
 
 float next_random(std::uint64_t& state) {
 	state = state * 6364136223846793005ULL + 1442695040888963407ULL;
@@ -271,8 +233,8 @@ void run_case(
 	params.nll = device_out + 0 * tokens;
 	params.lse = device_out + 1 * tokens;
 	params.entropy = device_out + 2 * tokens;
-	params.nccl_comm_handle =
-		reinterpret_cast<std::int64_t>(g_nccl_comm);
+	params.team_handle =
+		static_cast<std::int64_t>(NVSHMEM_TEAM_WORLD);
 
 	fslce::fused_linear_scaled_cross_entropy_forward<
 		ReturnEntropy, 90>(params, nullptr);
@@ -377,12 +339,18 @@ int main() {
 	if (g_pe == 0) {
 		std::printf("tensor-parallel forward over %d PEs\n", g_n_pes);
 	}
-	g_nccl_comm = bootstrap_nccl();
-
 	// Capacities are immutable once allocated, so configure for the largest
 	// shape used below before any launch.
 	constexpr int kMaxTokens = 1024;
+	constexpr int kMaxHidden = 192;
 	constexpr int kMaxLocalVocab = 2560;
+	fslce::configure_backward_tp_symmetric(
+		kMaxTokens,
+		kMaxHidden,
+		kMaxLocalVocab,
+		1,
+		1,
+		static_cast<std::int64_t>(NVSHMEM_TEAM_WORLD));
 	fslce::configure_forward_tp_workspace(kMaxTokens, kMaxLocalVocab);
 
 	try {
@@ -393,7 +361,6 @@ int main() {
 		run_case<true>("tp large split", 1024, 128, 2560, 1.0f, 105);
 	} catch (const std::exception& error) {
 		std::printf("[pe %d] exception: %s\n", g_pe, error.what());
-		ncclCommDestroy(g_nccl_comm);
 		nvshmem_finalize();
 		return 1;
 	}
@@ -417,8 +384,7 @@ int main() {
 		std::printf("%s: %d comparison failures across %d PEs\n",
 			host_total == 0 ? "OK" : "FAILED", host_total, g_n_pes);
 	}
-	NCCL_OK(ncclCommDestroy(g_nccl_comm));
-	fslce::reset_forward_tp_workspace_configuration();
+	fslce::reset_fslce_tp_configuration();
 	liger::global_buffer_pool().clear();
 	nvshmem_finalize();
 	return host_total == 0 ? 0 : 1;

--- a/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/fused_linear_scaled_cross_entropy_forward.cu
+++ b/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/fused_linear_scaled_cross_entropy_forward.cu
@@ -5,10 +5,10 @@
 //
 //   fused_linear_scaled_cross_entropy_forward
 //     -> forward_gemm_kernel_sm90
-//     -> forward_split_reduce_kernel_sm90
-//     -> NCCL MAX
-//     -> pack_forward_reduction_kernel
-//     -> NCCL SUM
+//        -> split last-arrival epilogue
+//        -> local NVSHMEM MAX
+//        -> corrected local NVSHMEM SUM
+//     -> optional sharded remote NVSHMEM state merge
 //     -> finalize_forward_kernel
 //
 // The WGMMA translation unit is deliberately non-RDC. NVSHMEM collective
@@ -23,72 +23,17 @@
 #include "forward_reduce.cuh"
 #include "gemm_sm90.cuh"
 #include "liger_cute/check.h"
+#include "liger_cute/detail/tp_reduce.cuh"
 #include "online_softmax.cuh"
-
-#include <nccl.h>
+#include "workspace.cuh"
 
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 namespace liger {
 namespace fused_scaled_linear_cross_entropy {
 namespace {
-
-template <bool ReturnEntropy>
-__global__ void pack_forward_reduction_kernel(
-		const float* local_max,
-		const float* global_max,
-		const float* local_sum,
-		const float* local_target,
-		const float* local_weighted_sum,
-		float* packed,
-		int tokens) {
-	int row = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
-	if (row >= tokens) return;
-
-	float correction = local_sum[row] == 0.0f
-		? 0.0f
-		: expf(local_max[row] - global_max[row]);
-	packed[kForwardReducedSumField * tokens + row] =
-		local_sum[row] * correction;
-	packed[kForwardReducedTargetField * tokens + row] =
-		local_target[row];
-	if constexpr (ReturnEntropy) {
-		packed[kForwardReducedWeightedField * tokens + row] =
-			local_weighted_sum[row] * correction;
-	}
-}
-
-template <bool ReturnEntropy>
-__global__ void finalize_forward_kernel(
-		const float* global_max,
-		const float* reduced,
-		const std::int64_t* target,
-		float* nll,
-		float* lse,
-		float* entropy,
-		int tokens,
-		std::int64_t ignore_index) {
-	int row = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
-	if (row >= tokens) return;
-
-	float global_weighted = 0.0f;
-	if constexpr (ReturnEntropy) {
-		global_weighted =
-			reduced[kForwardReducedWeightedField * tokens + row];
-	}
-	FinalizedSoftmax result = finalize_softmax<ReturnEntropy>(
-		global_max[row],
-		reduced[kForwardReducedSumField * tokens + row],
-		reduced[kForwardReducedTargetField * tokens + row],
-		global_weighted,
-		target[row] == ignore_index);
-	nll[row] = result.nll;
-	lse[row] = result.lse;
-	if constexpr (ReturnEntropy) {
-		entropy[row] = result.entropy;
-	}
-}
 
 void check_cuda(cudaError_t error, const char* what) {
 	LIGER_CHECK(
@@ -97,15 +42,6 @@ void check_cuda(cudaError_t error, const char* what) {
 		what,
 		" failed: ",
 		cudaGetErrorString(error));
-}
-
-void check_nccl(ncclResult_t result, const char* what) {
-	LIGER_CHECK(
-		result == ncclSuccess,
-		"fused_scaled_linear_cross_entropy forward: ",
-		what,
-		" failed: ",
-		ncclGetErrorString(result));
 }
 
 }  // namespace
@@ -141,8 +77,8 @@ void fused_linear_scaled_cross_entropy_forward(
 			"entropy output is required when ReturnEntropy=true");
 	}
 	LIGER_CHECK(
-		params.nccl_comm_handle != 0,
-		"forward TP requires a valid ncclComm_t handle");
+		params.team_handle == backward_dx_team_handle(),
+		"forward TP team must match the configured reduction team");
 	LIGER_CHECK(
 		reinterpret_cast<std::uintptr_t>(input.x) % 16 == 0 &&
 			reinterpret_cast<std::uintptr_t>(input.weight) % 16 == 0,
@@ -200,9 +136,6 @@ void fused_linear_scaled_cross_entropy_forward(
 				gemm_params.local_vocab,
 				gemm_params.hidden);
 
-	auto* kernel_fn = &forward_gemm_kernel_sm90<
-		ReturnEntropy, Compute, decltype(tma_load_x), decltype(tma_load_w)>;
-
 	constexpr int kSmemBytes = static_cast<int>(sizeof(Smem));
 	static_assert(kSmemBytes <= kHopperMaxSmemBytes,
 		"SM90 forward shared-memory footprint exceeds the Hopper limit");
@@ -210,131 +143,203 @@ void fused_linear_scaled_cross_entropy_forward(
 		"ForwardGemmLaunchSm90::smem_bytes must bound the real footprint");
 
 	using Cluster = sm90::ClusterLaunchSm90<Compute>;
-	check_cuda(
-		Cluster::prepare(kernel_fn, kSmemBytes),
-		"cudaFuncSetAttribute(MaxDynamicSharedMemorySize / "
-		"NonPortableClusterSizeAllowed)");
+	liger_cute::detail::TpReducePlan reduce =
+		liger_cute::detail::tp_reduce_plan();
+	DxReduceWorkspace<float> comm = {};
+	float* remote_source = reduce.remote.enabled()
+		? reduce.remote.reduced_shard
+		: nullptr;
 
-	int max_active_cluster_pairs = Cluster::max_active_clusters(
-		kernel_fn, Config::kNumThreads, kSmemBytes, Config::kClusterM);
-	ForwardGemmSplitSm90<Compute> split = Launch::resolve_split(
-		gemm_params.tuning,
-		gemm_params.tokens,
-		gemm_params.local_vocab,
-		max_active_cluster_pairs);
-	LIGER_CHECK(
-		split.base_split_n >= 1 &&
-			split.split_n <= split.num_logical_n_tiles,
-		"split_n must be between 1 and the number of logical vocabulary tiles");
-	LIGER_CHECK(
-		split.extra_m_pairs < split.num_m_pairs &&
-			split.split_n ==
-				split.base_split_n + (split.extra_m_pairs != 0 ? 1 : 0),
-		"uneven split tuning must use split_n=base_split_n+1 for a proper "
-		"subset of M pairs");
+	auto launch_local = [&](auto mapping, auto backend_tag, auto remote_tag) {
+		constexpr auto Backend = decltype(backend_tag)::value;
+		constexpr bool RequiresRemote = decltype(remote_tag)::value;
+		using Mapping = std::decay_t<decltype(mapping)>;
+		auto* kernel_fn = &forward_gemm_tp_kernel_sm90<
+			ReturnEntropy,
+			Compute,
+			RequiresRemote,
+			Backend,
+			decltype(tma_load_x),
+			decltype(tma_load_w),
+			Mapping>;
 
-	// Split partials are laid out [statistic][M tile][split][row].
-	std::size_t partial_rows =
-		static_cast<std::size_t>(split.num_m_tiles) *
-		static_cast<std::size_t>(split.split_n) *
-		static_cast<std::size_t>(Config::kTileM);
-	std::size_t partial_bytes = partial_rows * sizeof(float);
-	std::size_t required_bytes =
-		partial_bytes * (ReturnEntropy ? 4u : 3u);
-	LIGER_CHECK(
-		gemm_params.workspace != nullptr &&
-			gemm_params.workspace_bytes >= required_bytes,
-		"forward GEMM needs a ",
-		required_bytes,
-		" B split-partial workspace, got ",
-		gemm_params.workspace_bytes);
-	LIGER_CHECK(
-		reinterpret_cast<std::uintptr_t>(gemm_params.workspace) % 16 == 0,
-		"forward GEMM workspace must be 16 B aligned");
-
-	float* scratch = static_cast<float*>(gemm_params.workspace);
-	ForwardGemmPartialsSm90<Compute> partials;
-	partials.partial_max = scratch + 0 * partial_rows;
-	partials.partial_sum = scratch + 1 * partial_rows;
-	partials.partial_target = scratch + 2 * partial_rows;
-	partials.partial_weighted =
-		ReturnEntropy ? scratch + 3 * partial_rows : nullptr;
-
-	check_cuda(
-		Cluster::launch(
+		check_cuda(
+			Cluster::prepare(kernel_fn, kSmemBytes),
+			"cudaFuncSetAttribute(MaxDynamicSharedMemorySize / "
+			"NonPortableClusterSizeAllowed)");
+		int max_active_cluster_pairs = Cluster::max_active_clusters(
 			kernel_fn,
-			dim3(
-				static_cast<unsigned>(Config::kClusterM),
-				1u,
-				static_cast<unsigned>(split.num_cluster_pairs)),
 			Config::kNumThreads,
 			kSmemBytes,
-			Config::kClusterM,
-			stream,
-			tma_load_x,
-			tma_load_w,
-			gemm_params,
-			partials,
-			split),
-		"cudaLaunchKernelEx(forward_gemm_kernel_sm90)");
-
-	forward_split_reduce_kernel_sm90<ReturnEntropy, Compute>
-		<<<split.num_m_tiles, Config::kTileM, 0, stream>>>(
-			gemm_params, partials, split);
-	check_cuda(
-		cudaGetLastError(), "forward_split_reduce_kernel_sm90 launch");
-
-	ncclComm_t comm =
-		reinterpret_cast<ncclComm_t>(params.nccl_comm_handle);
-	check_nccl(
-		ncclAllReduce(
-			reduce_workspace.local.local_max,
-			reduce_workspace.global_max,
+			Config::kClusterM);
+		ForwardGemmSplitSm90<Compute> split = Launch::resolve_split(
+			gemm_params.tuning,
 			gemm_params.tokens,
-			ncclFloat32,
-			ncclMax,
-			comm,
-			stream),
-		"ncclAllReduce(MAX)");
+			gemm_params.local_vocab,
+			max_active_cluster_pairs);
+		LIGER_CHECK(
+			split.num_cluster_pairs <= max_active_cluster_pairs,
+			"forward local reduction requires the complete cluster grid "
+			"to remain resident");
+		LIGER_CHECK(
+			split.base_split_n >= 1 &&
+				split.split_n <= split.num_logical_n_tiles,
+			"split_n must be between 1 and the number of logical vocabulary "
+			"tiles");
+		LIGER_CHECK(
+			split.extra_m_pairs < split.num_m_pairs &&
+				split.split_n ==
+					split.base_split_n +
+						(split.extra_m_pairs != 0 ? 1 : 0),
+			"uneven split tuning must use split_n=base_split_n+1 for a "
+			"proper subset of M pairs");
 
-	constexpr int kPostThreads = 256;
-	int post_blocks = ceil_div(gemm_params.tokens, kPostThreads);
-	pack_forward_reduction_kernel<ReturnEntropy>
-		<<<post_blocks, kPostThreads, 0, stream>>>(
-			reduce_workspace.local.local_max,
-			reduce_workspace.global_max,
-			reduce_workspace.local.local_sum,
-			reduce_workspace.local.local_target,
-			reduce_workspace.local.local_weighted_sum,
-			reduce_workspace.packed,
-			gemm_params.tokens);
-	check_cuda(
-		cudaGetLastError(), "pack_forward_reduction_kernel launch");
+		std::size_t partial_rows =
+			static_cast<std::size_t>(split.num_m_tiles) *
+			static_cast<std::size_t>(split.split_n) *
+			static_cast<std::size_t>(Config::kTileM);
+		std::size_t partial_bytes = partial_rows * sizeof(float);
+		std::size_t required_bytes =
+			partial_bytes * (ReturnEntropy ? 4u : 3u);
+		LIGER_CHECK(
+			gemm_params.workspace != nullptr &&
+				gemm_params.workspace_bytes >= required_bytes,
+			"forward GEMM needs a ",
+			required_bytes,
+			" B split-partial workspace, got ",
+			gemm_params.workspace_bytes);
+		LIGER_CHECK(
+			reinterpret_cast<std::uintptr_t>(gemm_params.workspace) % 16 ==
+				0,
+			"forward GEMM workspace must be 16 B aligned");
 
-	check_nccl(
-		ncclAllReduce(
-			reduce_workspace.packed,
-			reduce_workspace.reduced,
-			static_cast<std::size_t>(reduce_workspace.fields) *
-				static_cast<std::size_t>(gemm_params.tokens),
-			ncclFloat32,
-			ncclSum,
-			comm,
-			stream),
-		"ncclAllReduce(SUM)");
+		float* scratch = static_cast<float*>(gemm_params.workspace);
+		ForwardGemmPartialsSm90<Compute> partials;
+		partials.partial_max = scratch + 0 * partial_rows;
+		partials.partial_sum = scratch + 1 * partial_rows;
+		partials.partial_target = scratch + 2 * partial_rows;
+		partials.partial_weighted =
+			ReturnEntropy ? scratch + 3 * partial_rows : nullptr;
 
-	finalize_forward_kernel<ReturnEntropy>
-		<<<post_blocks, kPostThreads, 0, stream>>>(
-			reduce_workspace.global_max,
-			reduce_workspace.reduced,
-			gemm_params.target,
-			params.nll,
-			params.lse,
-			params.entropy,
-			gemm_params.tokens,
-			gemm_params.ignore_index);
-	check_cuda(
-		cudaGetLastError(), "finalize_forward_kernel launch");
+		int grid_ctas = split.num_cluster_pairs * Config::kClusterM;
+		comm = reserve_dx_reduce_workspace(
+			1, kDxRingStages, grid_ctas);
+		std::size_t forward_comm_elements =
+			static_cast<std::size_t>(split.num_m_tiles) *
+			kForwardReducedFields *
+			Config::kTileM;
+		LIGER_CHECK(
+			forward_comm_elements * sizeof(float) <=
+				backward_dx_configured_staging_bytes(),
+			"forward local reduction exceeds the configured TP staging "
+			"capacity");
+		if constexpr (RequiresRemote) {
+			static_assert(
+				Backend ==
+					liger_cute::detail::LocalReduceBackend::kNvls);
+			int rows_per_rank = ceil_div(
+				gemm_params.tokens, mapping.size);
+			std::size_t remote_elements =
+				static_cast<std::size_t>(rows_per_rank) *
+				static_cast<std::size_t>(
+					1 + reduce_workspace.fields);
+			LIGER_CHECK(
+				remote_elements * sizeof(float) <=
+					backward_dx_configured_packed_durable_bytes(),
+				"forward remote reduction exceeds the configured "
+				"symmetric durable capacity");
+			std::size_t gathered_elements =
+				remote_elements *
+				static_cast<std::size_t>(mapping.size);
+			LIGER_CHECK(
+				gathered_elements * sizeof(float) <=
+					backward_dx_configured_staging_bytes(),
+				"forward remote all-gather exceeds the configured "
+				"symmetric staging capacity");
+		}
+		LIGER_CHECK(
+			reduce_workspace.split_ready != nullptr,
+			"forward split completion counters must be non-null");
+
+		check_cuda(
+			cudaMemsetAsync(
+				reduce_workspace.split_ready,
+				0,
+				static_cast<std::size_t>(split.num_m_tiles) *
+					sizeof(int),
+				stream),
+			"cudaMemsetAsync(forward split counters)");
+		liger_cute::detail::begin_tp_reduce(
+			comm.launch_epoch, stream);
+		check_cuda(
+			Cluster::launch(
+				kernel_fn,
+				dim3(
+					static_cast<unsigned>(Config::kClusterM),
+					1u,
+					static_cast<unsigned>(split.num_cluster_pairs)),
+				Config::kNumThreads,
+				kSmemBytes,
+				Config::kClusterM,
+				stream,
+				tma_load_x,
+				tma_load_w,
+				gemm_params,
+				partials,
+				split,
+				comm,
+				mapping,
+				reduce_workspace.split_ready,
+				reduce_workspace.global_max,
+				reduce_workspace.reduced,
+				remote_source),
+			"cudaLaunchKernelEx(forward_gemm_tp_kernel_sm90)");
+	};
+
+	if (reduce.backend ==
+		liger_cute::detail::LocalReduceBackend::kNvls) {
+		if (reduce.remote.enabled()) {
+			launch_local(
+				reduce.nvls,
+				std::integral_constant<
+					liger_cute::detail::LocalReduceBackend,
+					liger_cute::detail::LocalReduceBackend::kNvls>{},
+				std::true_type{});
+		} else {
+			launch_local(
+				reduce.nvls,
+				std::integral_constant<
+					liger_cute::detail::LocalReduceBackend,
+					liger_cute::detail::LocalReduceBackend::kNvls>{},
+				std::false_type{});
+		}
+	} else {
+		LIGER_CHECK(
+			reduce.direct.available != 0,
+			"forward TP requires NVLS or complete direct-peer mappings");
+		launch_local(
+			reduce.direct,
+			std::integral_constant<
+				liger_cute::detail::LocalReduceBackend,
+				liger_cute::detail::LocalReduceBackend::kDirectPeer>{},
+			std::false_type{});
+	}
+
+	launch_forward_remote_finalize(
+		ReturnEntropy,
+		reduce.remote,
+		reduce.nvls,
+		comm,
+		comm.launch_epoch,
+		reduce_workspace,
+		gemm_params.target,
+		params.nll,
+		params.lse,
+		params.entropy,
+		gemm_params.tokens,
+		gemm_params.ignore_index,
+		stream);
+	liger_cute::detail::end_tp_reduce(stream);
 }
 
 template void fused_linear_scaled_cross_entropy_forward<false, 90>(

--- a/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/workspace.cu
+++ b/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/workspace.cu
@@ -352,6 +352,11 @@ std::size_t backward_dx_configured_durable_bytes() {
 	return g_durable_bytes;
 }
 
+std::size_t backward_dx_configured_packed_durable_bytes() {
+	ensure_configured();
+	return g_packed_durable_bytes;
+}
+
 void validate_backward_tp_shape(
 		int tokens, int hidden, int local_vocab) {
 	ensure_configured();

--- a/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/workspace.cuh
+++ b/liger_cute_kernels/csrc/core/src/fused_scaled_linear_cross_entropy/workspace.cuh
@@ -125,6 +125,7 @@ DxReduceWorkspace<float> reserve_dx_reduce_workspace(
 std::size_t backward_dx_staging_bytes(int max_tiles_per_reduce);
 std::size_t backward_dx_configured_staging_bytes();
 std::size_t backward_dx_configured_durable_bytes();
+std::size_t backward_dx_configured_packed_durable_bytes();
 
 void validate_backward_tp_shape(
 	int tokens, int hidden, int local_vocab);

--- a/liger_cute_kernels/liger_cute_kernels/nvshmem.py
+++ b/liger_cute_kernels/liger_cute_kernels/nvshmem.py
@@ -28,8 +28,10 @@ import torch
 from liger_cute_kernels import tvm_ffi
 
 __all__ = [
+    "ensure_initialized",
     "init_from_pg",
     "init_pmi",
+    "is_initialized",
     "finalize",
     "my_pe",
     "n_pes",
@@ -48,6 +50,7 @@ __all__ = [
 _BOOTSTRAP_PG: Optional["torch.distributed.ProcessGroup"] = None
 _BOOTSTRAP_GLOBAL_RANKS: tuple[int, ...] | None = None
 _PG_TEAM_CACHE: dict[int, int] = {}
+_INITIALIZED = False
 
 
 def _reset_team_state() -> None:
@@ -89,9 +92,10 @@ def init_from_pg(pg: Optional["torch.distributed.ProcessGroup"] = None) -> None:
     tvm_ffi.init_with_uniqueid(rank, world, uid_cpu.data_ptr())
 
     _reset_team_state()
-    global _BOOTSTRAP_PG, _BOOTSTRAP_GLOBAL_RANKS
+    global _BOOTSTRAP_PG, _BOOTSTRAP_GLOBAL_RANKS, _INITIALIZED
     _BOOTSTRAP_PG = pg
     _BOOTSTRAP_GLOBAL_RANKS = global_ranks
+    _INITIALIZED = True
 
 
 def init_pmi(pg: Optional["torch.distributed.ProcessGroup"] = None) -> None:
@@ -111,6 +115,8 @@ def init_pmi(pg: Optional["torch.distributed.ProcessGroup"] = None) -> None:
 
     tvm_ffi.init_pmi()
     _reset_team_state()
+    global _INITIALIZED
+    _INITIALIZED = True
 
     if not dist.is_initialized():
         return
@@ -123,6 +129,7 @@ def init_pmi(pg: Optional["torch.distributed.ProcessGroup"] = None) -> None:
             return
         tvm_ffi.finalize()
         _reset_team_state()
+        _INITIALIZED = False
         raise RuntimeError(
             f"PMI NVSHMEM job has {nvshmem_size} PEs, but the supplied torch process group has {pg_size} ranks"
         )
@@ -135,6 +142,7 @@ def init_pmi(pg: Optional["torch.distributed.ProcessGroup"] = None) -> None:
             return
         tvm_ffi.finalize()
         _reset_team_state()
+        _INITIALIZED = False
         raise RuntimeError("the supplied torch process-group rank order does not match PMI NVSHMEM PE numbering")
 
     global _BOOTSTRAP_PG, _BOOTSTRAP_GLOBAL_RANKS
@@ -142,10 +150,23 @@ def init_pmi(pg: Optional["torch.distributed.ProcessGroup"] = None) -> None:
     _BOOTSTRAP_GLOBAL_RANKS = tuple(dist.get_global_rank(pg, i) for i in range(pg_size))
 
 
+def is_initialized() -> bool:
+    """Return whether NVSHMEM was initialized through this module."""
+    return _INITIALIZED
+
+
+def ensure_initialized(pg: Optional["torch.distributed.ProcessGroup"] = None) -> None:
+    """Initialize NVSHMEM from ``pg`` once, leaving an existing runtime intact."""
+    if not _INITIALIZED:
+        init_from_pg(pg)
+
+
 def finalize() -> None:
+    global _INITIALIZED
     try:
         tvm_ffi.finalize()
     finally:
+        _INITIALIZED = False
         _reset_team_state()
 
 

--- a/liger_cute_kernels/liger_cute_kernels/nvshmem.py
+++ b/liger_cute_kernels/liger_cute_kernels/nvshmem.py
@@ -28,10 +28,8 @@ import torch
 from liger_cute_kernels import tvm_ffi
 
 __all__ = [
-    "ensure_initialized",
     "init_from_pg",
     "init_pmi",
-    "is_initialized",
     "finalize",
     "my_pe",
     "n_pes",
@@ -50,7 +48,6 @@ __all__ = [
 _BOOTSTRAP_PG: Optional["torch.distributed.ProcessGroup"] = None
 _BOOTSTRAP_GLOBAL_RANKS: tuple[int, ...] | None = None
 _PG_TEAM_CACHE: dict[int, int] = {}
-_INITIALIZED = False
 
 
 def _reset_team_state() -> None:
@@ -92,10 +89,9 @@ def init_from_pg(pg: Optional["torch.distributed.ProcessGroup"] = None) -> None:
     tvm_ffi.init_with_uniqueid(rank, world, uid_cpu.data_ptr())
 
     _reset_team_state()
-    global _BOOTSTRAP_PG, _BOOTSTRAP_GLOBAL_RANKS, _INITIALIZED
+    global _BOOTSTRAP_PG, _BOOTSTRAP_GLOBAL_RANKS
     _BOOTSTRAP_PG = pg
     _BOOTSTRAP_GLOBAL_RANKS = global_ranks
-    _INITIALIZED = True
 
 
 def init_pmi(pg: Optional["torch.distributed.ProcessGroup"] = None) -> None:
@@ -115,8 +111,6 @@ def init_pmi(pg: Optional["torch.distributed.ProcessGroup"] = None) -> None:
 
     tvm_ffi.init_pmi()
     _reset_team_state()
-    global _INITIALIZED
-    _INITIALIZED = True
 
     if not dist.is_initialized():
         return
@@ -129,7 +123,6 @@ def init_pmi(pg: Optional["torch.distributed.ProcessGroup"] = None) -> None:
             return
         tvm_ffi.finalize()
         _reset_team_state()
-        _INITIALIZED = False
         raise RuntimeError(
             f"PMI NVSHMEM job has {nvshmem_size} PEs, but the supplied torch process group has {pg_size} ranks"
         )
@@ -142,7 +135,6 @@ def init_pmi(pg: Optional["torch.distributed.ProcessGroup"] = None) -> None:
             return
         tvm_ffi.finalize()
         _reset_team_state()
-        _INITIALIZED = False
         raise RuntimeError("the supplied torch process-group rank order does not match PMI NVSHMEM PE numbering")
 
     global _BOOTSTRAP_PG, _BOOTSTRAP_GLOBAL_RANKS
@@ -150,23 +142,10 @@ def init_pmi(pg: Optional["torch.distributed.ProcessGroup"] = None) -> None:
     _BOOTSTRAP_GLOBAL_RANKS = tuple(dist.get_global_rank(pg, i) for i in range(pg_size))
 
 
-def is_initialized() -> bool:
-    """Return whether NVSHMEM was initialized through this module."""
-    return _INITIALIZED
-
-
-def ensure_initialized(pg: Optional["torch.distributed.ProcessGroup"] = None) -> None:
-    """Initialize NVSHMEM from ``pg`` once, leaving an existing runtime intact."""
-    if not _INITIALIZED:
-        init_from_pg(pg)
-
-
 def finalize() -> None:
-    global _INITIALIZED
     try:
         tvm_ffi.finalize()
     finally:
-        _INITIALIZED = False
         _reset_team_state()
 
 

--- a/liger_cute_kernels/liger_cute_kernels/tvm_ffi.py
+++ b/liger_cute_kernels/liger_cute_kernels/tvm_ffi.py
@@ -14,7 +14,6 @@ import torch
 
 _MOD = None
 _NVSHMEM_LIBS_LOADED = False
-_POOL_GENERATION = 0
 
 
 def is_available() -> bool:
@@ -101,10 +100,14 @@ def nccl_comm_destroy(comm_handle: int) -> None:
     _load_module().nccl_comm_destroy(int(comm_handle))
 
 
+def nccl_runtime_version() -> tuple[int, int, int]:
+    out = torch.empty(3, dtype=torch.int32, device="cpu")
+    _load_module().nccl_runtime_version(out)
+    return tuple(int(value) for value in out.tolist())
+
+
 def finalize() -> None:
-    global _POOL_GENERATION
     _load_module().finalize()
-    _POOL_GENERATION += 1
 
 
 def my_pe() -> int:
@@ -154,19 +157,11 @@ def team_translate_pe(src_team: int, src_pe: int, dst_team: int) -> int:
 
 
 def pool_clear_all() -> None:
-    global _POOL_GENERATION
     _load_module().pool_clear_all()
-    _POOL_GENERATION += 1
 
 
 def pool_clear_buffers() -> None:
-    global _POOL_GENERATION
     _load_module().pool_clear_buffers()
-    _POOL_GENERATION += 1
-
-
-def pool_generation() -> int:
-    return _POOL_GENERATION
 
 
 def moe_configure_symmetric(

--- a/liger_cute_kernels/liger_cute_kernels/tvm_ffi.py
+++ b/liger_cute_kernels/liger_cute_kernels/tvm_ffi.py
@@ -78,34 +78,6 @@ def init_pmi() -> None:
     _load_module().init_pmi()
 
 
-def nccl_unique_id_nbytes() -> int:
-    out = _int64_out()
-    _load_module().nccl_unique_id_nbytes(out)
-    return int(out.item())
-
-
-def nccl_get_unique_id() -> torch.Tensor:
-    out = torch.empty(nccl_unique_id_nbytes(), dtype=torch.uint8, device="cpu")
-    _load_module().nccl_get_unique_id(out)
-    return out
-
-
-def nccl_comm_init_rank(rank: int, nranks: int, unique_id: torch.Tensor) -> int:
-    out = _int64_out()
-    _load_module().nccl_comm_init_rank(int(rank), int(nranks), unique_id, out)
-    return int(out.item())
-
-
-def nccl_comm_destroy(comm_handle: int) -> None:
-    _load_module().nccl_comm_destroy(int(comm_handle))
-
-
-def nccl_runtime_version() -> tuple[int, int, int]:
-    out = torch.empty(3, dtype=torch.int32, device="cpu")
-    _load_module().nccl_runtime_version(out)
-    return tuple(int(value) for value in out.tolist())
-
-
 def finalize() -> None:
     _load_module().finalize()
 
@@ -312,10 +284,10 @@ def fused_linear_scaled_cross_entropy_forward(
     vocab_start: int,
     ignore_index: int,
     inverse_temperature: float,
-    nccl_comm_handle: int,
+    team_handle: int,
     return_entropy: bool,
 ):
-    """Run the complete tensor-parallel forward using a caller-owned NCCL communicator."""
+    """Run the complete tensor-parallel forward on a prepared NVSHMEM team."""
     tokens = x.shape[0]
     nll = torch.empty(tokens, dtype=torch.float32, device=x.device)
     lse = torch.empty(tokens, dtype=torch.float32, device=x.device)
@@ -331,7 +303,7 @@ def fused_linear_scaled_cross_entropy_forward(
         int(vocab_start),
         int(ignore_index),
         float(inverse_temperature),
-        int(nccl_comm_handle),
+        int(team_handle),
         bool(return_entropy),
         nll,
         lse,

--- a/liger_cute_kernels/liger_cute_kernels/tvm_ffi.py
+++ b/liger_cute_kernels/liger_cute_kernels/tvm_ffi.py
@@ -14,6 +14,7 @@ import torch
 
 _MOD = None
 _NVSHMEM_LIBS_LOADED = False
+_POOL_GENERATION = 0
 
 
 def is_available() -> bool:
@@ -101,7 +102,9 @@ def nccl_comm_destroy(comm_handle: int) -> None:
 
 
 def finalize() -> None:
+    global _POOL_GENERATION
     _load_module().finalize()
+    _POOL_GENERATION += 1
 
 
 def my_pe() -> int:
@@ -151,11 +154,19 @@ def team_translate_pe(src_team: int, src_pe: int, dst_team: int) -> int:
 
 
 def pool_clear_all() -> None:
+    global _POOL_GENERATION
     _load_module().pool_clear_all()
+    _POOL_GENERATION += 1
 
 
 def pool_clear_buffers() -> None:
+    global _POOL_GENERATION
     _load_module().pool_clear_buffers()
+    _POOL_GENERATION += 1
+
+
+def pool_generation() -> int:
+    return _POOL_GENERATION
 
 
 def moe_configure_symmetric(

--- a/liger_cute_kernels/liger_cute_kernels/tvm_ffi_bindings.cpp
+++ b/liger_cute_kernels/liger_cute_kernels/tvm_ffi_bindings.cpp
@@ -232,6 +232,16 @@ void nccl_comm_destroy(int64_t comm_handle) {
       "ncclCommDestroy");
 }
 
+void nccl_runtime_version(ffi::TensorView out) {
+  RequireCpuInt32(out, 3);
+  int version = 0;
+  CheckNccl(ncclGetVersion(&version), "ncclGetVersion");
+  auto* values = static_cast<int32_t*>(out.data_ptr());
+  values[0] = version / 10000;
+  values[1] = (version % 10000) / 100;
+  values[2] = version % 100;
+}
+
 void my_pe(ffi::TensorView out) {
   RequireCpuInt32(out, 1);
   CheckStatus(liger_cute_nvshmem_my_pe(static_cast<int*>(out.data_ptr())), "my_pe");
@@ -642,6 +652,7 @@ TVM_FFI_DLL_EXPORT_TYPED_FUNC(nccl_unique_id_nbytes, nccl_unique_id_nbytes);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(nccl_get_unique_id, nccl_get_unique_id);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(nccl_comm_init_rank, nccl_comm_init_rank);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(nccl_comm_destroy, nccl_comm_destroy);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(nccl_runtime_version, nccl_runtime_version);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(my_pe, my_pe);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(n_pes, n_pes);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(team_world, team_world);

--- a/liger_cute_kernels/liger_cute_kernels/tvm_ffi_bindings.cpp
+++ b/liger_cute_kernels/liger_cute_kernels/tvm_ffi_bindings.cpp
@@ -2,12 +2,10 @@
 #include <tvm/ffi/tvm_ffi.h>
 
 #include <cuda_runtime.h>
-#include <nccl.h>
 
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <exception>
 
 #include "backward_gemm_sm90.cuh"
@@ -72,13 +70,6 @@ void CheckStatus(liger_cute_status_t status, const char* what) {
     TVM_FFI_THROW(RuntimeError) << "liger_cute: " << what << " failed ("
                                 << liger_cute_status_string(status)
                                 << "): " << liger_cute_last_error_string();
-  }
-}
-
-void CheckNccl(ncclResult_t status, const char* what) {
-  if (status != ncclSuccess) {
-    TVM_FFI_THROW(RuntimeError) << "liger_cute: " << what << " failed: "
-                                << ncclGetErrorString(status);
   }
 }
 
@@ -185,62 +176,6 @@ void init_pmi() { CheckStatus(liger_cute_nvshmem_init_pmi(), "init_pmi"); }
 void finalize() { CheckStatus(liger_cute_nvshmem_finalize(), "finalize"); }
 void pool_clear_all() { CheckStatus(liger_cute_pool_clear_all(), "pool_clear_all"); }
 void pool_clear_buffers() { CheckStatus(liger_cute_pool_clear_buffers(), "pool_clear_buffers"); }
-
-void nccl_unique_id_nbytes(ffi::TensorView out) {
-  RequireCpuInt64(out, 1);
-  static_cast<int64_t*>(out.data_ptr())[0] = sizeof(ncclUniqueId);
-}
-
-void nccl_get_unique_id(ffi::TensorView out) {
-  DLDataType u8{kDLUInt, 8, 1};
-  RequireTensor(out, 1, u8, "out");
-  TVM_FFI_ICHECK_EQ(out.device().device_type, kDLCPU);
-  TVM_FFI_ICHECK_EQ(out.size(0), static_cast<int64_t>(sizeof(ncclUniqueId)));
-  ncclUniqueId unique_id;
-  CheckNccl(ncclGetUniqueId(&unique_id), "ncclGetUniqueId");
-  std::memcpy(out.data_ptr(), &unique_id, sizeof(unique_id));
-}
-
-void nccl_comm_init_rank(
-    int64_t rank, int64_t nranks, ffi::TensorView unique_id, ffi::TensorView out) {
-  DLDataType u8{kDLUInt, 8, 1};
-  RequireTensor(unique_id, 1, u8, "unique_id");
-  TVM_FFI_ICHECK_EQ(unique_id.device().device_type, kDLCPU);
-  TVM_FFI_ICHECK_EQ(
-      unique_id.size(0), static_cast<int64_t>(sizeof(ncclUniqueId)));
-  RequireCpuInt64(out, 1);
-  TVM_FFI_ICHECK_GT(nranks, 0);
-  TVM_FFI_ICHECK_GE(rank, 0);
-  TVM_FFI_ICHECK_LT(rank, nranks);
-  ncclUniqueId id;
-  std::memcpy(&id, unique_id.data_ptr(), sizeof(id));
-  ncclComm_t comm = nullptr;
-  CheckNccl(
-      ncclCommInitRank(
-          &comm, static_cast<int>(nranks), id, static_cast<int>(rank)),
-      "ncclCommInitRank");
-  static_cast<int64_t*>(out.data_ptr())[0] =
-      reinterpret_cast<int64_t>(comm);
-}
-
-void nccl_comm_destroy(int64_t comm_handle) {
-  if (comm_handle == 0) {
-    return;
-  }
-  CheckNccl(
-      ncclCommDestroy(reinterpret_cast<ncclComm_t>(comm_handle)),
-      "ncclCommDestroy");
-}
-
-void nccl_runtime_version(ffi::TensorView out) {
-  RequireCpuInt32(out, 3);
-  int version = 0;
-  CheckNccl(ncclGetVersion(&version), "ncclGetVersion");
-  auto* values = static_cast<int32_t*>(out.data_ptr());
-  values[0] = version / 10000;
-  values[1] = (version % 10000) / 100;
-  values[2] = version % 100;
-}
 
 void my_pe(ffi::TensorView out) {
   RequireCpuInt32(out, 1);
@@ -499,7 +434,7 @@ void fused_linear_scaled_cross_entropy_configure_backward(
 void fused_linear_scaled_cross_entropy_forward(
     ffi::TensorView x, ffi::TensorView weight, ffi::TensorView target,
     int64_t vocab_start, int64_t ignore_index, double inverse_temperature,
-    int64_t nccl_comm_handle, bool return_entropy, ffi::TensorView nll,
+    int64_t team_handle, bool return_entropy, ffi::TensorView nll,
     ffi::TensorView lse, ffi::TensorView entropy) {
   DLDataType bf16{kDLBfloat, 16, 1};
   DLDataType f32{kDLFloat, 32, 1};
@@ -525,7 +460,6 @@ void fused_linear_scaled_cross_entropy_forward(
   TVM_FFI_ICHECK_EQ(lse.size(0), tokens);
   TVM_FFI_ICHECK_EQ(entropy.size(0), tokens);
   TVM_FFI_ICHECK_GE(vocab_start, 0);
-  TVM_FFI_ICHECK_NE(nccl_comm_handle, 0);
   RequirePositiveInverseTemperature(inverse_temperature);
 
   using namespace liger::fused_scaled_linear_cross_entropy;
@@ -542,7 +476,7 @@ void fused_linear_scaled_cross_entropy_forward(
   params.nll = static_cast<float*>(nll.data_ptr());
   params.lse = static_cast<float*>(lse.data_ptr());
   params.entropy = static_cast<float*>(entropy.data_ptr());
-  params.nccl_comm_handle = nccl_comm_handle;
+  params.team_handle = team_handle;
   cudaStream_t stream = reinterpret_cast<cudaStream_t>(
       TVMFFIEnvGetStream(x.device().device_type, x.device().device_id));
   try {
@@ -648,11 +582,6 @@ TVM_FFI_DLL_EXPORT_TYPED_FUNC(get_uniqueid, get_uniqueid);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(init_with_uniqueid, init_with_uniqueid);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(init_pmi, init_pmi);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(finalize, finalize);
-TVM_FFI_DLL_EXPORT_TYPED_FUNC(nccl_unique_id_nbytes, nccl_unique_id_nbytes);
-TVM_FFI_DLL_EXPORT_TYPED_FUNC(nccl_get_unique_id, nccl_get_unique_id);
-TVM_FFI_DLL_EXPORT_TYPED_FUNC(nccl_comm_init_rank, nccl_comm_init_rank);
-TVM_FFI_DLL_EXPORT_TYPED_FUNC(nccl_comm_destroy, nccl_comm_destroy);
-TVM_FFI_DLL_EXPORT_TYPED_FUNC(nccl_runtime_version, nccl_runtime_version);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(my_pe, my_pe);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(n_pes, n_pes);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(team_world, team_world);

--- a/liger_cute_kernels/test/test_fslce_teams.py
+++ b/liger_cute_kernels/test/test_fslce_teams.py
@@ -39,6 +39,7 @@ def test_fslce_forward_binding_is_exposed():
     for name in (
         "nccl_get_unique_id",
         "nccl_comm_init_rank",
+        "nccl_runtime_version",
         "fused_linear_scaled_cross_entropy_configure_forward",
         "fused_linear_scaled_cross_entropy_forward",
     ):

--- a/liger_cute_kernels/test/test_fslce_teams.py
+++ b/liger_cute_kernels/test/test_fslce_teams.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import shutil
-import sys
 import tempfile
 
 from datetime import timedelta
@@ -37,9 +36,6 @@ def test_fslce_forward_binding_is_exposed():
         pytest.skip("requires the native core")
     module = tvm_ffi._load_module()
     for name in (
-        "nccl_get_unique_id",
-        "nccl_comm_init_rank",
-        "nccl_runtime_version",
         "fused_linear_scaled_cross_entropy_configure_forward",
         "fused_linear_scaled_cross_entropy_forward",
     ):
@@ -63,7 +59,7 @@ def test_forward_returns_zero_entropy_when_disabled(monkeypatch):
         vocab_start=0,
         ignore_index=-100,
         inverse_temperature=1.0,
-        nccl_comm_handle=1,
+        team_handle=1,
         return_entropy=False,
     )
     torch.testing.assert_close(entropy, torch.zeros_like(entropy))
@@ -95,7 +91,6 @@ def _worker(rank: int, world_size: int, init_file: str, subgroup: bool):
     )
 
     team = None
-    nccl_comm = 0
     try:
         nvshmem.init_from_pg()
         pg = dist.group.WORLD
@@ -113,16 +108,6 @@ def _worker(rank: int, world_size: int, init_file: str, subgroup: bool):
 
         local_rank = group_ranks.index(rank)
         team_size = len(group_ranks)
-        unique_id_payload = [tvm_ffi.nccl_get_unique_id().tolist() if local_rank == 0 else None]
-        dist.broadcast_object_list(
-            unique_id_payload,
-            src=group_ranks[0],
-            group=pg,
-            device=torch.device("cuda", rank),
-        )
-        unique_id = torch.tensor(unique_id_payload[0], dtype=torch.uint8)
-        nccl_comm = tvm_ffi.nccl_comm_init_rank(local_rank, team_size, unique_id)
-
         tokens = 128
         hidden = 2048
         local_vocab = 320
@@ -161,7 +146,7 @@ def _worker(rank: int, world_size: int, init_file: str, subgroup: bool):
             local_rank * local_vocab,
             -100,
             1.0 / temperature,
-            nccl_comm,
+            team,
             True,
         )
         actual_dx, actual_dw = tvm_ffi.fused_linear_scaled_cross_entropy_backward(
@@ -183,6 +168,40 @@ def _worker(rank: int, world_size: int, init_file: str, subgroup: bool):
         torch.testing.assert_close(actual_nll, expected_nll, atol=2e-4, rtol=2e-4)
         torch.testing.assert_close(lse, expected_lse, atol=2e-4, rtol=2e-4)
         torch.testing.assert_close(entropy, expected_entropy, atol=2e-4, rtol=2e-4)
+
+        replay_nll = torch.empty_like(actual_nll)
+        replay_lse = torch.empty_like(lse)
+        replay_entropy = torch.empty_like(entropy)
+        module = tvm_ffi._load_module()
+        forward_graph = torch.cuda.CUDAGraph()
+        dist.barrier()
+        with torch.cuda.graph(forward_graph):
+            module.fused_linear_scaled_cross_entropy_forward(
+                x,
+                weight,
+                target,
+                local_rank * local_vocab,
+                -100,
+                1.0 / temperature,
+                team,
+                True,
+                replay_nll,
+                replay_lse,
+                replay_entropy,
+            )
+        dist.barrier()
+        for _ in range(2):
+            replay_nll.fill_(float("nan"))
+            replay_lse.fill_(float("nan"))
+            replay_entropy.fill_(float("nan"))
+            torch.cuda.synchronize()
+            forward_graph.replay()
+            torch.cuda.synchronize()
+            torch.testing.assert_close(replay_nll, expected_nll, atol=2e-4, rtol=2e-4)
+            torch.testing.assert_close(replay_lse, expected_lse, atol=2e-4, rtol=2e-4)
+            torch.testing.assert_close(replay_entropy, expected_entropy, atol=2e-4, rtol=2e-4)
+        del forward_graph
+
         torch.testing.assert_close(actual_dx.float(), expected_dx, atol=8e-3, rtol=4e-2)
         torch.testing.assert_close(actual_dw.float(), expected_dw, atol=8e-3, rtol=4e-2)
 
@@ -190,7 +209,6 @@ def _worker(rank: int, world_size: int, init_file: str, subgroup: bool):
         tvm_ffi.fused_linear_scaled_cross_entropy_configure_backward(tokens, hidden, local_vocab, 1, team)
         replay_dx = torch.empty_like(x)
         replay_dw = torch.empty_like(weight)
-        module = tvm_ffi._load_module()
         graph = torch.cuda.CUDAGraph()
         dist.barrier()
         with torch.cuda.graph(graph):
@@ -225,8 +243,6 @@ def _worker(rank: int, world_size: int, init_file: str, subgroup: bool):
         torch.testing.assert_close(replay_dx.float(), expected_dx, atol=8e-3, rtol=4e-2)
         torch.testing.assert_close(replay_dw.float(), expected_dw, atol=8e-3, rtol=4e-2)
 
-        tvm_ffi.nccl_comm_destroy(nccl_comm)
-        nccl_comm = 0
         nvshmem.pool_clear_all()
         if subgroup and team != nvshmem.team_world():
             nvshmem.team_destroy(team)
@@ -235,11 +251,6 @@ def _worker(rank: int, world_size: int, init_file: str, subgroup: bool):
         nvshmem.finalize()
         dist.destroy_process_group()
     except BaseException:
-        if nccl_comm:
-            try:
-                tvm_ffi.nccl_comm_destroy(nccl_comm)
-            except Exception as cleanup_error:
-                print(f"NCCL communicator cleanup failed: {cleanup_error}", file=sys.stderr)
         try:
             dist.destroy_process_group()
         except Exception:

--- a/liger_cute_kernels/test/test_nvshmem.py
+++ b/liger_cute_kernels/test/test_nvshmem.py
@@ -109,8 +109,10 @@ def test_ranks_to_strided_rejects(bad):
 @pytest.fixture
 def isolated_team_state():
     nvshmem._reset_team_state()
+    nvshmem._INITIALIZED = False
     yield
     nvshmem._reset_team_state()
+    nvshmem._INITIALIZED = False
 
 
 def test_team_from_pg_uses_bootstrap_pe_numbering(monkeypatch, isolated_team_state):
@@ -186,6 +188,7 @@ def test_init_pmi_records_aligned_torch_world(monkeypatch, isolated_team_state):
 
     assert nvshmem._BOOTSTRAP_PG is world_pg
     assert nvshmem._BOOTSTRAP_GLOBAL_RANKS == (0, 1, 2, 3)
+    assert nvshmem.is_initialized()
 
 
 def test_init_pmi_without_matching_world_keeps_world_only_mode(monkeypatch, isolated_team_state):
@@ -198,6 +201,23 @@ def test_init_pmi_without_matching_world_keeps_world_only_mode(monkeypatch, isol
 
     assert nvshmem._BOOTSTRAP_PG is None
     assert nvshmem._BOOTSTRAP_GLOBAL_RANKS is None
+    assert nvshmem.is_initialized()
+
+
+def test_ensure_initialized_bootstraps_only_once(monkeypatch, isolated_team_state):
+    pg = object()
+    calls = []
+
+    def fake_init(actual_pg):
+        calls.append(actual_pg)
+        nvshmem._INITIALIZED = True
+
+    monkeypatch.setattr(nvshmem, "init_from_pg", fake_init)
+
+    nvshmem.ensure_initialized(pg)
+    nvshmem.ensure_initialized(pg)
+
+    assert calls == [pg]
 
 
 # ── Distributed harness ──────────────────────────────────────────────────────

--- a/liger_cute_kernels/test/test_nvshmem.py
+++ b/liger_cute_kernels/test/test_nvshmem.py
@@ -109,10 +109,8 @@ def test_ranks_to_strided_rejects(bad):
 @pytest.fixture
 def isolated_team_state():
     nvshmem._reset_team_state()
-    nvshmem._INITIALIZED = False
     yield
     nvshmem._reset_team_state()
-    nvshmem._INITIALIZED = False
 
 
 def test_team_from_pg_uses_bootstrap_pe_numbering(monkeypatch, isolated_team_state):
@@ -188,7 +186,6 @@ def test_init_pmi_records_aligned_torch_world(monkeypatch, isolated_team_state):
 
     assert nvshmem._BOOTSTRAP_PG is world_pg
     assert nvshmem._BOOTSTRAP_GLOBAL_RANKS == (0, 1, 2, 3)
-    assert nvshmem.is_initialized()
 
 
 def test_init_pmi_without_matching_world_keeps_world_only_mode(monkeypatch, isolated_team_state):
@@ -201,23 +198,6 @@ def test_init_pmi_without_matching_world_keeps_world_only_mode(monkeypatch, isol
 
     assert nvshmem._BOOTSTRAP_PG is None
     assert nvshmem._BOOTSTRAP_GLOBAL_RANKS is None
-    assert nvshmem.is_initialized()
-
-
-def test_ensure_initialized_bootstraps_only_once(monkeypatch, isolated_team_state):
-    pg = object()
-    calls = []
-
-    def fake_init(actual_pg):
-        calls.append(actual_pg)
-        nvshmem._INITIALIZED = True
-
-    monkeypatch.setattr(nvshmem, "init_from_pg", fake_init)
-
-    nvshmem.ensure_initialized(pg)
-    nvshmem.ensure_initialized(pg)
-
-    assert calls == [pg]
 
 
 # ── Distributed harness ──────────────────────────────────────────────────────

--- a/src/liger_kernel/ops/__init__.py
+++ b/src/liger_kernel/ops/__init__.py
@@ -50,6 +50,9 @@ from liger_kernel.ops.fused_linear_jsd import LigerFusedLinearJSDFunction  # noq
 from liger_kernel.ops.fused_linear_jsd import fused_linear_jsd_backward  # noqa: F401
 from liger_kernel.ops.fused_linear_jsd import fused_linear_jsd_forward  # noqa: F401
 from liger_kernel.ops.fused_linear_scaled_cross_entropy import LigerFusedLinearScaledCrossEntropyFunction  # noqa: F401
+from liger_kernel.ops.fused_linear_scaled_cross_entropy import (
+    LigerFusedLinearScaledCrossEntropyTPFunction,  # noqa: F401
+)
 from liger_kernel.ops.fused_moe import LigerFusedMoEFunction  # noqa: F401
 from liger_kernel.ops.fused_neighborhood_attention import LigerFusedNeighborhoodAttentionFunction  # noqa: F401
 from liger_kernel.ops.geglu import LigerGELUMulFunction  # noqa: F401

--- a/src/liger_kernel/ops/cute/fused_linear_scaled_cross_entropy_tp.py
+++ b/src/liger_kernel/ops/cute/fused_linear_scaled_cross_entropy_tp.py
@@ -39,26 +39,10 @@ def is_available() -> bool:
         "fused_linear_scaled_cross_entropy_configure_forward",
         "fused_linear_scaled_cross_entropy_backward",
         "fused_linear_scaled_cross_entropy_forward",
-        "nccl_runtime_version",
     )
     if not all(hasattr(native_module, name) for name in required_native):
         return False
     return callable(getattr(nvshmem, "resolve_team", None))
-
-
-def supports_process_group(process_group: "ProcessGroup", device: torch.device) -> bool:
-    try:
-        backend = process_group._get_backend(device)
-    except (AttributeError, RuntimeError):
-        return False
-    required = (
-        "_comm_ptr",
-        "eager_connect_single_device",
-        "get_runtime_nccl_version",
-    )
-    if not all(callable(getattr(backend, name, None)) for name in required):
-        return False
-    return tuple(backend.get_runtime_nccl_version()) == _get_tvm_ffi().nccl_runtime_version()
 
 
 def _validate_temperature(temperature) -> None:
@@ -118,25 +102,6 @@ def _cuda_device_context(tensor):
         yield
 
 
-def _borrow_nccl_communicator(process_group: "ProcessGroup", device: torch.device) -> int:
-    """Borrow the current-device communicator without storing or owning it."""
-    backend = process_group._get_backend(device)
-    torch_nccl_version = tuple(backend.get_runtime_nccl_version())
-    lck_nccl_version = _get_tvm_ffi().nccl_runtime_version()
-    if torch_nccl_version != lck_nccl_version:
-        raise RuntimeError(
-            "the PyTorch and LCK NCCL runtime versions must match before sharing a communicator: "
-            f"torch={torch_nccl_version}, lck={lck_nccl_version}"
-        )
-    comm_handle = int(backend._comm_ptr())
-    if comm_handle == 0:
-        backend.eager_connect_single_device(device)
-        comm_handle = int(backend._comm_ptr())
-    if comm_handle == 0:
-        raise RuntimeError("PyTorch did not expose a ready NCCL communicator for the tensor-parallel process group")
-    return comm_handle
-
-
 def _prepare_lck_call(process_group: "ProcessGroup", device, tokens, hidden, local_vocab, tiles_per_reduce) -> int:
     tvm_ffi = _get_tvm_ffi()
     with torch.cuda.device(device):
@@ -184,7 +149,6 @@ class LigerFusedLinearScaledCrossEntropyLckTPFunction(torch.autograd.Function):
             tiles_per_reduce,
         )
         with _cuda_device_context(x_padded):
-            nccl_comm_handle = _borrow_nccl_communicator(tp_group, x_padded.device)
             nll, lse, entropy = _get_tvm_ffi().fused_linear_scaled_cross_entropy_forward(
                 x_padded,
                 weight_padded,
@@ -192,7 +156,7 @@ class LigerFusedLinearScaledCrossEntropyLckTPFunction(torch.autograd.Function):
                 vocab_start,
                 ignore_index,
                 1.0 / temperature,
-                nccl_comm_handle,
+                team_handle,
                 return_entropy,
             )
 

--- a/src/liger_kernel/ops/cute/fused_linear_scaled_cross_entropy_tp.py
+++ b/src/liger_kernel/ops/cute/fused_linear_scaled_cross_entropy_tp.py
@@ -1,0 +1,293 @@
+"""LCK adapter for tensor-parallel fused linear scaled cross entropy."""
+
+from __future__ import annotations
+
+import math
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+
+if TYPE_CHECKING:
+    from torch.distributed import ProcessGroup
+
+_HIDDEN_ALIGNMENT = 8
+_RUNTIME = None
+
+
+@dataclass
+class _Runtime:
+    group_ranks: tuple[int, ...]
+    device_index: int
+    team_handle: int
+    nccl_comm_handle: int
+    pool_generation: int
+    max_tokens: int = 0
+    max_hidden: int = 0
+    max_local_vocab: int = 0
+    max_tiles_per_reduce: int = 0
+
+
+def _get_tvm_ffi():
+    from liger_kernel.ops.cute import _load_tvm_ffi
+
+    return _load_tvm_ffi()
+
+
+def _get_nvshmem():
+    from liger_cute_kernels import nvshmem
+
+    return nvshmem
+
+
+def is_available() -> bool:
+    try:
+        tvm_ffi = _get_tvm_ffi()
+        nvshmem = _get_nvshmem()
+    except ImportError:
+        return False
+    required_tvm_ffi = (
+        "fused_linear_scaled_cross_entropy_configure_backward",
+        "fused_linear_scaled_cross_entropy_configure_forward",
+        "fused_linear_scaled_cross_entropy_backward",
+        "fused_linear_scaled_cross_entropy_forward",
+        "nccl_comm_destroy",
+        "nccl_comm_init_rank",
+        "nccl_get_unique_id",
+        "nccl_unique_id_nbytes",
+        "pool_generation",
+    )
+    if not all(callable(getattr(tvm_ffi, name, None)) for name in required_tvm_ffi):
+        return False
+    return all(
+        callable(getattr(nvshmem, name, None)) for name in ("ensure_initialized", "is_initialized", "resolve_team")
+    )
+
+
+def _validate_temperature(temperature) -> None:
+    if isinstance(temperature, bool) or not isinstance(temperature, (int, float)):
+        raise TypeError("temperature must be a real number")
+    if not math.isfinite(temperature) or temperature <= 0:
+        raise ValueError("temperature must be finite and > 0")
+
+
+def _validate_inputs(x, weight, target, vocab_start, tiles_per_reduce, return_entropy) -> None:
+    if x.device != weight.device or x.device != target.device:
+        raise ValueError("input, weight, and target must be on the same CUDA device")
+    if not x.is_cuda:
+        raise RuntimeError("the LCK tensor-parallel path requires CUDA tensors")
+    if x.dtype != torch.bfloat16 or weight.dtype != torch.bfloat16:
+        raise TypeError("the LCK tensor-parallel path supports BF16 input and weight only")
+    if target.dtype != torch.int64:
+        raise TypeError("target must be an int64 tensor of global vocabulary indices")
+    if x.ndim != 2 or weight.ndim != 2 or target.ndim != 1:
+        raise ValueError("expected input[M,H], weight[V_local,H], and target[M]")
+    if x.shape[0] != target.shape[0] or x.shape[1] != weight.shape[1]:
+        raise ValueError(
+            f"input {tuple(x.shape)}, weight {tuple(weight.shape)}, and target {tuple(target.shape)} are incompatible"
+        )
+    if x.shape[0] == 0 or x.shape[1] == 0 or weight.shape[0] == 0:
+        raise ValueError("token, hidden, and local vocabulary dimensions must be non-empty")
+    if not isinstance(vocab_start, int) or isinstance(vocab_start, bool):
+        raise TypeError("vocab_start must be an int")
+    if vocab_start < 0:
+        raise ValueError("vocab_start must be non-negative")
+    if tiles_per_reduce not in (1, 2, 4):
+        raise ValueError("tiles_per_reduce must be one of 1, 2, or 4")
+    if not isinstance(return_entropy, bool):
+        raise TypeError("return_entropy must be a bool")
+
+
+def _pad_hidden(x, weight):
+    hidden = x.shape[1]
+    padded_hidden = (hidden + _HIDDEN_ALIGNMENT - 1) // _HIDDEN_ALIGNMENT * _HIDDEN_ALIGNMENT
+    if padded_hidden == hidden:
+        return x.contiguous(), weight.contiguous(), hidden
+    padding = (0, padded_hidden - hidden)
+    return (
+        torch.nn.functional.pad(x.contiguous(), padding),
+        torch.nn.functional.pad(weight.contiguous(), padding),
+        hidden,
+    )
+
+
+def _group_ranks(process_group: "ProcessGroup") -> tuple[int, ...]:
+    return tuple(dist.get_global_rank(process_group, rank) for rank in range(dist.get_world_size(process_group)))
+
+
+def _create_nccl_communicator(process_group: "ProcessGroup", device: torch.device) -> int:
+    tvm_ffi = _get_tvm_ffi()
+    rank = dist.get_rank(process_group)
+    group_ranks = _group_ranks(process_group)
+    unique_id = torch.empty(tvm_ffi.nccl_unique_id_nbytes(), dtype=torch.uint8, device=device)
+    if rank == 0:
+        unique_id.copy_(tvm_ffi.nccl_get_unique_id(), non_blocking=False)
+    dist.broadcast(unique_id, src=group_ranks[0], group=process_group)
+    return tvm_ffi.nccl_comm_init_rank(rank, len(group_ranks), unique_id.cpu().contiguous())
+
+
+def _configure_runtime(runtime: _Runtime, tokens: int, hidden: int, local_vocab: int, tiles_per_reduce: int) -> None:
+    if (
+        tokens <= runtime.max_tokens
+        and hidden <= runtime.max_hidden
+        and local_vocab <= runtime.max_local_vocab
+        and tiles_per_reduce <= runtime.max_tiles_per_reduce
+    ):
+        return
+
+    tvm_ffi = _get_tvm_ffi()
+    tvm_ffi.fused_linear_scaled_cross_entropy_configure_backward(
+        max(tokens, runtime.max_tokens),
+        max(hidden, runtime.max_hidden),
+        max(local_vocab, runtime.max_local_vocab),
+        max(tiles_per_reduce, runtime.max_tiles_per_reduce),
+        runtime.team_handle,
+    )
+    tvm_ffi.fused_linear_scaled_cross_entropy_configure_forward(
+        max(tokens, runtime.max_tokens),
+        max(local_vocab, runtime.max_local_vocab),
+    )
+    runtime.max_tokens = max(tokens, runtime.max_tokens)
+    runtime.max_hidden = max(hidden, runtime.max_hidden)
+    runtime.max_local_vocab = max(local_vocab, runtime.max_local_vocab)
+    runtime.max_tiles_per_reduce = max(tiles_per_reduce, runtime.max_tiles_per_reduce)
+
+
+def _prepare_runtime(process_group: "ProcessGroup", device, tokens, hidden, local_vocab, tiles_per_reduce) -> _Runtime:
+    global _RUNTIME
+
+    nvshmem = _get_nvshmem()
+    tvm_ffi = _get_tvm_ffi()
+    if _RUNTIME is not None and not nvshmem.is_initialized():
+        tvm_ffi.nccl_comm_destroy(_RUNTIME.nccl_comm_handle)
+        _RUNTIME = None
+
+    ranks = _group_ranks(process_group)
+    device_index = device.index if device.index is not None else torch.cuda.current_device()
+    if _RUNTIME is not None:
+        if _RUNTIME.group_ranks != ranks or _RUNTIME.device_index != device_index:
+            raise RuntimeError(
+                "the LCK tensor-parallel runtime is already bound to another process group or CUDA device"
+            )
+        pool_generation = tvm_ffi.pool_generation()
+        if _RUNTIME.pool_generation != pool_generation:
+            _RUNTIME.pool_generation = pool_generation
+            _RUNTIME.max_tokens = 0
+            _RUNTIME.max_hidden = 0
+            _RUNTIME.max_local_vocab = 0
+            _RUNTIME.max_tiles_per_reduce = 0
+        _configure_runtime(_RUNTIME, tokens, hidden, local_vocab, tiles_per_reduce)
+        return _RUNTIME
+
+    with torch.cuda.device(device):
+        # Share one WORLD bootstrap with LigerMoE; EP and TP remain separate
+        # cached NVSHMEM teams underneath that process-wide runtime.
+        nvshmem.ensure_initialized()
+        team_handle = nvshmem.resolve_team(process_group)
+        runtime = _Runtime(
+            group_ranks=ranks,
+            device_index=device_index,
+            team_handle=team_handle,
+            nccl_comm_handle=0,
+            pool_generation=tvm_ffi.pool_generation(),
+        )
+        _configure_runtime(runtime, tokens, hidden, local_vocab, tiles_per_reduce)
+        runtime.nccl_comm_handle = _create_nccl_communicator(process_group, device)
+    _RUNTIME = runtime
+    return runtime
+
+
+class LigerFusedLinearScaledCrossEntropyLckTPFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        x,
+        weight,
+        target,
+        vocab_start,
+        temperature,
+        ignore_index,
+        tiles_per_reduce,
+        return_entropy,
+        tp_group,
+    ):
+        ctx.set_materialize_grads(False)
+        _validate_temperature(temperature)
+        _validate_inputs(x, weight, target, vocab_start, tiles_per_reduce, return_entropy)
+
+        x_padded, weight_padded, hidden = _pad_hidden(x, weight)
+        target = target.contiguous()
+        runtime = _prepare_runtime(
+            tp_group,
+            x.device,
+            target.shape[0],
+            x_padded.shape[1],
+            weight.shape[0],
+            tiles_per_reduce,
+        )
+        tvm_ffi = _get_tvm_ffi()
+        nll, lse, entropy = tvm_ffi.fused_linear_scaled_cross_entropy_forward(
+            x_padded,
+            weight_padded,
+            target,
+            vocab_start,
+            ignore_index,
+            1.0 / temperature,
+            runtime.nccl_comm_handle,
+            return_entropy,
+        )
+
+        ctx.save_for_backward(x_padded, weight_padded, target, lse, entropy)
+        ctx.hidden = hidden
+        ctx.vocab_start = vocab_start
+        ctx.ignore_index = ignore_index
+        ctx.inverse_temperature = 1.0 / temperature
+        ctx.team_handle = runtime.team_handle
+        ctx.tiles_per_reduce = tiles_per_reduce
+        ctx.return_entropy = return_entropy
+        return (nll, entropy) if return_entropy else nll
+
+    @staticmethod
+    def backward(ctx, grad_nll, grad_entropy=None):
+        x, weight, target, lse, entropy = ctx.saved_tensors
+        tokens = target.shape[0]
+        if grad_nll is None:
+            grad_nll = torch.zeros(tokens, dtype=torch.float32, device=target.device)
+        else:
+            grad_nll = grad_nll.detach().to(torch.float32).contiguous()
+        if grad_nll.shape != (tokens,):
+            raise ValueError(f"expected per-token NLL gradients with shape {(tokens,)}, got {tuple(grad_nll.shape)}")
+
+        if grad_entropy is None:
+            grad_entropy = torch.zeros(tokens, dtype=torch.float32, device=target.device)
+        else:
+            grad_entropy = grad_entropy.detach().to(torch.float32).contiguous()
+        if grad_entropy.shape != (tokens,):
+            raise ValueError(
+                f"expected per-token entropy gradients with shape {(tokens,)}, got {tuple(grad_entropy.shape)}"
+            )
+
+        grad_input, grad_weight = _get_tvm_ffi().fused_linear_scaled_cross_entropy_backward(
+            grad_nll,
+            grad_entropy,
+            x,
+            weight,
+            target,
+            lse,
+            entropy,
+            ctx.vocab_start,
+            ctx.ignore_index,
+            ctx.inverse_temperature,
+            ctx.team_handle,
+            ctx.tiles_per_reduce,
+            ctx.return_entropy,
+        )
+        if ctx.hidden != x.shape[1]:
+            grad_input = grad_input[:, : ctx.hidden].contiguous()
+            grad_weight = grad_weight[:, : ctx.hidden].contiguous()
+        return grad_input, grad_weight, None, None, None, None, None, None, None
+
+
+__all__ = ["LigerFusedLinearScaledCrossEntropyLckTPFunction", "is_available"]

--- a/src/liger_kernel/ops/cute/fused_linear_scaled_cross_entropy_tp.py
+++ b/src/liger_kernel/ops/cute/fused_linear_scaled_cross_entropy_tp.py
@@ -5,30 +5,14 @@ from __future__ import annotations
 import math
 
 from contextlib import contextmanager
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import torch
-import torch.distributed as dist
 
 if TYPE_CHECKING:
     from torch.distributed import ProcessGroup
 
 _HIDDEN_ALIGNMENT = 8
-_RUNTIME = None
-
-
-@dataclass
-class _Runtime:
-    group_ranks: tuple[int, ...]
-    device_index: int
-    team_handle: int
-    nccl_comm_handle: int
-    pool_generation: int
-    max_tokens: int = 0
-    max_hidden: int = 0
-    max_local_vocab: int = 0
-    max_tiles_per_reduce: int = 0
 
 
 def _get_tvm_ffi():
@@ -47,24 +31,34 @@ def is_available() -> bool:
     try:
         tvm_ffi = _get_tvm_ffi()
         nvshmem = _get_nvshmem()
+        native_module = tvm_ffi._load_module()
     except ImportError:
         return False
-    required_tvm_ffi = (
+    required_native = (
         "fused_linear_scaled_cross_entropy_configure_backward",
         "fused_linear_scaled_cross_entropy_configure_forward",
         "fused_linear_scaled_cross_entropy_backward",
         "fused_linear_scaled_cross_entropy_forward",
-        "nccl_comm_destroy",
-        "nccl_comm_init_rank",
-        "nccl_get_unique_id",
-        "nccl_unique_id_nbytes",
-        "pool_generation",
+        "nccl_runtime_version",
     )
-    if not all(callable(getattr(tvm_ffi, name, None)) for name in required_tvm_ffi):
+    if not all(hasattr(native_module, name) for name in required_native):
         return False
-    return all(
-        callable(getattr(nvshmem, name, None)) for name in ("ensure_initialized", "is_initialized", "resolve_team")
+    return callable(getattr(nvshmem, "resolve_team", None))
+
+
+def supports_process_group(process_group: "ProcessGroup", device: torch.device) -> bool:
+    try:
+        backend = process_group._get_backend(device)
+    except (AttributeError, RuntimeError):
+        return False
+    required = (
+        "_comm_ptr",
+        "eager_connect_single_device",
+        "get_runtime_nccl_version",
     )
+    if not all(callable(getattr(backend, name, None)) for name in required):
+        return False
+    return tuple(backend.get_runtime_nccl_version()) == _get_tvm_ffi().nccl_runtime_version()
 
 
 def _validate_temperature(temperature) -> None:
@@ -124,98 +118,41 @@ def _cuda_device_context(tensor):
         yield
 
 
-def _group_ranks(process_group: "ProcessGroup") -> tuple[int, ...]:
-    return tuple(dist.get_global_rank(process_group, rank) for rank in range(dist.get_world_size(process_group)))
-
-
-def _create_nccl_communicator(process_group: "ProcessGroup", device: torch.device) -> int:
-    tvm_ffi = _get_tvm_ffi()
-    rank = dist.get_rank(process_group)
-    group_ranks = _group_ranks(process_group)
-    unique_id = torch.empty(tvm_ffi.nccl_unique_id_nbytes(), dtype=torch.uint8, device=device)
-    if rank == 0:
-        unique_id.copy_(tvm_ffi.nccl_get_unique_id(), non_blocking=False)
-    dist.broadcast(unique_id, src=group_ranks[0], group=process_group)
-    return tvm_ffi.nccl_comm_init_rank(rank, len(group_ranks), unique_id.cpu().contiguous())
-
-
-def _configure_runtime(runtime: _Runtime, tokens: int, hidden: int, local_vocab: int, tiles_per_reduce: int) -> None:
-    if (
-        tokens <= runtime.max_tokens
-        and hidden <= runtime.max_hidden
-        and local_vocab <= runtime.max_local_vocab
-        and tiles_per_reduce <= runtime.max_tiles_per_reduce
-    ):
-        return
-
-    tvm_ffi = _get_tvm_ffi()
-    tvm_ffi.fused_linear_scaled_cross_entropy_configure_backward(
-        max(tokens, runtime.max_tokens),
-        max(hidden, runtime.max_hidden),
-        max(local_vocab, runtime.max_local_vocab),
-        max(tiles_per_reduce, runtime.max_tiles_per_reduce),
-        runtime.team_handle,
-    )
-    tvm_ffi.fused_linear_scaled_cross_entropy_configure_forward(
-        max(tokens, runtime.max_tokens),
-        max(local_vocab, runtime.max_local_vocab),
-    )
-    runtime.max_tokens = max(tokens, runtime.max_tokens)
-    runtime.max_hidden = max(hidden, runtime.max_hidden)
-    runtime.max_local_vocab = max(local_vocab, runtime.max_local_vocab)
-    runtime.max_tiles_per_reduce = max(tiles_per_reduce, runtime.max_tiles_per_reduce)
-
-
-def _prepare_runtime(process_group: "ProcessGroup", device, tokens, hidden, local_vocab, tiles_per_reduce) -> _Runtime:
-    global _RUNTIME
-
-    nvshmem = _get_nvshmem()
-    tvm_ffi = _get_tvm_ffi()
-    if _RUNTIME is not None and not nvshmem.is_initialized():
-        tvm_ffi.nccl_comm_destroy(_RUNTIME.nccl_comm_handle)
-        _RUNTIME = None
-
-    ranks = _group_ranks(process_group)
-    device_index = device.index if device.index is not None else torch.cuda.current_device()
-    if _RUNTIME is not None:
-        if _RUNTIME.group_ranks != ranks or _RUNTIME.device_index != device_index:
-            raise RuntimeError(
-                "the LCK tensor-parallel runtime is already bound to another process group or CUDA device"
-            )
-        pool_generation = tvm_ffi.pool_generation()
-        if _RUNTIME.pool_generation != pool_generation:
-            _RUNTIME.pool_generation = pool_generation
-            _RUNTIME.max_tokens = 0
-            _RUNTIME.max_hidden = 0
-            _RUNTIME.max_local_vocab = 0
-            _RUNTIME.max_tiles_per_reduce = 0
-        _configure_runtime(_RUNTIME, tokens, hidden, local_vocab, tiles_per_reduce)
-        return _RUNTIME
-
-    with torch.cuda.device(device):
-        # Share one WORLD bootstrap with LigerMoE; EP and TP remain separate
-        # cached NVSHMEM teams underneath that process-wide runtime.
-        nvshmem.ensure_initialized()
-        team_handle = nvshmem.resolve_team(process_group)
-        runtime = _Runtime(
-            group_ranks=ranks,
-            device_index=device_index,
-            team_handle=team_handle,
-            nccl_comm_handle=0,
-            pool_generation=tvm_ffi.pool_generation(),
+def _borrow_nccl_communicator(process_group: "ProcessGroup", device: torch.device) -> int:
+    """Borrow the current-device communicator without storing or owning it."""
+    backend = process_group._get_backend(device)
+    torch_nccl_version = tuple(backend.get_runtime_nccl_version())
+    lck_nccl_version = _get_tvm_ffi().nccl_runtime_version()
+    if torch_nccl_version != lck_nccl_version:
+        raise RuntimeError(
+            "the PyTorch and LCK NCCL runtime versions must match before sharing a communicator: "
+            f"torch={torch_nccl_version}, lck={lck_nccl_version}"
         )
-        _configure_runtime(runtime, tokens, hidden, local_vocab, tiles_per_reduce)
-        runtime.nccl_comm_handle = _create_nccl_communicator(process_group, device)
-    _RUNTIME = runtime
-    return runtime
+    comm_handle = int(backend._comm_ptr())
+    if comm_handle == 0:
+        backend.eager_connect_single_device(device)
+        comm_handle = int(backend._comm_ptr())
+    if comm_handle == 0:
+        raise RuntimeError("PyTorch did not expose a ready NCCL communicator for the tensor-parallel process group")
+    return comm_handle
 
 
-def _release_runtime() -> None:
-    global _RUNTIME
-    if _RUNTIME is None:
-        return
-    _get_tvm_ffi().nccl_comm_destroy(_RUNTIME.nccl_comm_handle)
-    _RUNTIME = None
+def _prepare_lck_call(process_group: "ProcessGroup", device, tokens, hidden, local_vocab, tiles_per_reduce) -> int:
+    tvm_ffi = _get_tvm_ffi()
+    with torch.cuda.device(device):
+        team_handle = _get_nvshmem().resolve_team(process_group, create=False)
+        tvm_ffi.fused_linear_scaled_cross_entropy_configure_backward(
+            tokens,
+            hidden,
+            local_vocab,
+            tiles_per_reduce,
+            team_handle,
+        )
+        tvm_ffi.fused_linear_scaled_cross_entropy_configure_forward(
+            tokens,
+            local_vocab,
+        )
+    return team_handle
 
 
 class LigerFusedLinearScaledCrossEntropyLckTPFunction(torch.autograd.Function):
@@ -238,7 +175,7 @@ class LigerFusedLinearScaledCrossEntropyLckTPFunction(torch.autograd.Function):
 
         x_padded, weight_padded, hidden = _pad_hidden(x, weight)
         target = target.contiguous()
-        runtime = _prepare_runtime(
+        team_handle = _prepare_lck_call(
             tp_group,
             x.device,
             target.shape[0],
@@ -247,6 +184,7 @@ class LigerFusedLinearScaledCrossEntropyLckTPFunction(torch.autograd.Function):
             tiles_per_reduce,
         )
         with _cuda_device_context(x_padded):
+            nccl_comm_handle = _borrow_nccl_communicator(tp_group, x_padded.device)
             nll, lse, entropy = _get_tvm_ffi().fused_linear_scaled_cross_entropy_forward(
                 x_padded,
                 weight_padded,
@@ -254,7 +192,7 @@ class LigerFusedLinearScaledCrossEntropyLckTPFunction(torch.autograd.Function):
                 vocab_start,
                 ignore_index,
                 1.0 / temperature,
-                runtime.nccl_comm_handle,
+                nccl_comm_handle,
                 return_entropy,
             )
 
@@ -263,7 +201,7 @@ class LigerFusedLinearScaledCrossEntropyLckTPFunction(torch.autograd.Function):
         ctx.vocab_start = vocab_start
         ctx.ignore_index = ignore_index
         ctx.inverse_temperature = 1.0 / temperature
-        ctx.team_handle = runtime.team_handle
+        ctx.team_handle = team_handle
         ctx.tiles_per_reduce = tiles_per_reduce
         ctx.return_entropy = return_entropy
         return (nll, entropy) if return_entropy else nll

--- a/src/liger_kernel/ops/cute/fused_linear_scaled_cross_entropy_tp.py
+++ b/src/liger_kernel/ops/cute/fused_linear_scaled_cross_entropy_tp.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -113,6 +114,16 @@ def _pad_hidden(x, weight):
     )
 
 
+@contextmanager
+def _cuda_device_context(tensor):
+    if not tensor.is_cuda:
+        yield
+        return
+    with torch.cuda.device(tensor.device):
+        torch.cuda.set_device(tensor.device)
+        yield
+
+
 def _group_ranks(process_group: "ProcessGroup") -> tuple[int, ...]:
     return tuple(dist.get_global_rank(process_group, rank) for rank in range(dist.get_world_size(process_group)))
 
@@ -199,6 +210,14 @@ def _prepare_runtime(process_group: "ProcessGroup", device, tokens, hidden, loca
     return runtime
 
 
+def _release_runtime() -> None:
+    global _RUNTIME
+    if _RUNTIME is None:
+        return
+    _get_tvm_ffi().nccl_comm_destroy(_RUNTIME.nccl_comm_handle)
+    _RUNTIME = None
+
+
 class LigerFusedLinearScaledCrossEntropyLckTPFunction(torch.autograd.Function):
     @staticmethod
     def forward(
@@ -227,17 +246,17 @@ class LigerFusedLinearScaledCrossEntropyLckTPFunction(torch.autograd.Function):
             weight.shape[0],
             tiles_per_reduce,
         )
-        tvm_ffi = _get_tvm_ffi()
-        nll, lse, entropy = tvm_ffi.fused_linear_scaled_cross_entropy_forward(
-            x_padded,
-            weight_padded,
-            target,
-            vocab_start,
-            ignore_index,
-            1.0 / temperature,
-            runtime.nccl_comm_handle,
-            return_entropy,
-        )
+        with _cuda_device_context(x_padded):
+            nll, lse, entropy = _get_tvm_ffi().fused_linear_scaled_cross_entropy_forward(
+                x_padded,
+                weight_padded,
+                target,
+                vocab_start,
+                ignore_index,
+                1.0 / temperature,
+                runtime.nccl_comm_handle,
+                return_entropy,
+            )
 
         ctx.save_for_backward(x_padded, weight_padded, target, lse, entropy)
         ctx.hidden = hidden
@@ -269,21 +288,22 @@ class LigerFusedLinearScaledCrossEntropyLckTPFunction(torch.autograd.Function):
                 f"expected per-token entropy gradients with shape {(tokens,)}, got {tuple(grad_entropy.shape)}"
             )
 
-        grad_input, grad_weight = _get_tvm_ffi().fused_linear_scaled_cross_entropy_backward(
-            grad_nll,
-            grad_entropy,
-            x,
-            weight,
-            target,
-            lse,
-            entropy,
-            ctx.vocab_start,
-            ctx.ignore_index,
-            ctx.inverse_temperature,
-            ctx.team_handle,
-            ctx.tiles_per_reduce,
-            ctx.return_entropy,
-        )
+        with _cuda_device_context(x):
+            grad_input, grad_weight = _get_tvm_ffi().fused_linear_scaled_cross_entropy_backward(
+                grad_nll,
+                grad_entropy,
+                x,
+                weight,
+                target,
+                lse,
+                entropy,
+                ctx.vocab_start,
+                ctx.ignore_index,
+                ctx.inverse_temperature,
+                ctx.team_handle,
+                ctx.tiles_per_reduce,
+                ctx.return_entropy,
+            )
         if ctx.hidden != x.shape[1]:
             grad_input = grad_input[:, : ctx.hidden].contiguous()
             grad_weight = grad_weight[:, : ctx.hidden].contiguous()

--- a/src/liger_kernel/ops/fused_linear_scaled_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_scaled_cross_entropy.py
@@ -3,17 +3,39 @@
 import math
 
 import torch
+import torch.distributed as dist
 
 # The fallback formulas and 512-token chunking are adapted from Verl's
 # Apache-2.0 FusedLinearForPPOFunction:
 # https://github.com/verl-project/verl/blob/main/verl/utils/experimental/torch_functional.py
 _FALLBACK_CHUNK_SIZE = 512
+_VERL_TP_HIDDEN_ALIGNMENT = 128
 
 
 def _load_sm90_function():
     from liger_kernel.ops.cutedsl.ops.fused_scaled_cross_entropy_sm90 import LigerFusedScaledCrossEntropySM90Function
 
     return LigerFusedScaledCrossEntropySM90Function
+
+
+def _load_lck_tp_function():
+    from liger_kernel.ops.cute.fused_linear_scaled_cross_entropy_tp import (
+        LigerFusedLinearScaledCrossEntropyLckTPFunction,
+    )
+    from liger_kernel.ops.cute.fused_linear_scaled_cross_entropy_tp import is_available
+
+    return LigerFusedLinearScaledCrossEntropyLckTPFunction if is_available() else None
+
+
+def _load_verl_tp_function():
+    try:
+        from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
+    except ImportError as exc:
+        raise ImportError(
+            "tensor-parallel fused linear scaled cross entropy requires Verl when the LCK Hopper backend "
+            "is unavailable; install Verl or install a matching liger_cute_kernels wheel"
+        ) from exc
+    return linear_cross_entropy
 
 
 def _validate_temperature(temperature):
@@ -45,6 +67,89 @@ def _validate_fallback_inputs(_input, weight, target, ignore_index):
         raise ValueError(
             f"target contains values outside [0, {weight.shape[0]}) that are not ignore_index={ignore_index}"
         )
+
+
+def _tp_group_info(process_group):
+    if not dist.is_available() or not dist.is_initialized():
+        raise RuntimeError("torch.distributed must be initialized before using tensor-parallel scaled cross entropy")
+    process_group = process_group if process_group is not None else dist.group.WORLD
+    if str(dist.get_backend(process_group)).lower() != "nccl":
+        raise RuntimeError("tensor-parallel fused linear scaled cross entropy requires an NCCL process group")
+    return process_group, dist.get_rank(process_group)
+
+
+def _validate_tp_inputs(_input, weight, target):
+    if _input.ndim != 2 or weight.ndim != 2 or target.ndim != 1:
+        raise ValueError("expected input[M,H], weight[V_local,H], and target[M]")
+    if _input.shape[0] != target.shape[0] or _input.shape[1] != weight.shape[1]:
+        raise ValueError(
+            f"input {tuple(_input.shape)}, weight {tuple(weight.shape)}, and target {tuple(target.shape)} "
+            "shapes are incompatible"
+        )
+    if _input.shape[0] == 0 or _input.shape[1] == 0 or weight.shape[0] == 0:
+        raise ValueError("token, hidden, and local vocabulary dimensions must be non-empty")
+    if _input.device != weight.device or _input.device != target.device:
+        raise ValueError("input, weight, and target must be on the same device")
+    if not _input.is_cuda:
+        raise RuntimeError("tensor-parallel fused linear scaled cross entropy requires CUDA tensors")
+    if _input.dtype != weight.dtype or not torch.is_floating_point(_input):
+        raise TypeError("input and weight must have the same floating-point dtype")
+    if target.dtype != torch.int64:
+        raise TypeError("target must be an int64 tensor")
+
+
+def _is_hopper(device):
+    if device.type != "cuda" or not torch.cuda.is_available() or torch.version.hip is not None:
+        return False
+    return torch.cuda.get_device_capability(device) == (9, 0)
+
+
+class _AllReduceInputGradient(torch.autograd.Function):
+    """Match LCK's globally reduced dX around Verl's rank-local backward."""
+
+    @staticmethod
+    def forward(ctx, _input, process_group):
+        ctx.process_group = process_group
+        return _input
+
+    @staticmethod
+    def backward(ctx, grad_input):
+        if grad_input is None:
+            return None, None
+        grad_input = grad_input.clone()
+        dist.all_reduce(grad_input, op=dist.ReduceOp.SUM, group=ctx.process_group)
+        return grad_input, None
+
+
+def _apply_verl_tp_fallback(
+    _input,
+    weight,
+    target,
+    temperature,
+    ignore_index,
+    return_entropy,
+    process_group,
+):
+    valid = target != ignore_index
+    safe_target = target.masked_fill(~valid, 0).contiguous()
+    hidden_padding = (-_input.shape[1]) % _VERL_TP_HIDDEN_ALIGNMENT
+    if hidden_padding:
+        _input = torch.nn.functional.pad(_input.contiguous(), (0, hidden_padding))
+        weight = torch.nn.functional.pad(weight.contiguous(), (0, hidden_padding))
+    reduced_input = _AllReduceInputGradient.apply(_input.contiguous(), process_group)
+    log_probs, entropy = _load_verl_tp_function()(
+        reduced_input,
+        weight.contiguous(),
+        safe_target,
+        float(temperature),
+        "none",
+        process_group,
+    )
+    nll = torch.where(valid, -log_probs, torch.zeros_like(log_probs))
+    if not return_entropy:
+        return nll
+    entropy = torch.where(valid, entropy, torch.zeros_like(entropy))
+    return nll, entropy
 
 
 def _fallback_forward_chunk(hidden_states, vocab_weights, input_ids, valid, temperature):
@@ -199,4 +304,67 @@ class LigerFusedLinearScaledCrossEntropyFunction:
         )
 
 
-__all__ = ["LigerFusedLinearScaledCrossEntropyFunction"]
+class LigerFusedLinearScaledCrossEntropyTPFunction:
+    """Tensor-parallel frontend using LCK on Hopper and Verl otherwise.
+
+    ``weight`` is the calling rank's equally sized contiguous vocabulary shard,
+    while ``target`` contains global vocabulary indices.
+    """
+
+    @staticmethod
+    def apply(
+        _input,
+        weight,
+        target,
+        tp_group,
+        temperature=1.0,
+        ignore_index=-100,
+        tiles_per_reduce=1,
+        return_entropy=False,
+    ):
+        _validate_temperature(temperature)
+        if not isinstance(tiles_per_reduce, int) or isinstance(tiles_per_reduce, bool):
+            raise TypeError("tiles_per_reduce must be an int")
+        if tiles_per_reduce not in (1, 2, 4):
+            raise ValueError("tiles_per_reduce must be one of 1, 2, or 4")
+        if not isinstance(return_entropy, bool):
+            raise TypeError("return_entropy must be a bool")
+
+        process_group, rank = _tp_group_info(tp_group)
+        _validate_tp_inputs(_input, weight, target)
+        vocab_start = rank * weight.shape[0]
+
+        lck_function = None
+        if _input.dtype == torch.bfloat16 and _is_hopper(_input.device):
+            try:
+                lck_function = _load_lck_tp_function()
+            except ImportError:
+                lck_function = None
+        if lck_function is not None:
+            return lck_function.apply(
+                _input,
+                weight,
+                target,
+                vocab_start,
+                temperature,
+                ignore_index,
+                tiles_per_reduce,
+                return_entropy,
+                process_group,
+            )
+
+        return _apply_verl_tp_fallback(
+            _input,
+            weight,
+            target,
+            temperature,
+            ignore_index,
+            return_entropy,
+            process_group,
+        )
+
+
+__all__ = [
+    "LigerFusedLinearScaledCrossEntropyFunction",
+    "LigerFusedLinearScaledCrossEntropyTPFunction",
+]

--- a/src/liger_kernel/ops/fused_linear_scaled_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_scaled_cross_entropy.py
@@ -17,16 +17,13 @@ def _load_sm90_function():
     return LigerFusedScaledCrossEntropySM90Function
 
 
-def _load_lck_tp_function(process_group, device):
+def _load_lck_tp_function():
     from liger_kernel.ops.cute.fused_linear_scaled_cross_entropy_tp import (
         LigerFusedLinearScaledCrossEntropyLckTPFunction,
     )
     from liger_kernel.ops.cute.fused_linear_scaled_cross_entropy_tp import is_available
-    from liger_kernel.ops.cute.fused_linear_scaled_cross_entropy_tp import supports_process_group
 
-    if not is_available() or not supports_process_group(process_group, device):
-        return None
-    return LigerFusedLinearScaledCrossEntropyLckTPFunction
+    return LigerFusedLinearScaledCrossEntropyLckTPFunction if is_available() else None
 
 
 def _validate_temperature(temperature):
@@ -64,8 +61,6 @@ def _tp_group_info(process_group):
     if not dist.is_available() or not dist.is_initialized():
         raise RuntimeError("torch.distributed must be initialized before using tensor-parallel scaled cross entropy")
     process_group = process_group if process_group is not None else dist.group.WORLD
-    if str(dist.get_backend(process_group)).lower() != "nccl":
-        raise RuntimeError("tensor-parallel fused linear scaled cross entropy requires an NCCL process group")
     return process_group, dist.get_rank(process_group)
 
 
@@ -405,7 +400,7 @@ class LigerFusedLinearScaledCrossEntropyTPFunction:
         lck_function = None
         if _input.dtype == torch.bfloat16 and _is_hopper(_input.device):
             try:
-                lck_function = _load_lck_tp_function(process_group, _input.device)
+                lck_function = _load_lck_tp_function()
             except ImportError:
                 lck_function = None
         if lck_function is not None:

--- a/src/liger_kernel/ops/fused_linear_scaled_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_scaled_cross_entropy.py
@@ -9,7 +9,6 @@ import torch.distributed as dist
 # Apache-2.0 FusedLinearForPPOFunction:
 # https://github.com/verl-project/verl/blob/main/verl/utils/experimental/torch_functional.py
 _FALLBACK_CHUNK_SIZE = 512
-_VERL_TP_HIDDEN_ALIGNMENT = 128
 
 
 def _load_sm90_function():
@@ -25,17 +24,6 @@ def _load_lck_tp_function():
     from liger_kernel.ops.cute.fused_linear_scaled_cross_entropy_tp import is_available
 
     return LigerFusedLinearScaledCrossEntropyLckTPFunction if is_available() else None
-
-
-def _load_verl_tp_function():
-    try:
-        from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
-    except ImportError as exc:
-        raise ImportError(
-            "tensor-parallel fused linear scaled cross entropy requires Verl when the LCK Hopper backend "
-            "is unavailable; install Verl or install a matching liger_cute_kernels wheel"
-        ) from exc
-    return linear_cross_entropy
 
 
 def _validate_temperature(temperature):
@@ -104,52 +92,129 @@ def _is_hopper(device):
     return torch.cuda.get_device_capability(device) == (9, 0)
 
 
-class _AllReduceInputGradient(torch.autograd.Function):
-    """Match LCK's globally reduced dX around Verl's rank-local backward."""
+class _TensorParallelFusedLinearPPOFallbackFunction(torch.autograd.Function):
+    """Chunked TP fallback adapted from Verl's fused linear PPO formulas."""
 
     @staticmethod
-    def forward(ctx, _input, process_group):
+    def forward(ctx, hidden_states, vocab_weights, input_ids, temperature, ignore_index, return_entropy, process_group):
+        ctx.set_materialize_grads(False)
+        rank = dist.get_rank(process_group)
+        world_size = dist.get_world_size(process_group)
+        local_vocab = vocab_weights.shape[0]
+        vocab_start = rank * local_vocab
+        valid = input_ids != ignore_index
+        safe_input_ids = input_ids.masked_fill(~valid, 0)
+        token_count = hidden_states.shape[0]
+
+        nll = torch.empty(token_count, dtype=torch.float32, device=hidden_states.device)
+        lse = torch.empty_like(nll)
+        entropy = torch.empty_like(nll) if return_entropy else torch.zeros_like(nll)
+
+        for start in range(0, token_count, _FALLBACK_CHUNK_SIZE):
+            end = min(start + _FALLBACK_CHUNK_SIZE, token_count)
+            logits = (hidden_states[start:end] @ vocab_weights.t()).float() / temperature
+            global_max = logits.amax(dim=-1)
+            if world_size > 1:
+                dist.all_reduce(global_max, op=dist.ReduceOp.MAX, group=process_group)
+
+            exp_logits = torch.exp(logits - global_max[:, None])
+            local_sum = exp_logits.sum(dim=-1)
+            local_target = safe_input_ids[start:end] - vocab_start
+            owns_target = valid[start:end] & (local_target >= 0) & (local_target < local_vocab)
+            target_index = local_target.clamp(0, local_vocab - 1)
+            target_logit = torch.where(
+                owns_target,
+                logits.gather(-1, target_index[:, None]).squeeze(-1),
+                torch.zeros_like(local_sum),
+            )
+
+            if return_entropy:
+                local_weighted_sum = (exp_logits * logits).sum(dim=-1)
+                reduced = torch.stack((local_sum, local_weighted_sum, target_logit))
+            else:
+                reduced = torch.stack((local_sum, target_logit))
+            if world_size > 1:
+                dist.all_reduce(reduced, op=dist.ReduceOp.SUM, group=process_group)
+
+            global_lse = global_max + torch.log(reduced[0])
+            chunk_nll = global_lse - reduced[-1]
+            nll[start:end] = torch.where(valid[start:end], chunk_nll, torch.zeros_like(chunk_nll))
+            lse[start:end] = global_lse
+            if return_entropy:
+                chunk_entropy = global_lse - reduced[1] / reduced[0]
+                entropy[start:end] = torch.where(
+                    valid[start:end],
+                    chunk_entropy,
+                    torch.zeros_like(chunk_entropy),
+                )
+
+        ctx.save_for_backward(hidden_states, vocab_weights, safe_input_ids, valid, lse, entropy)
+        ctx.temperature = temperature
+        ctx.vocab_start = vocab_start
+        ctx.local_vocab = local_vocab
+        ctx.return_entropy = return_entropy
         ctx.process_group = process_group
-        return _input
+        ctx.world_size = world_size
+        return (nll, entropy) if return_entropy else nll
 
     @staticmethod
-    def backward(ctx, grad_input):
-        if grad_input is None:
-            return None, None
-        grad_input = grad_input.clone()
-        dist.all_reduce(grad_input, op=dist.ReduceOp.SUM, group=ctx.process_group)
-        return grad_input, None
+    def backward(ctx, grad_nll, grad_entropy=None):
+        hidden_states, vocab_weights, input_ids, valid, lse, entropy = ctx.saved_tensors
+        token_count = hidden_states.shape[0]
+        if grad_nll is None:
+            grad_nll = torch.zeros(token_count, dtype=torch.float32, device=hidden_states.device)
+        else:
+            grad_nll = grad_nll.to(torch.float32)
+        if grad_entropy is None:
+            grad_entropy = torch.zeros_like(grad_nll)
+        else:
+            grad_entropy = grad_entropy.to(torch.float32)
+
+        grad_hidden_states = torch.zeros_like(hidden_states) if ctx.needs_input_grad[0] else None
+        grad_vocab_weights = torch.zeros_like(vocab_weights) if ctx.needs_input_grad[1] else None
+        inverse_temperature = 1.0 / ctx.temperature
+
+        for start in range(0, token_count, _FALLBACK_CHUNK_SIZE):
+            end = min(start + _FALLBACK_CHUNK_SIZE, token_count)
+            hidden_chunk = hidden_states[start:end]
+            logits = (hidden_chunk @ vocab_weights.t()).float() * inverse_temperature
+            probabilities = torch.exp(logits - lse[start:end, None])
+            nll_scale = grad_nll[start:end] * valid[start:end]
+            grad_logits = probabilities * nll_scale[:, None]
+
+            local_target = input_ids[start:end] - ctx.vocab_start
+            owns_target = valid[start:end] & (local_target >= 0) & (local_target < ctx.local_vocab)
+            target_index = local_target.clamp(0, ctx.local_vocab - 1)
+            rows = torch.arange(end - start, device=hidden_states.device)
+            grad_logits[rows, target_index] -= nll_scale * owns_target
+
+            if ctx.return_entropy:
+                entropy_scale = grad_entropy[start:end] * valid[start:end]
+                grad_logits += (
+                    probabilities * (lse[start:end, None] - entropy[start:end, None] - logits) * entropy_scale[:, None]
+                )
+
+            grad_logits = (grad_logits * inverse_temperature).to(hidden_states.dtype)
+            if grad_hidden_states is not None:
+                grad_hidden_states[start:end] = grad_logits @ vocab_weights
+            if grad_vocab_weights is not None:
+                grad_vocab_weights.add_(grad_logits.t() @ hidden_chunk)
+
+        if grad_hidden_states is not None and ctx.world_size > 1:
+            dist.all_reduce(grad_hidden_states, op=dist.ReduceOp.SUM, group=ctx.process_group)
+        return grad_hidden_states, grad_vocab_weights, None, None, None, None, None
 
 
-def _apply_verl_tp_fallback(
-    _input,
-    weight,
-    target,
-    temperature,
-    ignore_index,
-    return_entropy,
-    process_group,
-):
-    valid = target != ignore_index
-    safe_target = target.masked_fill(~valid, 0).contiguous()
-    hidden_padding = (-_input.shape[1]) % _VERL_TP_HIDDEN_ALIGNMENT
-    if hidden_padding:
-        _input = torch.nn.functional.pad(_input.contiguous(), (0, hidden_padding))
-        weight = torch.nn.functional.pad(weight.contiguous(), (0, hidden_padding))
-    reduced_input = _AllReduceInputGradient.apply(_input.contiguous(), process_group)
-    log_probs, entropy = _load_verl_tp_function()(
-        reduced_input,
+def _apply_tp_fallback(_input, weight, target, temperature, ignore_index, return_entropy, process_group):
+    return _TensorParallelFusedLinearPPOFallbackFunction.apply(
+        _input.contiguous(),
         weight.contiguous(),
-        safe_target,
-        float(temperature),
-        "none",
+        target.contiguous(),
+        temperature,
+        ignore_index,
+        return_entropy,
         process_group,
     )
-    nll = torch.where(valid, -log_probs, torch.zeros_like(log_probs))
-    if not return_entropy:
-        return nll
-    entropy = torch.where(valid, entropy, torch.zeros_like(entropy))
-    return nll, entropy
 
 
 def _fallback_forward_chunk(hidden_states, vocab_weights, input_ids, valid, temperature):
@@ -305,7 +370,7 @@ class LigerFusedLinearScaledCrossEntropyFunction:
 
 
 class LigerFusedLinearScaledCrossEntropyTPFunction:
-    """Tensor-parallel frontend using LCK on Hopper and Verl otherwise.
+    """Tensor-parallel frontend using LCK on Hopper and a Liger fallback otherwise.
 
     ``weight`` is the calling rank's equally sized contiguous vocabulary shard,
     while ``target`` contains global vocabulary indices.
@@ -353,7 +418,7 @@ class LigerFusedLinearScaledCrossEntropyTPFunction:
                 process_group,
             )
 
-        return _apply_verl_tp_fallback(
+        return _apply_tp_fallback(
             _input,
             weight,
             target,

--- a/src/liger_kernel/ops/fused_linear_scaled_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_scaled_cross_entropy.py
@@ -17,13 +17,16 @@ def _load_sm90_function():
     return LigerFusedScaledCrossEntropySM90Function
 
 
-def _load_lck_tp_function():
+def _load_lck_tp_function(process_group, device):
     from liger_kernel.ops.cute.fused_linear_scaled_cross_entropy_tp import (
         LigerFusedLinearScaledCrossEntropyLckTPFunction,
     )
     from liger_kernel.ops.cute.fused_linear_scaled_cross_entropy_tp import is_available
+    from liger_kernel.ops.cute.fused_linear_scaled_cross_entropy_tp import supports_process_group
 
-    return LigerFusedLinearScaledCrossEntropyLckTPFunction if is_available() else None
+    if not is_available() or not supports_process_group(process_group, device):
+        return None
+    return LigerFusedLinearScaledCrossEntropyLckTPFunction
 
 
 def _validate_temperature(temperature):
@@ -402,7 +405,7 @@ class LigerFusedLinearScaledCrossEntropyTPFunction:
         lck_function = None
         if _input.dtype == torch.bfloat16 and _is_hopper(_input.device):
             try:
-                lck_function = _load_lck_tp_function()
+                lck_function = _load_lck_tp_function(process_group, _input.device)
             except ImportError:
                 lck_function = None
         if lck_function is not None:

--- a/src/liger_kernel/transformers/functional.py
+++ b/src/liger_kernel/transformers/functional.py
@@ -9,6 +9,7 @@ from liger_kernel.ops import LigerDyTFunction
 from liger_kernel.ops import LigerFusedAddRMSNormFunction
 from liger_kernel.ops import LigerFusedLinearCrossEntropyFunction
 from liger_kernel.ops import LigerFusedLinearJSDFunction
+from liger_kernel.ops import LigerFusedLinearScaledCrossEntropyTPFunction
 from liger_kernel.ops import LigerFusedNeighborhoodAttentionFunction
 from liger_kernel.ops import LigerGELUMulFunction
 from liger_kernel.ops import LigerGroupNormFunction
@@ -118,6 +119,29 @@ def liger_fused_linear_cross_entropy(
 
     return CrossEntropyOutput(
         loss=loss, z_loss=z_loss, token_accuracy=token_accuracy, predicted_tokens=predicted_tokens
+    )
+
+
+def liger_fused_linear_scaled_cross_entropy_tp(
+    input,
+    weight,
+    target,
+    tp_group,
+    temperature: float = 1.0,
+    ignore_index: int = -100,
+    tiles_per_reduce: int = 1,
+    return_entropy: bool = False,
+):
+    """Return per-token TP negative log-likelihood and optional entropy."""
+    return LigerFusedLinearScaledCrossEntropyTPFunction.apply(
+        input,
+        weight,
+        target,
+        tp_group,
+        temperature,
+        ignore_index,
+        tiles_per_reduce,
+        return_entropy,
     )
 
 

--- a/test/cute/test_fused_linear_scaled_cross_entropy_tp.py
+++ b/test/cute/test_fused_linear_scaled_cross_entropy_tp.py
@@ -28,7 +28,7 @@ except ImportError:
     _LCK_AVAILABLE = False
 
 _NDEV = torch.cuda.device_count() if torch is not None and torch.cuda.is_available() else 0
-_TOKENS = 128
+_TOKENS = 521
 _HIDDEN = 2048
 _LOCAL_VOCAB = 320
 _TEMPERATURE = 0.8
@@ -87,8 +87,14 @@ def _reference(x, global_weight, target, grad_nll, grad_entropy):
     return nll, entropy, dz @ global_weight.float(), dz
 
 
-def _worker(rank: int, world_size: int, init_file: str, layout: str):
-    from liger_cute_kernels import nvshmem
+def _worker(rank: int, world_size: int, init_file: str, layout: str, implementation: str):
+    if implementation == "fallback":
+        import liger_kernel.ops.fused_linear_scaled_cross_entropy as frontend
+
+        frontend._load_lck_tp_function = lambda: None
+        nvshmem = None
+    else:
+        from liger_cute_kernels import nvshmem
 
     torch.cuda.set_device(rank)
     dist.init_process_group(
@@ -161,30 +167,32 @@ def _worker(rank: int, world_size: int, init_file: str, layout: str):
         torch.testing.assert_close(x.grad.float(), expected_dx, atol=8e-3, rtol=4e-2)
         torch.testing.assert_close(weight.grad.float(), expected_dw, atol=8e-3, rtol=4e-2)
 
-        runtime = lck_frontend._RUNTIME
-        assert runtime is not None
-        assert runtime.group_ranks == tuple(tp_ranks)
-        team_handle = runtime.team_handle
-
         torch.cuda.synchronize()
-        lck_frontend._release_runtime()
-        nvshmem.pool_clear_all()
-        if team_handle != nvshmem.team_world():
-            nvshmem.team_destroy(team_handle)
-            team_handle = None
+        if implementation == "lck":
+            runtime = lck_frontend._RUNTIME
+            assert runtime is not None
+            assert runtime.group_ranks == tuple(tp_ranks)
+            team_handle = runtime.team_handle
+            lck_frontend._release_runtime()
+            nvshmem.pool_clear_all()
+            if team_handle != nvshmem.team_world():
+                nvshmem.team_destroy(team_handle)
+                team_handle = None
         dist.barrier()
-        nvshmem.finalize()
+        if implementation == "lck":
+            nvshmem.finalize()
         dist.destroy_process_group()
     except BaseException:
-        try:
-            lck_frontend._release_runtime()
-        except Exception:
-            pass
-        try:
-            if nvshmem.is_initialized():
-                nvshmem.finalize()
-        except Exception:
-            pass
+        if implementation == "lck":
+            try:
+                lck_frontend._release_runtime()
+            except Exception:
+                pass
+            try:
+                if nvshmem.is_initialized():
+                    nvshmem.finalize()
+            except Exception:
+                pass
         try:
             dist.destroy_process_group()
         except Exception:
@@ -192,7 +200,7 @@ def _worker(rank: int, world_size: int, init_file: str, layout: str):
         raise
 
 
-def _run(world_size: int, layout: str):
+def _run(world_size: int, layout: str, implementation: str):
     rendezvous = tempfile.mkdtemp(prefix=f"liger_fslce_tp_{layout}_")
     init_file = os.path.join(rendezvous, "store")
     env = {
@@ -205,7 +213,7 @@ def _run(world_size: int, layout: str):
     try:
         mp.spawn(
             _worker,
-            args=(world_size, init_file, layout),
+            args=(world_size, init_file, layout, implementation),
             nprocs=world_size,
             join=True,
         )
@@ -224,7 +232,7 @@ def test_tp_frontend_world_process_group(world_size):
         pytest.skip("requires a matching liger_cute_kernels wheel")
     if _NDEV < world_size:
         pytest.skip(f"requires at least {world_size} CUDA devices")
-    _run(world_size, "world")
+    _run(world_size, "world", "lck")
 
 
 @pytest.mark.parametrize("layout", ["contiguous", "strided"])
@@ -233,4 +241,17 @@ def test_tp_frontend_subgroups(layout):
         pytest.skip("requires a matching liger_cute_kernels wheel")
     if _NDEV < 4:
         pytest.skip("requires at least four CUDA devices")
-    _run(4, layout)
+    _run(4, layout, "lck")
+
+
+@pytest.mark.parametrize(
+    ("world_size", "layout"),
+    [
+        (2, "world"),
+        (4, "strided"),
+    ],
+)
+def test_tp_frontend_liger_fallback(world_size, layout):
+    if torch is None or _NDEV < world_size:
+        pytest.skip(f"requires at least {world_size} CUDA devices")
+    _run(world_size, layout, "fallback")

--- a/test/cute/test_fused_linear_scaled_cross_entropy_tp.py
+++ b/test/cute/test_fused_linear_scaled_cross_entropy_tp.py
@@ -1,0 +1,236 @@
+"""Multi-GPU tests for the tensor-parallel scaled cross-entropy frontend."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+
+from datetime import timedelta
+
+import pytest
+
+try:
+    import torch
+    import torch.distributed as dist
+    import torch.multiprocessing as mp
+
+    from liger_kernel.ops import LigerFusedLinearScaledCrossEntropyTPFunction
+    from liger_kernel.ops.cute import fused_linear_scaled_cross_entropy_tp as lck_frontend
+
+    _LCK_AVAILABLE = lck_frontend.is_available()
+except ImportError:
+    torch = None
+    dist = None
+    mp = None
+    LigerFusedLinearScaledCrossEntropyTPFunction = None
+    lck_frontend = None
+    _LCK_AVAILABLE = False
+
+_NDEV = torch.cuda.device_count() if torch is not None and torch.cuda.is_available() else 0
+_TOKENS = 128
+_HIDDEN = 2048
+_LOCAL_VOCAB = 320
+_TEMPERATURE = 0.8
+_IGNORE_INDEX = -100
+
+
+def _group_layout(layout: str, world_size: int):
+    if layout == "world":
+        return [list(range(world_size))]
+    if layout == "contiguous":
+        return [[0, 1], [2, 3]]
+    if layout == "strided":
+        return [[0, 2], [1, 3]]
+    raise ValueError(f"unknown process-group layout: {layout}")
+
+
+def _create_tp_group(rank: int, world_size: int, layout: str):
+    groups = _group_layout(layout, world_size)
+    if layout == "world":
+        return dist.group.WORLD, groups[0], []
+
+    tp_group = None
+    tp_ranks = None
+    created_groups = []
+    for ranks in groups:
+        group = dist.new_group(ranks=ranks)
+        created_groups.append(group)
+        if rank in ranks:
+            tp_group = group
+            tp_ranks = ranks
+    if tp_group is None or tp_ranks is None:
+        raise RuntimeError(f"rank {rank} was not assigned to a tensor-parallel group")
+    return tp_group, tp_ranks, created_groups
+
+
+def _reference(x, global_weight, target, grad_nll, grad_entropy):
+    inverse_temperature = 1.0 / _TEMPERATURE
+    logits = x.float() @ global_weight.float().t()
+    scaled_logits = logits * inverse_temperature
+    lse = torch.logsumexp(scaled_logits, dim=-1)
+    probabilities = torch.softmax(scaled_logits, dim=-1)
+    entropy = lse - torch.sum(probabilities * scaled_logits, dim=-1)
+
+    valid = target != _IGNORE_INDEX
+    safe_target = target.masked_fill(~valid, 0)
+    rows = torch.arange(x.shape[0], device=x.device)
+    nll = lse - scaled_logits[rows, safe_target]
+    nll = torch.where(valid, nll, torch.zeros_like(nll))
+    entropy = torch.where(valid, entropy, torch.zeros_like(entropy))
+
+    dz = probabilities * grad_nll[:, None]
+    dz += probabilities * (lse[:, None] - entropy[:, None] - scaled_logits) * grad_entropy[:, None]
+    dz[rows, safe_target] -= grad_nll
+    dz *= valid[:, None] * inverse_temperature
+    dz = dz.to(torch.bfloat16).float()
+    return nll, entropy, dz @ global_weight.float(), dz
+
+
+def _worker(rank: int, world_size: int, init_file: str, layout: str):
+    from liger_cute_kernels import nvshmem
+
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=180),
+    )
+
+    team_handle = None
+    try:
+        tp_group, tp_ranks, _created_groups = _create_tp_group(rank, world_size, layout)
+        tp_rank = tp_ranks.index(rank)
+        tp_size = len(tp_ranks)
+        group_index = _group_layout(layout, world_size).index(tp_ranks)
+
+        x_generator = torch.Generator(device="cpu")
+        x_generator.manual_seed(2027 + group_index)
+        x = (
+            torch.randn(_TOKENS, _HIDDEN, generator=x_generator)
+            .mul_(0.05)
+            .to(device="cuda", dtype=torch.bfloat16)
+            .requires_grad_(True)
+        )
+        weight_generator = torch.Generator(device="cpu")
+        weight_generator.manual_seed(3100 + 17 * group_index + tp_rank)
+        weight = (
+            torch.randn(_LOCAL_VOCAB, _HIDDEN, generator=weight_generator)
+            .mul_(0.05)
+            .to(device="cuda", dtype=torch.bfloat16)
+            .requires_grad_(True)
+        )
+
+        gathered_weights = [torch.empty_like(weight) for _ in range(tp_size)]
+        dist.all_gather(gathered_weights, weight.detach(), group=tp_group)
+        global_weight = torch.cat(gathered_weights, dim=0)
+        global_vocab = tp_size * _LOCAL_VOCAB
+
+        target = (torch.arange(_TOKENS, device="cuda", dtype=torch.int64) * 17 + 3) % global_vocab
+        target[::19] = _IGNORE_INDEX
+        grad_nll = torch.linspace(0.25, 1.0, _TOKENS, device="cuda", dtype=torch.float32)
+        grad_entropy = torch.linspace(-0.2, 0.3, _TOKENS, device="cuda", dtype=torch.float32)
+
+        expected_nll, expected_entropy, expected_dx, dz = _reference(
+            x.detach(),
+            global_weight,
+            target,
+            grad_nll,
+            grad_entropy,
+        )
+        local_start = tp_rank * _LOCAL_VOCAB
+        expected_dw = dz[:, local_start : local_start + _LOCAL_VOCAB].t() @ x.detach().float()
+
+        actual_nll, actual_entropy = LigerFusedLinearScaledCrossEntropyTPFunction.apply(
+            x,
+            weight,
+            target,
+            tp_group,
+            _TEMPERATURE,
+            _IGNORE_INDEX,
+            1,
+            True,
+        )
+        torch.autograd.backward((actual_nll, actual_entropy), (grad_nll, grad_entropy))
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(actual_nll, expected_nll, atol=3e-4, rtol=3e-4)
+        torch.testing.assert_close(actual_entropy, expected_entropy, atol=3e-4, rtol=3e-4)
+        torch.testing.assert_close(x.grad.float(), expected_dx, atol=8e-3, rtol=4e-2)
+        torch.testing.assert_close(weight.grad.float(), expected_dw, atol=8e-3, rtol=4e-2)
+
+        runtime = lck_frontend._RUNTIME
+        assert runtime is not None
+        assert runtime.group_ranks == tuple(tp_ranks)
+        team_handle = runtime.team_handle
+
+        torch.cuda.synchronize()
+        lck_frontend._release_runtime()
+        nvshmem.pool_clear_all()
+        if team_handle != nvshmem.team_world():
+            nvshmem.team_destroy(team_handle)
+            team_handle = None
+        dist.barrier()
+        nvshmem.finalize()
+        dist.destroy_process_group()
+    except BaseException:
+        try:
+            lck_frontend._release_runtime()
+        except Exception:
+            pass
+        try:
+            if nvshmem.is_initialized():
+                nvshmem.finalize()
+        except Exception:
+            pass
+        try:
+            dist.destroy_process_group()
+        except Exception:
+            pass
+        raise
+
+
+def _run(world_size: int, layout: str):
+    rendezvous = tempfile.mkdtemp(prefix=f"liger_fslce_tp_{layout}_")
+    init_file = os.path.join(rendezvous, "store")
+    env = {
+        "NVSHMEM_DISABLE_NCCL": "1",
+        "NVSHMEM_REMOTE_TRANSPORT": "none",
+        "NVSHMEM_SYMMETRIC_SIZE": "3G",
+    }
+    previous = {name: os.environ.get(name) for name in env}
+    os.environ.update(env)
+    try:
+        mp.spawn(
+            _worker,
+            args=(world_size, init_file, layout),
+            nprocs=world_size,
+            join=True,
+        )
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        shutil.rmtree(rendezvous, ignore_errors=True)
+
+
+@pytest.mark.parametrize("world_size", [1, 2, 4, 8])
+def test_tp_frontend_world_process_group(world_size):
+    if not _LCK_AVAILABLE:
+        pytest.skip("requires a matching liger_cute_kernels wheel")
+    if _NDEV < world_size:
+        pytest.skip(f"requires at least {world_size} CUDA devices")
+    _run(world_size, "world")
+
+
+@pytest.mark.parametrize("layout", ["contiguous", "strided"])
+def test_tp_frontend_subgroups(layout):
+    if not _LCK_AVAILABLE:
+        pytest.skip("requires a matching liger_cute_kernels wheel")
+    if _NDEV < 4:
+        pytest.skip("requires at least four CUDA devices")
+    _run(4, layout)

--- a/test/cute/test_fused_linear_scaled_cross_entropy_tp.py
+++ b/test/cute/test_fused_linear_scaled_cross_entropy_tp.py
@@ -33,6 +33,11 @@ _HIDDEN = 2048
 _LOCAL_VOCAB = 320
 _TEMPERATURE = 0.8
 _IGNORE_INDEX = -100
+_MOE_TOKENS = 512
+_MOE_HIDDEN = 4096
+_MOE_INTERMEDIATE = 2048
+_MOE_EXPERTS = 16
+_MOE_TOP_K = 2
 
 
 def _group_layout(layout: str, world_size: int):
@@ -87,11 +92,72 @@ def _reference(x, global_weight, target, grad_nll, grad_entropy):
     return nll, entropy, dz @ global_weight.float(), dz
 
 
-def _worker(rank: int, world_size: int, init_file: str, layout: str, implementation: str):
+def _run_moe(rank: int, world_size: int):
+    from liger_cute_kernels import tvm_ffi
+
+    from liger_kernel.ops.cute.ops.moe import moe_fused
+
+    tvm_ffi.moe_configure_symmetric(
+        max_tokens=_MOE_TOKENS,
+        hidden_dim=_MOE_HIDDEN,
+        max_num_experts=_MOE_EXPERTS,
+        max_top_k=_MOE_TOP_K,
+        num_pes=world_size,
+        num_hosts=1,
+        gpus_per_host=world_size,
+    )
+    experts_per_rank = _MOE_EXPERTS // world_size
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(4100 + rank)
+    x = torch.randn(_MOE_TOKENS, _MOE_HIDDEN, generator=generator).to(device="cuda", dtype=torch.bfloat16)
+    all_b = torch.randn(
+        experts_per_rank,
+        _MOE_INTERMEDIATE,
+        _MOE_HIDDEN,
+        generator=generator,
+    ).to(device="cuda", dtype=torch.bfloat16)
+    all_c = torch.randn(
+        experts_per_rank,
+        _MOE_INTERMEDIATE,
+        _MOE_HIDDEN,
+        generator=generator,
+    ).to(device="cuda", dtype=torch.bfloat16)
+    all_a = torch.randn(
+        experts_per_rank,
+        _MOE_HIDDEN,
+        _MOE_INTERMEDIATE,
+        generator=generator,
+    ).to(device="cuda", dtype=torch.bfloat16)
+    rows = torch.arange(_MOE_TOKENS, device="cuda", dtype=torch.int32)
+    expert_indices = torch.stack((rows % _MOE_EXPERTS, (rows + 1) % _MOE_EXPERTS), dim=-1)
+    expert_weights = torch.full(
+        (_MOE_TOKENS, _MOE_TOP_K),
+        1.0 / _MOE_TOP_K,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    with torch.no_grad():
+        output = moe_fused(
+            x,
+            expert_indices,
+            expert_weights,
+            all_b,
+            all_c,
+            all_a,
+            _MOE_EXPERTS,
+            _MOE_TOP_K,
+            dist.group.WORLD,
+        )
+    torch.cuda.synchronize()
+    assert output.shape == x.shape
+    assert torch.isfinite(output).all()
+
+
+def _worker(rank: int, world_size: int, init_file: str, layout: str, implementation: str, run_moe: bool):
     if implementation == "fallback":
         import liger_kernel.ops.fused_linear_scaled_cross_entropy as frontend
 
-        frontend._load_lck_tp_function = lambda: None
+        frontend._load_lck_tp_function = lambda group, device: None
         nvshmem = None
     else:
         from liger_cute_kernels import nvshmem
@@ -105,12 +171,19 @@ def _worker(rank: int, world_size: int, init_file: str, layout: str, implementat
         timeout=timedelta(seconds=180),
     )
 
+    nvshmem_initialized = False
     team_handle = None
     try:
         tp_group, tp_ranks, _created_groups = _create_tp_group(rank, world_size, layout)
         tp_rank = tp_ranks.index(rank)
         tp_size = len(tp_ranks)
         group_index = _group_layout(layout, world_size).index(tp_ranks)
+        if implementation == "lck":
+            nvshmem.init_from_pg()
+            nvshmem_initialized = True
+            team_handle = nvshmem.resolve_team(tp_group)
+            if run_moe:
+                _run_moe(rank, world_size)
 
         x_generator = torch.Generator(device="cpu")
         x_generator.manual_seed(2027 + group_index)
@@ -169,11 +242,6 @@ def _worker(rank: int, world_size: int, init_file: str, layout: str, implementat
 
         torch.cuda.synchronize()
         if implementation == "lck":
-            runtime = lck_frontend._RUNTIME
-            assert runtime is not None
-            assert runtime.group_ranks == tuple(tp_ranks)
-            team_handle = runtime.team_handle
-            lck_frontend._release_runtime()
             nvshmem.pool_clear_all()
             if team_handle != nvshmem.team_world():
                 nvshmem.team_destroy(team_handle)
@@ -185,11 +253,7 @@ def _worker(rank: int, world_size: int, init_file: str, layout: str, implementat
     except BaseException:
         if implementation == "lck":
             try:
-                lck_frontend._release_runtime()
-            except Exception:
-                pass
-            try:
-                if nvshmem.is_initialized():
+                if nvshmem_initialized:
                     nvshmem.finalize()
             except Exception:
                 pass
@@ -200,7 +264,7 @@ def _worker(rank: int, world_size: int, init_file: str, layout: str, implementat
         raise
 
 
-def _run(world_size: int, layout: str, implementation: str):
+def _run(world_size: int, layout: str, implementation: str, run_moe: bool = False):
     rendezvous = tempfile.mkdtemp(prefix=f"liger_fslce_tp_{layout}_")
     init_file = os.path.join(rendezvous, "store")
     env = {
@@ -213,7 +277,7 @@ def _run(world_size: int, layout: str, implementation: str):
     try:
         mp.spawn(
             _worker,
-            args=(world_size, init_file, layout, implementation),
+            args=(world_size, init_file, layout, implementation, run_moe),
             nprocs=world_size,
             join=True,
         )
@@ -255,3 +319,11 @@ def test_tp_frontend_liger_fallback(world_size, layout):
     if torch is None or _NDEV < world_size:
         pytest.skip(f"requires at least {world_size} CUDA devices")
     _run(world_size, layout, "fallback")
+
+
+def test_lck_moe_and_tp_frontend_use_different_process_groups():
+    if not _LCK_AVAILABLE:
+        pytest.skip("requires a matching liger_cute_kernels wheel")
+    if _NDEV < 4:
+        pytest.skip("requires at least four CUDA devices")
+    _run(4, "strided", "lck", run_moe=True)

--- a/test/cute/test_fused_linear_scaled_cross_entropy_tp.py
+++ b/test/cute/test_fused_linear_scaled_cross_entropy_tp.py
@@ -157,7 +157,7 @@ def _worker(rank: int, world_size: int, init_file: str, layout: str, implementat
     if implementation == "fallback":
         import liger_kernel.ops.fused_linear_scaled_cross_entropy as frontend
 
-        frontend._load_lck_tp_function = lambda group, device: None
+        frontend._load_lck_tp_function = lambda: None
         nvshmem = None
     else:
         from liger_cute_kernels import nvshmem
@@ -264,11 +264,18 @@ def _worker(rank: int, world_size: int, init_file: str, layout: str, implementat
         raise
 
 
-def _run(world_size: int, layout: str, implementation: str, run_moe: bool = False):
+def _run(
+    world_size: int,
+    layout: str,
+    implementation: str,
+    run_moe: bool = False,
+    disable_nvls: bool = False,
+):
     rendezvous = tempfile.mkdtemp(prefix=f"liger_fslce_tp_{layout}_")
     init_file = os.path.join(rendezvous, "store")
     env = {
         "NVSHMEM_DISABLE_NCCL": "1",
+        "NVSHMEM_DISABLE_NVLS": "1" if disable_nvls else "0",
         "NVSHMEM_REMOTE_TRANSPORT": "none",
         "NVSHMEM_SYMMETRIC_SIZE": "3G",
     }
@@ -327,3 +334,11 @@ def test_lck_moe_and_tp_frontend_use_different_process_groups():
     if _NDEV < 4:
         pytest.skip("requires at least four CUDA devices")
     _run(4, "strided", "lck", run_moe=True)
+
+
+def test_tp_frontend_direct_peer_fallback():
+    if not _LCK_AVAILABLE:
+        pytest.skip("requires a matching liger_cute_kernels wheel")
+    if _NDEV < 2:
+        pytest.skip("requires at least two CUDA devices")
+    _run(2, "world", "lck", disable_nvls=True)

--- a/test/transformers/test_fused_linear_scaled_cross_entropy.py
+++ b/test/transformers/test_fused_linear_scaled_cross_entropy.py
@@ -1,7 +1,6 @@
 import importlib.util
 import inspect
 import os
-import sys
 
 from contextlib import nullcontext
 from pathlib import Path
@@ -31,14 +30,7 @@ _LCK_SPEC = importlib.util.spec_from_file_location(
 )
 assert _LCK_SPEC is not None and _LCK_SPEC.loader is not None
 _LCK_FRONTEND = importlib.util.module_from_spec(_LCK_SPEC)
-sys.modules[_LCK_SPEC.name] = _LCK_FRONTEND
 _LCK_SPEC.loader.exec_module(_LCK_FRONTEND)
-
-_TVM_FFI_PATH = Path(__file__).resolve().parents[2] / "liger_cute_kernels" / "liger_cute_kernels" / "tvm_ffi.py"
-_TVM_FFI_SPEC = importlib.util.spec_from_file_location("_fused_linear_scaled_cross_entropy_tvm_ffi", _TVM_FFI_PATH)
-assert _TVM_FFI_SPEC is not None and _TVM_FFI_SPEC.loader is not None
-_TVM_FFI = importlib.util.module_from_spec(_TVM_FFI_SPEC)
-_TVM_FFI_SPEC.loader.exec_module(_TVM_FFI)
 
 _CUTILE_ENABLED = os.environ.get("LIGER_KERNEL_IMPL", "").strip().lower() == "cutile"
 
@@ -215,7 +207,7 @@ def test_tp_frontend_dispatches_hopper_bf16_to_lck(monkeypatch):
     monkeypatch.setattr(_FRONTEND, "_tp_group_info", lambda actual: (actual, 2))
     monkeypatch.setattr(_FRONTEND, "_validate_tp_inputs", lambda *args: None)
     monkeypatch.setattr(_FRONTEND, "_is_hopper", lambda actual: actual == device)
-    monkeypatch.setattr(_FRONTEND, "_load_lck_tp_function", lambda: StubLckFunction)
+    monkeypatch.setattr(_FRONTEND, "_load_lck_tp_function", lambda group, actual_device: StubLckFunction)
     monkeypatch.setattr(
         _FRONTEND,
         "_apply_tp_fallback",
@@ -256,7 +248,7 @@ def test_tp_frontend_uses_liger_fallback_when_lck_is_unavailable(monkeypatch, lc
     monkeypatch.setattr(_FRONTEND, "_validate_tp_inputs", lambda *args: None)
     monkeypatch.setattr(_FRONTEND, "_is_hopper", lambda actual: True)
 
-    def load_lck():
+    def load_lck(group, actual_device):
         if isinstance(lck_result, BaseException):
             raise lck_result
         return lck_result
@@ -344,10 +336,10 @@ def test_lck_tp_autograd_forwards_runtime_and_inverse_temperature(monkeypatch):
             calls["backward"] = args
             return torch.full_like(args[2], 3.0), torch.full_like(args[3], 4.0)
 
-    runtime = SimpleNamespace(team_handle=17, nccl_comm_handle=23)
     monkeypatch.setattr(_LCK_FRONTEND, "_validate_inputs", lambda *args: None)
     monkeypatch.setattr(_LCK_FRONTEND, "_pad_hidden", lambda x, weight: (x, weight, x.shape[1]))
-    monkeypatch.setattr(_LCK_FRONTEND, "_prepare_runtime", lambda *args: runtime)
+    monkeypatch.setattr(_LCK_FRONTEND, "_prepare_lck_call", lambda *args: 17)
+    monkeypatch.setattr(_LCK_FRONTEND, "_borrow_nccl_communicator", lambda group, device: 23)
     monkeypatch.setattr(_LCK_FRONTEND, "_get_tvm_ffi", lambda: FakeTvmFfi)
 
     _input = torch.randn(3, 4, requires_grad=True)
@@ -374,34 +366,17 @@ def test_lck_tp_autograd_forwards_runtime_and_inverse_temperature(monkeypatch):
     torch.testing.assert_close(weight.grad, torch.full_like(weight, 4.0))
 
 
-def test_lck_runtime_initializes_group_and_configures_once(monkeypatch):
+def test_lck_call_uses_prepared_group_without_global_state(monkeypatch):
     process_group = object()
     calls = []
 
     class FakeNvshmem:
-        initialized = False
-
-        @classmethod
-        def is_initialized(cls):
-            return cls.initialized
-
-        @classmethod
-        def ensure_initialized(cls, group=None):
-            calls.append(("ensure", group))
-            cls.initialized = True
-
         @staticmethod
-        def resolve_team(group):
-            calls.append(("team", group))
+        def resolve_team(group, *, create=True):
+            calls.append(("team", group, create))
             return 17
 
     class FakeTvmFfi:
-        generation = 0
-
-        @staticmethod
-        def pool_generation():
-            return FakeTvmFfi.generation
-
         @staticmethod
         def fused_linear_scaled_cross_entropy_configure_backward(*args):
             calls.append(("backward_config", args))
@@ -410,18 +385,11 @@ def test_lck_runtime_initializes_group_and_configures_once(monkeypatch):
         def fused_linear_scaled_cross_entropy_configure_forward(*args):
             calls.append(("forward_config", args))
 
-    monkeypatch.setattr(_LCK_FRONTEND, "_RUNTIME", None)
     monkeypatch.setattr(_LCK_FRONTEND, "_get_nvshmem", lambda: FakeNvshmem)
     monkeypatch.setattr(_LCK_FRONTEND, "_get_tvm_ffi", lambda: FakeTvmFfi)
-    monkeypatch.setattr(_LCK_FRONTEND, "_group_ranks", lambda group: (0, 2))
-    monkeypatch.setattr(
-        _LCK_FRONTEND,
-        "_create_nccl_communicator",
-        lambda group, device: calls.append(("nccl", group, device)) or 23,
-    )
     monkeypatch.setattr(_LCK_FRONTEND.torch.cuda, "device", lambda device: nullcontext())
 
-    runtime = _LCK_FRONTEND._prepare_runtime(
+    team = _LCK_FRONTEND._prepare_lck_call(
         process_group,
         torch.device("cuda:1"),
         128,
@@ -429,7 +397,7 @@ def test_lck_runtime_initializes_group_and_configures_once(monkeypatch):
         320,
         2,
     )
-    repeated = _LCK_FRONTEND._prepare_runtime(
+    repeated = _LCK_FRONTEND._prepare_lck_call(
         process_group,
         torch.device("cuda:1"),
         64,
@@ -437,56 +405,77 @@ def test_lck_runtime_initializes_group_and_configures_once(monkeypatch):
         160,
         1,
     )
-    FakeTvmFfi.generation = 1
-    reconfigured = _LCK_FRONTEND._prepare_runtime(
-        process_group,
-        torch.device("cuda:1"),
-        64,
-        1024,
-        160,
-        1,
-    )
-
-    assert repeated is runtime
-    assert reconfigured is runtime
-    assert runtime.team_handle == 17
-    assert runtime.nccl_comm_handle == 23
+    assert team == 17
+    assert repeated == 17
     assert calls == [
-        ("ensure", None),
-        ("team", process_group),
+        ("team", process_group, False),
         ("backward_config", (128, 2048, 320, 2, 17)),
         ("forward_config", (128, 320)),
-        ("nccl", process_group, torch.device("cuda:1")),
+        ("team", process_group, False),
         ("backward_config", (64, 1024, 160, 1, 17)),
         ("forward_config", (64, 160)),
     ]
 
 
-def test_lck_pool_generation_tracks_configuration_resets(monkeypatch):
+def test_lck_borrows_matching_process_group_nccl_communicator(monkeypatch):
     calls = []
+    comm_handles = iter((0, 23))
+    device = torch.device("cuda:2")
 
-    class FakeModule:
+    class FakeBackend:
         @staticmethod
-        def pool_clear_all():
-            calls.append("all")
-
-        @staticmethod
-        def pool_clear_buffers():
-            calls.append("buffers")
+        def get_runtime_nccl_version():
+            return (2, 27, 6)
 
         @staticmethod
-        def finalize():
-            calls.append("finalize")
+        def eager_connect_single_device(actual_device):
+            calls.append(("eager", actual_device))
 
-    monkeypatch.setattr(_TVM_FFI, "_load_module", lambda: FakeModule)
-    start = _TVM_FFI.pool_generation()
+        @staticmethod
+        def _comm_ptr():
+            calls.append(("comm_ptr",))
+            return next(comm_handles)
 
-    _TVM_FFI.pool_clear_all()
-    _TVM_FFI.pool_clear_buffers()
-    _TVM_FFI.finalize()
+    class FakeProcessGroup:
+        @staticmethod
+        def _get_backend(actual_device):
+            calls.append(("backend", actual_device))
+            return FakeBackend()
 
-    assert _TVM_FFI.pool_generation() == start + 3
-    assert calls == ["all", "buffers", "finalize"]
+    fake_tvm_ffi = SimpleNamespace(nccl_runtime_version=lambda: (2, 27, 6))
+    monkeypatch.setattr(_LCK_FRONTEND, "_get_tvm_ffi", lambda: fake_tvm_ffi)
+
+    assert _LCK_FRONTEND._borrow_nccl_communicator(FakeProcessGroup(), device) == 23
+    assert calls == [("backend", device), ("comm_ptr",), ("eager", device), ("comm_ptr",)]
+
+
+def test_lck_rejects_mismatched_nccl_runtime(monkeypatch):
+    class FakeBackend:
+        @staticmethod
+        def get_runtime_nccl_version():
+            return (2, 27, 6)
+
+        @staticmethod
+        def eager_connect_single_device(device):
+            pytest.fail(f"must not initialize a mismatched communicator on {device}")
+
+        @staticmethod
+        def _comm_ptr():
+            return 23
+
+    class FakeProcessGroup:
+        @staticmethod
+        def _get_backend(device):
+            return FakeBackend()
+
+    monkeypatch.setattr(
+        _LCK_FRONTEND,
+        "_get_tvm_ffi",
+        lambda: SimpleNamespace(nccl_runtime_version=lambda: (2, 26, 5)),
+    )
+
+    with pytest.raises(RuntimeError, match="NCCL runtime versions must match"):
+        _LCK_FRONTEND._borrow_nccl_communicator(FakeProcessGroup(), torch.device("cuda:0"))
 
 
 def test_frontend_is_exported_from_ops_root():

--- a/test/transformers/test_fused_linear_scaled_cross_entropy.py
+++ b/test/transformers/test_fused_linear_scaled_cross_entropy.py
@@ -218,8 +218,8 @@ def test_tp_frontend_dispatches_hopper_bf16_to_lck(monkeypatch):
     monkeypatch.setattr(_FRONTEND, "_load_lck_tp_function", lambda: StubLckFunction)
     monkeypatch.setattr(
         _FRONTEND,
-        "_apply_verl_tp_fallback",
-        lambda *args: pytest.fail("Verl fallback must not run when LCK is available"),
+        "_apply_tp_fallback",
+        lambda *args: pytest.fail("the Liger fallback must not run when LCK is available"),
     )
 
     result = _FRONTEND.LigerFusedLinearScaledCrossEntropyTPFunction.apply(
@@ -244,7 +244,7 @@ def test_tp_group_is_a_call_argument():
 
 
 @pytest.mark.parametrize("lck_result", [None, ImportError("lck unavailable")])
-def test_tp_frontend_uses_verl_when_lck_is_unavailable(monkeypatch, lck_result):
+def test_tp_frontend_uses_liger_fallback_when_lck_is_unavailable(monkeypatch, lck_result):
     process_group = object()
     device = torch.device("cuda:0")
     _input = SimpleNamespace(device=device, dtype=torch.bfloat16)
@@ -264,8 +264,8 @@ def test_tp_frontend_uses_verl_when_lck_is_unavailable(monkeypatch, lck_result):
     monkeypatch.setattr(_FRONTEND, "_load_lck_tp_function", load_lck)
     monkeypatch.setattr(
         _FRONTEND,
-        "_apply_verl_tp_fallback",
-        lambda *args: calls.append(args) or "verl-result",
+        "_apply_tp_fallback",
+        lambda *args: calls.append(args) or "fallback-result",
     )
 
     result = _FRONTEND.LigerFusedLinearScaledCrossEntropyTPFunction.apply(
@@ -275,51 +275,58 @@ def test_tp_frontend_uses_verl_when_lck_is_unavailable(monkeypatch, lck_result):
         process_group,
     )
 
-    assert result == "verl-result"
+    assert result == "fallback-result"
     assert calls == [(_input, weight, target, 1.0, -100, False, process_group)]
 
 
-def test_tp_verl_fallback_masks_ignored_rows_and_reduces_input_gradient(monkeypatch):
+def test_tp_fallback_matches_torch_with_entropy_and_ignored_rows(monkeypatch):
     process_group = object()
-    _input = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], requires_grad=True)
-    weight = torch.tensor([[1.0, 2.0], [4.0, 8.0]], requires_grad=True)
-    target = torch.tensor([0, -100, 1], dtype=torch.int64)
-    seen = {}
+    token_count, hidden_size, vocab_size = 521, 7, 13
+    temperature = 0.7
+    target = torch.randint(vocab_size, (token_count,), dtype=torch.int64)
+    target[::5] = -100
+    grad_nll = torch.rand(token_count)
+    grad_entropy = torch.rand(token_count) - 0.5
 
-    def fake_verl(hidden, local_weight, labels, temperature, reduction, group):
-        seen["labels"] = labels.clone()
-        seen["temperature"] = temperature
-        seen["reduction"] = reduction
-        seen["group"] = group
-        logits = hidden @ local_weight.t()
-        return logits[:, 0], logits[:, 1]
+    monkeypatch.setattr(_FRONTEND.dist, "get_rank", lambda group: 0)
+    monkeypatch.setattr(_FRONTEND.dist, "get_world_size", lambda group: 1)
 
-    def fake_all_reduce(tensor, op, group):
-        seen["all_reduce"] = (op, group)
-        tensor.mul_(2)
-
-    monkeypatch.setattr(_FRONTEND, "_load_verl_tp_function", lambda: fake_verl)
-    monkeypatch.setattr(_FRONTEND.dist, "all_reduce", fake_all_reduce)
-
-    nll, entropy = _FRONTEND._apply_verl_tp_fallback(
-        _input,
-        weight,
+    actual_input = torch.randn(token_count, hidden_size, requires_grad=True)
+    actual_weight = torch.randn(vocab_size, hidden_size, requires_grad=True)
+    actual_nll, actual_entropy = _FRONTEND._apply_tp_fallback(
+        actual_input,
+        actual_weight,
         target,
-        0.5,
+        temperature,
         -100,
         True,
         process_group,
     )
-    (nll + entropy).sum().backward()
+    torch.autograd.backward((actual_nll, actual_entropy), (grad_nll, grad_entropy))
 
-    torch.testing.assert_close(nll, torch.tensor([-5.0, 0.0, -17.0]))
-    torch.testing.assert_close(entropy, torch.tensor([20.0, 0.0, 68.0]))
-    torch.testing.assert_close(_input.grad, torch.tensor([[6.0, 12.0], [0.0, 0.0], [6.0, 12.0]]))
-    assert seen["labels"].tolist() == [0, 0, 1]
-    assert seen["temperature"] == 0.5
-    assert seen["reduction"] == "none"
-    assert seen["group"] is process_group
-    assert seen["all_reduce"] == (torch.distributed.ReduceOp.SUM, process_group)
+    expected_input = actual_input.detach().clone().requires_grad_(True)
+    expected_weight = actual_weight.detach().clone().requires_grad_(True)
+    logits = (expected_input @ expected_weight.t()).float() / temperature
+    log_probs = logits.log_softmax(dim=-1)
+    probabilities = log_probs.exp()
+    valid = target != -100
+    safe_target = target.masked_fill(~valid, 0)
+    expected_nll = torch.where(
+        valid,
+        -log_probs.gather(-1, safe_target[:, None]).squeeze(-1),
+        torch.zeros(token_count),
+    )
+    expected_entropy = torch.where(
+        valid,
+        -(probabilities * log_probs).sum(dim=-1),
+        torch.zeros(token_count),
+    )
+    torch.autograd.backward((expected_nll, expected_entropy), (grad_nll, grad_entropy))
+
+    torch.testing.assert_close(actual_nll, expected_nll)
+    torch.testing.assert_close(actual_entropy, expected_entropy)
+    torch.testing.assert_close(actual_input.grad, expected_input.grad, atol=2e-5, rtol=2e-5)
+    torch.testing.assert_close(actual_weight.grad, expected_weight.grad, atol=2e-5, rtol=2e-5)
 
 
 def test_lck_tp_autograd_forwards_runtime_and_inverse_temperature(monkeypatch):

--- a/test/transformers/test_fused_linear_scaled_cross_entropy.py
+++ b/test/transformers/test_fused_linear_scaled_cross_entropy.py
@@ -1,6 +1,9 @@
 import importlib.util
+import inspect
 import os
+import sys
 
+from contextlib import nullcontext
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -14,6 +17,28 @@ _SPEC = importlib.util.spec_from_file_location("_fused_linear_scaled_cross_entro
 assert _SPEC is not None and _SPEC.loader is not None
 _FRONTEND = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_FRONTEND)
+
+_LCK_FRONTEND_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "liger_kernel"
+    / "ops"
+    / "cute"
+    / "fused_linear_scaled_cross_entropy_tp.py"
+)
+_LCK_SPEC = importlib.util.spec_from_file_location(
+    "_fused_linear_scaled_cross_entropy_lck_frontend", _LCK_FRONTEND_PATH
+)
+assert _LCK_SPEC is not None and _LCK_SPEC.loader is not None
+_LCK_FRONTEND = importlib.util.module_from_spec(_LCK_SPEC)
+sys.modules[_LCK_SPEC.name] = _LCK_FRONTEND
+_LCK_SPEC.loader.exec_module(_LCK_FRONTEND)
+
+_TVM_FFI_PATH = Path(__file__).resolve().parents[2] / "liger_cute_kernels" / "liger_cute_kernels" / "tvm_ffi.py"
+_TVM_FFI_SPEC = importlib.util.spec_from_file_location("_fused_linear_scaled_cross_entropy_tvm_ffi", _TVM_FFI_PATH)
+assert _TVM_FFI_SPEC is not None and _TVM_FFI_SPEC.loader is not None
+_TVM_FFI = importlib.util.module_from_spec(_TVM_FFI_SPEC)
+_TVM_FFI_SPEC.loader.exec_module(_TVM_FFI)
 
 _CUTILE_ENABLED = os.environ.get("LIGER_KERNEL_IMPL", "").strip().lower() == "cutile"
 
@@ -173,6 +198,290 @@ def test_frontend_fallback_supports_entropy_only_backward():
     assert weight.grad is not None
 
 
+def test_tp_frontend_dispatches_hopper_bf16_to_lck(monkeypatch):
+    process_group = object()
+    device = torch.device("cuda:3")
+    _input = SimpleNamespace(device=device, dtype=torch.bfloat16)
+    weight = SimpleNamespace(shape=(16, 32))
+    target = object()
+    calls = []
+
+    class StubLckFunction:
+        @staticmethod
+        def apply(*args):
+            calls.append(args)
+            return "lck-result"
+
+    monkeypatch.setattr(_FRONTEND, "_tp_group_info", lambda actual: (actual, 2))
+    monkeypatch.setattr(_FRONTEND, "_validate_tp_inputs", lambda *args: None)
+    monkeypatch.setattr(_FRONTEND, "_is_hopper", lambda actual: actual == device)
+    monkeypatch.setattr(_FRONTEND, "_load_lck_tp_function", lambda: StubLckFunction)
+    monkeypatch.setattr(
+        _FRONTEND,
+        "_apply_verl_tp_fallback",
+        lambda *args: pytest.fail("Verl fallback must not run when LCK is available"),
+    )
+
+    result = _FRONTEND.LigerFusedLinearScaledCrossEntropyTPFunction.apply(
+        _input,
+        weight,
+        target,
+        process_group,
+        0.5,
+        -1,
+        2,
+        True,
+    )
+
+    assert result == "lck-result"
+    assert calls == [(_input, weight, target, 32, 0.5, -1, 2, True, process_group)]
+
+
+def test_tp_group_is_a_call_argument():
+    parameters = inspect.signature(_FRONTEND.LigerFusedLinearScaledCrossEntropyTPFunction.apply).parameters
+
+    assert list(parameters)[3] == "tp_group"
+
+
+@pytest.mark.parametrize("lck_result", [None, ImportError("lck unavailable")])
+def test_tp_frontend_uses_verl_when_lck_is_unavailable(monkeypatch, lck_result):
+    process_group = object()
+    device = torch.device("cuda:0")
+    _input = SimpleNamespace(device=device, dtype=torch.bfloat16)
+    weight = SimpleNamespace(shape=(8, 16))
+    target = object()
+    calls = []
+
+    monkeypatch.setattr(_FRONTEND, "_tp_group_info", lambda actual: (actual, 1))
+    monkeypatch.setattr(_FRONTEND, "_validate_tp_inputs", lambda *args: None)
+    monkeypatch.setattr(_FRONTEND, "_is_hopper", lambda actual: True)
+
+    def load_lck():
+        if isinstance(lck_result, BaseException):
+            raise lck_result
+        return lck_result
+
+    monkeypatch.setattr(_FRONTEND, "_load_lck_tp_function", load_lck)
+    monkeypatch.setattr(
+        _FRONTEND,
+        "_apply_verl_tp_fallback",
+        lambda *args: calls.append(args) or "verl-result",
+    )
+
+    result = _FRONTEND.LigerFusedLinearScaledCrossEntropyTPFunction.apply(
+        _input,
+        weight,
+        target,
+        process_group,
+    )
+
+    assert result == "verl-result"
+    assert calls == [(_input, weight, target, 1.0, -100, False, process_group)]
+
+
+def test_tp_verl_fallback_masks_ignored_rows_and_reduces_input_gradient(monkeypatch):
+    process_group = object()
+    _input = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], requires_grad=True)
+    weight = torch.tensor([[1.0, 2.0], [4.0, 8.0]], requires_grad=True)
+    target = torch.tensor([0, -100, 1], dtype=torch.int64)
+    seen = {}
+
+    def fake_verl(hidden, local_weight, labels, temperature, reduction, group):
+        seen["labels"] = labels.clone()
+        seen["temperature"] = temperature
+        seen["reduction"] = reduction
+        seen["group"] = group
+        logits = hidden @ local_weight.t()
+        return logits[:, 0], logits[:, 1]
+
+    def fake_all_reduce(tensor, op, group):
+        seen["all_reduce"] = (op, group)
+        tensor.mul_(2)
+
+    monkeypatch.setattr(_FRONTEND, "_load_verl_tp_function", lambda: fake_verl)
+    monkeypatch.setattr(_FRONTEND.dist, "all_reduce", fake_all_reduce)
+
+    nll, entropy = _FRONTEND._apply_verl_tp_fallback(
+        _input,
+        weight,
+        target,
+        0.5,
+        -100,
+        True,
+        process_group,
+    )
+    (nll + entropy).sum().backward()
+
+    torch.testing.assert_close(nll, torch.tensor([-5.0, 0.0, -17.0]))
+    torch.testing.assert_close(entropy, torch.tensor([20.0, 0.0, 68.0]))
+    torch.testing.assert_close(_input.grad, torch.tensor([[6.0, 12.0], [0.0, 0.0], [6.0, 12.0]]))
+    assert seen["labels"].tolist() == [0, 0, 1]
+    assert seen["temperature"] == 0.5
+    assert seen["reduction"] == "none"
+    assert seen["group"] is process_group
+    assert seen["all_reduce"] == (torch.distributed.ReduceOp.SUM, process_group)
+
+
+def test_lck_tp_autograd_forwards_runtime_and_inverse_temperature(monkeypatch):
+    calls = {}
+
+    class FakeTvmFfi:
+        @staticmethod
+        def fused_linear_scaled_cross_entropy_forward(*args):
+            calls["forward"] = args
+            tokens = args[0].shape[0]
+            return torch.arange(tokens, dtype=torch.float32), torch.ones(tokens), torch.full((tokens,), 2.0)
+
+        @staticmethod
+        def fused_linear_scaled_cross_entropy_backward(*args):
+            calls["backward"] = args
+            return torch.full_like(args[2], 3.0), torch.full_like(args[3], 4.0)
+
+    runtime = SimpleNamespace(team_handle=17, nccl_comm_handle=23)
+    monkeypatch.setattr(_LCK_FRONTEND, "_validate_inputs", lambda *args: None)
+    monkeypatch.setattr(_LCK_FRONTEND, "_pad_hidden", lambda x, weight: (x, weight, x.shape[1]))
+    monkeypatch.setattr(_LCK_FRONTEND, "_prepare_runtime", lambda *args: runtime)
+    monkeypatch.setattr(_LCK_FRONTEND, "_get_tvm_ffi", lambda: FakeTvmFfi)
+
+    _input = torch.randn(3, 4, requires_grad=True)
+    weight = torch.randn(5, 4, requires_grad=True)
+    target = torch.tensor([0, 1, 2], dtype=torch.int64)
+    nll, entropy = _LCK_FRONTEND.LigerFusedLinearScaledCrossEntropyLckTPFunction.apply(
+        _input,
+        weight,
+        target,
+        10,
+        0.5,
+        -100,
+        2,
+        True,
+        object(),
+    )
+    torch.autograd.backward((nll, entropy), (torch.ones_like(nll), torch.full_like(entropy, 0.25)))
+
+    assert calls["forward"][3:] == (10, -100, 2.0, 23, True)
+    torch.testing.assert_close(calls["backward"][0], torch.ones(3))
+    torch.testing.assert_close(calls["backward"][1], torch.full((3,), 0.25))
+    assert calls["backward"][7:] == (10, -100, 2.0, 17, 2, True)
+    torch.testing.assert_close(_input.grad, torch.full_like(_input, 3.0))
+    torch.testing.assert_close(weight.grad, torch.full_like(weight, 4.0))
+
+
+def test_lck_runtime_initializes_group_and_configures_once(monkeypatch):
+    process_group = object()
+    calls = []
+
+    class FakeNvshmem:
+        initialized = False
+
+        @classmethod
+        def is_initialized(cls):
+            return cls.initialized
+
+        @classmethod
+        def ensure_initialized(cls, group=None):
+            calls.append(("ensure", group))
+            cls.initialized = True
+
+        @staticmethod
+        def resolve_team(group):
+            calls.append(("team", group))
+            return 17
+
+    class FakeTvmFfi:
+        generation = 0
+
+        @staticmethod
+        def pool_generation():
+            return FakeTvmFfi.generation
+
+        @staticmethod
+        def fused_linear_scaled_cross_entropy_configure_backward(*args):
+            calls.append(("backward_config", args))
+
+        @staticmethod
+        def fused_linear_scaled_cross_entropy_configure_forward(*args):
+            calls.append(("forward_config", args))
+
+    monkeypatch.setattr(_LCK_FRONTEND, "_RUNTIME", None)
+    monkeypatch.setattr(_LCK_FRONTEND, "_get_nvshmem", lambda: FakeNvshmem)
+    monkeypatch.setattr(_LCK_FRONTEND, "_get_tvm_ffi", lambda: FakeTvmFfi)
+    monkeypatch.setattr(_LCK_FRONTEND, "_group_ranks", lambda group: (0, 2))
+    monkeypatch.setattr(
+        _LCK_FRONTEND,
+        "_create_nccl_communicator",
+        lambda group, device: calls.append(("nccl", group, device)) or 23,
+    )
+    monkeypatch.setattr(_LCK_FRONTEND.torch.cuda, "device", lambda device: nullcontext())
+
+    runtime = _LCK_FRONTEND._prepare_runtime(
+        process_group,
+        torch.device("cuda:1"),
+        128,
+        2048,
+        320,
+        2,
+    )
+    repeated = _LCK_FRONTEND._prepare_runtime(
+        process_group,
+        torch.device("cuda:1"),
+        64,
+        1024,
+        160,
+        1,
+    )
+    FakeTvmFfi.generation = 1
+    reconfigured = _LCK_FRONTEND._prepare_runtime(
+        process_group,
+        torch.device("cuda:1"),
+        64,
+        1024,
+        160,
+        1,
+    )
+
+    assert repeated is runtime
+    assert reconfigured is runtime
+    assert runtime.team_handle == 17
+    assert runtime.nccl_comm_handle == 23
+    assert calls == [
+        ("ensure", None),
+        ("team", process_group),
+        ("backward_config", (128, 2048, 320, 2, 17)),
+        ("forward_config", (128, 320)),
+        ("nccl", process_group, torch.device("cuda:1")),
+        ("backward_config", (64, 1024, 160, 1, 17)),
+        ("forward_config", (64, 160)),
+    ]
+
+
+def test_lck_pool_generation_tracks_configuration_resets(monkeypatch):
+    calls = []
+
+    class FakeModule:
+        @staticmethod
+        def pool_clear_all():
+            calls.append("all")
+
+        @staticmethod
+        def pool_clear_buffers():
+            calls.append("buffers")
+
+        @staticmethod
+        def finalize():
+            calls.append("finalize")
+
+    monkeypatch.setattr(_TVM_FFI, "_load_module", lambda: FakeModule)
+    start = _TVM_FFI.pool_generation()
+
+    _TVM_FFI.pool_clear_all()
+    _TVM_FFI.pool_clear_buffers()
+    _TVM_FFI.finalize()
+
+    assert _TVM_FFI.pool_generation() == start + 3
+    assert calls == ["all", "buffers", "finalize"]
+
+
 def test_frontend_is_exported_from_ops_root():
     try:
         import liger_kernel.ops as ops
@@ -187,3 +496,6 @@ def test_frontend_is_exported_from_ops_root():
         else "liger_kernel.ops.fused_linear_scaled_cross_entropy"
     )
     assert ops.LigerFusedLinearScaledCrossEntropyFunction.__module__ == expected_module
+    assert ops.LigerFusedLinearScaledCrossEntropyTPFunction.__module__ == (
+        "liger_kernel.ops.fused_linear_scaled_cross_entropy"
+    )

--- a/test/transformers/test_fused_linear_scaled_cross_entropy.py
+++ b/test/transformers/test_fused_linear_scaled_cross_entropy.py
@@ -207,7 +207,7 @@ def test_tp_frontend_dispatches_hopper_bf16_to_lck(monkeypatch):
     monkeypatch.setattr(_FRONTEND, "_tp_group_info", lambda actual: (actual, 2))
     monkeypatch.setattr(_FRONTEND, "_validate_tp_inputs", lambda *args: None)
     monkeypatch.setattr(_FRONTEND, "_is_hopper", lambda actual: actual == device)
-    monkeypatch.setattr(_FRONTEND, "_load_lck_tp_function", lambda group, actual_device: StubLckFunction)
+    monkeypatch.setattr(_FRONTEND, "_load_lck_tp_function", lambda: StubLckFunction)
     monkeypatch.setattr(
         _FRONTEND,
         "_apply_tp_fallback",
@@ -248,7 +248,7 @@ def test_tp_frontend_uses_liger_fallback_when_lck_is_unavailable(monkeypatch, lc
     monkeypatch.setattr(_FRONTEND, "_validate_tp_inputs", lambda *args: None)
     monkeypatch.setattr(_FRONTEND, "_is_hopper", lambda actual: True)
 
-    def load_lck(group, actual_device):
+    def load_lck():
         if isinstance(lck_result, BaseException):
             raise lck_result
         return lck_result
@@ -339,7 +339,6 @@ def test_lck_tp_autograd_forwards_runtime_and_inverse_temperature(monkeypatch):
     monkeypatch.setattr(_LCK_FRONTEND, "_validate_inputs", lambda *args: None)
     monkeypatch.setattr(_LCK_FRONTEND, "_pad_hidden", lambda x, weight: (x, weight, x.shape[1]))
     monkeypatch.setattr(_LCK_FRONTEND, "_prepare_lck_call", lambda *args: 17)
-    monkeypatch.setattr(_LCK_FRONTEND, "_borrow_nccl_communicator", lambda group, device: 23)
     monkeypatch.setattr(_LCK_FRONTEND, "_get_tvm_ffi", lambda: FakeTvmFfi)
 
     _input = torch.randn(3, 4, requires_grad=True)
@@ -358,7 +357,7 @@ def test_lck_tp_autograd_forwards_runtime_and_inverse_temperature(monkeypatch):
     )
     torch.autograd.backward((nll, entropy), (torch.ones_like(nll), torch.full_like(entropy, 0.25)))
 
-    assert calls["forward"][3:] == (10, -100, 2.0, 23, True)
+    assert calls["forward"][3:] == (10, -100, 2.0, 17, True)
     torch.testing.assert_close(calls["backward"][0], torch.ones(3))
     torch.testing.assert_close(calls["backward"][1], torch.full((3,), 0.25))
     assert calls["backward"][7:] == (10, -100, 2.0, 17, 2, True)
@@ -415,67 +414,6 @@ def test_lck_call_uses_prepared_group_without_global_state(monkeypatch):
         ("backward_config", (64, 1024, 160, 1, 17)),
         ("forward_config", (64, 160)),
     ]
-
-
-def test_lck_borrows_matching_process_group_nccl_communicator(monkeypatch):
-    calls = []
-    comm_handles = iter((0, 23))
-    device = torch.device("cuda:2")
-
-    class FakeBackend:
-        @staticmethod
-        def get_runtime_nccl_version():
-            return (2, 27, 6)
-
-        @staticmethod
-        def eager_connect_single_device(actual_device):
-            calls.append(("eager", actual_device))
-
-        @staticmethod
-        def _comm_ptr():
-            calls.append(("comm_ptr",))
-            return next(comm_handles)
-
-    class FakeProcessGroup:
-        @staticmethod
-        def _get_backend(actual_device):
-            calls.append(("backend", actual_device))
-            return FakeBackend()
-
-    fake_tvm_ffi = SimpleNamespace(nccl_runtime_version=lambda: (2, 27, 6))
-    monkeypatch.setattr(_LCK_FRONTEND, "_get_tvm_ffi", lambda: fake_tvm_ffi)
-
-    assert _LCK_FRONTEND._borrow_nccl_communicator(FakeProcessGroup(), device) == 23
-    assert calls == [("backend", device), ("comm_ptr",), ("eager", device), ("comm_ptr",)]
-
-
-def test_lck_rejects_mismatched_nccl_runtime(monkeypatch):
-    class FakeBackend:
-        @staticmethod
-        def get_runtime_nccl_version():
-            return (2, 27, 6)
-
-        @staticmethod
-        def eager_connect_single_device(device):
-            pytest.fail(f"must not initialize a mismatched communicator on {device}")
-
-        @staticmethod
-        def _comm_ptr():
-            return 23
-
-    class FakeProcessGroup:
-        @staticmethod
-        def _get_backend(device):
-            return FakeBackend()
-
-    monkeypatch.setattr(
-        _LCK_FRONTEND,
-        "_get_tvm_ffi",
-        lambda: SimpleNamespace(nccl_runtime_version=lambda: (2, 26, 5)),
-    )
-
-    with pytest.raises(RuntimeError, match="NCCL runtime versions must match"):
-        _LCK_FRONTEND._borrow_nccl_communicator(FakeProcessGroup(), torch.device("cuda:0"))
 
 
 def test_frontend_is_exported_from_ops_root():


### PR DESCRIPTION
## Summary

- Add `LigerFusedLinearScaledCrossEntropyTPFunction` and `liger_fused_linear_scaled_cross_entropy_tp`, with `tp_group` passed as a call-time argument.
- Route Hopper BF16 inputs to the optional `liger_cute_kernels` implementation when its FSLCE runtime surface is available.
- Keep the fallback entirely in Liger using a chunked tensor-parallel implementation adapted from Verl's fused PPO formulas; there is no runtime dependency on the Verl package.
- Match both paths on global per-token NLL/entropy, ignored targets, local `dW`, and TP-summed `dX`.
- Leave NVSHMEM bootstrap and team preparation application-owned. FSLCE resolves only the call-time `tp_group`, so it coexists with LigerMoE using a different `ep_group` without frontend-global process-group state.
- Remove the native NCCL dependency and all Torch communicator internals from the `liger_cute_kernels` path. Forward and backward communicate exclusively through the prepared NVSHMEM team, and the TVM-FFI core remains Torch-ABI-independent.
- Extend the reusable local reduction API with FP32 `MAX`. The forward WGMMA kernel performs split last-arrival merging, local MAX, correction, and local SUM in its epilogue.
- For two-host execution, each local GPU sends one unique contiguous token shard over IBRC; the follow-up kernel merges the remote online-softmax state, gathers shards with NVLS, and writes NLL/LSE/entropy.
- Bind native FFI calls to the input CUDA device so autograd worker threads have a valid context for TMA descriptor construction.

## Validation

- `make checkstyle`
- `python -m pytest test/transformers/test_fused_linear_scaled_cross_entropy.py -q` - 15 passed, 1 skipped
- H200 distributed frontend matrix using `torch.multiprocessing.spawn` - 10 passed in 77.45s:
  - WORLD process groups at TP1, TP2, TP4, and TP8
  - 4-GPU contiguous subgroups `[0,1]` / `[2,3]`
  - 4-GPU strided subgroups `[0,2]` / `[1,3]`
  - Built-in Liger fallback at TP2 WORLD and strided TP4
  - LigerMoE on `ep_group=WORLD` followed by FSLCE on independent strided TP groups in the same four processes
  - DirectPeer fallback with NVLS disabled
- Native forward self-test: aligned, entropy, ragged M/H/V, temperature, and large split-N cases passed.
- Raw TVM-FFI world/subgroup tests, including forward and backward CUDA Graph replay: 4 passed.
- Two-host TP16 IBRC random-data correctness: passed.
- `libliger_cute_kernels.so` has no NCCL dynamic dependency.

### Forward performance

M=8192, H=4096, Vglobal=131072, entropy disabled:

| TP | NVSHMEM p50 | Previous p50 | Delta |
|---:|---:|---:|---:|
| 1 | 11.227 ms | 11.148 ms | +0.7% |
| 2 | 5.639 ms | 5.594 ms | +0.8% |
| 4 | 2.832 ms | 2.821 ms | +0.4% |
| 8 | 1.442 ms | 1.453 ms | -0.8% |
| 16 (two-host IBRC) | 0.829 ms | 0.784 ms | +5.7% |

TP1-8 are within the agreed 1% run-to-run noise threshold; the TP16 IBRC gap is accepted.
