### PR TITLE
perf(flce): write the weight-gradient product directly into grad_weight

### DIFF
--- a/src/liger_kernel/ops/fused_linear_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_cross_entropy.py
@@ -40,6 +40,48 @@ _TORCH_VERSION = Version(torch.__version__.split("+")[0])
 _ADDMM_SUPPORTS_OUT_DTYPE = _TORCH_VERSION >= Version("2.8.0")
 
 
+def _supports_out_dtype_accumulation(grad_weight, grad_logits_t):
+    return (
+        _ADDMM_SUPPORTS_OUT_DTYPE
+        and grad_weight.device.type == "cuda"
+        and torch.cuda.get_device_capability(grad_weight.device)[0] >= 8
+        and grad_weight.dtype == torch.float32
+        and grad_logits_t.dtype in (torch.float16, torch.bfloat16)
+    )
+
+
+def _accumulate_grad_weight(grad_weight, grad_logits_t, input_chunk, accumulate):
+    """grad_weight = (grad_weight if accumulate else 0) + grad_logits_t @ input_chunk.
+
+    The product is a full V x H tensor, so it is written straight into grad_weight through
+    mm/addmm ``out=`` instead of being materialized. ``accumulate=False`` (first chunk) also
+    skips one read-modify-write pass over grad_weight, which at LLM vocab shapes is several
+    GB of traffic per chunk and dominates the chunk loop at small token counts.
+    """
+    if _supports_out_dtype_accumulation(grad_weight, grad_logits_t):
+        # Unlike torch.mm, torch.addmm's out_dtype path does not participate in
+        # autocast operand casting, so under AMP (fp32 params, no bias) input_chunk
+        # can stay fp32 while grad_logits is the autocast dtype. addmm requires mat1
+        # and mat2 to share a dtype, so align input_chunk before accumulating.
+        if input_chunk.dtype != grad_logits_t.dtype:
+            input_chunk = input_chunk.to(grad_logits_t.dtype)
+        if accumulate:
+            torch.addmm(grad_weight, grad_logits_t, input_chunk, out_dtype=torch.float32, out=grad_weight)
+        else:
+            torch.mm(grad_logits_t, input_chunk, out_dtype=torch.float32, out=grad_weight)
+    elif grad_weight.dtype == grad_logits_t.dtype == input_chunk.dtype:
+        if accumulate:
+            torch.addmm(grad_weight, grad_logits_t, input_chunk, out=grad_weight)
+        else:
+            torch.mm(grad_logits_t, input_chunk, out=grad_weight)
+    else:
+        product = torch.mm(grad_logits_t, input_chunk).float()
+        if accumulate:
+            grad_weight += product
+        else:
+            grad_weight.copy_(product)
+
+
 def fused_linear_cross_entropy_forward(
     _input,
     weight,
@@ -94,15 +136,19 @@ def fused_linear_cross_entropy_forward(
     chunk_size = min(chunk_size, BT)  # a single chunk covers BT when the budget allows; never exceed BT
     num_chunks = triton.cdiv(BT, chunk_size)  # (BT + chunk_size - 1) // chunk_size
 
-    grad_input = torch.zeros_like(_input, device=device)
+    # every chunk writes its own slice of grad_input, and the first chunk writes all of
+    # grad_weight (accumulate=False), so neither buffer needs to be zero-filled first
+    grad_input = (
+        torch.empty_like(_input, device=device) if input_requires_grad else torch.zeros_like(_input, device=device)
+    )
 
     # we use fp32 for loss and gradients accumulator
     if input_requires_grad:
         if accum_dtype is None:
-            grad_weight = torch.zeros_like(weight, device=device) if weight_needs_grad else None
+            grad_weight = torch.empty_like(weight, device=device) if weight_needs_grad else None
             grad_bias = torch.zeros_like(bias, device=device) if bias is not None else None
         else:
-            grad_weight = torch.zeros_like(weight, dtype=accum_dtype, device=device) if weight_needs_grad else None
+            grad_weight = torch.empty_like(weight, dtype=accum_dtype, device=device) if weight_needs_grad else None
             grad_bias = torch.zeros_like(bias, dtype=accum_dtype, device=device) if bias is not None else None
     else:
         grad_weight = None
@@ -280,30 +326,7 @@ def fused_linear_cross_entropy_forward(
             grad_input[start_idx:end_idx] = grad_logits_chunk @ weight
 
         if grad_weight is not None and input_requires_grad:
-            grad_logits_t = grad_logits_chunk.t()
-            if (
-                _ADDMM_SUPPORTS_OUT_DTYPE
-                and grad_weight.device.type == "cuda"
-                and torch.cuda.get_device_capability(grad_weight.device)[0] >= 8
-                and grad_weight.dtype == torch.float32
-                and grad_logits_t.dtype in (torch.float16, torch.bfloat16)
-            ):
-                # Unlike torch.mm, torch.addmm's out_dtype path does not participate in
-                # autocast operand casting, so under AMP (fp32 params, no bias) _input_chunk
-                # can stay fp32 while grad_logits is the autocast dtype. addmm requires mat1
-                # and mat2 to share a dtype, so align _input_chunk before accumulating.
-                input_chunk = _input_chunk
-                if input_chunk.dtype != grad_logits_t.dtype:
-                    input_chunk = input_chunk.to(grad_logits_t.dtype)
-                torch.addmm(
-                    grad_weight,
-                    grad_logits_t,
-                    input_chunk,
-                    out_dtype=torch.float32,
-                    out=grad_weight,
-                )
-            else:
-                grad_weight += torch.mm(grad_logits_chunk.t(), _input_chunk).float()
+            _accumulate_grad_weight(grad_weight, grad_logits_chunk.t(), _input_chunk, accumulate=chunk_id > 0)
 
         if bias is not None and input_requires_grad:
             torch.add(


### PR DESCRIPTION
## Summary

The default FLCE path (`accum_dtype=None`) accumulates the weight gradient per chunk as

    grad_weight += torch.mm(grad_logits_chunk.t(), _input_chunk).float()

This materializes the V×H product twice (a bf16 mm output, then a ~2.0 GB fp32 copy at
llama-3-8B shapes) and re-reads/rewrites `grad_weight`: several GB of avoidable HBM
traffic per chunk, O(V·H) regardless of token count. It made default FLCE slower than
the HF `linear`+`CrossEntropyLoss` baseline at all measured sizes and heavier below
BT=8192.

Changes (Triton kernel and chunk geometry untouched):

- write the product straight into `grad_weight` via `mm`/`addmm` `out=` on both accumulation paths
- first chunk overwrites (`mm`, beta=0) instead of accumulating, dropping one
  read-modify-write pass over `grad_weight`
- allocate `grad_weight`/`grad_input` with `empty_like`; the loop writes every element
- older torch / non-CUDA / mixed-dtype cases keep the previous fallback

Numerics are equal or better: cuBLAS accumulates the product and `beta*C` in fp32 and
rounds once, where the old path rounded the product to bf16 before adding.

Overlaps with #1324, which also routes same-dtype fp16/bf16/fp32 accumulation through
`addmm out=`. This PR additionally skips the first-chunk read-modify-write, drops the
zero-fills, and keeps the mixed-dtype fallback. Happy to consolidate the two.

## Details

Measured on current `main` (2798d08) vs this branch, H100 80GB HBM3, torch
2.13.0+cu130 / triton 3.7.1, llama-3-8B shapes (V=128256, H=4096), bf16,
reduction=mean, full pass (fwd+bwd). Standalone script equivalent to
`benchmark/scripts/benchmark_fused_linear_cross_entropy.py` (same model definitions
and providers), median of `triton.testing.do_bench`; each config run twice, runs
agreed within ~1–3%.

Default `liger` provider (`accum_dtype=None`):

| BT | time before → after | peak mem before → after | HF torch (time / mem) |
|----|---------------------|-------------------------|-----------------------|
| 1024 | 13.21 → **5.86** ms (−56%) | 5215 → **2335** MB (−55%) | 4.93 ms / 2335 MB |
| 2048 | 16.89 → **9.75** ms (−42%) | 5357 → **2601** MB (−51%) | 9.74 ms / 2602 MB |
| 4096 | 26.39 → **20.18** ms (−24%) | 5640 → **3136** MB (−44%) | 20.54 ms / 4104 MB |
| 8192 | 44.47 → **37.34** ms (−16%) | 6204 → **4200** MB (−32%) | 40.02 ms / 7142 MB |

After the change the default path matches or beats the HF baseline on latency at
BT ≥ 2048 (previously slower at every size) and uses less peak memory everywhere,
41% less at BT=8192. At BT=1024 it remains ~1 ms slower on latency at equal memory.
The 2.0–2.9 GB memory drop matches the eliminated V×H fp32 product
(128256×4096×4 B ≈ 2.0 GB).

`accum_dtype=torch.float32` (already on the `addmm(out_dtype=)` path) gains 7–16%
latency from the beta=0 first chunk and the dropped zero-fills, memory flat; the
BT=8192 row is within noise.

The dispatch layer added in #1416 is unaffected: the default (no `LIGER_KERNEL_IMPL`)
path and the `_triton` backend adapter both import
`LigerFusedLinearCrossEntropyFunction` from the patched module;
`ascend`/`cute`/`cutedsl`/`cutile` backends are opt-in and untouched.

Developed with AI assistance (Cognition's Devin: profiling, patch, and benchmark
runs); human-reviewed.

## Testing Done

On this branch (current `main` 2798d08 + this commit), H100 80GB:

- `make test` (full suite): passed
- `python -m pytest test/transformers/test_fused_linear_cross_entropy.py`: **141 passed**
  (AMP, `accum_dtype`, ce_weight, softcap, z-loss, label smoothing, `reduction="none"`)
- `python -m pytest test/convergence/bf16/test_mini_models.py -k llama3`: **passed**
- `make checkstyle`: clean

- Hardware Type: H100-80G-HBM3
- [x] run `make test` to ensure correctness
- [x] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence (llama3 bf16 subset run; full suite not run)