### PR TITLE
fix(cutedsl): fp32 CE loss precision on B200 + restore LigerCrossEntropyFunction export

### DIFF
--- a/src/liger_kernel/ops/cutedsl/ops/cross_entropy.py
+++ b/src/liger_kernel/ops/cutedsl/ops/cross_entropy.py
@@ -184,7 +184,7 @@ def _scale_in_place_host(mX: cute.Tensor, mScale: cute.Tensor, stream: cuda.CUst
 
 def _scale_in_place(x, scale):
     x_ct = to_cute_tensor(x)
-    scale_ct = to_cute_tensor(scale.reshape(1), assumed_align=2)
+    scale_ct = to_cute_tensor(scale.reshape(1), assumed_align=scale.element_size())
     stream = _cute_stream()
     key = (x.dtype, scale.dtype)
     if key not in _scale_compile_cache:
@@ -713,7 +713,7 @@ def _launch_ce_fwd(
     softcap_val = float(softcap) if has_softcap else 0.0
     x_ct = to_cute_tensor(x)
     y_ct = to_cute_tensor(y, assumed_align=8)  # int64
-    loss_ct = to_cute_tensor(loss, assumed_align=2)  # bf16/fp16/fp32 scalar
+    loss_ct = to_cute_tensor(loss, assumed_align=loss.element_size())  # bf16/fp16/fp32 scalar
     stream = _cute_stream()
     # Key on EVERY dtype the kernel bakes at compile time, not just x.dtype:
     #   mX.element_type (x), mY.element_type (y), mLoss.element_type (loss, via
@@ -727,7 +727,7 @@ def _launch_ce_fwd(
     # False, and the compile key carries that flag so a real-output compile can't reuse it.
     # Reuse the already-marshalled loss_ct/y_ct handles for the dummies (no extra from_dlpack
     # on the common path — one fewer DLPack capsule per call).
-    z_ct = to_cute_tensor(z_loss_out, assumed_align=2) if return_z_loss else loss_ct
+    z_ct = to_cute_tensor(z_loss_out, assumed_align=loss.element_size()) if return_z_loss else loss_ct
     ta_ct = to_cute_tensor(token_acc_out, assumed_align=4) if return_token_accuracy else loss_ct
     pt_ct = to_cute_tensor(pred_tok_out, assumed_align=8) if return_predicted_tokens else y_ct
     # weight is a fp32 (V,) vector when present (caller upcasts); dummy reuses int64 `y`.

--- a/src/liger_kernel/transformers/cross_entropy.py
+++ b/src/liger_kernel/transformers/cross_entropy.py
@@ -3,6 +3,7 @@ from typing import Optional
 import torch
 
 from liger_kernel.backends import dispatch
+from liger_kernel.ops import LigerCrossEntropyFunction  # noqa: F401 — re-exported for backend-routing checks
 from liger_kernel.transformers.functional import CrossEntropyOutput
 
 


### PR DESCRIPTION
## Summary

Two bugs fixed, both caught by `make test-cutedsl` on B200 (SM100).

---

### Bug 1 — `assumed_align=2` causes bf16-precision stores for fp32 loss tensors (pre-existing)

**Failing tests (26):** all fp32 CE tests with feature flags — z_loss, softcap, label_smoothing — when `requires_grad=True`.

**Symptom:** Forward loss quantised to bf16 precision (`1.46875` instead of `1.47212`, `~2.8e-2` error) even though `loss_1d` is fp32. Error only appears with `HAS_GRAD=True`.

**Root cause:** `to_cute_tensor(loss, assumed_align=2)` passed a 2-byte alignment hint to `from_dlpack` for a 4-byte (fp32) tensor. When compiled with `HAS_GRAD=True`, the CuTe DSL compiler generated 16-bit (bf16) stores for `mLoss[row]` instead of correct 32-bit stores. Same issue affected the backward `_scale_in_place` gradient scaler.

**Fix:** Replace hardcoded `assumed_align=2` with `assumed_align=<tensor>.element_size()` at three call sites (loss buffer, z_loss buffer, scale buffer). Keeps 2-byte alignment for bf16/fp16, uses 4-byte for fp32.

---

### Bug 2 — `LigerCrossEntropyFunction` not exported from `transformers.cross_entropy` (since #1416)

**Failing tests (2):** `test_backend.py::test_liger_kernel_impl_cutedsl_routes` and `test_cross_entropy.py::test_liger_kernel_impl_cutedsl_selects_cutedsl_ce`.

**Root cause:** PR #1416 refactored `liger_kernel/transformers/cross_entropy.py` to use `dispatch()` from the new multi-DSL backends system, removing the explicit `LigerCrossEntropyFunction` import. The cutedsl routing tests expect this attribute to be importable and to resolve to the cutedsl class when `LIGER_KERNEL_IMPL=cutedsl`.

**Fix:** Re-add the import as a re-export (`# noqa: F401`). Because `liger_kernel.ops` applies backend replacement at import time, the attribute correctly resolves to the cutedsl implementation when `LIGER_KERNEL_IMPL=cutedsl`.

---

## Verification (B200 / SM100)

```
641 passed, 50 skipped, 0 failed  (50 skipped = SM90-only tests self-skip on B200)
```
