### PR TITLE
Use native CUTLASS + NVSHMEM package terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,17 +262,17 @@ nll, entropy = LigerFusedLinearScaledCrossEntropyTPFunction.apply(
 ```
 
 The TP frontend derives `vocab_start` from the process-group rank. BF16 inputs on Hopper use the optional
-`liger_cute_kernels` (LCK) implementation when its native core is available; other configurations use Liger's chunked
+`liger_cute_kernels` implementation when its native core is available; other configurations use Liger's chunked
 tensor-parallel fallback adapted from Verl's fused PPO formulas. Both paths return globally correct per-token outputs
-and sum the input gradient across the TP group. The LCK forward and backward paths communicate exclusively through
+and sum the input gradient across the TP group. The native CUTLASS + NVSHMEM paths communicate exclusively through
 NVSHMEM; no Torch communicator or Torch C++ ABI crosses the TVM-FFI boundary. Calls remain collectives on `tp_group`, so
 they must have the same ordering on every member.
 
-LCK shares the process-wide NVSHMEM bootstrap used by `LigerExpertParallelFusedMoe`, while TP and EP use separate cached
-teams and separately named workspaces. Application setup must initialize NVSHMEM from a common parent group (normally
-`WORLD`) and resolve both process groups before invoking either kernel. The first FSLCE call fixes its workspace
-capacity, so warm it up with the largest expected token, hidden, local-vocabulary, and `tiles_per_reduce` settings
-before CUDA Graph capture.
+The native operators share the process-wide NVSHMEM bootstrap used by `LigerExpertParallelFusedMoe`, while TP and EP
+use separate cached teams and separately named workspaces. Application setup must initialize NVSHMEM from a common
+parent group (normally `WORLD`) and resolve both process groups before invoking either kernel. The first FSLCE call
+fixes its workspace capacity, so warm it up with the largest expected token, hidden, local-vocabulary, and
+`tiles_per_reduce` settings before CUDA Graph capture.
 
 H100 BF16 forward medians from 60 interleaved samples per provider at
 `H=4096`, `V=131072`. Effective TFLOPS count the common projection work,

--- a/liger_cute_kernels/CMakeLists.txt
+++ b/liger_cute_kernels/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# LigerCute — native build harness (ported from LigerCommKernels)
+# LigerCuteKernels — native build harness
 #
 # Target split:
 #

--- a/liger_cute_kernels/CMakeLists.txt
+++ b/liger_cute_kernels/CMakeLists.txt
@@ -15,9 +15,9 @@
 #     cmake -S . -B build -DLIGER_CUTE_BUILD_BINDINGS=OFF
 #     cmake --build build --target liger_cute_kernels
 #
-# The fused MoE kernels (csrc/core/src/moe/{moe,moe_bwd,mlp*}.cu) are wired into
-# the core; csrc/core/src/moe/tune/ is a separate standalone autotuner project
-# (see README "Offline autotuner"), excluded from the core target.
+# The core includes CUTLASS + NVSHMEM operators such as expert-parallel MoE and
+# tensor-parallel fused scaled linear cross entropy. csrc/core/src/moe/tune/ is
+# a separate standalone autotuner project, excluded from the core target.
 # ─────────────────────────────────────────────────────────────────────────────
 cmake_minimum_required(VERSION 3.24)
 project(LigerCute LANGUAGES CXX CUDA)
@@ -29,7 +29,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 option(LIGER_CUTE_BUILD_BINDINGS
-    "Deprecated compatibility option. The lck wheel now exposes tensor APIs through TVM FFI only." OFF)
+    "Deprecated compatibility option. The native wheel exposes tensor APIs through TVM FFI only." OFF)
 
 # Core-reuse knob: when set to a directory containing a prebuilt
 # libliger_cute_kernels.so, the core is NOT compiled from source — it is linked

--- a/liger_cute_kernels/README.md
+++ b/liger_cute_kernels/README.md
@@ -1,6 +1,10 @@
-# LigerCute — native MoE kernels (CUTLASS + NVSHMEM)
+# LigerCute — native CUTLASS + NVSHMEM kernels
 
 ## Overview
+
+`liger_cute_kernels` is the native CUTLASS + NVSHMEM kernel package for Liger.
+It currently provides expert-parallel MoE and tensor-parallel fused scaled
+linear cross entropy, with a Torch-ABI-independent core exposed through TVM FFI.
 
 Liger MoE is a fused expert-parallel MoE implementation for NVIDIA Hopper and
 Blackwell GPUs. A persistent kernel uses warp specialization to overlap
@@ -8,6 +12,11 @@ NVSHMEM communication with CUTLASS matrix multiplication: communication warps
 move remote token tiles while the remaining warps execute the expert MLP. Both
 the forward and backward passes are fused, use statically sized symmetric
 buffers, and support CUDA Graph execution without a token-capacity limit.
+
+The tensor-parallel fused scaled linear cross-entropy implementation fuses the
+classifier projection with per-token NLL and optional entropy. Local MAX/SUM
+reductions run in the WGMMA epilogue through NVLS or DirectPeer, with a sharded
+IBRC follow-up for two-host execution.
 
 ### Hopper results
 
@@ -19,6 +28,7 @@ model or system.
 |---|---|
 | Standalone MoE kernels | Up to **32% lower forward latency** and **7% lower backward latency** than the strongest compared implementation |
 | Communication-intensive H200 cases | **10–35% higher forward throughput** than Comet; selected backward cases reach up to **~108% higher throughput** than DeepEP |
+| Tensor-parallel fused scaled linear cross entropy | **783.5 TFLOP/s/GPU at TP1**, **762.3 at TP8**, and **662.9 at two-host TP16** for M8192/H4096/V131072 |
 | Qwen3-30B-A3B training on 8 H100 GPUs | **2.35× speedup / 57% lower step time** than Megatron and **~17% lower step time** than Transformer Engine |
 | End-to-end convergence | **5.06% final-loss improvement** over the Megatron baseline |
 
@@ -79,13 +89,12 @@ remote reduction, and local all-gather/scatter pipeline.
 
 ## Package architecture
 
-Native CUDA build for the MoE port (from `LigerCommKernels`). The lck wheel
-packages one native core shared library that also exports the Python-facing TVM
-FFI functions:
+The native wheel packages one shared core library containing the CUTLASS +
+NVSHMEM operators and Python-facing TVM FFI functions:
 
 | Artifact | Sources | Links | Boundary | Built |
 |---|---|---|---|---|
-| `libliger_cute_kernels.so` (the "core", aka *lck*) | `csrc/core` + `liger_cute_kernels/tvm_ffi_bindings.cpp` | CUTLASS + NVSHMEM + CUDA + TVM FFI — **no torch** | flat `extern "C"` (`liger_cute.h`) and TVM FFI exports (`__tvm_ffi_*`) | **once** |
+| `libliger_cute_kernels.so` (the core) | `csrc/core` + `liger_cute_kernels/tvm_ffi_bindings.cpp` | CUTLASS + NVSHMEM + CUDA + TVM FFI — **no torch** | flat `extern "C"` (`liger_cute.h`) and TVM FFI exports (`__tvm_ffi_*`) | **once** |
 
 The core's public ABI is `extern "C"` only (no `std::`/torch types cross it),
 symbols are hidden except `liger_cute_*` and `__tvm_ffi_*`, and libstdc++/libgcc
@@ -97,18 +106,18 @@ compile.
 
 The top-level **`liger_kernel` wheel is pure Python/Triton** and does **not**
 build or contain any of this native code. The native libraries ship as a
-**separate, CUDA/torch-version-prefixed `lck` wheel** that installs its own
+**separate, CUDA/torch-version-prefixed wheel** that installs its own
 standalone top-level package **`liger_cute_kernels`** (kept separate from
 `liger_kernel` so the native libs don't mix in). `liger_kernel.ops.cute` imports
 `liger_cute_kernels.tvm_ffi` at runtime. Intended order:
 
 1. Install the top-level `liger_kernel` wheel (pure Python).
-2. *Optionally* install the matching `lck` wheel (package `liger_cute_kernels`)
+2. *Optionally* install the matching native wheel (package `liger_cute_kernels`)
    for the local CUDA + torch environment.
 
-The lck wheel is built by this module's `setup.py` (see **Building the lck
-wheel** below). Selecting/installing the right lck wheel automatically for the
-local CUDA + torch environment is a separate follow-up.
+The native wheel is built by this module's `setup.py` (see **Building the
+native wheel** below). Selecting/installing the right wheel automatically for
+the local CUDA + torch environment is a separate follow-up.
 
 ## Layout
 
@@ -120,14 +129,14 @@ in-liger entry point) lives separately, under `src/liger_kernel/ops/cute/`.
 liger_cute_kernels/             # ← standalone native build module (repo root)
 ├── README.md
 ├── assets/                     # README benchmark figures
-├── setup.py                    # builds the lck wheel (package liger_cute_kernels)
+├── setup.py                    # builds the native wheel (package liger_cute_kernels)
 ├── pyproject.toml
-├── cute_build.py               # build_core() helper + LckBuildExt
-├── liger_cute_kernels/         # the lck wheel's package source
+├── cute_build.py               # build_core() helper + native wheel build extension
+├── liger_cute_kernels/         # native package source
 │   ├── __init__.py             # (.so are added here at build time)
 │   ├── tvm_ffi.py              # Python facade over the TVM FFI exports
 │   └── tvm_ffi_bindings.cpp    # TVM FFI C++ exports compiled into the core
-├── test/                       # the lck package's own unit tests
+├── test/                       # native package unit tests
 │   └── test_moe_bindings.py
 ├── CMakeLists.txt              # core with TVM FFI exports
 ├── cmake/
@@ -140,10 +149,10 @@ liger_cute_kernels/             # ← standalone native build module (repo root)
     │   │   ├── {check.h, moe.h}             # core control/config surface
     │   │   └── detail/symmetric_memory.h    # core-internal (nvshmem+STL); not ABI
     │   ├── src/                 # *.{cu,cpp} compiled INTO the core …
-    │   │   └── moe/             #   … fused MoE kernels (moe.cu, moe_bwd.cu, mlp*.cu)
-    │   │       └── tune/        # standalone offline autotuner — NOT a core source
-    │   │           ├── CMakeLists.txt        #   its own project; links torch
-    │   │           └── tune_moe_fwd_bwd.cu   #   (excluded from the core glob)
+    │   │   ├── moe/             # expert-parallel MoE kernels
+    │   │   │   └── tune/        # standalone offline autotuner — NOT a core source
+    │   │   └── fused_scaled_linear_cross_entropy/
+    │   │                        # tensor-parallel fused loss kernels
     │   └── liger_cute.version   # exports only liger_cute_* and __tvm_ffi_*
 
 src/liger_kernel/ops/cute/
@@ -294,10 +303,10 @@ router distribution. `MOE_FWDBWD_TUNE_EXACT=1` runs exactly one arbitrary
 shape and requires the `T`, `D`, `I`, and local-`E` overrides (plus optional
 `K`).
 
-## Building the lck wheel
+## Building the native wheel
 
 This module's `setup.py` packages the native libraries into the independent
-**lck wheel**, whose package is the standalone top-level **`liger_cute_kernels`**.
+wheel whose package is the standalone top-level **`liger_cute_kernels`**.
 It builds the core and ships
 `liger_cute_kernels/{libliger_cute_kernels.so, libnvshmem_host.so,
 tvm_ffi.py, tvm_ffi_bindings.cpp}`. Build against the **local** CUDA/NVSHMEM
@@ -334,7 +343,7 @@ LIGER_CUTE_CORE_DIR=/abs/dir-with-core \
 ```
 
 Install order at the consumer side: the `liger_kernel` wheel first, then
-optionally the matching lck wheel.
+optionally the matching native wheel.
 
 ## Source-tree Python verification
 

--- a/liger_cute_kernels/csrc/core/include/liger_cute/detail/comm_schedule.cuh
+++ b/liger_cute_kernels/csrc/core/include/liger_cute/detail/comm_schedule.cuh
@@ -1,6 +1,6 @@
 // comm_schedule.cuh — CORE-INTERNAL communication schedule (device tables + host setup).
 //
-// Ported from LigerCommKernels' nvshmem_helpers.{h,cuh}. NOT part of the flat
+// Adapted from LigerCuteKernels' NVSHMEM scheduling helpers. NOT part of the flat
 // ABI: it declares __constant__ device storage and a device accessor for the
 // dispatch/combine kernels, plus the host-side functions that populate them.
 // The flat ABI wrapper (liger_cute_init_comm_schedule, in nvshmem.h) calls the

--- a/liger_cute_kernels/csrc/core/include/liger_cute/detail/symmetric_memory.h
+++ b/liger_cute_kernels/csrc/core/include/liger_cute/detail/symmetric_memory.h
@@ -7,7 +7,7 @@
 // never reach the boundary. Frontends must use the flat liger_cute_* control
 // entry points or the TVM FFI facade rather than including this header.
 //
-// Ported from LigerCommKernels' utils/buffer_pool.cuh; the torch-free change is
+// Adapted from LigerCuteKernels' buffer-pool utilities; the torch-free change is
 // TORCH_CHECK/abort -> LIGER_CHECK (throws liger_cute::Error, caught at the
 // boundary).
 #pragma once

--- a/liger_cute_kernels/csrc/core/include/liger_cute/nvshmem.h
+++ b/liger_cute_kernels/csrc/core/include/liger_cute/nvshmem.h
@@ -1,6 +1,6 @@
 // nvshmem.h — flat extern "C" ABI for NVSHMEM bootstrap, teams, and the comm schedule.
 //
-// Ported from LigerCommKernels' nvshmem_helpers.h, adapted to the liger_cute
+// Adapted from LigerCuteKernels' NVSHMEM helpers and the liger_cute
 // boundary contract (see liger_cute.h): every entry point returns a
 // liger_cute_status_t, results come back through out-pointers, and the failure
 // detail is read with liger_cute_last_error_string(). No exceptions cross the

--- a/liger_cute_kernels/csrc/core/src/moe/moe_bwd_sm100.inc
+++ b/liger_cute_kernels/csrc/core/src/moe/moe_bwd_sm100.inc
@@ -1,8 +1,8 @@
 // Fused MoE Backward: sort → fwd-dispatch (for X) → reverse-combine (for dY)
 //   → MLP_bwd + comm overlap → reverse-dispatch (for dX).
-// Compiled with separable compilation. Do NOT link liger_comm_kernels library.
+// Compiled with separable compilation directly into the native core.
 //
-// Torch-free core (liger_cute): ported from LigerCommKernels' moe_bwd.cu. The
+// Torch-free core (liger_cute): adapted from LigerCuteKernels' MoE backward. The
 // device kernel + templated launcher are upstream-verbatim (namespace liger).
 // Tensor-carrying backward calls are exported through TVM FFI and lower directly
 // into MoeBwdArgs.

--- a/liger_cute_kernels/csrc/core/src/moe/moe_bwd_sm90.inc
+++ b/liger_cute_kernels/csrc/core/src/moe/moe_bwd_sm90.inc
@@ -1,8 +1,8 @@
 // Fused MoE Backward: sort → fwd-dispatch (for X) → reverse-combine (for dY)
 //   → MLP_bwd + comm overlap → reverse-dispatch (for dX).
-// Compiled with separable compilation. Do NOT link liger_comm_kernels library.
+// Compiled with separable compilation directly into the native core.
 //
-// Torch-free core (liger_cute): ported from LigerCommKernels' moe_bwd.cu. The
+// Torch-free core (liger_cute): adapted from LigerCuteKernels' MoE backward. The
 // device kernel + templated launcher are upstream-verbatim (namespace liger).
 // Tensor-carrying backward calls are exported through TVM FFI and lower directly
 // into MoeBwdArgs.

--- a/liger_cute_kernels/csrc/core/src/moe/moe_sm100.inc
+++ b/liger_cute_kernels/csrc/core/src/moe/moe_sm100.inc
@@ -1,6 +1,6 @@
 // Fused MoE: sort+dispatch → MLP+combine — torch-free core (liger_cute).
 //
-// Ported from LigerCommKernels' moe.cu. The device kernels and the templated
+// Adapted from LigerCuteKernels' MoE forward. The device kernels and the templated
 // host launcher are upstream-verbatim (namespace liger, internal to the .so);
 // only the boundary changed: the remaining public entry points here are flat
 // extern "C" control/configuration APIs. Tensor-carrying MoE calls are exposed

--- a/liger_cute_kernels/csrc/core/src/moe/moe_sm90.inc
+++ b/liger_cute_kernels/csrc/core/src/moe/moe_sm90.inc
@@ -1,6 +1,6 @@
 // Fused MoE: sort+dispatch → MLP+combine — torch-free core (liger_cute).
 //
-// Ported from LigerCommKernels' moe.cu. The device kernels and the templated
+// Adapted from LigerCuteKernels' MoE forward. The device kernels and the templated
 // host launcher are upstream-verbatim (namespace liger, internal to the .so);
 // only the boundary changed: the remaining public entry points here are flat
 // extern "C" control/configuration APIs. Tensor-carrying MoE calls are exposed

--- a/liger_cute_kernels/csrc/core/src/nvshmem.cu
+++ b/liger_cute_kernels/csrc/core/src/nvshmem.cu
@@ -7,7 +7,7 @@
 // LIGER_CHECK / a non-zero NVSHMEM return code becomes a liger_cute_status_t +
 // a last-error string instead of unwinding across the .so boundary.
 //
-// Ported from LigerCommKernels' nvshmem_helpers.cu; the throw-based error model
+// Adapted from LigerCuteKernels' NVSHMEM helpers; the throw-based error model
 // (std::runtime_error) becomes the status-code model, and the explicit
 // clear_global_pools()/finalize ordering is preserved.
 #define LIGER_CUTE_BUILDING 1

--- a/liger_cute_kernels/cute_build.py
+++ b/liger_cute_kernels/cute_build.py
@@ -1,4 +1,4 @@
-"""Build helpers for the LigerCute native core (the "lck" library).
+"""Build helpers for the LigerCute native CUTLASS + NVSHMEM core.
 
 This module lives in the standalone ``liger_cute_kernels`` module at the repo
 root and is self-contained: it knows how to compile the torch-free core
@@ -6,7 +6,7 @@ root and is self-contained: it knows how to compile the torch-free core
 
 It is deliberately decoupled from the top-level ``liger_kernel`` wheel — that
 wheel is pure Python/Triton and never builds native code. The separate,
-CUDA/torch-version-prefixed **lck wheel** (its own setup.py + optional install)
+CUDA/torch-version-prefixed native wheel (its own setup.py + optional install)
 is handled separately; see this module's README.md.
 
 Phase 3.1 — build the torch-free core (no torch required)::
@@ -34,7 +34,7 @@ CMAKE_DIR = HERE  # CMakeLists.txt sits beside this module
 CORE_SO = "libliger_cute_kernels.so"
 NVSHMEM_SO = "libnvshmem_host.so"
 
-# In-wheel location of the native libraries: the lck wheel's own top-level
+# In-wheel location of the native libraries: the native wheel's own top-level
 # package, kept separate from liger_kernel so it doesn't mix with it.
 PKG_REL = Path("liger_cute_kernels")
 
@@ -126,7 +126,7 @@ def _stage_nvshmem(out_dir: Path) -> None:
                 shutil.copy2(versioned_plugin, out_dir / versioned_plugin.name)
     else:
         print(
-            f"WARNING: {NVSHMEM_SO} not found under NVSHMEM_HOME; the lck wheel will not bundle nvshmem",
+            f"WARNING: {NVSHMEM_SO} not found under NVSHMEM_HOME; the native wheel will not bundle nvshmem",
             file=sys.stderr,
         )
 
@@ -157,7 +157,7 @@ def build_core(out_dir: Path | str, build_temp: Path | str | None = None) -> Pat
     return out_dir / CORE_SO
 
 
-# ── lck wheel build (used by backend/setup.py) ───────────────────────────────
+# ── native wheel build (used by setup.py) ────────────────────────────────────
 
 
 class CMakeExtension(Extension):
@@ -168,7 +168,7 @@ class CMakeExtension(Extension):
 
 
 class LckBuildExt(build_ext):
-    """Build the lck wheel: compile the core plus TVM FFI shim.
+    """Build the native wheel: compile the core plus TVM FFI shim.
 
     If ``LIGER_CUTE_CORE_DIR`` points at a prebuilt core, it is linked as an
     imported lib (no core recompile); otherwise the core is built from source.
@@ -193,7 +193,7 @@ class LckBuildExt(build_ext):
                 ["cmake", "--build", str(build_temp), "--config", "Release", "-j", "--target", "liger_cute_kernels"]
             )
 
-        # Place native artifacts into the lck wheel's own liger_cute_kernels package.
+        # Place native artifacts into the wheel's own liger_cute_kernels package.
         dest = Path(self.build_lib) / PKG_REL
         dest.mkdir(parents=True, exist_ok=True)
         if use_prebuilt:
@@ -201,7 +201,7 @@ class LckBuildExt(build_ext):
         else:
             shutil.copy2(next(build_temp.rglob(CORE_SO)), dest / CORE_SO)
         _stage_nvshmem(dest)
-        print(f"staged lck artifacts -> {dest}")
+        print(f"staged native artifacts -> {dest}")
 
 
 def lck_local_version() -> str:
@@ -215,7 +215,7 @@ def lck_local_version() -> str:
         import torch
     except ImportError as exc:  # pragma: no cover
         raise RuntimeError(
-            "building the lck wheel needs torch importable to tag the wheel "
+            "building the native wheel needs torch importable to tag the wheel "
             "with the CUDA/torch version; install torch or set "
             "LIGER_CUTE_LOCAL_VERSION"
         ) from exc

--- a/liger_cute_kernels/liger_cute_kernels/__init__.py
+++ b/liger_cute_kernels/liger_cute_kernels/__init__.py
@@ -1,4 +1,4 @@
-"""liger_cute_kernels — native CUTLASS + NVSHMEM MoE kernels (the "lck" wheel).
+"""Native CUTLASS + NVSHMEM kernels for Liger.
 
 Standalone top-level package, kept separate from ``liger_kernel`` so the native
 libraries don't mix into the pure-Python package. It ships the compiled
@@ -12,8 +12,9 @@ extension and its support libraries side by side::
 The Python API loads the core through TVM FFI, so the runtime boundary is the
 torch-free core ABI rather than a Torch extension.
 
-Consumers should go through ``liger_kernel.ops.cute`` rather than importing this
-package directly.
+The package currently includes expert-parallel MoE and tensor-parallel fused
+scaled linear cross-entropy kernels. Consumers should go through
+``liger_kernel.ops.cute`` rather than importing this package directly.
 """
 
 from __future__ import annotations

--- a/liger_cute_kernels/liger_cute_kernels/nvshmem.py
+++ b/liger_cute_kernels/liger_cute_kernels/nvshmem.py
@@ -15,8 +15,8 @@ Typical use::
     ...                                 # MoE forward only reads the cached team
     nvshmem.finalize()
 
-Ported from LigerCommKernels' ``liger_comm_kernels/__init__.py`` (bootstrap /
-team section) and ``moe_ops._resolve_team`` (the per-ProcessGroup cache).
+Adapted from the LigerCuteKernels bootstrap/team implementation and its
+per-ProcessGroup team cache.
 """
 
 from __future__ import annotations

--- a/liger_cute_kernels/setup.py
+++ b/liger_cute_kernels/setup.py
@@ -1,9 +1,10 @@
-"""Build script for the **lck wheel** — the native CUTLASS + NVSHMEM MoE
-kernels, shipped as the standalone top-level package ``liger_cute_kernels``.
+"""Build script for the native CUTLASS + NVSHMEM kernel wheel.
+
+The wheel installs the standalone top-level package ``liger_cute_kernels``.
 
 This is a SEPARATE distribution from the top-level ``liger_kernel`` wheel (which
 is pure Python/Triton) and is intentionally its OWN package so it does not mix
-into ``liger_kernel``. The lck wheel:
+into ``liger_kernel``. The native wheel:
 
   * builds the torch-free core ``libliger_cute_kernels.so`` with TVM FFI exports
     compiled into that same shared library,
@@ -35,7 +36,7 @@ BASE_VERSION = "0.1.0"
 setup(
     name="liger_cute_kernels",
     version=f"{BASE_VERSION}+{lck_local_version()}",
-    description="Native CUTLASS + NVSHMEM MoE kernels (lck) for liger_kernel.ops.cute",
+    description="Native CUTLASS + NVSHMEM kernels for liger_kernel.ops.cute",
     python_requires=">=3.9",
     install_requires=["torch", "apache-tvm-ffi"],
     extras_require={"nvshmem-pypi": ["nvidia-nvshmem-cu13"]},

--- a/liger_cute_kernels/test/test_moe_cuda_graph.py
+++ b/liger_cute_kernels/test/test_moe_cuda_graph.py
@@ -2,7 +2,7 @@
 
 Ported from LigerCommKernels' ``tests/python/test_autograd.py`` (the
 ``test_moe_fused_cuda_graph`` / fwd+bwd graph tests). Those upstream tests drove
-the kernels through the ``lck.moe_fused`` autograd wrapper and ``moe_router_fwd``;
+the kernels through the LigerCommKernels autograd wrapper and ``moe_router_fwd``;
 neither is in scope for this package yet, so here we drive the **raw TVM FFI
 bindings** directly — which is exactly what the graph tests are about: proving the
 *kernel itself* is CUDA-graph-safe (no host syncs, no non-capturable NVSHMEM calls,

--- a/liger_cute_kernels/test/test_moe_cuda_graph.py
+++ b/liger_cute_kernels/test/test_moe_cuda_graph.py
@@ -1,8 +1,8 @@
 """CUDA-graph capture/replay tests for the fused MoE fwd/bwd kernels.
 
-Ported from LigerCommKernels' ``tests/python/test_autograd.py`` (the
+Adapted from LigerCuteKernels' CUDA Graph tests (the
 ``test_moe_fused_cuda_graph`` / fwd+bwd graph tests). Those upstream tests drove
-the kernels through the LigerCommKernels autograd wrapper and ``moe_router_fwd``;
+the kernels through the LigerCuteKernels autograd wrapper and ``moe_router_fwd``;
 neither is in scope for this package yet, so here we drive the **raw TVM FFI
 bindings** directly — which is exactly what the graph tests are about: proving the
 *kernel itself* is CUDA-graph-safe (no host syncs, no non-capturable NVSHMEM calls,

--- a/liger_cute_kernels/tests/cpp/CMakeLists.txt
+++ b/liger_cute_kernels/tests/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 # C++ unit tests (gtest). Torch-free: tests include the device-function headers
 # from csrc/core/src/moe directly and define their own launcher kernels, so they
-# only need CUTLASS (header-only), CUDA, and gtest. The lck.so API dispatch
+# only need CUTLASS (header-only), CUDA, and gtest. The native core API dispatch
 # coverage test links the core library when it is built in this CMake run.
 #
 # Enabled via -DLIGER_CUTE_BUILD_TESTS=ON. Global CMAKE_CUDA_FLAGS already sets

--- a/src/liger_kernel/ops/cute/__init__.py
+++ b/src/liger_kernel/ops/cute/__init__.py
@@ -1,20 +1,21 @@
-"""LigerCute — fused MoE + NVSHMEM kernels (ported from LigerCommKernels).
+"""LigerCute — native CUTLASS + NVSHMEM kernels.
 
 The native kernels live in a SEPARATE top-level package ``liger_cute_kernels``,
-shipped by its own CUDA/torch-version prefixed **lck wheel** — not by the
+shipped by its own CUDA/torch-version-prefixed wheel — not by the
 top-level ``liger_kernel`` wheel, which stays pure Python/Triton. This module is
 just the entry point that loads ``liger_cute_kernels.tvm_ffi`` when it is installed::
 
-    liger_cute_kernels/           # the lck wheel (optional, separate package)
+    liger_cute_kernels/           # optional, separate native package
       __init__.py
       tvm_ffi.py                  # TVM FFI facade over the native core
       libliger_cute_kernels.so    # torch-free CUTLASS + NVSHMEM core
       libnvshmem_host.so          # bundled nvshmem
 
-The fused MoE op (``moe_fused``) lives in ``cute/ops/`` and is wired up as the
-opt-in ``cute`` implementation (``LIGER_KERNEL_IMPL=cute``). The lck wheel is
-optional, so the rest of ``liger_kernel`` keeps working without it — the ops
-module is imported only when the ``cute`` implementation is actively selected.
+The package currently backs the expert-parallel fused MoE op and the Hopper
+tensor-parallel fused scaled linear cross-entropy path. MoE is wired up as the
+opt-in ``cute`` implementation (``LIGER_KERNEL_IMPL=cute``); the scaled-loss
+frontend loads its native adapter lazily. The package remains optional, so the
+rest of ``liger_kernel`` works without it.
 """
 
 from __future__ import annotations
@@ -40,7 +41,7 @@ def _load_tvm_ffi():
             raise ImportError("liger_cute_kernels.tvm_ffi could not load the native core")
     except ImportError as exc:  # pragma: no cover - depends on a CUDA build
         raise ImportError(
-            "liger_cute_kernels is not installed. Install the matching lck wheel "
+            "liger_cute_kernels is not installed. Install the matching native package "
             "for your CUDA/torch environment, or build it locally (see the "
             "liger_cute_kernels/ module at the repo root)."
         ) from exc
@@ -62,7 +63,7 @@ __all__ = ["is_available"]
 # default_devices, so it is never auto-applied — users select it explicitly via
 # ``LIGER_KERNEL_IMPL=cute``. Registration is pure metadata and must not import
 # the native extension: this __init__ is imported during impl discovery even when
-# the lck wheel is absent. The ops module (``cute.ops``) — which does load the
+# the native package is absent. The ops module (``cute.ops``) — which does load the
 # extension — is imported only when this implementation is actively selected.
 register_impl(
     ImplInfo(

--- a/src/liger_kernel/ops/cute/fused_linear_scaled_cross_entropy_tp.py
+++ b/src/liger_kernel/ops/cute/fused_linear_scaled_cross_entropy_tp.py
@@ -1,4 +1,4 @@
-"""LCK adapter for tensor-parallel fused linear scaled cross entropy."""
+"""Native CUTLASS + NVSHMEM adapter for tensor-parallel scaled cross entropy."""
 
 from __future__ import annotations
 
@@ -56,9 +56,9 @@ def _validate_inputs(x, weight, target, vocab_start, tiles_per_reduce, return_en
     if x.device != weight.device or x.device != target.device:
         raise ValueError("input, weight, and target must be on the same CUDA device")
     if not x.is_cuda:
-        raise RuntimeError("the LCK tensor-parallel path requires CUDA tensors")
+        raise RuntimeError("the native tensor-parallel path requires CUDA tensors")
     if x.dtype != torch.bfloat16 or weight.dtype != torch.bfloat16:
-        raise TypeError("the LCK tensor-parallel path supports BF16 input and weight only")
+        raise TypeError("the native tensor-parallel path supports BF16 input and weight only")
     if target.dtype != torch.int64:
         raise TypeError("target must be an int64 tensor of global vocabulary indices")
     if x.ndim != 2 or weight.ndim != 2 or target.ndim != 1:
@@ -102,7 +102,7 @@ def _cuda_device_context(tensor):
         yield
 
 
-def _prepare_lck_call(process_group: "ProcessGroup", device, tokens, hidden, local_vocab, tiles_per_reduce) -> int:
+def _prepare_native_call(process_group: "ProcessGroup", device, tokens, hidden, local_vocab, tiles_per_reduce) -> int:
     tvm_ffi = _get_tvm_ffi()
     with torch.cuda.device(device):
         team_handle = _get_nvshmem().resolve_team(process_group, create=False)
@@ -120,7 +120,7 @@ def _prepare_lck_call(process_group: "ProcessGroup", device, tokens, hidden, loc
     return team_handle
 
 
-class LigerFusedLinearScaledCrossEntropyLckTPFunction(torch.autograd.Function):
+class LigerFusedLinearScaledCrossEntropyNativeTPFunction(torch.autograd.Function):
     @staticmethod
     def forward(
         ctx,
@@ -140,7 +140,7 @@ class LigerFusedLinearScaledCrossEntropyLckTPFunction(torch.autograd.Function):
 
         x_padded, weight_padded, hidden = _pad_hidden(x, weight)
         target = target.contiguous()
-        team_handle = _prepare_lck_call(
+        team_handle = _prepare_native_call(
             tp_group,
             x.device,
             target.shape[0],
@@ -212,4 +212,4 @@ class LigerFusedLinearScaledCrossEntropyLckTPFunction(torch.autograd.Function):
         return grad_input, grad_weight, None, None, None, None, None, None, None
 
 
-__all__ = ["LigerFusedLinearScaledCrossEntropyLckTPFunction", "is_available"]
+__all__ = ["LigerFusedLinearScaledCrossEntropyNativeTPFunction", "is_available"]

--- a/src/liger_kernel/ops/cute/ops/__init__.py
+++ b/src/liger_kernel/ops/cute/ops/__init__.py
@@ -3,7 +3,7 @@ cute-specific operator implementations — fused MoE over NVSHMEM.
 
 Imported only when the ``cute`` implementation is actively selected
 (``LIGER_KERNEL_IMPL=cute``). The native kernels live in the separate
-``liger_cute_kernels`` lck wheel; importing this module loads that compiled
+``liger_cute_kernels`` package; importing this module loads that compiled
 extension and raises a clear ImportError if it is not installed (see
 ``liger_kernel.ops.cute._load_tvm_ffi``).
 """

--- a/src/liger_kernel/ops/cute/ops/moe.py
+++ b/src/liger_kernel/ops/cute/ops/moe.py
@@ -1,7 +1,7 @@
 """Fused expert-parallel MoE autograd op for the ``cute`` backend.
 
 Thin autograd wrapper around the native fused MoE fwd/bwd kernels shipped by the
-separate ``liger_cute_kernels`` (lck) wheel. Ported from LigerCommKernels'
+separate ``liger_cute_kernels`` package. Ported from LigerCommKernels'
 ``liger_comm_kernels/moe_ops.py``; the kernel ABI is identical, only the package
 plumbing differs:
 
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 __all__ = ["LigerExpertParallelFusedMoEFunction", "moe_fused"]
 
 # Resolve the TVM FFI facade once at import. cute/ops is imported only when the
-# "cute" implementation is actively selected, so a missing lck wheel surfaces as
+# "cute" implementation is actively selected, so a missing native package surfaces as
 # a clear ImportError to the user who asked for it (see _load_tvm_ffi).
 tvm_ffi = _load_tvm_ffi()
 

--- a/src/liger_kernel/ops/cute/ops/moe.py
+++ b/src/liger_kernel/ops/cute/ops/moe.py
@@ -1,9 +1,8 @@
 """Fused expert-parallel MoE autograd op for the ``cute`` backend.
 
 Thin autograd wrapper around the native fused MoE fwd/bwd kernels shipped by the
-separate ``liger_cute_kernels`` package. Ported from LigerCommKernels'
-``liger_comm_kernels/moe_ops.py``; the kernel ABI is identical, only the package
-plumbing differs:
+separate ``liger_cute_kernels`` package. Adapted from the LigerCuteKernels MoE
+frontend; the kernel ABI is identical, only the package plumbing differs:
 
   - the TVM FFI facade is reached through the parent package's
     ``_load_tvm_ffi()`` (``liger_cute_kernels.tvm_ffi``), and

--- a/src/liger_kernel/ops/fused_linear_scaled_cross_entropy.py
+++ b/src/liger_kernel/ops/fused_linear_scaled_cross_entropy.py
@@ -17,13 +17,13 @@ def _load_sm90_function():
     return LigerFusedScaledCrossEntropySM90Function
 
 
-def _load_lck_tp_function():
+def _load_native_tp_function():
     from liger_kernel.ops.cute.fused_linear_scaled_cross_entropy_tp import (
-        LigerFusedLinearScaledCrossEntropyLckTPFunction,
+        LigerFusedLinearScaledCrossEntropyNativeTPFunction,
     )
     from liger_kernel.ops.cute.fused_linear_scaled_cross_entropy_tp import is_available
 
-    return LigerFusedLinearScaledCrossEntropyLckTPFunction if is_available() else None
+    return LigerFusedLinearScaledCrossEntropyNativeTPFunction if is_available() else None
 
 
 def _validate_temperature(temperature):
@@ -368,7 +368,7 @@ class LigerFusedLinearScaledCrossEntropyFunction:
 
 
 class LigerFusedLinearScaledCrossEntropyTPFunction:
-    """Tensor-parallel frontend using LCK on Hopper and a Liger fallback otherwise.
+    """Tensor-parallel frontend using native CUTLASS + NVSHMEM on Hopper.
 
     ``weight`` is the calling rank's equally sized contiguous vocabulary shard,
     while ``target`` contains global vocabulary indices.
@@ -397,14 +397,14 @@ class LigerFusedLinearScaledCrossEntropyTPFunction:
         _validate_tp_inputs(_input, weight, target)
         vocab_start = rank * weight.shape[0]
 
-        lck_function = None
+        native_function = None
         if _input.dtype == torch.bfloat16 and _is_hopper(_input.device):
             try:
-                lck_function = _load_lck_tp_function()
+                native_function = _load_native_tp_function()
             except ImportError:
-                lck_function = None
-        if lck_function is not None:
-            return lck_function.apply(
+                native_function = None
+        if native_function is not None:
+            return native_function.apply(
                 _input,
                 weight,
                 target,

--- a/src/liger_kernel/transformers/moe.py
+++ b/src/liger_kernel/transformers/moe.py
@@ -8,9 +8,9 @@ The autograd op currently lives in the ``cute`` backend
 (``liger_kernel.ops.cute.ops.moe``); ``cute`` is just the backend implementation
 and the frontend stays backend-neutral.
 
-The op is backed by the separate, optional ``liger_cute_kernels`` (lck) wheel.
+The op is backed by the separate, optional ``liger_cute_kernels`` package.
 Importing it eagerly here means that pulling in this module on an environment
-without the lck wheel fails fast with a clear, actionable error rather than
+without the native package fails fast with a clear, actionable error rather than
 blowing up later inside ``forward``.
 """
 
@@ -25,14 +25,14 @@ import torch.nn as nn
 # Import the backend autograd op eagerly so a missing/unbuildable backend
 # sub-package surfaces immediately as a clear error at import time. The op module
 # loads the native ``liger_cute_kernels.tvm_ffi`` facade at its own import, which
-# raises ImportError when the lck wheel is absent.
+# raises ImportError when the native package is absent.
 try:
     from liger_kernel.ops.cute.ops.moe import moe_fused
-except ImportError as exc:  # pragma: no cover - depends on a CUDA/lck build
+except ImportError as exc:  # pragma: no cover - depends on a native CUDA build
     raise ImportError(
         "LigerExpertParallelFusedMoe requires the fused MoE backend, which is "
-        "backed by the separate liger_cute_kernels (lck) wheel. Install the "
-        "matching lck wheel for your CUDA/torch environment, or build it locally "
+        "backed by the separate liger_cute_kernels package. Install the "
+        "matching native package for your CUDA/torch environment, or build it locally "
         "(see the liger_cute_kernels/ module at the repo root)."
     ) from exc
 

--- a/test/cute/test_fused_linear_scaled_cross_entropy_tp.py
+++ b/test/cute/test_fused_linear_scaled_cross_entropy_tp.py
@@ -16,16 +16,16 @@ try:
     import torch.multiprocessing as mp
 
     from liger_kernel.ops import LigerFusedLinearScaledCrossEntropyTPFunction
-    from liger_kernel.ops.cute import fused_linear_scaled_cross_entropy_tp as lck_frontend
+    from liger_kernel.ops.cute import fused_linear_scaled_cross_entropy_tp as native_frontend
 
-    _LCK_AVAILABLE = lck_frontend.is_available()
+    _NATIVE_AVAILABLE = native_frontend.is_available()
 except ImportError:
     torch = None
     dist = None
     mp = None
     LigerFusedLinearScaledCrossEntropyTPFunction = None
-    lck_frontend = None
-    _LCK_AVAILABLE = False
+    native_frontend = None
+    _NATIVE_AVAILABLE = False
 
 _NDEV = torch.cuda.device_count() if torch is not None and torch.cuda.is_available() else 0
 _TOKENS = 521
@@ -157,7 +157,7 @@ def _worker(rank: int, world_size: int, init_file: str, layout: str, implementat
     if implementation == "fallback":
         import liger_kernel.ops.fused_linear_scaled_cross_entropy as frontend
 
-        frontend._load_lck_tp_function = lambda: None
+        frontend._load_native_tp_function = lambda: None
         nvshmem = None
     else:
         from liger_cute_kernels import nvshmem
@@ -178,7 +178,7 @@ def _worker(rank: int, world_size: int, init_file: str, layout: str, implementat
         tp_rank = tp_ranks.index(rank)
         tp_size = len(tp_ranks)
         group_index = _group_layout(layout, world_size).index(tp_ranks)
-        if implementation == "lck":
+        if implementation == "native":
             nvshmem.init_from_pg()
             nvshmem_initialized = True
             team_handle = nvshmem.resolve_team(tp_group)
@@ -241,17 +241,17 @@ def _worker(rank: int, world_size: int, init_file: str, layout: str, implementat
         torch.testing.assert_close(weight.grad.float(), expected_dw, atol=8e-3, rtol=4e-2)
 
         torch.cuda.synchronize()
-        if implementation == "lck":
+        if implementation == "native":
             nvshmem.pool_clear_all()
             if team_handle != nvshmem.team_world():
                 nvshmem.team_destroy(team_handle)
                 team_handle = None
         dist.barrier()
-        if implementation == "lck":
+        if implementation == "native":
             nvshmem.finalize()
         dist.destroy_process_group()
     except BaseException:
-        if implementation == "lck":
+        if implementation == "native":
             try:
                 if nvshmem_initialized:
                     nvshmem.finalize()
@@ -299,20 +299,20 @@ def _run(
 
 @pytest.mark.parametrize("world_size", [1, 2, 4, 8])
 def test_tp_frontend_world_process_group(world_size):
-    if not _LCK_AVAILABLE:
+    if not _NATIVE_AVAILABLE:
         pytest.skip("requires a matching liger_cute_kernels wheel")
     if _NDEV < world_size:
         pytest.skip(f"requires at least {world_size} CUDA devices")
-    _run(world_size, "world", "lck")
+    _run(world_size, "world", "native")
 
 
 @pytest.mark.parametrize("layout", ["contiguous", "strided"])
 def test_tp_frontend_subgroups(layout):
-    if not _LCK_AVAILABLE:
+    if not _NATIVE_AVAILABLE:
         pytest.skip("requires a matching liger_cute_kernels wheel")
     if _NDEV < 4:
         pytest.skip("requires at least four CUDA devices")
-    _run(4, layout, "lck")
+    _run(4, layout, "native")
 
 
 @pytest.mark.parametrize(
@@ -328,17 +328,17 @@ def test_tp_frontend_liger_fallback(world_size, layout):
     _run(world_size, layout, "fallback")
 
 
-def test_lck_moe_and_tp_frontend_use_different_process_groups():
-    if not _LCK_AVAILABLE:
+def test_native_moe_and_tp_frontend_use_different_process_groups():
+    if not _NATIVE_AVAILABLE:
         pytest.skip("requires a matching liger_cute_kernels wheel")
     if _NDEV < 4:
         pytest.skip("requires at least four CUDA devices")
-    _run(4, "strided", "lck", run_moe=True)
+    _run(4, "strided", "native", run_moe=True)
 
 
 def test_tp_frontend_direct_peer_fallback():
-    if not _LCK_AVAILABLE:
+    if not _NATIVE_AVAILABLE:
         pytest.skip("requires a matching liger_cute_kernels wheel")
     if _NDEV < 2:
         pytest.skip("requires at least two CUDA devices")
-    _run(2, "world", "lck", disable_nvls=True)
+    _run(2, "world", "native", disable_nvls=True)

--- a/test/cute/test_moe.py
+++ b/test/cute/test_moe.py
@@ -4,11 +4,11 @@ Two layers of coverage, mirroring ``test_cute_moe_autograd.py``:
 
   * ``test_frontend_import_guard`` — pure-Python, always runs. The frontend
     imports the fused-MoE backend op eagerly, so importing
-    ``liger_kernel.transformers.moe`` must succeed iff the lck wheel is present
+    ``liger_kernel.transformers.moe`` must succeed iff the native package is present
     and raise a clear ``ImportError`` otherwise. When it does import, the module
     is a weightless ``nn.Module`` op-wrapper. Needs neither a GPU nor the wheel.
 
-  * ``test_frontend_module_forward`` — functional, **skipped unless the lck wheel
+  * ``test_frontend_module_forward`` — functional, **skipped unless the native package
     is installed and >= 2 CUDA devices are present**. Drives the module end to
     end across real PEs and checks the behaviour the wrapper adds on top of the
     raw ``moe_fused`` op: the ``(B, S, D)`` reshape round-trip, the int32 cast of
@@ -42,7 +42,7 @@ try:
 
     from liger_kernel.ops import cute as _cute
 
-    _LCK_AVAILABLE = _cute.is_available()
+    _NATIVE_AVAILABLE = _cute.is_available()
 except ImportError:  # torch missing, or liger_kernel import failure
     torch = None
     dist = None
@@ -50,7 +50,7 @@ except ImportError:  # torch missing, or liger_kernel import failure
     nn = None
     Fnn = None
     _cute = None
-    _LCK_AVAILABLE = False
+    _NATIVE_AVAILABLE = False
 
 _NDEV = torch.cuda.device_count() if (torch is not None and torch.cuda.is_available()) else 0
 
@@ -64,14 +64,14 @@ _B, _S = 4, _T // 4  # (batch, seq) view that flattens back to T tokens
 
 
 def test_frontend_import_guard():
-    """Importing the frontend tracks lck availability; the module is weightless.
+    """Importing the frontend tracks native package availability; the module is weightless.
 
     The op is imported eagerly at module import, so the import itself is the
     backend-availability gate: it succeeds with the wheel and raises a clear
     ``ImportError`` without it. When present, ``LigerExpertParallelFusedMoe`` is
     an ``nn.Module`` op-wrapper that owns no parameters of its own.
     """
-    if _LCK_AVAILABLE:
+    if _NATIVE_AVAILABLE:
         mod = importlib.import_module("liger_kernel.transformers.moe")
         layer_cls = mod.LigerExpertParallelFusedMoe
         assert issubclass(layer_cls, nn.Module)
@@ -89,7 +89,7 @@ def test_frontend_import_guard():
             importlib.import_module("liger_kernel.transformers.moe")
 
 
-# ── functional test (needs the lck wheel + GPUs) ──────────────────────────────
+# ── functional test (needs the native package + GPUs) ────────────────────────
 
 
 def _world_size() -> int:
@@ -257,7 +257,7 @@ def _module_worker(rank, world_size, init_file):
         raise
 
 
-@pytest.mark.skipif(not _LCK_AVAILABLE, reason="liger_cute_kernels (lck wheel) not installed")
+@pytest.mark.skipif(not _NATIVE_AVAILABLE, reason="liger_cute_kernels native package not installed")
 @pytest.mark.skipif(_NDEV < 2, reason="needs >=2 CUDA devices")
 def test_frontend_module_forward():
     """``LigerExpertParallelFusedMoe`` runs end to end and matches the reference.
@@ -269,7 +269,7 @@ def test_frontend_module_forward():
     import shutil
 
     world_size = _world_size()
-    rdzv = tempfile.mkdtemp(prefix="lck_frontend_")
+    rdzv = tempfile.mkdtemp(prefix="liger_cute_frontend_")
     init_file = os.path.join(rdzv, "store")
     try:
         mp.spawn(_module_worker, args=(world_size, init_file), nprocs=world_size, join=True)

--- a/test/cute/test_moe_autograd.py
+++ b/test/cute/test_moe_autograd.py
@@ -5,9 +5,9 @@ Two layers of coverage:
   * ``test_cute_registration`` — pure-Python, always runs. Asserts the ``cute``
     implementation self-registers as an *opt-in* CUDA backend (no
     ``default_devices``, selected only via ``LIGER_KERNEL_IMPL=cute``). This
-    needs neither a GPU nor the lck wheel, so it gives signal on plain CI too.
+    needs neither a GPU nor the native package, so it gives signal on plain CI too.
 
-  * ``test_moe_fused_autograd`` — the functional test, **skipped unless the lck
+  * ``test_moe_fused_autograd`` — the functional test, **skipped unless the native
     wheel is installed and >= 2 CUDA devices are present**. It drives the
     autograd wrapper ``liger_kernel.ops.cute.ops.moe_fused`` (not the raw TVM FFI
     bindings) through both paths: the no-grad fast path (which must pop the
@@ -43,7 +43,7 @@ def test_cute_registration():
 
     Importing ``liger_kernel.ops`` runs impl discovery, which imports every
     backend's ``__init__`` (registration is metadata-only and must not need the
-    lck wheel). ``cute`` declares no ``default_devices``, so it is never
+    native package). ``cute`` declares no ``default_devices``, so it is never
     auto-applied — only an explicit ``LIGER_KERNEL_IMPL=cute`` selects it.
     """
     import liger_kernel.ops  # noqa: F401  -- triggers _discover_impls()
@@ -59,7 +59,7 @@ def test_cute_registration():
     assert select_impl("cuda", explicit="cute") is info
 
 
-# ── functional autograd test (needs the lck wheel + GPUs) ─────────────────────
+# ── functional autograd test (needs the native package + GPUs) ────────────────
 
 try:
     import torch
@@ -69,14 +69,14 @@ try:
 
     from liger_kernel.ops import cute as _cute
 
-    _LCK_AVAILABLE = _cute.is_available()
+    _NATIVE_AVAILABLE = _cute.is_available()
 except ImportError:  # torch missing, or liger_kernel import failure
     torch = None
     dist = None
     mp = None
     Fnn = None
     _cute = None
-    _LCK_AVAILABLE = False
+    _NATIVE_AVAILABLE = False
 
 _NDEV = torch.cuda.device_count() if (torch is not None and torch.cuda.is_available()) else 0
 
@@ -278,7 +278,7 @@ def _autograd_worker(rank, world_size, init_file):
 
         # Backward sanity: every grad-requiring input gets a finite grad of the
         # right shape. Numerical bwd correctness is covered by the kernel-level
-        # CUDA-graph fwd+bwd test in the lck package.
+        # CUDA-graph fwd+bwd test in the native package.
         Y.float().sum().backward()
         for name, t in [("X", X), ("all_B", all_B), ("all_C", all_C), ("all_A", all_A)]:
             assert t.grad is not None, f"{name}.grad is None after backward"
@@ -296,7 +296,7 @@ def _autograd_worker(rank, world_size, init_file):
         raise
 
 
-@pytest.mark.skipif(not _LCK_AVAILABLE, reason="liger_cute_kernels (lck wheel) not installed")
+@pytest.mark.skipif(not _NATIVE_AVAILABLE, reason="liger_cute_kernels native package not installed")
 @pytest.mark.skipif(_NDEV < 2, reason="needs >=2 CUDA devices")
 def test_moe_fused_autograd():
     """``moe_fused`` runs its no-grad and grad paths and matches the reference.
@@ -309,7 +309,7 @@ def test_moe_fused_autograd():
     import shutil
 
     world_size = _world_size()
-    rdzv = tempfile.mkdtemp(prefix="lck_autograd_")
+    rdzv = tempfile.mkdtemp(prefix="liger_cute_autograd_")
     init_file = os.path.join(rdzv, "store")
     try:
         mp.spawn(_autograd_worker, args=(world_size, init_file), nprocs=world_size, join=True)

--- a/test/transformers/test_fused_linear_scaled_cross_entropy.py
+++ b/test/transformers/test_fused_linear_scaled_cross_entropy.py
@@ -17,7 +17,7 @@ assert _SPEC is not None and _SPEC.loader is not None
 _FRONTEND = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_FRONTEND)
 
-_LCK_FRONTEND_PATH = (
+_NATIVE_FRONTEND_PATH = (
     Path(__file__).resolve().parents[2]
     / "src"
     / "liger_kernel"
@@ -25,12 +25,12 @@ _LCK_FRONTEND_PATH = (
     / "cute"
     / "fused_linear_scaled_cross_entropy_tp.py"
 )
-_LCK_SPEC = importlib.util.spec_from_file_location(
-    "_fused_linear_scaled_cross_entropy_lck_frontend", _LCK_FRONTEND_PATH
+_NATIVE_SPEC = importlib.util.spec_from_file_location(
+    "_fused_linear_scaled_cross_entropy_native_frontend", _NATIVE_FRONTEND_PATH
 )
-assert _LCK_SPEC is not None and _LCK_SPEC.loader is not None
-_LCK_FRONTEND = importlib.util.module_from_spec(_LCK_SPEC)
-_LCK_SPEC.loader.exec_module(_LCK_FRONTEND)
+assert _NATIVE_SPEC is not None and _NATIVE_SPEC.loader is not None
+_NATIVE_FRONTEND = importlib.util.module_from_spec(_NATIVE_SPEC)
+_NATIVE_SPEC.loader.exec_module(_NATIVE_FRONTEND)
 
 _CUTILE_ENABLED = os.environ.get("LIGER_KERNEL_IMPL", "").strip().lower() == "cutile"
 
@@ -190,7 +190,7 @@ def test_frontend_fallback_supports_entropy_only_backward():
     assert weight.grad is not None
 
 
-def test_tp_frontend_dispatches_hopper_bf16_to_lck(monkeypatch):
+def test_tp_frontend_dispatches_hopper_bf16_to_native(monkeypatch):
     process_group = object()
     device = torch.device("cuda:3")
     _input = SimpleNamespace(device=device, dtype=torch.bfloat16)
@@ -198,20 +198,20 @@ def test_tp_frontend_dispatches_hopper_bf16_to_lck(monkeypatch):
     target = object()
     calls = []
 
-    class StubLckFunction:
+    class StubNativeFunction:
         @staticmethod
         def apply(*args):
             calls.append(args)
-            return "lck-result"
+            return "native-result"
 
     monkeypatch.setattr(_FRONTEND, "_tp_group_info", lambda actual: (actual, 2))
     monkeypatch.setattr(_FRONTEND, "_validate_tp_inputs", lambda *args: None)
     monkeypatch.setattr(_FRONTEND, "_is_hopper", lambda actual: actual == device)
-    monkeypatch.setattr(_FRONTEND, "_load_lck_tp_function", lambda: StubLckFunction)
+    monkeypatch.setattr(_FRONTEND, "_load_native_tp_function", lambda: StubNativeFunction)
     monkeypatch.setattr(
         _FRONTEND,
         "_apply_tp_fallback",
-        lambda *args: pytest.fail("the Liger fallback must not run when LCK is available"),
+        lambda *args: pytest.fail("the Liger fallback must not run when the native package is available"),
     )
 
     result = _FRONTEND.LigerFusedLinearScaledCrossEntropyTPFunction.apply(
@@ -225,7 +225,7 @@ def test_tp_frontend_dispatches_hopper_bf16_to_lck(monkeypatch):
         True,
     )
 
-    assert result == "lck-result"
+    assert result == "native-result"
     assert calls == [(_input, weight, target, 32, 0.5, -1, 2, True, process_group)]
 
 
@@ -235,8 +235,8 @@ def test_tp_group_is_a_call_argument():
     assert list(parameters)[3] == "tp_group"
 
 
-@pytest.mark.parametrize("lck_result", [None, ImportError("lck unavailable")])
-def test_tp_frontend_uses_liger_fallback_when_lck_is_unavailable(monkeypatch, lck_result):
+@pytest.mark.parametrize("native_result", [None, ImportError("native package unavailable")])
+def test_tp_frontend_uses_liger_fallback_when_native_is_unavailable(monkeypatch, native_result):
     process_group = object()
     device = torch.device("cuda:0")
     _input = SimpleNamespace(device=device, dtype=torch.bfloat16)
@@ -248,12 +248,12 @@ def test_tp_frontend_uses_liger_fallback_when_lck_is_unavailable(monkeypatch, lc
     monkeypatch.setattr(_FRONTEND, "_validate_tp_inputs", lambda *args: None)
     monkeypatch.setattr(_FRONTEND, "_is_hopper", lambda actual: True)
 
-    def load_lck():
-        if isinstance(lck_result, BaseException):
-            raise lck_result
-        return lck_result
+    def load_native():
+        if isinstance(native_result, BaseException):
+            raise native_result
+        return native_result
 
-    monkeypatch.setattr(_FRONTEND, "_load_lck_tp_function", load_lck)
+    monkeypatch.setattr(_FRONTEND, "_load_native_tp_function", load_native)
     monkeypatch.setattr(
         _FRONTEND,
         "_apply_tp_fallback",
@@ -321,7 +321,7 @@ def test_tp_fallback_matches_torch_with_entropy_and_ignored_rows(monkeypatch):
     torch.testing.assert_close(actual_weight.grad, expected_weight.grad, atol=2e-5, rtol=2e-5)
 
 
-def test_lck_tp_autograd_forwards_runtime_and_inverse_temperature(monkeypatch):
+def test_native_tp_autograd_forwards_runtime_and_inverse_temperature(monkeypatch):
     calls = {}
 
     class FakeTvmFfi:
@@ -336,15 +336,15 @@ def test_lck_tp_autograd_forwards_runtime_and_inverse_temperature(monkeypatch):
             calls["backward"] = args
             return torch.full_like(args[2], 3.0), torch.full_like(args[3], 4.0)
 
-    monkeypatch.setattr(_LCK_FRONTEND, "_validate_inputs", lambda *args: None)
-    monkeypatch.setattr(_LCK_FRONTEND, "_pad_hidden", lambda x, weight: (x, weight, x.shape[1]))
-    monkeypatch.setattr(_LCK_FRONTEND, "_prepare_lck_call", lambda *args: 17)
-    monkeypatch.setattr(_LCK_FRONTEND, "_get_tvm_ffi", lambda: FakeTvmFfi)
+    monkeypatch.setattr(_NATIVE_FRONTEND, "_validate_inputs", lambda *args: None)
+    monkeypatch.setattr(_NATIVE_FRONTEND, "_pad_hidden", lambda x, weight: (x, weight, x.shape[1]))
+    monkeypatch.setattr(_NATIVE_FRONTEND, "_prepare_native_call", lambda *args: 17)
+    monkeypatch.setattr(_NATIVE_FRONTEND, "_get_tvm_ffi", lambda: FakeTvmFfi)
 
     _input = torch.randn(3, 4, requires_grad=True)
     weight = torch.randn(5, 4, requires_grad=True)
     target = torch.tensor([0, 1, 2], dtype=torch.int64)
-    nll, entropy = _LCK_FRONTEND.LigerFusedLinearScaledCrossEntropyLckTPFunction.apply(
+    nll, entropy = _NATIVE_FRONTEND.LigerFusedLinearScaledCrossEntropyNativeTPFunction.apply(
         _input,
         weight,
         target,
@@ -365,7 +365,7 @@ def test_lck_tp_autograd_forwards_runtime_and_inverse_temperature(monkeypatch):
     torch.testing.assert_close(weight.grad, torch.full_like(weight, 4.0))
 
 
-def test_lck_call_uses_prepared_group_without_global_state(monkeypatch):
+def test_native_call_uses_prepared_group_without_global_state(monkeypatch):
     process_group = object()
     calls = []
 
@@ -384,11 +384,11 @@ def test_lck_call_uses_prepared_group_without_global_state(monkeypatch):
         def fused_linear_scaled_cross_entropy_configure_forward(*args):
             calls.append(("forward_config", args))
 
-    monkeypatch.setattr(_LCK_FRONTEND, "_get_nvshmem", lambda: FakeNvshmem)
-    monkeypatch.setattr(_LCK_FRONTEND, "_get_tvm_ffi", lambda: FakeTvmFfi)
-    monkeypatch.setattr(_LCK_FRONTEND.torch.cuda, "device", lambda device: nullcontext())
+    monkeypatch.setattr(_NATIVE_FRONTEND, "_get_nvshmem", lambda: FakeNvshmem)
+    monkeypatch.setattr(_NATIVE_FRONTEND, "_get_tvm_ffi", lambda: FakeTvmFfi)
+    monkeypatch.setattr(_NATIVE_FRONTEND.torch.cuda, "device", lambda device: nullcontext())
 
-    team = _LCK_FRONTEND._prepare_lck_call(
+    team = _NATIVE_FRONTEND._prepare_native_call(
         process_group,
         torch.device("cuda:1"),
         128,
@@ -396,7 +396,7 @@ def test_lck_call_uses_prepared_group_without_global_state(monkeypatch):
         320,
         2,
     )
-    repeated = _LCK_FRONTEND._prepare_lck_call(
+    repeated = _NATIVE_FRONTEND._prepare_native_call(
         process_group,
         torch.device("cuda:1"),
         64,


### PR DESCRIPTION
## Summary

- Remove the internal "LCK" nickname from Liger frontend classes, helpers, messages, tests, and user-facing documentation.
- Use `native` terminology for the CUTLASS + NVSHMEM tensor-parallel adapter.
- Describe `liger_cute_kernels` as the native CUTLASS + NVSHMEM kernel package rather than a MoE-only package.
- Document both current operator families: expert-parallel MoE and tensor-parallel fused scaled linear cross entropy.
- Replace all remaining `LigerCommKernels` and `liger_comm_kernels` references with `LigerCuteKernels`.
- Keep existing internal build identifiers unchanged; this is a terminology/documentation update with no runtime behavior change.

## Validation

- `make checkstyle`
- H200 frontend tests: 28 passed
