### PR TITLE
fix(mlp): correct SwiGLU backward_dI on Blackwell (SM100/B200)

### DIFF
--- a/src/liger_kernel/ops/mlp.py
+++ b/src/liger_kernel/ops/mlp.py
@@ -367,6 +367,15 @@ def _swiglu_kernel_backward_dI(
 
     # Compute dI = dG @ gate_weight + dU @ up_weight
     # [B, S, hidden_dim] @ [hidden_dim, dim] + ... @ ... = [B, S, dim]
+    #
+    # The two matmuls are accumulated in *separate* sequential K-loops rather
+    # than interleaved into one accumulator inside a single loop body. On
+    # Blackwell (SM100 / tcgen05) issuing two `tl.dot(..., acc=acc)` calls that
+    # target the same accumulator within one iteration miscompiles: it produces
+    # ~45% wrong results for bf16/fp16 and pipelines all four operands at once,
+    # which overflows shared memory (OOM) for fp32. Splitting into two loops
+    # keeps the result correct and pipelines only two operands at a time, so the
+    # BLOCK_K=64 configs fit inside the SM100 shared-memory budget.
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
     for k in range(0, hidden_dim, BLOCK_K):
         dG_block = desc_dG.load([b, M_start, k])  # [1, BLOCK_M, BLOCK_K]
@@ -374,6 +383,7 @@ def _swiglu_kernel_backward_dI(
         gate_weight_block = desc_Wg.load([k, N_start])  # [BLOCK_K, BLOCK_N]
         acc = tl.dot(dG_block, gate_weight_block, acc=acc)
 
+    for k in range(0, hidden_dim, BLOCK_K):
         dU_block = desc_dU.load([b, M_start, k])  # [1, BLOCK_M, BLOCK_K]
         dU_block = tl.reshape(dU_block, [BLOCK_M, BLOCK_K])  # [BLOCK_M, BLOCK_K]
         up_weight_block = desc_Wu.load([k, N_start])  # [BLOCK_K, BLOCK_N]


### PR DESCRIPTION
## Summary

`test/transformers/test_mlp.py` (the Triton SwiGLU MLP correctness suite) fails on B200 (SM100) for **every** dtype. Root-caused to a single kernel — `_swiglu_kernel_backward_dI` — and fixed with a minimal restructuring of its accumulation loop.

## Symptoms on B200

| dtype | failure |
|-------|---------|
| fp32 | `triton.runtime.errors.OutOfResources: shared memory, Required: 327744, Hardware limit: 232448` |
| bf16 / fp16 | wrong `x.grad` — `calc_diff ≈ 0.12`, relative error ≈ **45%** (forward + weight-grads pass; only `dI` is wrong) |

## Root cause

`dI = dG @ Wg + dU @ Wu` was computed by interleaving **two `tl.dot(..., acc=acc)` calls into the same accumulator within one K-loop iteration**:

```python
for k in range(0, hidden_dim, BLOCK_K):
    acc = tl.dot(dG_block, gate_weight_block, acc=acc)
    acc = tl.dot(dU_block, up_weight_block, acc=acc)   # same acc
```

On Blackwell (tcgen05) this miscompiles. Minimal repro on B200 (TMA descriptors, `M,K,N = 256,512,256`, bf16):

| pattern | relative error |
|---------|-----|
| single accumulating dot in a K-loop | ✅ 1.7e-3 |
| **two dots interleaved into one accumulator** | ❌ **4.6e-1** |
| two dots via `+=` into one accumulator | ❌ 4.6e-1 |
| two separate accumulators, added at end | ✅ 1.7e-3 |
| **two sequential K-loops, one accumulator** | ✅ 1.7e-3 |

The same interleaving also pipelines all four operands (`dG, Wg, dU, Wu`) at once, so for fp32 with `num_stages≥2` the smallest config needs ≥327744 bytes of shared memory — more than SM100 exposes (232448). Because **every** config in the autotune grid OOMs, the autotuner falls back to the first (also-OOM) config and the launch crashes.

## Fix

Accumulate the two matmuls in **two sequential K-loops sharing one accumulator**. This:
- is correct on SM100 (and unchanged behaviour on SM90/H100), and
- pipelines only two operands at a time, so the `BLOCK_K=64` configs fit in smem and the autotuner selects a valid config for fp32.

The `forward` kernel (two separate accumulators) and `backward_dGU` kernel (single dot) already use safe patterns and are untouched. The `fixA` alternative (two separate accumulators) was rejected: it keeps the 4-operand smem footprint (fp32 still OOMs) and hit `PTXAS Internal Triton PTX codegen` errors on B200 for `BLOCK_M=128` configs.

## Verification

On B200: `test/transformers/test_mlp.py` → **59 passed, 1 xfailed** (was 28 failed before). fp32/bf16/fp16 across all parametrised shapes now pass.
