### PR TITLE
ci(nvi): add cuTile tests on B200 to the daily run

### DIFF
--- a/.github/workflows/nvi-ci.yml
+++ b/.github/workflows/nvi-ci.yml
@@ -11,7 +11,8 @@ on:
           - daily
           - weekly
   schedule:
-    # Daily: correctness + cuTile + cuTeDSL (SM90) on H100, cuTeDSL (SM100) on B200.
+    # Daily: correctness + cuTeDSL (SM90) on H100, cuTeDSL (SM100) on B200,
+    # and cuTile on BOTH archs.
     # Randomized off-peak minute; round hours (esp. 00:00) get throttled/queued by GitHub.
     - cron: '24 9 * * *'
     # Weekly (Sundays): convergence (latest tf) + oldest-tf correctness & convergence.
@@ -29,7 +30,8 @@ jobs:
   # ---------------------------------------------------------------------------
   # Daily: general correctness + cuTile + cuTeDSL, split across H100 and B200.
   # cuTeDSL runs on BOTH archs on purpose: SM90 tests only run on H100 and SM100
-  # tests only run on B200 (each arch self-skips the other half).
+  # tests only run on B200 (each arch self-skips the other half). cuTile likewise
+  # runs on BOTH archs to catch arch-specific (e.g. SM100/tcgen05) regressions.
   # ---------------------------------------------------------------------------
   daily:
     name: daily / ${{ matrix.name }}
@@ -45,6 +47,8 @@ jobs:
             modal_fn: liger_correctness_tests
           - name: cuTile (H100)
             modal_fn: liger_cutile_tests
+          - name: cuTile (B200)
+            modal_fn: liger_cutile_tests_b200
           - name: cuTeDSL SM90 (H100)
             modal_fn: liger_cutedsl_tests_h100
           - name: cuTeDSL SM100 (B200)

--- a/dev/modal/tests.py
+++ b/dev/modal/tests.py
@@ -58,6 +58,22 @@ def liger_cutile_tests():
     subprocess.run(["make test-cutile"], check=True, shell=True, cwd=REMOTE_ROOT_PATH)
 
 
+@app.function(gpu="B200!", image=repo, timeout=90 * 60)
+def liger_cutile_tests_b200():
+    import subprocess
+
+    # cutile-tileiras pulls in the tileiras compiler so `import cuda.tile` resolves;
+    # without it the cuTile tests importorskip (skip) rather than run.
+    subprocess.run(
+        ["uv pip install -e '.[dev,cutile-tileiras]' --system"],
+        check=True,
+        shell=True,
+        cwd=REMOTE_ROOT_PATH,
+    )
+    # make test-cutile sets LIGER_KERNEL_IMPL=cutile internally.
+    subprocess.run(["make test-cutile"], check=True, shell=True, cwd=REMOTE_ROOT_PATH)
+
+
 @app.function(gpu="H100!", image=repo, timeout=90 * 60)
 def liger_cutedsl_tests_h100():
     import subprocess
@@ -73,7 +89,7 @@ def liger_cutedsl_tests_h100():
     subprocess.run(["make test-cutedsl"], check=True, shell=True, cwd=REMOTE_ROOT_PATH)
 
 
-@app.function(gpu="B200", image=repo, timeout=90 * 60)
+@app.function(gpu="B200!", image=repo, timeout=90 * 60)
 def liger_cutedsl_tests_b200():
     import subprocess
 


### PR DESCRIPTION
## Summary

Adds a B200 (SM100) counterpart to the daily H100 cuTile CI job, so the cuTile suite runs on **both** archs — mirroring cuTeDSL, which already runs on H100 and B200. Arch-specific cuTile regressions (e.g. SM100/tcgen05 codegen issues) would otherwise go uncaught by CI.

## Changes

- **`dev/modal/tests.py`** — new `liger_cutile_tests_b200` Modal function, identical to `liger_cutile_tests` but on B200. Installs `.[dev,cutile-tileiras]` (so `import cuda.tile` resolves and the tests run rather than `importorskip`) and runs `make test-cutile` (which sets `LIGER_KERNEL_IMPL=cutile`).
- **`.github/workflows/nvi-ci.yml`** — adds a `cuTile (B200)` entry to the `daily` matrix and refreshes the surrounding comments.

## Strict `B200!` GPU spec

Both B200 jobs now use the strict `gpu="B200!"` form, matching the H100 jobs' `H100!`. The `!` tells Modal not to substitute a different GPU family. This matters for arch-specific SM100 tests: without it, a fallback/substituted GPU could produce a **misleading pass**. This PR also flips the pre-existing `liger_cutedsl_tests_b200` from `"B200"` → `"B200!"` for consistency (small, related change — easy to drop if undesired).

`max-parallel: 3` and the workflow-level concurrency group are unchanged, so the 5th daily matrix entry still runs at most 3 GPU jobs at once.

## Verification

Locally on a B200: `LIGER_KERNEL_IMPL=cutile pytest test/cutile/` → **199 passed, 12 skipped**. The new job is meaningful and currently green on B200.