### PR TITLE
Update tests.py to use B200 instead of B200!

### DIFF
--- a/dev/modal/tests.py
+++ b/dev/modal/tests.py
@@ -58,7 +58,7 @@ def liger_cutile_tests():
     subprocess.run(["make test-cutile"], check=True, shell=True, cwd=REMOTE_ROOT_PATH)
 
 
-@app.function(gpu="B200!", image=repo, timeout=90 * 60)
+@app.function(gpu="B200", image=repo, timeout=90 * 60)
 def liger_cutile_tests_b200():
     import subprocess
 
@@ -89,7 +89,7 @@ def liger_cutedsl_tests_h100():
     subprocess.run(["make test-cutedsl"], check=True, shell=True, cwd=REMOTE_ROOT_PATH)
 
 
-@app.function(gpu="B200!", image=repo, timeout=90 * 60)
+@app.function(gpu="B200", image=repo, timeout=90 * 60)
 def liger_cutedsl_tests_b200():
     import subprocess
 


### PR DESCRIPTION
## Summary
<!--- This is a required section; please describe the main purpose of this proposed code change. --->
"B200!" is not a defined GPU type unlike "H100!". Need to use "B200" instead of "B200!" at all locations.

Refer: https://modal.com/docs/guide/gpu#b200-gpus

<!---
## Details
This is an optional section; is there anything specific that reviewers should be aware of?
--->

## Testing Done
<!--- This is a required section; please describe how this change was tested. --->

<!-- 
Replace BLANK with your device type. For example, A100-80G-PCIe

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them. 
-->

- Hardware Type: <BLANK>
- [ ] run `make test` to ensure correctness
- [ ] run `make checkstyle` to ensure code style
- [ ] run `make test-convergence` to ensure convergence
