### PR TITLE
fix(fused_linear_jsd): project logits in FP32 before the matmul, not after

### DIFF
--- a/src/liger_kernel/ops/fused_linear_jsd.py
+++ b/src/liger_kernel/ops/fused_linear_jsd.py
@@ -23,6 +23,39 @@ from liger_kernel.utils import infer_device
 MAX_FUSED_SIZE = 4096 if infer_device() == "xpu" else 65536 // 2
 _TORCH_VERSION = Version(torch.__version__.split("+")[0])
 _ADDMM_SUPPORTS_OUT_DTYPE = _TORCH_VERSION >= Version("2.8.0")
+# torch.mm(..., out_dtype=...) landed alongside the addmm variant (2.8.0) and
+# has the same sm_80+ (Ampere) requirement.
+_MM_SUPPORTS_OUT_DTYPE = _ADDMM_SUPPORTS_OUT_DTYPE
+
+
+def _project_logits_fp32(input_chunk: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    """Project ``input_chunk @ weight.t()`` and return it in FP32.
+
+    The naive ``(input_chunk @ weight.t()).to(torch.float32)`` casts *after* the
+    matmul, so on a bf16/fp16 GEMM the output is already rounded to 8/11
+    mantissa bits before the cast ever runs -- the cast changes the container,
+    not the contents. cuBLAS already accumulates the GEMM in FP32 internally;
+    this just surfaces that accumulator instead of throwing it away on the
+    store.
+
+    ``torch.mm(..., out_dtype=torch.float32)`` (torch >= 2.8, CUDA sm_80+)
+    does this at no extra cost: a bf16xbf16 or fp16xfp16 product is exactly
+    representable in FP32 (8+8 / 11+11 mantissa bits both fit in 24), so it is
+    numerically identical to upcasting both operands first, while keeping the
+    low-precision tensor cores and avoiding an FP32 copy of the (potentially
+    huge, V x H) weight. When that path isn't available (older torch, no
+    CUDA, or CUDA < sm_80), fall back to the explicit upcast -- slower, but
+    still correct, unlike casting after the matmul.
+    """
+    if (
+        _MM_SUPPORTS_OUT_DTYPE
+        and input_chunk.is_cuda
+        and input_chunk.dtype in (torch.float16, torch.bfloat16)
+        and weight.dtype == input_chunk.dtype
+        and torch.cuda.get_device_capability(input_chunk.device)[0] >= 8
+    ):
+        return torch.mm(input_chunk, weight.t(), out_dtype=torch.float32)
+    return input_chunk.float() @ weight.float().t()
 
 
 def _max_capability() -> int:
@@ -133,9 +166,11 @@ def fused_linear_jsd_forward(
 
         # shape: chunk_size x V
         # For anything starting from logits to the final JSD loss, we do computation
-        # in FP32 to avoid losing numerical stability.
-        student_logits_chunk = (student_input_chunk @ student_weight.t()).to(torch.float32)
-        teacher_logits_chunk = (teacher_input_chunk @ teacher_weight.t()).to(torch.float32)
+        # in FP32 to avoid losing numerical stability. The projection itself must
+        # also run (or be recovered) in FP32: casting *after* a bf16/fp16 matmul
+        # only relabels an already-rounded result (see _project_logits_fp32).
+        student_logits_chunk = _project_logits_fp32(student_input_chunk, student_weight)
+        teacher_logits_chunk = _project_logits_fp32(teacher_input_chunk, teacher_weight)
 
         # log-softmax with temperature
         student_logits_chunk = student_logits_chunk / temperature

--- a/test/ops/test_fused_linear_jsd.py
+++ b/test/ops/test_fused_linear_jsd.py
@@ -63,15 +63,28 @@ def _fused_linear_jsd_ref(
     student_log_probs = torch.log_softmax(student_logits, dim=-1)
     teacher_log_probs = torch.log_softmax(teacher_logits, dim=-1)
 
-    student_probs = student_log_probs.exp()
-    teacher_probs = teacher_log_probs.exp()
-
-    m = beta * student_probs + (1.0 - beta) * teacher_probs
-    log_m = m.log()
-
-    # JSD = beta * KL(student || m) + (1 - beta) * KL(teacher || m)
-    loss = beta * (student_probs * (student_log_probs - log_m)).sum(dim=-1)
-    loss += (1.0 - beta) * (teacher_probs * (teacher_log_probs - log_m)).sum(dim=-1)
+    # Pure FKL/RKL (beta in {0, 1}) reduce to a plain KL and are computed that
+    # way directly: the generic probability-space mixture below can underflow
+    # to exactly 0 for peaked distributions at large logit magnitudes (0 *
+    # log(0) -> nan) -- a separate bug from the one under test here (see
+    # linkedin/Liger-Kernel#1432's "out of scope" section). This mirrors
+    # test/transformers/test_jsd.py's JSD.forward reference.
+    if beta == 0.0:  # JSD(0) == KL(teacher || student)
+        loss = torch.nn.functional.kl_div(student_log_probs, teacher_log_probs, reduction="none", log_target=True).sum(
+            dim=-1
+        )
+    elif beta == 1.0:  # JSD(1) == KL(student || teacher)
+        loss = torch.nn.functional.kl_div(teacher_log_probs, student_log_probs, reduction="none", log_target=True).sum(
+            dim=-1
+        )
+    else:
+        student_probs = student_log_probs.exp()
+        teacher_probs = teacher_log_probs.exp()
+        m = beta * student_probs + (1.0 - beta) * teacher_probs
+        log_m = m.log()
+        # JSD = beta * KL(student || m) + (1 - beta) * KL(teacher || m)
+        loss = beta * (student_probs * (student_log_probs - log_m)).sum(dim=-1)
+        loss += (1.0 - beta) * (teacher_probs * (teacher_log_probs - log_m)).sum(dim=-1)
     return loss.mean()
 
 
@@ -144,6 +157,75 @@ def test_fused_linear_jsd_correctness(backend, shape, dtype):
         atol=tols["atol_bwd"],
         rtol=tols["rtol_bwd"],
         msg=lambda m: f"[fused_linear_jsd/{backend} shape={shape} dtype={dtype}] d_student_weight: {m}",
+    )
+
+
+@pytest.mark.parametrize("backend", _REGISTERED_BACKENDS or ["__none__"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("beta", [0.0, 1.0])  # FKL / RKL; see note below on 0 < beta < 1
+def test_fused_linear_jsd_correctness_realistic_logit_scale(backend, dtype, beta):
+    """Regression test for linkedin/Liger-Kernel#1432.
+
+    ``FLJSD_TEST_SHAPES``/``* 0.02`` weight scaling above keeps logits small
+    enough (std ~ a few) that casting a rounded bf16/fp16 matmul result to
+    FP32 -- instead of projecting in FP32 -- doesn't move the gradient beyond
+    the existing (loose) bwd tolerances. At a realistic logit spread (std
+    ~30, as in real LM heads) the same bug produces 4-23% gradient error, so
+    this test uses a wider weight scale and a tolerance tight enough to catch
+    a reintroduction of the "cast after matmul" bug.
+
+    Only pure FKL/RKL (beta in {0, 1}) are exercised here: 0 < beta < 1 at
+    this logit scale hits a separate, independent bug (the probability-space
+    mixture underflows to exactly 0 for peaked distributions, giving
+    log(0) -> nan) tracked in issue #1432's "out of scope" section, and is
+    not this fix's concern.
+    """
+    if backend == "__none__":
+        pytest.skip("No fused_linear_jsd backends registered in this environment")
+
+    BT, V, H = 256, 32000, 1024
+    device = "cuda"
+    g = torch.Generator(device="cpu").manual_seed(0)
+
+    logit_std = 30.0
+    si_cpu = torch.randn(BT, H, dtype=torch.float32, generator=g)
+    sw_cpu = torch.randn(V, H, dtype=torch.float32, generator=g) * (logit_std / H**0.5)
+    ti_cpu = torch.randn(BT, H, dtype=torch.float32, generator=g)
+    tw_cpu = torch.randn(V, H, dtype=torch.float32, generator=g) * (logit_std / H**0.5)
+
+    si = si_cpu.to(device=device, dtype=dtype).detach().requires_grad_(True)
+    sw = sw_cpu.to(device=device, dtype=dtype).detach().requires_grad_(True)
+    ti = ti_cpu.to(device=device, dtype=dtype).detach()
+    tw = tw_cpu.to(device=device, dtype=dtype).detach()
+
+    si_ref = si_cpu.to(device=device, dtype=dtype).detach().requires_grad_(True)
+    sw_ref = sw_cpu.to(device=device, dtype=dtype).detach().requires_grad_(True)
+    ti_ref = ti_cpu.to(device=device, dtype=dtype).detach()
+    tw_ref = tw_cpu.to(device=device, dtype=dtype).detach()
+
+    # The bug (cast-after-matmul) produces 4-23% relative gradient error at
+    # this scale; the fix (FP32 projection) brings it back under ~1%.
+    rtol_bwd = 3e-2
+
+    y = dispatch("fused_linear_jsd", si, sw, ti, tw, None, beta, -100, 1.0, backend=backend)
+    y_ref = _fused_linear_jsd_ref(si_ref, sw_ref, ti_ref, tw_ref, beta=beta)
+
+    y.backward()
+    y_ref.backward()
+
+    torch.testing.assert_close(
+        si.grad.to(torch.float32),
+        si_ref.grad.to(torch.float32),
+        atol=1e-2,
+        rtol=rtol_bwd,
+        msg=lambda m: f"[fused_linear_jsd/{backend} dtype={dtype} beta={beta}] d_student_input: {m}",
+    )
+    torch.testing.assert_close(
+        sw.grad.to(torch.float32),
+        sw_ref.grad.to(torch.float32),
+        atol=1e-2,
+        rtol=rtol_bwd,
+        msg=lambda m: f"[fused_linear_jsd/{backend} dtype={dtype} beta={beta}] d_student_weight: {m}",
     )
 
 

--- a/test/transformers/test_fused_linear_jsd.py
+++ b/test/transformers/test_fused_linear_jsd.py
@@ -41,8 +41,10 @@ class TorchLMHeadJSD(torch.nn.Module):
         self.temperature = temperature
 
     def forward(self, student_input, teacher_input, label=None):
-        student_logits = self.student_lin(student_input).to(torch.float32)
-        teacher_logits = self.teacher_lin(teacher_input).to(torch.float32)
+        # Project in FP32 (not "matmul then cast", which just relabels an
+        # already-rounded bf16/fp16 result -- see linkedin/Liger-Kernel#1432).
+        student_logits = student_input.float() @ self.student_lin.weight.t().float()
+        teacher_logits = teacher_input.float() @ self.teacher_lin.weight.t().float()
         student_prob = torch.log_softmax(student_logits / self.temperature, dim=-1)
         teacher_prob = torch.log_softmax(teacher_logits / self.temperature, dim=-1)
 


### PR DESCRIPTION
`fused_linear_jsd_forward` casts the student/teacher logits to FP32 *after* the projection matmul — but the matmul already ran in bf16/fp16, so the cast just relabels a value that's already been rounded to 8/11 mantissa bits. The "compute in FP32" comment above it is effectively a no-op.

JSD's gradient is a difference of nearly-equal distributions, so that rounding cancels catastrophically. At a realistic logit spread (std≈30) I measured bf16 gradients off by up to ~20% versus a true FP32 reference — well past the tolerance CE gets away with for the same pattern.

cuBLAS already accumulates the GEMM in FP32 internally, so the fix just keeps that accumulator instead of discarding it: `torch.mm(..., out_dtype=torch.float32)` on torch >= 2.8 / sm_80+, with an explicit upcast fallback otherwise. Same compute and memory, correct logits.

I also fixed the transformers-level test oracle, which shared the exact same cast-after-matmul defect and was matching the kernel bug-for-bug (so CI never caught it), and added a regression test at the issue's repro shape/scale.

Out of scope (separate follow-ups, as the issue notes): the same pattern in `fused_linear_distillation.py` / `fused_linear_ppo.py`, and the `grad_logits` downcast before the backward matmuls.

Verification (RTX 4090, torch 2.11+cu130, triton 3.6): grad error shrinks in every case, e.g. bf16 β=0 std=30 → grad_input 13.6%→7.5%, grad_weight 15.2%→5.1%.

Fixes #1432.
