### PR TITLE
fix(monkey_patch): let the norm flags cover the whole vision tower

### DIFF
--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -547,14 +547,13 @@ def apply_liger_kernel_to_llama4(
                     _patch_rms_norm_module(decoder_layer.input_layernorm)
                     _patch_rms_norm_module(decoder_layer.post_attention_layernorm)
 
-        if vision_model:
+        if vision_model and layer_norm:
             _patch_layer_norm_module(vision_model.layernorm_pre)
             _patch_layer_norm_module(vision_model.layernorm_post)
 
             for layer in vision_model.model.layers:
-                if layer_norm:
-                    _patch_layer_norm_module(layer.input_layernorm)
-                    _patch_layer_norm_module(layer.post_attention_layernorm)
+                _patch_layer_norm_module(layer.input_layernorm)
+                _patch_layer_norm_module(layer.post_attention_layernorm)
 
 
 def apply_liger_kernel_to_mllama(
@@ -644,19 +643,17 @@ def apply_liger_kernel_to_mllama(
                     _patch_rms_norm_module(decoder_layer.input_layernorm)
                     _patch_rms_norm_module(decoder_layer.post_attention_layernorm)
 
-        if vision_model:
+        if vision_model and layer_norm:
             _patch_layer_norm_module(vision_model.layernorm_pre)
             _patch_layer_norm_module(vision_model.layernorm_post)
 
             for layer in vision_model.transformer.layers:
-                if layer_norm:
-                    _patch_layer_norm_module(layer.input_layernorm)
-                    _patch_layer_norm_module(layer.post_attention_layernorm)
+                _patch_layer_norm_module(layer.input_layernorm)
+                _patch_layer_norm_module(layer.post_attention_layernorm)
 
             for layer in vision_model.global_transformer.layers:
-                if layer_norm:
-                    _patch_layer_norm_module(layer.input_layernorm)
-                    _patch_layer_norm_module(layer.post_attention_layernorm)
+                _patch_layer_norm_module(layer.input_layernorm)
+                _patch_layer_norm_module(layer.post_attention_layernorm)
 
 
 def apply_liger_kernel_to_ministral(
@@ -1368,11 +1365,11 @@ def apply_liger_kernel_to_gemma3(
                 vision_tower = model.model.vision_tower
                 siglip_vision_model = getattr(vision_tower, "vision_model", vision_tower)
 
-                _patch_layer_norm_module(siglip_vision_model.post_layernorm)
+                if layer_norm:
+                    _patch_layer_norm_module(siglip_vision_model.post_layernorm)
 
-                for layer in siglip_vision_model.encoder.layers:
-                    layer: SiglipEncoderLayer
-                    if layer_norm:
+                    for layer in siglip_vision_model.encoder.layers:
+                        layer: SiglipEncoderLayer
                         _patch_layer_norm_module(layer.layer_norm1)
                         _patch_layer_norm_module(layer.layer_norm2)
             else:
@@ -1714,11 +1711,11 @@ def apply_liger_kernel_to_paligemma(
         vision_tower: SiglipVisionModel = model.model.vision_tower
         siglip_vision_model = getattr(vision_tower, "vision_model", vision_tower)
 
-        _patch_layer_norm_module(siglip_vision_model.post_layernorm)
+        if layer_norm:
+            _patch_layer_norm_module(siglip_vision_model.post_layernorm)
 
-        for layer in siglip_vision_model.encoder.layers:
-            layer: SiglipEncoderLayer
-            if layer_norm:
+            for layer in siglip_vision_model.encoder.layers:
+                layer: SiglipEncoderLayer
                 _patch_layer_norm_module(layer.layer_norm1)
                 _patch_layer_norm_module(layer.layer_norm2)
 
@@ -2792,8 +2789,9 @@ def apply_liger_kernel_to_glm4v_moe(
             )
 
         if vision_model is not None:
-            _patch_rms_norm_module(vision_model.post_conv_layernorm)
-            _patch_rms_norm_module(vision_model.post_layernorm)
+            if rms_norm:
+                _patch_rms_norm_module(vision_model.post_conv_layernorm)
+                _patch_rms_norm_module(vision_model.post_layernorm)
             for vision_block in vision_model.blocks:
                 if rms_norm:
                     _patch_rms_norm_module(vision_block.norm1)

--- a/test/transformers/test_monkey_patch.py
+++ b/test/transformers/test_monkey_patch.py
@@ -1479,6 +1479,52 @@ def test_apply_liger_kernel_to_instance_for_pixtral_vision_model():
             pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
 
 
+@pytest.mark.skipif(not is_mllama_available(), reason="mllama module not available")
+def test_apply_liger_kernel_to_instance_for_mllama_respects_layer_norm_false():
+    # Ensure any monkey patching is cleaned up for subsequent tests
+    with patch("transformers.models.mllama.modeling_mllama"):
+        from transformers.models.mllama.modeling_mllama import MllamaForConditionalGeneration
+
+        # Instantiate a dummy model
+        config = transformers.models.mllama.configuration_mllama.MllamaConfig(
+            dtype=torch.bfloat16,
+            text_config=transformers.models.mllama.configuration_mllama.MllamaTextConfig(
+                rms_norm_eps=1e-5,
+                hidden_size=32,
+                intermediate_size=64,
+                hidden_act="silu",
+                num_hidden_layers=2,
+                **get_mllama_rope_config(),  # Version-aware rope configuration
+            ),
+            vision_config=transformers.models.mllama.configuration_mllama.MllamaVisionConfig(
+                rms_norm_eps=1e-5,
+                hidden_size=32,
+                intermediate_size=64,
+                hidden_act="gelu",
+                num_hidden_layers=2,
+                vision_output_dim=64,
+            ),
+        )
+        dummy_model_instance = MllamaForConditionalGeneration._from_config(config)
+        vision_model = dummy_model_instance.model.vision_model
+
+        _apply_liger_kernel_to_instance(model=dummy_model_instance, layer_norm=False)
+
+        # layer_norm=False has to cover the whole vision tower, not just the encoder layers
+        assert inspect.getsource(vision_model.layernorm_pre.forward) != inspect.getsource(LigerLayerNorm.forward)
+        assert inspect.getsource(vision_model.layernorm_post.forward) != inspect.getsource(LigerLayerNorm.forward)
+        for layer in vision_model.transformer.layers:
+            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerLayerNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(
+                LigerLayerNorm.forward
+            )
+        for layer in vision_model.global_transformer.layers:
+            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerLayerNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(
+                LigerLayerNorm.forward
+            )
+
+
 @pytest.mark.skipif(not is_llama4_available(), reason="llama4 module not available")
 def test_apply_liger_kernel_to_instance_for_llama4_for_causal_lm():
     # Ensure any monkey patching is cleaned up for subsequent tests
@@ -1622,6 +1668,49 @@ def test_apply_liger_kernel_to_instance_for_llama4_for_conditional_generation():
             print(dummy_model_instance)
         except Exception as e:
             pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+
+
+@pytest.mark.skipif(not is_llama4_available(), reason="llama4 module not available")
+def test_apply_liger_kernel_to_instance_for_llama4_respects_layer_norm_false():
+    # Ensure any monkey patching is cleaned up for subsequent tests
+    with patch("transformers.models.llama4.modeling_llama4"):
+        from transformers.models.llama4.modeling_llama4 import Llama4ForConditionalGeneration
+
+        # Instantiate a dummy model
+        config = transformers.models.llama4.configuration_llama4.Llama4Config(
+            dtype=torch.bfloat16,
+            text_config=transformers.models.llama4.configuration_llama4.Llama4TextConfig(
+                dtype=torch.bfloat16,
+                rms_norm_eps=1e-5,
+                hidden_size=32,
+                intermediate_size=64,
+                hidden_act="silu",
+                num_hidden_layers=2,
+                moe_layers=[1],
+            ),
+            vision_config=transformers.models.llama4.configuration_llama4.Llama4VisionConfig(
+                rms_norm_eps=1e-5,
+                hidden_size=32,
+                intermediate_size=64,
+                hidden_act="gelu",
+                num_hidden_layers=2,
+                vision_output_dim=64,
+            ),
+            pad_token_id=None,
+        )
+        dummy_model_instance = Llama4ForConditionalGeneration._from_config(config)
+        vision_model = dummy_model_instance.vision_model
+
+        _apply_liger_kernel_to_instance(model=dummy_model_instance, layer_norm=False)
+
+        # layer_norm=False has to cover the whole vision tower, not just the encoder layers
+        assert inspect.getsource(vision_model.layernorm_pre.forward) != inspect.getsource(LigerLayerNorm.forward)
+        assert inspect.getsource(vision_model.layernorm_post.forward) != inspect.getsource(LigerLayerNorm.forward)
+        for layer in vision_model.model.layers:
+            assert inspect.getsource(layer.input_layernorm.forward) != inspect.getsource(LigerLayerNorm.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(
+                LigerLayerNorm.forward
+            )
 
 
 def test_apply_liger_kernel_to_instance_for_mistral():
@@ -1954,6 +2043,45 @@ def test_apply_liger_kernel_to_instance_for_paligemma():
             pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
 
 
+@pytest.mark.skipif(not is_paligemma_available(), reason="paligemma module not available")
+def test_apply_liger_kernel_to_instance_for_paligemma_respects_layer_norm_false():
+    # Ensure any monkey patching is cleaned up for subsequent tests
+    with patch("transformers.models.paligemma.modeling_paligemma"):
+        from transformers.models.paligemma.modeling_paligemma import PaliGemmaForConditionalGeneration
+
+        # Instantiate a dummy model
+        config = transformers.models.paligemma.configuration_paligemma.PaliGemmaConfig(
+            dtype=torch.bfloat16,
+            text_config={
+                "num_hidden_layers": 2,
+                "rms_norm_eps": 1e-5,
+                "hidden_size": 32,
+                "intermediate_size": 64,
+                "hidden_act": "silu",
+            },
+            vision_config={
+                "num_hidden_layers": 2,
+                "layer_norm_eps": 1e-5,
+                "hidden_size": 48,
+                "intermediate_size": 64,
+            },
+        )
+        dummy_model_instance = PaliGemmaForConditionalGeneration(config)
+        siglip_vision_model = getattr(
+            dummy_model_instance.model.vision_tower, "vision_model", dummy_model_instance.model.vision_tower
+        )
+
+        _apply_liger_kernel_to_instance(model=dummy_model_instance, layer_norm=False)
+
+        # layer_norm=False has to cover the whole vision tower, not just the encoder layers
+        assert inspect.getsource(siglip_vision_model.post_layernorm.forward) != inspect.getsource(
+            LigerLayerNorm.forward
+        )
+        for layer in siglip_vision_model.encoder.layers:
+            assert inspect.getsource(layer.layer_norm1.forward) != inspect.getsource(LigerLayerNorm.forward)
+            assert inspect.getsource(layer.layer_norm2.forward) != inspect.getsource(LigerLayerNorm.forward)
+
+
 @pytest.mark.skipif(not is_gemma3_available(), reason="gemma3 module not available")
 def test_apply_liger_kernel_to_instance_for_gemma3_text():
     # Ensure any monkey patching is cleaned up for subsequent tests
@@ -2103,6 +2231,45 @@ def test_apply_liger_kernel_to_instance_for_gemma3_conditional_generation():
             print(dummy_model_instance)
         except Exception as e:
             pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+
+
+@pytest.mark.skipif(not is_gemma3_available(), reason="gemma3 module not available")
+def test_apply_liger_kernel_to_instance_for_gemma3_respects_layer_norm_false():
+    # Ensure any monkey patching is cleaned up for subsequent tests
+    with patch("transformers.models.gemma3.modeling_gemma3"):
+        from transformers.models.gemma3.modeling_gemma3 import Gemma3ForConditionalGeneration
+
+        # Instantiate a dummy model
+        text_config = transformers.models.gemma3.configuration_gemma3.Gemma3TextConfig(
+            dtype=torch.bfloat16,
+            rms_norm_eps=1e-5,
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=2,
+        )
+        vision_config = transformers.models.siglip.configuration_siglip.SiglipVisionConfig(
+            layer_norm_eps=1e-5,
+            hidden_size=48,
+            intermediate_size=64,
+        )
+        config = transformers.models.gemma3.configuration_gemma3.Gemma3Config(
+            text_config=text_config, vision_config=vision_config
+        )
+
+        dummy_model_instance = Gemma3ForConditionalGeneration._from_config(config)
+        siglip_vision_model = getattr(
+            dummy_model_instance.model.vision_tower, "vision_model", dummy_model_instance.model.vision_tower
+        )
+
+        _apply_liger_kernel_to_instance(model=dummy_model_instance, layer_norm=False)
+
+        # layer_norm=False has to cover the whole vision tower, not just the encoder layers
+        assert inspect.getsource(siglip_vision_model.post_layernorm.forward) != inspect.getsource(
+            LigerLayerNorm.forward
+        )
+        for layer in siglip_vision_model.encoder.layers:
+            assert inspect.getsource(layer.layer_norm1.forward) != inspect.getsource(LigerLayerNorm.forward)
+            assert inspect.getsource(layer.layer_norm2.forward) != inspect.getsource(LigerLayerNorm.forward)
 
 
 @pytest.mark.skipif(not is_gemma4_available(), reason="gemma4 module not available")
@@ -3265,6 +3432,49 @@ def test_apply_liger_kernel_to_instance_for_glm4v_moe():
             print(dummy_model_instance)
         except Exception as e:
             pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+
+
+@pytest.mark.skipif(not is_glm4v_moe_available(), reason="glm4v_moe module not available")
+def test_apply_liger_kernel_to_instance_for_glm4v_moe_respects_rms_norm_false():
+    # Ensure any monkey patching is cleaned up for subsequent tests
+    with patch("transformers.models.glm4v_moe.modeling_glm4v_moe"):
+        from transformers.models.glm4v_moe.modeling_glm4v_moe import Glm4vMoeForConditionalGeneration
+
+        from liger_kernel.transformers.rms_norm import LigerRMSNormForGlm4
+
+        # Instantiate a dummy model
+        config = transformers.models.glm4v_moe.configuration_glm4v_moe.Glm4vMoeConfig(
+            dtype=torch.bfloat16,
+            hidden_size=32,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            text_config={
+                "hidden_size": 16,
+                "intermediate_size": 32,
+                "num_attention_heads": 4,
+                "num_hidden_layers": 2,
+                "rms_norm_eps": 1e-5,
+                "hidden_act": "silu",
+                "n_routed_experts": 1,
+            },
+            vision_config={
+                "num_hidden_layers": 2,
+                "rms_norm_eps": 1e-5,
+                "hidden_size": 48,
+                "intermediate_size": 64,
+            },
+        )
+        dummy_model_instance = Glm4vMoeForConditionalGeneration(config)
+        visual = dummy_model_instance.model.visual
+
+        _apply_liger_kernel_to_instance(model=dummy_model_instance, rms_norm=False)
+
+        # rms_norm=False has to cover the whole vision tower, not just the blocks
+        assert inspect.getsource(visual.post_conv_layernorm.forward) != inspect.getsource(LigerRMSNormForGlm4.forward)
+        assert inspect.getsource(visual.post_layernorm.forward) != inspect.getsource(LigerRMSNormForGlm4.forward)
+        for vision_block in visual.blocks:
+            assert inspect.getsource(vision_block.norm1.forward) != inspect.getsource(LigerRMSNormForGlm4.forward)
+            assert inspect.getsource(vision_block.norm2.forward) != inspect.getsource(LigerRMSNormForGlm4.forward)
 
 
 @pytest.mark.skipif(not is_smollm3_available(), reason="smollm3 module not available")


### PR DESCRIPTION
## Summary

Five patchers gate the *per-layer* norms of a vision tower on the corresponding flag, but patch the tower's *own* norms unconditionally. Passing the flag as `False` together with a `model=` instance therefore still swaps Liger norms in:

| patcher | flag | patched regardless |
| --- | --- | --- |
| `llama4`, `mllama` | `layer_norm` | `vision_model.layernorm_pre`, `layernorm_post` |
| `gemma3`, `paligemma` | `layer_norm` | `vision_model.post_layernorm` |
| `glm4v_moe` | `rms_norm` | `visual.post_conv_layernorm`, `post_layernorm` |

The class-level branch of the very same functions gets it right (`if layer_norm and model is None:` in mllama/gemma3/paligemma, `if rms_norm:` in glm4v_moe), so one function answers the same flag differently depending on whether you hand it a model. And `smolvlm`, `internvl`, `muse_glimmer` and `glm4v` already gate the tower norm exactly like their encoder layers, which is why these five read as oversights rather than deliberate exceptions.

Both flags default to `True` on all five, so nothing changes unless a caller explicitly opts out.

## Testing Done

Reproduced on transformers 5.9.0 / torch 2.11.0 before the change, patching an instance with the flag off:

```
paligemma (layer_norm=False)
  vision_model.post_layernorm             PATCHED  <-- ignored the flag
  encoder.layers[0].layer_norm1           untouched
mllama (layer_norm=False)
  vision_model.layernorm_pre              PATCHED  <-- ignored the flag
  vision_model.layernorm_post             PATCHED  <-- ignored the flag
  transformer.layers[0].input_layernorm   untouched
```

gemma3, llama4 and glm4v_moe behave the same way. After the change every one of those reads `untouched`.

- `pytest test/transformers/test_monkey_patch.py`: 63 passed / 1 skipped on `main`, 68 passed / 1 skipped here. The five added tests each fail on `main` and pass with the fix; the skip is `muse_glimmer` missing from the installed transformers.
- `ruff check .` and `ruff format --check .` with the v0.14.11 that `.pre-commit-config.yaml` pins: clean.
- Convergence is untouched by construction. Both `test_mini_models_multimodal.py` files pin `"rms_norm": True` and `kwargs["layer_norm"] = True` for these models, glm4v_moe is not in the convergence set at all, and this change only alters the `False` branch.

Also ran on GPU. This branch against `main`, both on the same A100 40GB in one job:

| | this branch | `main` |
| --- | --- | --- |
| `test_mini_models_multimodal.py` bf16 (`-k "mllama or paligemma or gemma3 or llama4 or glm4v"`) | 5 passed | 5 passed |
| the same, fp32 | 4 passed, 1 xfailed | 4 passed, 1 xfailed |
| `test_monkey_patch.py` | 68 passed, 1 skipped | 63 passed, 1 skipped |

Full `make test` scope, separately on an A100 80GB: 4496 passed, 18 failed, 931 skipped, 15 xfailed. Re-running just `test/chunked_loss/test_grpo_loss.py` on `main` gives the same 18 failing test ids (`luspo`/`cispo` cases that miss tolerance on sm80), and that file does not import `monkey_patch`.

Hardware Type: A100 40GB and A100 80GB, plus CPU for the unit suite. The patchers are pure Python and `test_monkey_patch.py` has no CUDA gating, so that suite is the one that actually exercises them.
