### PR TITLE
fix(monkey_patch): report the Liger name on patched gemma3/gemma4/exaone4 MLPs

### DIFF
--- a/src/liger_kernel/transformers/monkey_patch.py
+++ b/src/liger_kernel/transformers/monkey_patch.py
@@ -1289,7 +1289,7 @@ def apply_liger_kernel_to_gemma3_text(
             for decoder_layer in base_model.layers:
                 decoder_layer: Gemma3DecoderLayer
                 if geglu:
-                    _bind_method_to_module(decoder_layer.mlp, "forward", LigerGEGLUMLP.forward)
+                    _patch_geglu_module(decoder_layer.mlp)
                 if rms_norm:
                     _patch_rms_norm_module_for_gemma3(decoder_layer.input_layernorm)
                     _patch_rms_norm_module_for_gemma3(decoder_layer.post_attention_layernorm)
@@ -1526,7 +1526,7 @@ def apply_liger_kernel_to_gemma4_text(
                 decoder_layer: Gemma4TextDecoderLayer
                 # Defensive: skip MLP rebind if a future variant flips MoE on.
                 if geglu and not getattr(decoder_layer, "enable_moe_block", False):
-                    _bind_method_to_module(decoder_layer.mlp, "forward", LigerGEGLUMLP.forward)
+                    _patch_geglu_module(decoder_layer.mlp)
                 if rms_norm:
                     _maybe_patch_scaled_norm(decoder_layer.input_layernorm)
                     _maybe_patch_scaled_norm(decoder_layer.post_attention_layernorm)
@@ -3676,7 +3676,7 @@ def apply_liger_kernel_to_exaone4(
             _patch_rms_norm_module(base_model.norm, in_place=False)
         for decoder_layer in base_model.layers:
             if swiglu:
-                _bind_method_to_module(decoder_layer.mlp, "forward", LigerSwiGLUMLP.forward)
+                _patch_swiglu_module(decoder_layer.mlp, LigerSwiGLUMLP)
             if rms_norm:
                 _patch_rms_norm_module(decoder_layer.post_attention_layernorm, in_place=False)
                 _patch_rms_norm_module(decoder_layer.post_feedforward_layernorm, in_place=False)

--- a/test/transformers/test_monkey_patch.py
+++ b/test/transformers/test_monkey_patch.py
@@ -196,6 +196,15 @@ def is_glm4v_available():
         return False
 
 
+def is_exaone4_available():
+    try:
+        import transformers.models.exaone4  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 def is_glm4v_moe_available():
     try:
         import transformers.models.glm4v_moe  # noqa: F401
@@ -1839,6 +1848,7 @@ def test_apply_liger_kernel_to_instance_for_gemma():
         assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
             assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerGEGLUMLP.forward)
+            assert layer.mlp._get_name() == LigerGEGLUMLP.__name__
             assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
 
@@ -1882,6 +1892,7 @@ def test_apply_liger_kernel_to_instance_for_gemma2():
         assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
             assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerGEGLUMLP.forward)
+            assert layer.mlp._get_name() == LigerGEGLUMLP.__name__
             assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(layer.pre_feedforward_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
@@ -1992,6 +2003,7 @@ def test_apply_liger_kernel_to_instance_for_gemma3_text():
         assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
             assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerGEGLUMLP.forward)
+            assert layer.mlp._get_name() == LigerGEGLUMLP.__name__
             assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(layer.pre_feedforward_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
@@ -2090,6 +2102,7 @@ def test_apply_liger_kernel_to_instance_for_gemma3_conditional_generation():
         )
         for layer in dummy_model_instance.model.language_model.layers:
             assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerGEGLUMLP.forward)
+            assert layer.mlp._get_name() == LigerGEGLUMLP.__name__
             assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(layer.pre_feedforward_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
@@ -2153,6 +2166,7 @@ def test_apply_liger_kernel_to_instance_for_gemma4_text():
         assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
         for layer in dummy_model_instance.model.layers:
             assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerGEGLUMLP.forward)
+            assert layer.mlp._get_name() == LigerGEGLUMLP.__name__
             assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(layer.pre_feedforward_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
@@ -2237,6 +2251,7 @@ def test_apply_liger_kernel_to_instance_for_gemma4_conditional_generation():
         )
         for layer in dummy_model_instance.model.language_model.layers:
             assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerGEGLUMLP.forward)
+            assert layer.mlp._get_name() == LigerGEGLUMLP.__name__
             assert inspect.getsource(layer.input_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
             assert inspect.getsource(layer.pre_feedforward_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
@@ -3859,6 +3874,58 @@ def test_apply_liger_kernel_to_instance_for_nemotron():
         # Check that the activation function was correctly patched
         for decoder_layer in dummy_model_instance.model.layers:
             assert isinstance(decoder_layer.mlp.act_fn, LigerReLUSquared)
+
+        try:
+            print(dummy_model_instance)
+        except Exception as e:
+            pytest.fail(f"An exception occured in extra_expr: {type(e).__name__} - {e}")
+
+
+@pytest.mark.skipif(not is_exaone4_available(), reason="exaone4 module not available")
+def test_apply_liger_kernel_to_instance_for_exaone4():
+    # Ensure any monkey patching is cleaned up for subsequent tests
+    with patch("transformers.models.exaone4.modeling_exaone4"):
+        from transformers.models.exaone4.modeling_exaone4 import Exaone4ForCausalLM
+
+        from liger_kernel.transformers.model.exaone4 import lce_forward as exaone4_lce_forward
+
+        # Instantiate a dummy model
+        config = transformers.models.exaone4.configuration_exaone4.Exaone4Config(
+            dtype=torch.bfloat16,
+            rms_norm_eps=1e-5,
+            hidden_size=32,
+            intermediate_size=64,
+            hidden_act="silu",
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+        )
+        dummy_model_instance = Exaone4ForCausalLM._from_config(config)
+        assert isinstance(dummy_model_instance, Exaone4ForCausalLM)
+
+        # Check that model instance variables are not yet patched with Liger modules
+        assert inspect.getsource(dummy_model_instance.forward) != inspect.getsource(exaone4_lce_forward)
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) != inspect.getsource(LigerRMSNorm.forward)
+        for layer in dummy_model_instance.model.layers:
+            assert inspect.getsource(layer.mlp.forward) != inspect.getsource(LigerSwiGLUMLP.forward)
+            assert inspect.getsource(layer.post_attention_layernorm.forward) != inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_feedforward_layernorm.forward) != inspect.getsource(
+                LigerRMSNorm.forward
+            )
+
+        # Test applying kernels to the model instance
+        _apply_liger_kernel_to_instance(model=dummy_model_instance)
+
+        # Check that the model's instance variables were correctly patched with Liger modules
+        assert inspect.getsource(dummy_model_instance.forward) == inspect.getsource(exaone4_lce_forward)
+        assert inspect.getsource(dummy_model_instance.model.norm.forward) == inspect.getsource(LigerRMSNorm.forward)
+        for layer in dummy_model_instance.model.layers:
+            assert inspect.getsource(layer.mlp.forward) == inspect.getsource(LigerSwiGLUMLP.forward)
+            assert layer.mlp._get_name() == LigerSwiGLUMLP.__name__
+            assert inspect.getsource(layer.post_attention_layernorm.forward) == inspect.getsource(LigerRMSNorm.forward)
+            assert inspect.getsource(layer.post_feedforward_layernorm.forward) == inspect.getsource(
+                LigerRMSNorm.forward
+            )
 
         try:
             print(dummy_model_instance)


### PR DESCRIPTION
## Summary

`_patch_geglu_module` and `_patch_swiglu_module` rebind both `forward` and `_get_name`, so a patched MLP prints as `LigerGEGLUMLP` / `LigerSwiGLUMLP`. Three sites call `_bind_method_to_module` directly and rebind only `forward`:

- `apply_liger_kernel_to_gemma3_text`
- `apply_liger_kernel_to_gemma4_text`
- `apply_liger_kernel_to_exaone4`

Their MLPs run the Liger kernel but still report the stock name. So `print(model)`, which is the usual way of checking that patching landed, says `Gemma3MLP` where gemma2 in the same session says `LigerGEGLUMLP`:

```
gemma2      mlp repr name : LigerGEGLUMLP
gemma3_text mlp repr name : Gemma3MLP
forward actually swapped?  gemma2 True / gemma3_text True
```

Removing exactly this discrepancy was point 2 of #834; these three sites just never went through the helpers. Routing them through the same helpers is the whole change. Nothing outside the reported name moves.

## Testing Done

- Added the `_get_name` assertion next to the six existing GeGLU instance checks. On `main` four of them fail (`gemma3_text`, `gemma3_conditional_generation`, `gemma4_text`, `gemma4_conditional_generation`) and three pass (`gemma`, `gemma2`, `paligemma`, which already go through the helper), so the split matches the three sites above. All pass with the fix.
- `exaone4` had no instance test at all, so this adds one covering the lce forward, RMSNorm and SwiGLU MLP patching. It fails on `main` on the `_get_name` assertion.
- `pytest test/transformers/test_monkey_patch.py`: 63 passed / 1 skipped on `main`, 64 passed / 1 skipped here (the new exaone4 test). The skip is `muse_glimmer` missing from the installed transformers.
- `ruff check .` and `ruff format --check .` with the v0.14.11 pinned in `.pre-commit-config.yaml`: clean.

Hardware Type: CPU. The change is monkey-patch bookkeeping and `test_monkey_patch.py` has no CUDA gating. Ran on transformers 5.9.0 / torch 2.11.0.
