### PR TITLE
fix(llama4): honour skip_logits in lce_forward

### DIFF
--- a/src/liger_kernel/transformers/model/llama4.py
+++ b/src/liger_kernel/transformers/model/llama4.py
@@ -26,6 +26,7 @@ def lce_forward(
     return_dict: Optional[bool] = None,
     cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: Union[int, torch.Tensor] = 0,
+    skip_logits: Optional[bool] = None,
     **kwargs,
 ) -> Union[Tuple, LigerCausalLMOutputWithPast]:
     r"""
@@ -82,8 +83,15 @@ def lce_forward(
     token_accuracy = None
     predicted_tokens = None
 
+    if skip_logits and labels is None and shift_labels is None:
+        raise ValueError("skip_logits is True, but labels and shift_labels are None")
+
+    if skip_logits is None:
+        # By default, if in training mode, don't materialize logits
+        skip_logits = self.training and (labels is not None or shift_labels is not None)
+
     # Compute loss
-    if self.training and (labels is not None or shift_labels is not None):
+    if skip_logits:
         result = LigerForCausalLMLoss(
             hidden_states=kept_hidden_states,
             lm_head_weight=self.lm_head.weight,
@@ -94,7 +102,7 @@ def lce_forward(
         )
         loss, _, token_accuracy, predicted_tokens = unpack_cross_entropy_result(result)
 
-    else:  # if in inference mode materialize logits
+    else:  # materialize logits
         logits = self.lm_head(kept_hidden_states)
         if labels is not None or shift_labels is not None:
             loss = self.loss_function(

--- a/test/transformers/test_llama4.py
+++ b/test/transformers/test_llama4.py
@@ -1,0 +1,67 @@
+"""Contract tests for the Llama4 Liger forward.
+
+`test_monkey_patch.py` checks that `lce_forward` gets installed; it does not check what
+the installed forward does with `skip_logits`. These two cases stay on the non-fused
+branch, so they need no GPU.
+"""
+
+import pytest
+import torch
+import transformers
+
+from liger_kernel.transformers.monkey_patch import apply_liger_kernel_to_llama4
+
+
+def is_llama4_available():
+    try:
+        import transformers.models.llama4  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not is_llama4_available(), reason="llama4 module not available")
+
+
+def _build_patched_model():
+    from transformers.models.llama4.modeling_llama4 import Llama4ForCausalLM
+
+    config = transformers.models.llama4.configuration_llama4.Llama4TextConfig(
+        dtype=torch.float32,
+        rms_norm_eps=1e-5,
+        hidden_size=32,
+        intermediate_size=64,
+        hidden_act="silu",
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        vocab_size=64,
+        moe_layers=[],
+    )
+    model = Llama4ForCausalLM(config)
+    # Only the forward is swapped: the norm/MLP/rope kernels are Triton and would need a GPU.
+    apply_liger_kernel_to_llama4(model=model, rope=False, rms_norm=False, swiglu=False)
+    return model
+
+
+def test_llama4_skip_logits_false_materializes_logits_in_training():
+    model = _build_patched_model()
+    model.train()
+
+    input_ids = torch.randint(0, 64, (2, 8))
+
+    output = model(input_ids=input_ids, labels=input_ids, skip_logits=False)
+
+    assert output.logits is not None
+    assert output.loss is not None
+
+
+def test_llama4_skip_logits_true_without_labels_raises():
+    model = _build_patched_model()
+    model.eval()
+
+    input_ids = torch.randint(0, 64, (2, 8))
+
+    with pytest.raises(ValueError, match="skip_logits is True"):
+        model(input_ids=input_ids, skip_logits=True)


### PR DESCRIPTION
## Summary

`llama4.lce_forward` is the only one of the 42 forwards under `transformers/model/` that has no `skip_logits` parameter. It still decides on its own:

```python
if self.training and (labels is not None or shift_labels is not None):
```

#704 added `skip_logits` precisely so a caller could override that, and swept every model that existed on 2025-05-23. llama4 arrived a month later in #740 and never picked it up; everything added since has it.

Because the signature does not name it, a `skip_logits` argument lands in `**kwargs` and is silently ignored, so `skip_logits=False` during training still takes the fused path and returns `logits=None`. That is the one thing the flag exists to prevent, and the convergence harness relies on it, setting `eval_batch["skip_logits"] = False` before reading `eval_output.logits`.

The change mirrors `mllama`, which has the identical `LigerForCausalLMLoss` shape. `skip_logits=None` evaluates to the previous condition, so nothing moves for callers that do not pass it.

## Testing Done

New `test/transformers/test_llama4.py`. Both cases stay on the non-fused branch, so they run without a GPU:

- `skip_logits=False` in training mode returns logits and a loss. On `main` this fails: the flag is ignored, the fused path runs, and on a CPU box Triton raises `RuntimeError: 0 active drivers`. On a GPU box it fails on `logits is None` instead.
- `skip_logits=True` with no labels raises `ValueError`, as it does on every other model. On `main` this is `DID NOT RAISE`.

- `pytest test/transformers/test_monkey_patch.py test/transformers/test_llama4.py`: 65 passed / 1 skipped (63 + the 2 new; the skip is `muse_glimmer` missing from the installed transformers).
- `ruff check .` and `ruff format --check .` with the v0.14.11 pinned in `.pre-commit-config.yaml`: clean.

Hardware Type: CPU. Ran on transformers 5.9.0 / torch 2.11.0.
