### PR TITLE
fix(fused_linear_jsd): project logits directly in FP32

### DIFF
--- a/src/liger_kernel/ops/backends/_ascend/ops/fused_linear_jsd.py
+++ b/src/liger_kernel/ops/backends/_ascend/ops/fused_linear_jsd.py
@@ -90,10 +90,12 @@ def fused_linear_jsd_forward(
         teacher_input_chunk = teacher_input[start_idx:end_idx]
 
         # shape: chunk_size x V
-        # For anything starting from logits to the final JSD loss, we do computation
-        # in FP32 to avoid losing numerical stability.
-        student_logits_chunk = (student_input_chunk @ student_weight.t()).to(torch.float32)
-        teacher_logits_chunk = (teacher_input_chunk @ teacher_weight.t()).to(torch.float32)
+        # Project directly in FP32: the GEMM accumulator is FP32, so keep it
+        # instead of rounding logits to the input dtype first. Numerically
+        # equivalent to torch.mm(..., out_dtype=torch.float32) where supported;
+        # NPU has no out_dtype path, so upcast explicitly.
+        student_logits_chunk = student_input_chunk.float() @ student_weight.float().t()
+        teacher_logits_chunk = teacher_input_chunk.float() @ teacher_weight.float().t()
         chunk_n_rows = student_logits_chunk.shape[0]
 
         # unreduced loss

--- a/src/liger_kernel/ops/cutile/ops/fused_linear_jsd.py
+++ b/src/liger_kernel/ops/cutile/ops/fused_linear_jsd.py
@@ -56,8 +56,8 @@ def fused_linear_jsd_forward(
         student_input_chunk = student_input[start_idx:end_idx]
         teacher_input_chunk = teacher_input[start_idx:end_idx]
 
-        student_logits_chunk = (student_input_chunk @ student_weight.t()).to(torch.float32)
-        teacher_logits_chunk = (teacher_input_chunk @ teacher_weight.t()).to(torch.float32)
+        student_logits_chunk = student_input_chunk.float() @ student_weight.float().t()
+        teacher_logits_chunk = teacher_input_chunk.float() @ teacher_weight.float().t()
         chunk_n_rows = student_logits_chunk.shape[0]
 
         loss_chunk = loss_1d[start_idx:end_idx]

--- a/src/liger_kernel/ops/fused_linear_jsd.py
+++ b/src/liger_kernel/ops/fused_linear_jsd.py
@@ -25,6 +25,37 @@ _TORCH_VERSION = Version(torch.__version__.split("+")[0])
 _ADDMM_SUPPORTS_OUT_DTYPE = _TORCH_VERSION >= Version("2.8.0")
 
 
+def _fp32_projected_logits(x_chunk: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    """Compute ``x_chunk @ weight.t()`` directly in FP32.
+
+    The previous code ran the GEMM in the input dtype (bf16/fp16) and then
+    ``.to(torch.float32)`` — a precision-inert cast: cuBLAS already accumulates
+    in FP32 internally, but the store rounds to the low-precision mantissa
+    first. JSD gradients difference near-equal distributions, so that rounding
+    cancels catastrophically (4-23% grad error in bf16).
+
+    ``torch.mm(..., out_dtype=torch.float32)`` (torch >= 2.8, CUDA sm_80+)
+    keeps the FP32 accumulator at no cost: a bf16xbf16 / fp16xfp16 product is
+    exactly representable in FP32 and accumulation is FP32 either way, while
+    keeping low-precision tensor cores and no FP32 weight copy. Everywhere
+    else fall back to an explicit FP32 GEMM, which is numerically equivalent.
+    """
+    if x_chunk.dtype == torch.float32 and weight.dtype == torch.float32:
+        return x_chunk @ weight.t()
+    if (
+        _ADDMM_SUPPORTS_OUT_DTYPE
+        and x_chunk.device.type == "cuda"
+        and x_chunk.dtype == weight.dtype
+        and x_chunk.dtype in (torch.float16, torch.bfloat16)
+        and torch.cuda.get_device_capability(x_chunk.device)[0] >= 8
+    ):
+        try:
+            return torch.mm(x_chunk, weight.t(), out_dtype=torch.float32)
+        except RuntimeError:
+            pass
+    return x_chunk.float() @ weight.float().t()
+
+
 def _max_capability() -> int:
     # Runtime dispatch-plane key (e.g. 100 = sm_100/B200, 103 = sm_103/B300).
     # Called per wrapper invocation (never memoized) so mock-cc suites key
@@ -132,10 +163,12 @@ def fused_linear_jsd_forward(
         teacher_input_chunk = teacher_input[start_idx:end_idx]
 
         # shape: chunk_size x V
-        # For anything starting from logits to the final JSD loss, we do computation
-        # in FP32 to avoid losing numerical stability.
-        student_logits_chunk = (student_input_chunk @ student_weight.t()).to(torch.float32)
-        teacher_logits_chunk = (teacher_input_chunk @ teacher_weight.t()).to(torch.float32)
+        # Project directly in FP32: the GEMM accumulator is FP32, so keep it
+        # instead of rounding logits to the input dtype first (see
+        # _fp32_projected_logits). Everything from logits to the JSD loss then
+        # runs in FP32 for numerical stability.
+        student_logits_chunk = _fp32_projected_logits(student_input_chunk, student_weight)
+        teacher_logits_chunk = _fp32_projected_logits(teacher_input_chunk, teacher_weight)
 
         # log-softmax with temperature
         student_logits_chunk = student_logits_chunk / temperature

--- a/test/transformers/test_fused_linear_jsd.py
+++ b/test/transformers/test_fused_linear_jsd.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+import torch.nn.functional as F
 
 from test.transformers.test_jsd import JSD as TorchJSD
 from test.utils import assert_verbose_allclose
@@ -41,8 +42,12 @@ class TorchLMHeadJSD(torch.nn.Module):
         self.temperature = temperature
 
     def forward(self, student_input, teacher_input, label=None):
-        student_logits = self.student_lin(student_input).to(torch.float32)
-        teacher_logits = self.teacher_lin(teacher_input).to(torch.float32)
+        # Project directly in FP32: a low-precision GEMM followed by
+        # `.to(fp32)` would round logits to the input mantissa first (the bug
+        # fixed in fused_linear_jsd_forward). Upcasting both operands keeps the
+        # FP32 accumulator, matching the kernel's documented intent.
+        student_logits = F.linear(student_input.float(), self.student_lin.weight.float())
+        teacher_logits = F.linear(teacher_input.float(), self.teacher_lin.weight.float())
         student_prob = torch.log_softmax(student_logits / self.temperature, dim=-1)
         teacher_prob = torch.log_softmax(teacher_logits / self.temperature, dim=-1)
 
@@ -122,18 +127,18 @@ def test_correctness(B, T, H, V, scalar, dtype, beta, temperature, atol, rtol):
     ).to(device)
 
     # init the linear in all FusedLinearJSDs with the same weights
-    torch_lm_head_jsd.student_lin.weight.data = liger_lm_head_jsd.student_lin.weight.data = torch.rand(
+    torch_lm_head_jsd.student_lin.weight.data = liger_lm_head_jsd.student_lin.weight.data = torch.randn(
         V, H // 2, device=device, dtype=dtype
     )
-    torch_lm_head_jsd.teacher_lin.weight.data = liger_lm_head_jsd.teacher_lin.weight.data = torch.rand(
+    torch_lm_head_jsd.teacher_lin.weight.data = liger_lm_head_jsd.teacher_lin.weight.data = torch.randn(
         V, H, device=device, dtype=dtype
     )
 
-    _tensor = torch.rand(B * T, H // 2, device=device, dtype=dtype) * scalar
+    _tensor = torch.randn(B * T, H // 2, device=device, dtype=dtype) * scalar
     _input1 = _tensor.detach().clone().requires_grad_(True)
     _input2 = _tensor.detach().clone().requires_grad_(True)
 
-    teacher_input = torch.rand(B * T, H, device=device, dtype=dtype) * scalar
+    teacher_input = torch.randn(B * T, H, device=device, dtype=dtype) * scalar
 
     with torch.autograd.detect_anomaly():
         output1 = torch_lm_head_jsd(_input1, teacher_input)
@@ -198,18 +203,18 @@ def test_correctness_with_ignore_index(B, T, H, V, scalar, dtype, beta, ignore_i
     ).to(device)
 
     # init the linear in all FusedLinearJSDs with the same weights
-    torch_lm_head_jsd.student_lin.weight.data = liger_lm_head_jsd.student_lin.weight.data = torch.rand(
+    torch_lm_head_jsd.student_lin.weight.data = liger_lm_head_jsd.student_lin.weight.data = torch.randn(
         V, H // 2, device=device, dtype=dtype
     )
-    torch_lm_head_jsd.teacher_lin.weight.data = liger_lm_head_jsd.teacher_lin.weight.data = torch.rand(
+    torch_lm_head_jsd.teacher_lin.weight.data = liger_lm_head_jsd.teacher_lin.weight.data = torch.randn(
         V, H, device=device, dtype=dtype
     )
 
-    _tensor = torch.rand(B * T, H // 2, device=device, dtype=dtype) * scalar
+    _tensor = torch.randn(B * T, H // 2, device=device, dtype=dtype) * scalar
     _input1 = _tensor.detach().clone().requires_grad_(True)
     _input2 = _tensor.detach().clone().requires_grad_(True)
 
-    teacher_input = torch.rand(B * T, H, device=device, dtype=dtype) * scalar
+    teacher_input = torch.randn(B * T, H, device=device, dtype=dtype) * scalar
 
     label = torch.randint(0, V, (B * T,), device=device, dtype=torch.long)
 
@@ -257,15 +262,15 @@ def test_correctness_with_ignore_index(B, T, H, V, scalar, dtype, beta, ignore_i
 @pytest.mark.parametrize("accum_dtype", [None, torch.float32])
 def test_correctness_functional(B, T, H, V, scalar, dtype, beta, ignore_index, temperature, accum_dtype, atol, rtol):
     # init the linear in all FusedLinearJSDs with the same weights
-    _weight = torch.rand(V, H // 2, device=device, dtype=dtype)
+    _weight = torch.randn(V, H // 2, device=device, dtype=dtype)
     _weight1 = _weight.detach().clone().requires_grad_(True)
     _weight2 = _weight.detach().clone().requires_grad_(True)
-    teacher_weight = torch.rand(V, H, device=device, dtype=dtype)
+    teacher_weight = torch.randn(V, H, device=device, dtype=dtype)
 
-    _tensor = torch.rand(B * T, H // 2, device=device, dtype=dtype) * scalar
+    _tensor = torch.randn(B * T, H // 2, device=device, dtype=dtype) * scalar
     _input1 = _tensor.detach().clone().requires_grad_(True)
     _input2 = _tensor.detach().clone().requires_grad_(True)
-    teacher_input = torch.rand(B * T, H, device=device, dtype=dtype) * scalar
+    teacher_input = torch.randn(B * T, H, device=device, dtype=dtype) * scalar
 
     label = torch.randint(0, V, (B * T,), device=device, dtype=torch.long)
 
@@ -353,18 +358,18 @@ def test_correctness_all_ignored(B, T, H, V, scalar, dtype, beta, ignore_index, 
     ).to(device)
 
     # init the linear in all FusedLinearJSDs with the same weights
-    torch_lm_head_jsd.student_lin.weight.data = liger_lm_head_jsd.student_lin.weight.data = torch.rand(
+    torch_lm_head_jsd.student_lin.weight.data = liger_lm_head_jsd.student_lin.weight.data = torch.randn(
         V, H // 2, device=device, dtype=dtype
     )
-    torch_lm_head_jsd.teacher_lin.weight.data = liger_lm_head_jsd.teacher_lin.weight.data = torch.rand(
+    torch_lm_head_jsd.teacher_lin.weight.data = liger_lm_head_jsd.teacher_lin.weight.data = torch.randn(
         V, H, device=device, dtype=dtype
     )
 
-    _tensor = torch.rand(B * T, H // 2, device=device, dtype=dtype) * scalar
+    _tensor = torch.randn(B * T, H // 2, device=device, dtype=dtype) * scalar
     _input1 = _tensor.detach().clone().requires_grad_(True)
     _input2 = _tensor.detach().clone().requires_grad_(True)
 
-    teacher_input = torch.rand(B * T, H, device=device, dtype=dtype) * scalar
+    teacher_input = torch.randn(B * T, H, device=device, dtype=dtype) * scalar
 
     label = torch.full((B * T,), ignore_index, device=device, dtype=torch.long)
 
@@ -415,18 +420,18 @@ def test_amp(autocast_dtype, atol, rtol):
         beta=beta,
     ).to(device)
     # init the linear in all FusedLinearJSDs with the same weights
-    torch_lm_head_jsd.student_lin.weight.data = liger_lm_head_jsd.student_lin.weight.data = torch.rand(
+    torch_lm_head_jsd.student_lin.weight.data = liger_lm_head_jsd.student_lin.weight.data = torch.randn(
         V, H // 2, device=device, dtype=dtype
     )
-    torch_lm_head_jsd.teacher_lin.weight.data = liger_lm_head_jsd.teacher_lin.weight.data = torch.rand(
+    torch_lm_head_jsd.teacher_lin.weight.data = liger_lm_head_jsd.teacher_lin.weight.data = torch.randn(
         V, H, device=device, dtype=dtype
     )
 
-    _tensor = torch.rand(B * T, H // 2, device=device, dtype=autocast_dtype) * scalar
+    _tensor = torch.randn(B * T, H // 2, device=device, dtype=autocast_dtype) * scalar
     _input1 = _tensor.detach().clone().requires_grad_(True)
     _input2 = _tensor.detach().clone().requires_grad_(True)
 
-    teacher_input = torch.rand(B * T, H, device=device, dtype=autocast_dtype) * scalar
+    teacher_input = torch.randn(B * T, H, device=device, dtype=autocast_dtype) * scalar
 
     label = torch.randint(0, V, (B * T,), device=device, dtype=torch.long)
 


### PR DESCRIPTION
Fixes #1432.

Root cause: forward projected hidden states with low-precision GEMM then cast rounded result to FP32, discarding FP32 accumulator. JSD gradients difference near-equal distributions so rounding cancels catastrophically (4-23% grad error in bf16). Test oracle shared same defect with degenerate rand inputs masking it.

Fix: use torch.mm(..., out_dtype=torch.float32) where supported with explicit FP32 GEMM fallback. Same fix to Ascend and cuTile forwards. Fix oracle + rand to randn.

Tests: py_compile clean, needs GPU CI for numerical verification.